### PR TITLE
fix: 修复本地开发构建与会话流式中断

### DIFF
--- a/apps/desktop/scripts/dev-stack.mjs
+++ b/apps/desktop/scripts/dev-stack.mjs
@@ -6,6 +6,7 @@ import { spawn } from 'node:child_process'
 import {
   REPO_ROOT, spawnServer, waitForHealth, assertServerBuilt,
 } from './lib/paths.mjs'
+import { NPM_CMD, NPM_SHELL } from './lib/commands.mjs'
 
 assertServerBuilt()
 
@@ -21,15 +22,21 @@ process.on('SIGTERM', () => { cleanup(); process.exit(0) })
 
 await waitForHealth()
 
-const vite = spawn('npm', ['run', 'dev', '-w', 'opptrix-client'], {
+const vite = spawn(NPM_CMD, ['run', 'dev', '-w', 'opptrix-client'], {
   cwd: REPO_ROOT,
   stdio: 'inherit',
-  shell: false,
+  shell: NPM_SHELL,
   env: {
     ...process.env,
     API_PROXY_TARGET: 'http://127.0.0.1:8711',
     VITE_DESKTOP: '1',
   },
+})
+
+vite.on('error', err => {
+  console.error('[web] failed to start Vite dev server:', err)
+  cleanup()
+  process.exit(1)
 })
 
 vite.on('exit', code => {

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -6,11 +6,12 @@ import { spawn, spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { resolveElectronExecutable } from './ensure-electron.mjs'
+import { NODE_CMD } from './lib/commands.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const DESKTOP_ROOT = path.resolve(__dirname, '..')
 
-spawnSync('node', ['scripts/prepare-icons.mjs'], {
+spawnSync(NODE_CMD, ['scripts/prepare-icons.mjs'], {
   cwd: DESKTOP_ROOT,
   stdio: 'inherit',
 })
@@ -29,10 +30,15 @@ async function waitForUrl(url, timeoutMs = 60_000) {
   throw new Error(`Timed out waiting for ${url}`)
 }
 
-const stack = spawn('node', ['scripts/dev-stack.mjs'], {
+const stack = spawn(NODE_CMD, ['scripts/dev-stack.mjs'], {
   cwd: DESKTOP_ROOT,
   stdio: 'inherit',
   shell: false,
+})
+
+stack.on('error', (err) => {
+  console.error('[desktop] failed to start dev stack:', err)
+  process.exit(1)
 })
 
 const cleanup = () => {

--- a/apps/desktop/scripts/lib/commands.mjs
+++ b/apps/desktop/scripts/lib/commands.mjs
@@ -1,0 +1,3 @@
+export const NODE_CMD = process.execPath
+export const NPM_CMD = 'npm'
+export const NPM_SHELL = process.platform === 'win32'

--- a/apps/desktop/scripts/lib/runtime-target.mjs
+++ b/apps/desktop/scripts/lib/runtime-target.mjs
@@ -3,6 +3,7 @@
  * CI sets OPPTRIX_RUNTIME_ARCH on macOS cross-builds (arm64 runner → x64 package).
  */
 import { spawnSync } from 'node:child_process'
+import { NPM_CMD, NPM_SHELL } from './commands.mjs'
 
 export function normalizeArch(arch) {
   if (!arch) return arch
@@ -51,11 +52,11 @@ export function hostMatchesTarget(target) {
   return target.platform === process.platform && target.arch === hostArch
 }
 
-function spawn(cmd, args, { cwd, env }) {
+function spawn(cmd, args, { cwd, env, shell = false }) {
   return spawnSync(cmd, args, {
     cwd,
     stdio: 'inherit',
-    shell: false,
+    shell,
     env,
   })
 }
@@ -66,7 +67,7 @@ export function runNpm(args, { cwd, target, extraEnv = {} }) {
   if (target.useRosettaX64) {
     return spawn('arch', ['-x86_64', 'npm', ...args], { cwd, env })
   }
-  return spawn('npm', args, { cwd, env })
+  return spawn(NPM_CMD, args, { cwd, env, shell: NPM_SHELL })
 }
 
 /** @param {string} scriptPath */

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -86,8 +86,16 @@ function readStoredConfig(): Partial<AppConfig> & { llm?: LegacyLlmConfig } {
 export function loadConfig(): AppConfig {
   const file = readStoredConfig()
   const providers = migrateLegacy(file)
-  const defaultModel = file.default_model
-    ?? (providers[0] ? `${providers[0].id}:${providers[0].models[0]}` : undefined)
+  const availableModelRefs = new Set(
+    providers.flatMap(p => p.models.map(model => `${p.id}:${model}`)),
+  )
+  const fallbackModel = providers[0]?.models[0]
+    ? `${providers[0].id}:${providers[0].models[0]}`
+    : undefined
+  // 本地配置可能留下已删除 provider 的 default_model；启动时自动回落到第一个可用模型。
+  const defaultModel = file.default_model && availableModelRefs.has(file.default_model)
+    ? file.default_model
+    : fallbackModel
 
   return {
     providers,

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1016,7 +1016,10 @@ app.post<{ Params: { id: string }; Body: { message: string; model?: string } }>(
     }
 
     const ac = registerSessionChat(req.params.id)
-    req.raw.on('close', () => {
+    req.raw.on('aborted', () => {
+      if (!reply.raw.writableEnded) ac.abort()
+    })
+    reply.raw.on('close', () => {
       if (!reply.raw.writableEnded) ac.abort()
     })
 

--- a/client-ui/src/hooks/useBreakpoint.ts
+++ b/client-ui/src/hooks/useBreakpoint.ts
@@ -110,6 +110,10 @@ export function useSidebarPreference(isMobile: boolean) {
     if (isDesktopApp()) {
       return shouldAutoExpandSidebar()
     }
+    // Web 桌面没有 Electron 标题栏里的侧栏展开按钮；宽屏下默认展开，避免用户被隐藏偏好卡住。
+    if (!window.matchMedia(MOBILE_QUERY).matches) {
+      return shouldAutoExpandSidebar()
+    }
     return localStorage.getItem(SIDEBAR_KEY) === 'true' || localStorage.getItem('inno-sidebar-visible') === 'true'
   })
   const [drawerOpen, setDrawerOpen] = useState(false)

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "start": "npm run start -w @opptrix/server",
     "serve": "concurrently -k -n api,web -c blue,cyan \"npm run start\" \"npm run preview -w opptrix-client -- --host 0.0.0.0\"",
     "clean": "find packages apps -name dist -type d -prune -exec rm -rf {} + 2>/dev/null; find packages apps -name tsconfig.tsbuildinfo -delete 2>/dev/null; rm -rf client-ui/dist",
-    "test": "npm run build:packages && node --test tests/*.test.mjs",
-    "test:ci": "node --test tests/*.test.mjs"
+    "test": "npm run build:packages && node scripts/run-tests.mjs",
+    "test:ci": "node scripts/run-tests.mjs"
   },
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:web": "npm run dev -w opptrix-client",
     "build": "npm run build:packages && npm run build -w opptrix-client",
     "build:desktop": "npm run build -w @opptrix/desktop",
-    "build:packages": "node scripts/ensure-dev-deps.mjs && npm run build -w @opptrix/shared -w @opptrix/user-store -w @opptrix/local-inference -w @opptrix/news-feed -w @opptrix/article-enrichment -w @opptrix/a-stock-layer -w @opptrix/market-data-core -w @opptrix/provider-sdk -w @opptrix/market-data-providers-cn -w @opptrix/market-data-providers-us -w @opptrix/market-data-providers-crypto -w @opptrix/stock-eval -w @opptrix/market-data-store -w @opptrix/institutions -w @opptrix/t-strategy -w @opptrix/skills -w @opptrix/research-hub -w @opptrix/agent -w @opptrix/search-hub -w @opptrix/server",
+    "build:packages": "node scripts/ensure-dev-deps.mjs && npm run build -w @opptrix/shared -w @opptrix/user-store -w @opptrix/local-inference -w @opptrix/news-feed -w @opptrix/article-enrichment -w @opptrix/market-data-core -w @opptrix/a-stock-layer -w @opptrix/provider-sdk -w @opptrix/market-data-providers-cn -w @opptrix/market-data-providers-us -w @opptrix/market-data-providers-crypto -w @opptrix/stock-eval -w @opptrix/market-data-store -w @opptrix/institutions -w @opptrix/t-strategy -w @opptrix/skills -w @opptrix/research-hub -w @opptrix/agent -w @opptrix/search-hub -w @opptrix/server",
     "typecheck:ui": "tsc -p client-ui/tsconfig.json --noEmit",
     "start": "npm run start -w @opptrix/server",
     "serve": "concurrently -k -n api,web -c blue,cyan \"npm run start\" \"npm run preview -w opptrix-client -- --host 0.0.0.0\"",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } },
-  "scripts": { "build": "tsc -p tsconfig.json && cp src/chain-knowledge.json dist/" },
+  "scripts": { "build": "tsc -p tsconfig.json && node -e \"require('fs').copyFileSync('src/chain-knowledge.json','dist/chain-knowledge.json')\"" },
   "dependencies": {
     "@opptrix/shared": "*",
     "@opptrix/a-stock-layer": "*"

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { readdirSync } from 'node:fs'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const root = process.cwd()
+const testsDir = path.join(root, 'tests')
+const testFiles = readdirSync(testsDir)
+  .filter(name => name.endsWith('.test.mjs'))
+  .sort()
+  .map(name => path.join('tests', name))
+
+const result = spawnSync(process.execPath, ['--test', '--test-concurrency=1', ...testFiles], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: false,
+})
+
+process.exit(result.status ?? 1)

--- a/tests/multi-market-architecture.test.mjs
+++ b/tests/multi-market-architecture.test.mjs
@@ -249,16 +249,21 @@ test('regional list seeds sync writes instruments', async () => {
   process.env.OPPTRIX_MARKET_DB_PATH = dbPath
 
   const store = new MarketDataStore(dbPath)
-  const engine = new MarketDataSyncEngine(store, new MarketDataEngine())
-  await engine.sync({ jobs: ['jp_list'], mode: 'full' })
+  const de = new MarketDataEngine(false)
+  de.providerLoader.registerBuiltins()
+  try {
+    const engine = new MarketDataSyncEngine(store, de)
+    await engine.sync({ jobs: ['jp_list'], mode: 'full' })
 
-  assert.ok(store.countRegionalEquityInstruments('JP') >= getRegionalListSeeds('JP').length)
-  const toyota = store.db.prepare(`
-    SELECT name FROM instruments WHERE market = 'JP' AND code = ?
-  `).get('7203')
-  assert.equal(toyota?.name, '丰田汽车')
-  store.close()
-  rmSync(dir, { recursive: true, force: true })
+    assert.ok(store.countRegionalEquityInstruments('JP') >= getRegionalListSeeds('JP').length)
+    const toyota = store.db.prepare(`
+      SELECT name FROM instruments WHERE market = 'JP' AND code = ?
+    `).get('7203')
+    assert.equal(toyota?.name, '丰田汽车')
+  } finally {
+    store.close()
+    rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
+  }
 })
 
 test('US regime stub resolves strategy ids from SPY-like klines', () => {

--- a/tests/package.test.mjs
+++ b/tests/package.test.mjs
@@ -21,7 +21,9 @@ before(async () => {
 })
 
 after(async () => {
-  if (dataDir) await rm(dataDir, { recursive: true, force: true })
+  const { getUserDataStore } = await import('../packages/user-store/dist/index.js')
+  getUserDataStore().close()
+  if (dataDir) await rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 })
 })
 
 test('market data package round-trip preserves stock universe', async () => {


### PR DESCRIPTION
## 主要改动

- 修复 packages 构建顺序，确保 market-data-core 先于 a-stock-layer 构建
- 修复 skills 包在 Windows 下使用 cp 导致构建失败的问题
- 修复 Web 桌面布局下左侧会话栏默认不可见的问题
- 修复 SSE 请求被误判关闭导致回复立即显示“已停止”的问题
- 修复 default_model 指向已删除模型提供商时未自动回退的问题
- 修复测试脚本依赖 shell glob，导致 Windows 下 `npm run test` 无法执行的问题
- 收敛测试资源清理，避免 SQLite 临时文件锁和 provider watcher 让测试挂起
- 修复 Windows 下桌面开发栈 `spawn npm` 失败导致 Vite 无法启动的问题

## 验证

- npm run build
- npm run test
- npm run test:ci
- node --check apps/desktop/scripts/dev.mjs
- node --check apps/desktop/scripts/dev-stack.mjs
- node --check apps/desktop/scripts/lib/runtime-target.mjs
- node --check apps/desktop/scripts/lib/commands.mjs
- Windows 下验证 `npm --version` 可由桌面脚本 helper 正常 spawn
- 受控启动 `apps/desktop/scripts/dev-stack.mjs`，确认 API 与 Vite 均可访问

## 说明

- 模型配置仍保持项目原本逻辑：通过设置页添加模型提供商，不新增 `.env` 作为必需开发入口。
- 根目录 `clean` 脚本仍使用 `find/rm`，属于既有跨平台遗留，可后续单独处理。
