### PR TITLE
feat: sidebar archive tabs, title tools, and archive folder actions

### DIFF
--- a/.cursor/rules/engineering-guidelines.mdc
+++ b/.cursor/rules/engineering-guidelines.mdc
@@ -7,8 +7,14 @@ alwaysApply: true
 
 ## UI / UX 风格
 
+- **设计前必读（强制）**：动手编写或修改 **任何** `client-ui` 可见界面前，必须先查阅：
+  1. `docs/UI-DESIGN-SYSTEM.md` — 色彩、排版、毛玻璃、组件清单
+  2. `docs/UI-LAYOUT.md` — 三栏布局、侧栏、内容区
+  3. Electron 桌面壳：`docs/DESKTOP.md`
+  4. 浮层 / Dialog / 警告 / 通知：`.cursor/rules/ui-overlay-components.mdc`
+  不得跳过文档自行发明圆角、阴影、弹窗样式或原生 `window.confirm` / `alert` / `prompt`。
 - **严格沿用现有框架与设计语言**：React + Fluent UI v9（`@fluentui/react-components`）、项目 tokens（`client-ui/src/theme/tokens.ts`）、mixins（`mixins.ts`）、全局类（`global.css`）。
-- 新交互优先使用 Fluent 已有组件（Menu、Dialog、Button 等），样式与 `OpptrixButton`、`OpptrixField` 等封装保持一致。
+- 新交互优先使用 Fluent 已有组件（Menu、Dialog、Button 等），样式与 `OpptrixButton`、`OpptrixField`、`OpptrixDialogAlert` 等封装保持一致。
 - 布局与视觉规范以 `docs/UI-DESIGN-SYSTEM.md`、`docs/UI-LAYOUT.md` 为准；桌面壳层见 `docs/DESKTOP.md`。
 - **不要**在未获用户明确指示时自行引入移动版布局、额外 header、drawer 变体或与设计体系冲突的 shadow / 圆角 / 间距。
 

--- a/.cursor/rules/ui-overlay-components.mdc
+++ b/.cursor/rules/ui-overlay-components.mdc
@@ -1,0 +1,65 @@
+---
+description: client-ui 浮层/Dialog/面板/警告/通知 — 统一样式组件（必读 UI 文档后使用）
+globs: client-ui/**/*
+alwaysApply: false
+---
+
+# UI 浮层与反馈组件
+
+> 动手改 `client-ui` 可见界面前，**必须先读** `docs/UI-DESIGN-SYSTEM.md`、`docs/UI-LAYOUT.md`；Electron 壳层另读 `docs/DESKTOP.md`。细则与 `.cursor/rules/engineering-guidelines.mdc` 并列。
+
+## 禁止
+
+- **`window.confirm` / `window.alert` / `window.prompt`** — 一律用下方封装或内联控件
+- 裸 `DialogSurface` 无项目类名
+- 自写 shadow / blur / 圆角，未对照 tokens 与 `global.css`
+- 新建与下表职责重叠的「确认弹窗 / Toast / 毛玻璃面板」组件
+
+## 组件选型（按场景）
+
+| 场景 | 用法 | 样式 |
+|------|------|------|
+| **二次确认**（删除、清空、不可逆） | `OpptrixDialogAlert` 或 `useOpptrixDialogAlert().confirm()` | `opptrix-glass-dialog-surface` |
+| **复杂表单 Dialog**（向导、多字段编辑） | Fluent `Dialog` + `OpptrixField` / `OpptrixInput` | `opptrix-dialog-surface` 或毛玻璃（见设计文档 §5.1） |
+| **搜索 / 命令面板** | 专用组件（如 `WorkspaceSearchDialog`） | `opptrix-dialog-surface` + 文档约定 body 类 |
+| **下拉 / 锚定浮层** | `OpptrixDropdownPanel`、`mergeOpptrixDropdownListboxProps` | `opptrix-glass-panel` |
+| **Popover 选项列表** | Fluent Dropdown/Combobox listbox | `OPPTRIX_GLASS_DROPDOWN_LISTBOX_CLASS` |
+| **Transient 通知**（成功/失败/提示） | `useSettingsToast()`（需在 `SettingsToastProvider` 内） | mixin `glassPanel` |
+| **侧栏/列表内联确认** | 同行 `inlineEditRow` + ✓/✕（如归档文件夹） | 与列表行同高，**不用**额外 Dialog |
+| **分段切换**（Tab 胶囊） | `OpptrixSegmentedControl`（`variant="embedded"` 用于侧栏） | `opptrix-segmented-control` |
+| **分组设置块** | `OpptrixSurface`、`SettingsGroup` | 实底卡片，非毛玻璃 |
+
+## 二次确认 API
+
+```tsx
+// 全局 Provider：client-ui/src/main.tsx → OpptrixDialogAlertProvider
+
+const { confirm } = useOpptrixDialogAlert()
+const ok = await confirm({
+  title: '确定删除？',
+  message: '删除后无法恢复。',
+  confirmLabel: '删除',
+  confirmTone: 'danger', // 'default' | 'danger'
+})
+if (!ok) return
+```
+
+声明式：`<OpptrixDialogAlert open title message onConfirm onCancel confirmTone="danger" />`
+
+## 样式来源（单一事实）
+
+| 类型 | CSS 类 / mixin | 定义 |
+|------|----------------|------|
+| 毛玻璃 Dialog | `.opptrix-glass-dialog-surface` | `global.css` |
+| 实底大 Dialog | `.opptrix-dialog-surface` | `global.css` |
+| 毛玻璃面板 | `.opptrix-glass-panel` | `global.css` + `OPPTRIX_GLASS_PANEL_CLASS` |
+| Tokens | `opptrixCssVars.*` | `theme/tokens.ts` + `global.css` `--opptrix-*` |
+| 交互 mixin | `glassDropdown`、`glassPanel` | `theme/mixins.ts` |
+
+## 基础封装（表单与按钮）
+
+- 按钮：`OpptrixButton`（`primary` / `secondary` / `ghost`）
+- 输入：`OpptrixInput`、`OpptrixTextarea`、`OpptrixField`
+- 选择：`OpptrixSelect`
+
+新 UI **优先组合**上述组件；仅当设计文档未覆盖且用户明确要求时，才新增 `Opptrix*` 封装并 **同步更新** `docs/UI-DESIGN-SYSTEM.md` §7 与本规则。

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -482,6 +482,26 @@ function registerWindowIpc() {
     return filePath
   })
 
+  ipcMain.handle('pick-save-file', async (event, payload) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    const defaultPath = String(payload?.defaultPath ?? '对话.md').trim() || '对话.md'
+    const result = await dialog.showSaveDialog(win ?? undefined, {
+      title: String(payload?.title ?? '保存文件'),
+      defaultPath,
+      filters: [{ name: 'Markdown', extensions: ['md'] }],
+    })
+    if (result.canceled || !result.filePath) return null
+    return result.filePath
+  })
+
+  ipcMain.handle('write-text-file', async (_event, payload) => {
+    const filePath = String(payload?.filePath ?? '').trim()
+    const text = String(payload?.text ?? '')
+    if (!filePath) throw new Error('保存路径无效')
+    await fs.writeFile(filePath, text, 'utf8')
+    return filePath
+  })
+
   ipcMain.handle('client-version', async () => VERSION)
 
   ipcMain.handle('open-external-url', async (_event, url) => {

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -9,6 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getIsFullscreen: () => ipcRenderer.invoke('window-is-fullscreen'),
   pickExportDirectory: () => ipcRenderer.invoke('pick-export-directory'),
   writeBinaryFile: (payload) => ipcRenderer.invoke('write-binary-file', payload),
+  pickSaveFile: (payload) => ipcRenderer.invoke('pick-save-file', payload),
+  writeTextFile: (payload) => ipcRenderer.invoke('write-text-file', payload),
   openExternalUrl: (url) => ipcRenderer.invoke('open-external-url', url),
   clientVersion: () => ipcRenderer.invoke('client-version'),
   appUpdateGetStatus: () => ipcRenderer.invoke('app-update-get-status'),

--- a/apps/server/src/search-routes.ts
+++ b/apps/server/src/search-routes.ts
@@ -29,6 +29,42 @@ export function registerSearchRoutes(
     folders: agent.listSessionArchiveFolders(),
   }))
 
+  app.post<{ Body: { title?: string } }>('/api/sessions/archive-folders', async (req, reply) => {
+    const title = String(req.body?.title ?? '').trim()
+    if (!title) return reply.code(400).send({ error: 'title required' })
+    const folder = agent.createSessionArchiveFolder(title)
+    return { folder }
+  })
+
+  app.patch<{ Params: { id: string }; Body: { title?: string } }>(
+    '/api/sessions/archive-folders/:id',
+    async (req, reply) => {
+      const title = String(req.body?.title ?? '').trim()
+      if (!title) return reply.code(400).send({ error: 'title required' })
+      const folder = agent.renameSessionArchiveFolder(req.params.id, title)
+      if (!folder) return reply.code(400).send({ error: 'cannot rename folder' })
+      return { folder }
+    },
+  )
+
+  app.delete<{ Params: { id: string } }>(
+    '/api/sessions/archive-folders/:id',
+    async (req, reply) => {
+      const result = agent.deleteSessionArchiveFolder(req.params.id)
+      if (!result.ok) return reply.code(400).send({ error: 'cannot delete folder' })
+      return result
+    },
+  )
+
+  app.post<{ Params: { id: string } }>(
+    '/api/sessions/archive-folders/:id/clear',
+    async (req, reply) => {
+      const result = agent.clearSessionArchiveFolder(req.params.id)
+      if (!result.ok) return reply.code(404).send({ error: 'folder not found' })
+      return result
+    },
+  )
+
   app.post<{ Params: { id: string }; Body: { folderId?: string } }>(
     '/api/sessions/:id/archive',
     async (req, reply) => {
@@ -68,7 +104,7 @@ export function registerSearchRoutes(
   )
 
   app.get('/api/sessions/archived', async () => ({
-    groups: agent.listArchivedSessionsGrouped().map(g => ({
+    groups: agent.listAllArchivedByFolder().map(g => ({
       folder: g.folder,
       sessions: g.sessions,
     })),

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1269,6 +1269,40 @@ export async function listSessionArchiveFolders() {
   return jsonFetch<{ folders: import('../types/chat').SessionArchiveFolder[] }>('/sessions/archive-folders')
 }
 
+export async function createSessionArchiveFolder(title: string) {
+  return jsonFetch<{ folder: import('../types/chat').SessionArchiveFolder }>('/sessions/archive-folders', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+}
+
+export async function renameSessionArchiveFolder(id: string, title: string) {
+  return jsonFetch<{ folder: import('../types/chat').SessionArchiveFolder }>(`/sessions/archive-folders/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title }),
+  })
+}
+
+export async function deleteSessionArchiveFolder(id: string) {
+  return jsonFetch<{ ok: boolean; movedCount?: number }>(`/sessions/archive-folders/${id}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function clearSessionArchiveFolder(id: string) {
+  return jsonFetch<{ ok: boolean; deletedCount: number }>(`/sessions/archive-folders/${id}/clear`, {
+    method: 'POST',
+  })
+}
+
+export async function listArchivedSessions() {
+  return jsonFetch<{ groups: Array<{ folder: import('../types/chat').SessionArchiveFolder; sessions: SessionMeta[] }> }>(
+    '/sessions/archived',
+  )
+}
+
 export async function archiveSession(id: string, folderId: string) {
   return jsonFetch<{ session: SessionMeta }>(`/sessions/${id}/archive`, {
     method: 'POST',

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -15,7 +15,7 @@ import {
   streamSessionChat, cancelSessionChat, getHealth, listAvailableModels, setSessionModel,
   archiveSession,
   listArchivedSessions, createSessionArchiveFolder, renameSessionArchiveFolder, deleteSessionArchiveFolder,
-  clearSessionArchiveFolder,
+  clearSessionArchiveFolder, renameSession,
 } from '../api/client'
 import type {
   ChatDisplayMessage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
@@ -34,11 +34,14 @@ import { useAppNavigation } from '../hooks/useAppNavigation'
 import DesktopWindowChrome from '../desktop/DesktopWindowChrome'
 import OverlaySidebarEdgeTrigger from '../desktop/OverlaySidebarEdgeTrigger'
 import { useOpptrixDialogAlert } from '../components/opptrix/OpptrixDialogAlert'
+import ChatSessionTitleTools from './ChatSessionTitleTools'
+import { sessionToMarkdown } from './sessionExportMarkdown'
+import { saveTextFileWithDialog } from '../platform/saveTextFile'
 import { desktopChromeToolbarReserve } from '../desktop/layout'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { useDesktopShell } from '../hooks/useDesktopShell'
 import { isElectron } from '../platform/detect'
-import { DESKTOP_SIDEBAR_EXPAND_THRESHOLD, DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT } from '../desktop/constants'
+import { DESKTOP_SIDEBAR_EXPAND_THRESHOLD, DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT, SIDEBAR_INLINE_WIDTH } from '../desktop/constants'
 
 const useStyles = makeStyles({
   root: {
@@ -222,6 +225,7 @@ export default function ChatApp() {
   const [archivedGroups, setArchivedGroups] = useState<ArchiveFolderGroup[]>([])
   const [sidebarListTab, setSidebarListTab] = useState<SidebarListTab>('chat')
   const [activeId, setActiveId] = useState<string | null>(null)
+  const [activeSessionMeta, setActiveSessionMeta] = useState<SessionMeta | null>(null)
   const [messages, setMessages] = useState<ChatDisplayMessage[]>([])
   const [contextRef, setContextRef] = useState<SessionContextRef | null>(null)
   const [input, setInput] = useState('')
@@ -282,6 +286,7 @@ export default function ChatApp() {
   const loadSession = useCallback(async (id: string) => {
     const data = await getSession(id)
     setActiveId(id)
+    setActiveSessionMeta(data.session)
     setMessages(data.messages)
     setContextRef(data.contextRef ?? null)
     setSessionModelState(data.session.model)
@@ -368,6 +373,7 @@ export default function ChatApp() {
       const list = await refreshSessions()
       setSessions(list)
       setActiveId(session.id)
+      setActiveSessionMeta(session)
       setMessages([])
       setContextRef(null)
       setSessionModelState(undefined)
@@ -408,6 +414,7 @@ export default function ChatApp() {
           await loadSession(list[0].id)
         } else {
           setActiveId(null)
+          setActiveSessionMeta(null)
           setMessages([])
           setContextRef(null)
         }
@@ -428,6 +435,7 @@ export default function ChatApp() {
           await loadSession(list[0].id)
         } else {
           setActiveId(null)
+          setActiveSessionMeta(null)
           setMessages([])
           setContextRef(null)
           setSessionModelState(undefined)
@@ -478,6 +486,7 @@ export default function ChatApp() {
           await loadSession(list[0].id)
         } else {
           setActiveId(null)
+          setActiveSessionMeta(null)
           setMessages([])
           setContextRef(null)
           setSessionModelState(undefined)
@@ -498,6 +507,7 @@ export default function ChatApp() {
           await loadSession(list[0].id)
         } else {
           setActiveId(null)
+          setActiveSessionMeta(null)
           setMessages([])
           setContextRef(null)
           setSessionModelState(undefined)
@@ -507,6 +517,42 @@ export default function ChatApp() {
       setError(e instanceof Error ? e.message : '删除失败')
     }
   }, [activeId, loadSession, refreshArchived, refreshSessions])
+
+  const handleRenameSession = useCallback(async (title: string) => {
+    if (!activeId) return
+    try {
+      const { session } = await renameSession(activeId, title)
+      setActiveSessionMeta(prev => prev && prev.id === activeId
+        ? { ...prev, title: session.title, updatedAt: session.updatedAt }
+        : prev)
+      setSessions(prev => prev.map(sess =>
+        sess.id === activeId ? { ...sess, title: session.title, updatedAt: session.updatedAt } : sess,
+      ))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '重命名失败')
+    }
+  }, [activeId])
+
+  const handleArchiveActiveSession = useCallback(async (folderId: string) => {
+    if (!activeId) return
+    await handleArchive(activeId, folderId)
+  }, [activeId, handleArchive])
+
+  const handleDeleteActiveSession = useCallback(async () => {
+    if (!activeId) return
+    await handleDelete(activeId)
+  }, [activeId, handleDelete])
+
+  const handleExportSession = useCallback(async () => {
+    if (!activeId || !activeSessionMeta) return
+    try {
+      const md = sessionToMarkdown(activeSessionMeta, messages)
+      const result = await saveTextFileWithDialog(md, activeSessionMeta.title)
+      if (!result) return
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '导出失败')
+    }
+  }, [activeId, activeSessionMeta, messages])
 
   const handleSidebarListTabChange = useCallback((tab: SidebarListTab) => {
     setSidebarListTab(tab)
@@ -645,6 +691,7 @@ export default function ChatApp() {
         setActiveId(sid)
       }
       const fresh = await getSession(sid)
+      setActiveSessionMeta(fresh.session)
       setMessages(fresh.messages)
       setContextRef(fresh.contextRef ?? null)
       setSessionModelState(fresh.session.model)
@@ -658,6 +705,7 @@ export default function ChatApp() {
       if (aborted) {
         try {
           const fresh = await getSession(sessionId)
+          setActiveSessionMeta(fresh.session)
           setMessages(fresh.messages)
           setContextRef(fresh.contextRef ?? null)
           setSessionModelState(fresh.session.model)
@@ -672,6 +720,7 @@ export default function ChatApp() {
       setError(e instanceof Error ? e.message : '发送失败')
       try {
         const fresh = await getSession(sessionId)
+        setActiveSessionMeta(fresh.session)
         setMessages(fresh.messages)
         setContextRef(fresh.contextRef ?? null)
       } catch {
@@ -776,6 +825,7 @@ export default function ChatApp() {
       const list = await refreshSessions()
       setSessions(list)
       setActiveId(session.id)
+      setActiveSessionMeta(session)
       setMessages([])
       const data = await setSessionContext(session.id, nextRef)
       setContextRef(data.contextRef ?? nextRef)
@@ -819,12 +869,37 @@ export default function ChatApp() {
     }
   }
 
-  const activeSession = sessions.find(x => x.id === activeId)
+  const activeSession = activeSessionMeta ?? sessions.find(x => x.id === activeId) ?? null
   const isSettings = view === 'settings'
   const isNews = view === 'news'
   const chromeTitle = isNews ? '新闻中心' : (activeSession?.title ?? '新对话')
   const chromeViewMode = isSettings ? 'settings' : isNews ? 'news' : 'chat'
   const overlaySidebarOpen = isSettings ? settingsSidebarVisible : sidebarVisible
+
+  const sessionTitleTools = view === 'chat' && !isNews ? (
+    <ChatSessionTitleTools
+      title={activeSession?.title ?? '新对话'}
+      sessionId={activeId}
+      variant="chrome"
+      textClassName="opptrix-desktop-title-text"
+      onRename={handleRenameSession}
+      onArchive={handleArchiveActiveSession}
+      onDelete={() => { void handleDeleteActiveSession() }}
+      onExport={handleExportSession}
+    />
+  ) : null
+
+  const chatTitleSlot = view === 'chat' && !isNews ? (
+    <ChatSessionTitleTools
+      title={activeSession?.title ?? '新对话'}
+      sessionId={activeId}
+      variant="header"
+      onRename={handleRenameSession}
+      onArchive={handleArchiveActiveSession}
+      onDelete={() => { void handleDeleteActiveSession() }}
+      onExport={handleExportSession}
+    />
+  ) : null
 
   const handleEdgeRevealSidebar = useCallback(() => {
     if (isSettings) {
@@ -871,6 +946,7 @@ export default function ChatApp() {
       {electronChrome && (
         <DesktopWindowChrome
           title={chromeTitle}
+          titleSlot={sessionTitleTools}
           viewMode={chromeViewMode}
           sidebarOpen={isSettings ? settingsSidebarVisible : sidebarVisible}
           sidebarInline={isSettings
@@ -887,6 +963,8 @@ export default function ChatApp() {
           onGoForward={!isSettings ? goForward : undefined}
           rightPanelOpen={view === 'chat' && !isMobile ? rightPanelVisible : undefined}
           rightPanelWidth={view === 'chat' && !isMobile && rightPanelVisible ? rightPanelWidth : undefined}
+          chatColumnWidth={view === 'chat' && !isMobile && chatVisible && showSplitter ? chatWidth : undefined}
+          chatAreaLeft={sidebarInlineVisible ? SIDEBAR_INLINE_WIDTH : 0}
           chatColumnVisible={view === 'chat' && !isMobile ? chatVisible : undefined}
           onToggleRightPanel={view === 'chat' && !isMobile ? handleToggleRightPanel : undefined}
           onToggleChatColumn={view === 'chat' && !isMobile && canToggleChatColumn ? handleToggleChatColumn : undefined}
@@ -990,6 +1068,7 @@ export default function ChatApp() {
                 <div className={mergeClasses(s.chatPanel, electronChrome && 'opptrix-chat-panel')}>
                   <ChatView
                     title={activeSession?.title ?? '新对话'}
+                    titleSlot={electronChrome ? undefined : chatTitleSlot}
                     sessionId={activeId}
                     welcomeEpoch={welcomeEpoch}
                     chatScrollEpoch={chatScrollEpoch}

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { makeStyles, mergeClasses } from '@fluentui/react-components'
-import SessionSidebar from './SessionSidebar'
+import SessionSidebar, { type SidebarListTab } from './SessionSidebar'
+import type { ArchiveFolderGroup } from './SessionSidebarArchivePanel'
 import ChatView from './ChatView'
 import SettingsPage from '../pages/SettingsPage'
 import NewsCenterPage from '../pages/news/NewsCenterPage'
@@ -13,6 +14,8 @@ import {
   setSessionContext, ephemeralAsk,
   streamSessionChat, cancelSessionChat, getHealth, listAvailableModels, setSessionModel,
   archiveSession,
+  listArchivedSessions, createSessionArchiveFolder, renameSessionArchiveFolder, deleteSessionArchiveFolder,
+  clearSessionArchiveFolder,
 } from '../api/client'
 import type {
   ChatDisplayMessage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
@@ -30,6 +33,7 @@ import { useWorkspaceSplit } from '../hooks/useWorkspaceSplit'
 import { useAppNavigation } from '../hooks/useAppNavigation'
 import DesktopWindowChrome from '../desktop/DesktopWindowChrome'
 import OverlaySidebarEdgeTrigger from '../desktop/OverlaySidebarEdgeTrigger'
+import { useOpptrixDialogAlert } from '../components/opptrix/OpptrixDialogAlert'
 import { desktopChromeToolbarReserve } from '../desktop/layout'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { useDesktopShell } from '../hooks/useDesktopShell'
@@ -126,6 +130,7 @@ const useStyles = makeStyles({
 
 export default function ChatApp() {
   const s = useStyles()
+  const { confirm } = useOpptrixDialogAlert()
   const breakpoint = useBreakpoint()
   const isMobile = breakpoint === 'mobile'
   const {
@@ -214,6 +219,8 @@ export default function ChatApp() {
   }, [view, toggleVisible])
 
   const [sessions, setSessions] = useState<SessionMeta[]>([])
+  const [archivedGroups, setArchivedGroups] = useState<ArchiveFolderGroup[]>([])
+  const [sidebarListTab, setSidebarListTab] = useState<SidebarListTab>('chat')
   const [activeId, setActiveId] = useState<string | null>(null)
   const [messages, setMessages] = useState<ChatDisplayMessage[]>([])
   const [contextRef, setContextRef] = useState<SessionContextRef | null>(null)
@@ -264,6 +271,12 @@ export default function ChatApp() {
     const { sessions: list } = await listSessions()
     setSessions(list)
     return list
+  }, [])
+
+  const refreshArchived = useCallback(async () => {
+    const { groups } = await listArchivedSessions()
+    setArchivedGroups(groups)
+    return groups
   }, [])
 
   const loadSession = useCallback(async (id: string) => {
@@ -380,7 +393,13 @@ export default function ChatApp() {
   }
 
   const handleDelete = async (id: string) => {
-    if (!confirm('确定删除此对话？')) return
+    const ok = await confirm({
+      title: '确定删除此对话？',
+      message: '删除后无法恢复。',
+      confirmLabel: '删除',
+      confirmTone: 'danger',
+    })
+    if (!ok) return
     try {
       await deleteSession(id)
       const list = await refreshSessions()
@@ -403,6 +422,7 @@ export default function ChatApp() {
       await archiveSession(id, folderId)
       const list = await refreshSessions()
       setSessions(list)
+      void refreshArchived()
       if (activeId === id) {
         if (list.length > 0) {
           await loadSession(list[0].id)
@@ -417,6 +437,81 @@ export default function ChatApp() {
       setError(e instanceof Error ? e.message : '归档失败')
     }
   }
+
+  const handleCreateArchiveFolder = useCallback(async (title: string) => {
+    try {
+      await createSessionArchiveFolder(title)
+      await refreshArchived()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '创建文件夹失败')
+    }
+  }, [refreshArchived])
+
+  const handleRenameArchiveFolder = useCallback(async (id: string, title: string) => {
+    try {
+      await renameSessionArchiveFolder(id, title)
+      await refreshArchived()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '重命名失败')
+    }
+  }, [refreshArchived])
+
+  const handleDeleteArchiveFolder = useCallback(async (id: string) => {
+    try {
+      await deleteSessionArchiveFolder(id)
+      await refreshArchived()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '删除文件夹失败')
+    }
+  }, [refreshArchived])
+
+  const handleClearArchiveFolder = useCallback(async (id: string) => {
+    try {
+      const clearedIds = new Set(
+        archivedGroups.find(g => g.folder.id === id)?.sessions.map(s => s.id) ?? [],
+      )
+      await clearSessionArchiveFolder(id)
+      await refreshArchived()
+      if (activeId && clearedIds.has(activeId)) {
+        const list = await refreshSessions()
+        if (list.length > 0) {
+          await loadSession(list[0].id)
+        } else {
+          setActiveId(null)
+          setMessages([])
+          setContextRef(null)
+          setSessionModelState(undefined)
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '清空文件夹失败')
+    }
+  }, [activeId, archivedGroups, loadSession, refreshArchived, refreshSessions])
+
+  const handleDeleteArchivedSession = useCallback(async (id: string) => {
+    try {
+      await deleteSession(id)
+      await refreshArchived()
+      if (activeId === id) {
+        const list = await refreshSessions()
+        if (list.length > 0) {
+          await loadSession(list[0].id)
+        } else {
+          setActiveId(null)
+          setMessages([])
+          setContextRef(null)
+          setSessionModelState(undefined)
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '删除失败')
+    }
+  }, [activeId, loadSession, refreshArchived, refreshSessions])
+
+  const handleSidebarListTabChange = useCallback((tab: SidebarListTab) => {
+    setSidebarListTab(tab)
+    if (tab === 'archive') void refreshArchived()
+  }, [refreshArchived])
 
   const handleOpenSearch = useCallback(() => {
     closeDrawer()
@@ -750,6 +845,14 @@ export default function ChatApp() {
     onOpenSearch: handleOpenSearch,
     onOpenSettings: () => { openSettings() },
     onOpenNewsCenter: openNewsCenter,
+    listTab: sidebarListTab,
+    onListTabChange: handleSidebarListTabChange,
+    archivedGroups,
+    onCreateArchiveFolder: handleCreateArchiveFolder,
+    onRenameArchiveFolder: handleRenameArchiveFolder,
+    onDeleteArchiveFolder: handleDeleteArchiveFolder,
+    onClearArchiveFolder: handleClearArchiveFolder,
+    onDeleteArchivedSession: handleDeleteArchivedSession,
   }
 
   return (

--- a/client-ui/src/chat/ChatSessionTitleTools.tsx
+++ b/client-ui/src/chat/ChatSessionTitleTools.tsx
@@ -1,0 +1,497 @@
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type MouseEvent,
+} from 'react'
+import { createPortal } from 'react-dom'
+import { Input, mergeClasses } from '@fluentui/react-components'
+import {
+  AddRegular,
+  ArchiveRegular,
+  ArrowExportRegular,
+  CheckmarkRegular,
+  ChevronDownRegular,
+  ChevronRightRegular,
+  DeleteRegular,
+  DismissRegular,
+  EditRegular,
+  FolderRegular,
+} from '@fluentui/react-icons'
+import { OPPTRIX_GLASS_PANEL_CLASS } from '../theme/mixins'
+import type { SessionArchiveFolder } from '../types/chat'
+import { createSessionArchiveFolder, listSessionArchiveFolders } from '../api/client'
+import { ComposerTooltipMenuItem } from './ComposerTooltipMenu'
+
+const MENU_WIDTH = 208
+const ARCHIVE_PANEL_WIDTH = 220
+const VIEWPORT_PAD = 12
+const PANEL_GAP = 6
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+export interface ChatSessionTitleToolsProps {
+  title: string
+  sessionId: string | null
+  disabled?: boolean
+  /** 可用宽度上限（Electron 标题栏由 DesktopWindowChrome 传入） */
+  maxWidth?: number
+  /** Electron 标题栏 vs 聊天区顶栏 */
+  variant?: 'chrome' | 'header'
+  className?: string
+  textClassName?: string
+  style?: CSSProperties
+  onRename: (title: string) => void | Promise<void>
+  onArchive: (folderId: string) => void | Promise<void>
+  onDelete: () => void
+  onExport: () => void | Promise<void>
+}
+
+export default function ChatSessionTitleTools({
+  title,
+  sessionId,
+  disabled = false,
+  maxWidth,
+  variant = 'header',
+  className,
+  textClassName,
+  style,
+  onRename,
+  onArchive,
+  onDelete,
+  onExport,
+}: ChatSessionTitleToolsProps) {
+  const anchorRef = useRef<HTMLButtonElement>(null)
+  const renameInputRef = useRef<HTMLInputElement>(null)
+  const primaryPanelRef = useRef<HTMLDivElement>(null)
+  const archivePanelRef = useRef<HTMLDivElement>(null)
+
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [archiveOpen, setArchiveOpen] = useState(false)
+  const [renaming, setRenaming] = useState(false)
+  const [renameDraft, setRenameDraft] = useState(title)
+  const [primaryStyle, setPrimaryStyle] = useState<CSSProperties>({ visibility: 'hidden' })
+  const [archiveStyle, setArchiveStyle] = useState<CSSProperties>({ visibility: 'hidden' })
+
+  const [folders, setFolders] = useState<SessionArchiveFolder[]>([])
+  const [foldersLoading, setFoldersLoading] = useState(false)
+  const [creatingFolder, setCreatingFolder] = useState(false)
+  const [newFolderDraft, setNewFolderDraft] = useState('')
+  const newFolderInputRef = useRef<HTMLInputElement>(null)
+
+  const hasSession = Boolean(sessionId)
+  const canUseTools = hasSession && !disabled
+
+  useEffect(() => {
+    if (!renaming) setRenameDraft(title)
+  }, [title, renaming])
+
+  useEffect(() => {
+    if (!renaming) return
+    renameInputRef.current?.focus()
+    renameInputRef.current?.select()
+  }, [renaming])
+
+  useEffect(() => {
+    if (!creatingFolder) return
+    newFolderInputRef.current?.focus()
+  }, [creatingFolder])
+
+  const closeMenus = useCallback(() => {
+    setMenuOpen(false)
+    setArchiveOpen(false)
+    setCreatingFolder(false)
+    setNewFolderDraft('')
+  }, [])
+
+  const loadFolders = useCallback(async () => {
+    setFoldersLoading(true)
+    try {
+      const res = await listSessionArchiveFolders()
+      setFolders(res.folders)
+    } catch {
+      setFolders([])
+    } finally {
+      setFoldersLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!menuOpen || !archiveOpen) return
+    void loadFolders()
+  }, [archiveOpen, loadFolders, menuOpen])
+
+  const updatePanelPositions = useCallback(() => {
+    const anchor = anchorRef.current
+    const primary = primaryPanelRef.current
+    if (!menuOpen || !anchor || !primary) return
+
+    const rect = anchor.getBoundingClientRect()
+    const panelWidth = MENU_WIDTH
+    const panelHeight = primary.offsetHeight
+    const gap = 6
+
+    let left = rect.left
+    left = clamp(left, VIEWPORT_PAD, window.innerWidth - panelWidth - VIEWPORT_PAD)
+
+    let top = rect.bottom + gap
+    if (top + panelHeight > window.innerHeight - VIEWPORT_PAD) {
+      top = Math.max(VIEWPORT_PAD, rect.top - gap - panelHeight)
+    }
+
+    setPrimaryStyle({
+      position: 'fixed',
+      top,
+      left,
+      width: panelWidth,
+      zIndex: 2100,
+      visibility: 'visible',
+    })
+
+    if (archiveOpen) {
+      const archive = archivePanelRef.current
+      if (!archive) return
+      const archiveHeight = archive.offsetHeight
+      const archiveWidth = ARCHIVE_PANEL_WIDTH
+      let archiveLeft = left + panelWidth + PANEL_GAP
+      if (archiveLeft + archiveWidth > window.innerWidth - VIEWPORT_PAD) {
+        archiveLeft = left - archiveWidth - PANEL_GAP
+      }
+      archiveLeft = clamp(archiveLeft, VIEWPORT_PAD, window.innerWidth - archiveWidth - VIEWPORT_PAD)
+
+      let archiveTop = top
+      if (archiveTop + archiveHeight > window.innerHeight - VIEWPORT_PAD) {
+        archiveTop = Math.max(VIEWPORT_PAD, window.innerHeight - VIEWPORT_PAD - archiveHeight)
+      }
+
+      setArchiveStyle({
+        position: 'fixed',
+        top: archiveTop,
+        left: archiveLeft,
+        width: archiveWidth,
+        zIndex: 2100,
+        visibility: 'visible',
+      })
+    }
+  }, [archiveOpen, menuOpen])
+
+  useLayoutEffect(() => {
+    if (!menuOpen) return
+    updatePanelPositions()
+    const raf = window.requestAnimationFrame(updatePanelPositions)
+    return () => window.cancelAnimationFrame(raf)
+  }, [menuOpen, archiveOpen, creatingFolder, folders.length, foldersLoading, updatePanelPositions])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const onResize = () => updatePanelPositions()
+    window.addEventListener('resize', onResize)
+    window.addEventListener('scroll', onResize, true)
+    return () => {
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('scroll', onResize, true)
+    }
+  }, [menuOpen, updatePanelPositions])
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const onDocDown = (e: MouseEvent) => {
+      const target = e.target as Node
+      if (anchorRef.current?.contains(target)) return
+      if (primaryPanelRef.current?.contains(target)) return
+      if (archivePanelRef.current?.contains(target)) return
+      closeMenus()
+    }
+    document.addEventListener('mousedown', onDocDown)
+    return () => document.removeEventListener('mousedown', onDocDown)
+  }, [closeMenus, menuOpen])
+
+  const commitRename = useCallback(async () => {
+    const next = renameDraft.trim()
+    setRenaming(false)
+    if (!next || next === title) return
+    await onRename(next)
+  }, [onRename, renameDraft, title])
+
+  const cancelRename = useCallback(() => {
+    setRenaming(false)
+    setRenameDraft(title)
+  }, [title])
+
+  const handleRenameKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void commitRename()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancelRename()
+    }
+  }
+
+  const handleTitleClick = () => {
+    if (disabled || renaming) return
+    if (!canUseTools) return
+    setMenuOpen(prev => {
+      const next = !prev
+      if (!next) setArchiveOpen(false)
+      return next
+    })
+  }
+
+  const handleTitleMouseDown = (e: MouseEvent<HTMLButtonElement>) => {
+    if (disabled || renaming || !canUseTools) return
+    e.stopPropagation()
+  }
+
+  const startRename = () => {
+    closeMenus()
+    setRenameDraft(title)
+    setRenaming(true)
+  }
+
+  const openArchivePanel = () => {
+    setArchiveOpen(true)
+    void loadFolders()
+  }
+
+  const handleArchiveSelect = async (folderId: string) => {
+    closeMenus()
+    await onArchive(folderId)
+  }
+
+  const handleCreateFolderConfirm = async () => {
+    const name = newFolderDraft.trim()
+    if (!name) {
+      setCreatingFolder(false)
+      return
+    }
+    try {
+      const { folder } = await createSessionArchiveFolder(name)
+      closeMenus()
+      await onArchive(folder.id)
+    } catch {
+      setCreatingFolder(false)
+    }
+  }
+
+  const handleCreateFolderKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void handleCreateFolderConfirm()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setCreatingFolder(false)
+      setNewFolderDraft('')
+    }
+  }
+
+  const handleDeleteClick = () => {
+    closeMenus()
+    onDelete()
+  }
+
+  const handleExportClick = async () => {
+    closeMenus()
+    await onExport()
+  }
+
+  const titleStyle: CSSProperties | undefined = maxWidth != null
+    ? { maxWidth: `${maxWidth}px` }
+    : style
+
+  const titleButton = renaming ? (
+    <div
+      className={mergeClasses(
+        'opptrix-session-title-inline-edit',
+        variant === 'chrome' && 'opptrix-session-title-inline-edit--chrome',
+        className,
+      )}
+      style={titleStyle}
+      onMouseDown={handleTitleMouseDown}
+    >
+      <Input
+        ref={renameInputRef}
+        className="opptrix-session-title-inline-input opptrix-archive-inline-input"
+        value={renameDraft}
+        onChange={(_, data) => setRenameDraft(data.value)}
+        onKeyDown={handleRenameKeyDown}
+        aria-label="重命名对话"
+      />
+      <button
+        type="button"
+        className="opptrix-session-title-inline-btn opptrix-focusable"
+        aria-label="确认重命名"
+        onClick={() => { void commitRename() }}
+      >
+        <CheckmarkRegular fontSize={14} />
+      </button>
+      <button
+        type="button"
+        className="opptrix-session-title-inline-btn opptrix-focusable"
+        aria-label="取消重命名"
+        onClick={cancelRename}
+      >
+        <DismissRegular fontSize={14} />
+      </button>
+    </div>
+  ) : (
+    <button
+      ref={anchorRef}
+      type="button"
+      className={mergeClasses(
+        'opptrix-session-title-btn',
+        variant === 'chrome' && 'opptrix-session-title-btn--chrome',
+        canUseTools && 'opptrix-session-title-btn--clickable',
+        menuOpen && 'opptrix-session-title-btn--open',
+        className,
+      )}
+      style={titleStyle}
+      disabled={!canUseTools}
+      onMouseDown={handleTitleMouseDown}
+      onClick={handleTitleClick}
+      aria-haspopup={canUseTools ? 'menu' : undefined}
+      aria-expanded={canUseTools ? menuOpen : undefined}
+      aria-label={canUseTools ? `对话：${title}，打开工具菜单` : title}
+    >
+      <span className={mergeClasses('opptrix-session-title-btn__text', textClassName)}>
+        {title || '新对话'}
+      </span>
+      {canUseTools && (
+        <ChevronDownRegular
+          className={mergeClasses(
+            'opptrix-session-title-btn__chevron',
+            menuOpen && 'opptrix-session-title-btn__chevron--open',
+          )}
+          fontSize={14}
+        />
+      )}
+    </button>
+  )
+
+  const primaryMenu = menuOpen && canUseTools ? createPortal(
+    <div
+      ref={primaryPanelRef}
+      className={mergeClasses('opptrix-session-tools-menu', OPPTRIX_GLASS_PANEL_CLASS)}
+      style={primaryStyle}
+      role="menu"
+      aria-label="对话工具"
+    >
+      <ComposerTooltipMenuItem onClick={startRename}>
+        <EditRegular fontSize={16} />
+        <span>重命名</span>
+      </ComposerTooltipMenuItem>
+      <ComposerTooltipMenuItem
+        active={archiveOpen}
+        onClick={openArchivePanel}
+        className="opptrix-session-tools-menu__archive-item"
+      >
+        <ArchiveRegular fontSize={16} />
+        <span>归档移动</span>
+        <ChevronRightRegular fontSize={14} className="opptrix-session-tools-menu__arrow" />
+      </ComposerTooltipMenuItem>
+      <ComposerTooltipMenuItem onClick={handleDeleteClick} className="opptrix-session-tools-menu__danger">
+        <DeleteRegular fontSize={16} />
+        <span>删除</span>
+      </ComposerTooltipMenuItem>
+      <ComposerTooltipMenuItem onClick={() => { void handleExportClick() }}>
+        <ArrowExportRegular fontSize={16} />
+        <span>导出会话</span>
+      </ComposerTooltipMenuItem>
+    </div>,
+    document.body,
+  ) : null
+
+  const archiveMenu = menuOpen && archiveOpen && canUseTools ? createPortal(
+    <div
+      ref={archivePanelRef}
+      className={mergeClasses('opptrix-session-tools-archive', OPPTRIX_GLASS_PANEL_CLASS)}
+      style={archiveStyle}
+      role="menu"
+      aria-label="选择归档文件夹"
+    >
+      <div className="opptrix-session-tools-archive__head">归档到</div>
+      <div className="opptrix-session-tools-archive__body opptrix-scroll">
+        {foldersLoading && (
+          <div className="opptrix-session-tools-archive__empty">加载文件夹…</div>
+        )}
+        {!foldersLoading && folders.map(folder => (
+          <button
+            key={folder.id}
+            type="button"
+            className={mergeClasses(
+              'opptrix-session-tools-archive__folder',
+              'opptrix-focusable',
+            )}
+            onClick={() => { void handleArchiveSelect(folder.id) }}
+          >
+            <FolderRegular fontSize={16} />
+            <span>{folder.title}</span>
+          </button>
+        ))}
+      </div>
+      <div className="opptrix-session-tools-archive__foot">
+        {creatingFolder ? (
+          <div className="opptrix-session-tools-archive__inline">
+            <Input
+              ref={newFolderInputRef}
+              className="opptrix-session-tools-archive__inline-input opptrix-archive-inline-input"
+              placeholder="文件夹名称"
+              value={newFolderDraft}
+              onChange={(_, data) => setNewFolderDraft(data.value)}
+              onKeyDown={handleCreateFolderKeyDown}
+            />
+            <button
+              type="button"
+              className="opptrix-session-tools-archive__inline-btn opptrix-focusable"
+              aria-label="创建并归档"
+              onClick={() => { void handleCreateFolderConfirm() }}
+            >
+              <CheckmarkRegular fontSize={14} />
+            </button>
+            <button
+              type="button"
+              className="opptrix-session-tools-archive__inline-btn opptrix-focusable"
+              aria-label="取消"
+              onClick={() => {
+                setCreatingFolder(false)
+                setNewFolderDraft('')
+              }}
+            >
+              <DismissRegular fontSize={14} />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            className={mergeClasses(
+              'opptrix-session-tools-archive__new',
+              'opptrix-focusable',
+            )}
+            onClick={() => {
+              setCreatingFolder(true)
+              setNewFolderDraft('')
+            }}
+          >
+            <AddRegular fontSize={16} />
+            <span>新建文件夹</span>
+          </button>
+        )}
+      </div>
+    </div>,
+    document.body,
+  ) : null
+
+  return (
+    <>
+      {titleButton}
+      {primaryMenu}
+      {archiveMenu}
+    </>
+  )
+}

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -135,6 +135,13 @@ const useStyles = makeStyles({
     gap: '4px',
     flexShrink: 0,
   },
+  headerTitleSlot: {
+    flex: '1 1 auto',
+    minWidth: 0,
+    maxWidth: '100%',
+    display: 'flex',
+    alignItems: 'center',
+  },
   title: {
     fontSize: '14px',
     fontWeight: 500,
@@ -218,6 +225,8 @@ const WELCOME_LETTER_BASE_DELAY_S = 0.55
 
 interface ChatViewProps {
   title?: string
+  /** 顶栏标题区（可点击工具菜单）；未提供时使用纯文本 */
+  titleSlot?: React.ReactNode
   sessionId?: string | null
   welcomeEpoch?: number
   chatScrollEpoch?: number
@@ -256,7 +265,7 @@ interface ChatViewProps {
 }
 
 export default function ChatView({
-  title = '新对话', sessionId = null, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, input, loading, liveTrace = null, error,
+  title = '新对话', titleSlot, sessionId = null, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, input, loading, liveTrace = null, error,
   availableModels = [],
   sessionModel,
   isMobile = false,
@@ -486,7 +495,9 @@ export default function ChatView({
       {!isMobile && !electronChrome && (
         <div className={s.header}>
           <div className={s.headerInner}>
-            <Text className={s.title}>{title || '新对话'}</Text>
+            <div className={s.headerTitleSlot}>
+              {titleSlot ?? <Text className={s.title}>{title || '新对话'}</Text>}
+            </div>
             {!rightPanelOpen && (onToggleRightPanel || onToggleChatColumn) && (
               <div className={s.headerActions}>
                 {onToggleChatColumn && (

--- a/client-ui/src/chat/SessionSidebar.tsx
+++ b/client-ui/src/chat/SessionSidebar.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import {
-  Text, makeStyles, mergeClasses,
+  makeStyles, mergeClasses,
 } from '@fluentui/react-components'
 import { SettingsRegular, DeleteRegular, DismissRegular, NewsRegular, ArchiveRegular, SearchRegular } from '@fluentui/react-icons'
 import { ChatAddRegular } from './chatIcons'
@@ -8,14 +8,17 @@ import type { SessionMeta } from '../types/chat'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { ghostInteractive, motion, nativeIconInteractive, sidebarItemSelected, sidebarTopMenuIcon, sidebarTopMenuRow, SIDEBAR_TOP_MENU_ICON_SIZE } from '../theme/mixins'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
+import OpptrixSegmentedControl from '../components/opptrix/OpptrixSegmentedControl'
 import { isElectron } from '../platform/detect'
 import { useTheme } from '../theme/ThemeContext'
 import { DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT } from '../desktop/constants'
 import OverlaySidebarShell from '../desktop/OverlaySidebarShell'
 import AppUpdateNotice from '../desktop/AppUpdateNotice'
 import SessionArchiveFolderMenu from './SessionArchiveFolderMenu'
+import SessionSidebarArchivePanel, { type ArchiveFolderGroup } from './SessionSidebarArchivePanel'
 
 export type SidebarMode = 'panel' | 'drawer' | 'overlay'
+export type SidebarListTab = 'chat' | 'archive'
 
 const useStyles = makeStyles({
   sidebar: {
@@ -93,6 +96,10 @@ const useStyles = makeStyles({
     justifyContent: 'flex-end',
     padding: '8px 8px 0',
   },
+  menuSection: {
+    marginTop: '15px',
+    flexShrink: 0,
+  },
   menuRow: {
     ...sidebarTopMenuRow,
     marginBottom: '6px',
@@ -108,6 +115,17 @@ const useStyles = makeStyles({
     textTransform: 'uppercase',
     letterSpacing: '0.04em',
     padding: '6px 14px 2px',
+  },
+  listTabWrap: {
+    margin: '19px 8px 6px',
+    flexShrink: 0,
+  },
+  chatListWrap: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
   },
   list: {
     flex: 1,
@@ -255,6 +273,14 @@ interface SessionSidebarProps {
   onOpenSettings: () => void
   onOpenNewsCenter: () => void
   onClose?: () => void
+  listTab?: SidebarListTab
+  onListTabChange?: (tab: SidebarListTab) => void
+  archivedGroups?: ArchiveFolderGroup[]
+  onCreateArchiveFolder?: (title: string) => void | Promise<void>
+  onRenameArchiveFolder?: (id: string, title: string) => void | Promise<void>
+  onDeleteArchiveFolder?: (id: string) => void | Promise<void>
+  onClearArchiveFolder?: (id: string) => void | Promise<void>
+  onDeleteArchivedSession?: (id: string) => void | Promise<void>
 }
 
 function formatDate(iso: string) {
@@ -265,6 +291,14 @@ export default function SessionSidebar({
   mode, visible = true, drawerOpen = false,
   sessions, activeId, activeRoute = 'chat',
   onSelect, onNew, onDelete, onArchive, onOpenSearch, onOpenSettings, onOpenNewsCenter, onClose,
+  listTab: listTabProp,
+  onListTabChange,
+  archivedGroups = [],
+  onCreateArchiveFolder,
+  onRenameArchiveFolder,
+  onDeleteArchiveFolder,
+  onClearArchiveFolder,
+  onDeleteArchivedSession,
 }: SessionSidebarProps) {
   const s = useStyles()
   const { resolvedScheme } = useTheme()
@@ -272,6 +306,12 @@ export default function SessionSidebar({
   const isOverlay = mode === 'overlay'
   const electronChrome = isElectron() && !isDrawer
   const sidebarGlass = electronChrome && resolvedScheme !== 'dark'
+  const [listTabState, setListTabState] = useState<SidebarListTab>('chat')
+  const listTab = listTabProp ?? listTabState
+  const setListTab = useCallback((tab: SidebarListTab) => {
+    if (listTabProp == null) setListTabState(tab)
+    onListTabChange?.(tab)
+  }, [listTabProp, onListTabChange])
   const [archiveMenu, setArchiveMenu] = useState<{ sessionId: string; anchor: HTMLElement } | null>(null)
   const archiveAnchorRef = useRef<HTMLElement | null>(null)
   archiveAnchorRef.current = archiveMenu?.anchor ?? null
@@ -289,6 +329,7 @@ export default function SessionSidebar({
         </div>
       )}
 
+      <div className={s.menuSection}>
       <button type="button" className={mergeClasses(s.menuRow, 'opptrix-focusable')} onClick={onNew}>
         <ChatAddRegular className={s.menuIcon} fontSize={SIDEBAR_TOP_MENU_ICON_SIZE} />
         <span>新对话</span>
@@ -311,9 +352,23 @@ export default function SessionSidebar({
         <NewsRegular className={s.menuIcon} fontSize={SIDEBAR_TOP_MENU_ICON_SIZE} />
         <span>新闻中心</span>
       </button>
+      </div>
 
-      <Text className={s.sectionLabel}>对话</Text>
+      <div className={s.listTabWrap}>
+        <OpptrixSegmentedControl
+          aria-label="对话列表"
+          variant="embedded"
+          value={listTab}
+          options={[
+            { value: 'chat', label: '对话' },
+            { value: 'archive', label: '归档' },
+          ]}
+          onChange={setListTab}
+        />
+      </div>
 
+      {listTab === 'chat' ? (
+      <div className={s.chatListWrap}>
       <div className={mergeClasses(s.list, 'opptrix-scroll', 'opptrix-scroll-hover')}>
         {sessions.length === 0 && (
           <div className={s.empty}>暂无历史对话</div>
@@ -362,6 +417,23 @@ export default function SessionSidebar({
           )
         })}
       </div>
+      </div>
+      ) : (
+        onCreateArchiveFolder && onRenameArchiveFolder && onDeleteArchiveFolder && onDeleteArchivedSession ? (
+          <SessionSidebarArchivePanel
+            groups={archivedGroups}
+            activeId={activeId}
+            onSelect={handleSelect}
+            onDeleteSession={onDeleteArchivedSession}
+            onCreateFolder={onCreateArchiveFolder}
+            onRenameFolder={onRenameArchiveFolder}
+            onDeleteFolder={onDeleteArchiveFolder}
+            onClearFolder={onClearArchiveFolder}
+          />
+        ) : (
+          <div className={s.empty}>归档功能加载中…</div>
+        )
+      )}
 
       <div className={s.footer}>
         <AppUpdateNotice />

--- a/client-ui/src/chat/SessionSidebarArchivePanel.tsx
+++ b/client-ui/src/chat/SessionSidebarArchivePanel.tsx
@@ -13,11 +13,22 @@ import {
 } from '@fluentui/react-icons'
 import type { SessionArchiveFolder, SessionMeta } from '../types/chat'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
-import { ghostInteractive, nativeIconInteractive, sidebarItemSelected } from '../theme/mixins'
+import { ghostInteractive, motion, nativeIconInteractive, sidebarItemSelected } from '../theme/mixins'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import { OpptrixDialogAlert } from '../components/opptrix/OpptrixDialogAlert'
 
 const OTHER_ARCHIVE_FOLDER_ID = 'other'
+
+const SYSTEM_ARCHIVE_FOLDER_IDS = new Set([
+  'research',
+  'trades',
+  'review',
+  OTHER_ARCHIVE_FOLDER_ID,
+])
+
+function isSystemArchiveFolder(folder: Pick<SessionArchiveFolder, 'id'>) {
+  return SYSTEM_ARCHIVE_FOLDER_IDS.has(folder.id)
+}
 
 const useStyles = makeStyles({
   root: {
@@ -118,10 +129,10 @@ const useStyles = makeStyles({
     flex: 1,
     minHeight: 0,
     overflowY: 'auto',
-    padding: '0 8px 8px',
+    padding: '4px 8px 8px',
     display: 'flex',
     flexDirection: 'column',
-    gap: '4px',
+    gap: '2px',
   },
   folderBlock: {
     display: 'flex',
@@ -131,8 +142,8 @@ const useStyles = makeStyles({
   folderHead: {
     display: 'flex',
     alignItems: 'center',
-    gap: '4px',
-    padding: '4px 6px',
+    gap: '8px',
+    padding: '5px 10px',
     borderRadius: opptrixTokens.radiusMd,
     minHeight: '30px',
     ...ghostInteractive,
@@ -149,12 +160,11 @@ const useStyles = makeStyles({
     },
   },
   folderToggle: {
-    ...nativeIconInteractive,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: '22px',
-    height: '22px',
+    width: '14px',
+    height: '14px',
     flexShrink: 0,
     color: opptrixCssVars.textTertiary,
     lineHeight: 0,
@@ -162,28 +172,49 @@ const useStyles = makeStyles({
   folderIcon: {
     color: opptrixCssVars.textSecondary,
     flexShrink: 0,
+    lineHeight: 0,
   },
   folderTitle: {
     flex: 1,
     minWidth: 0,
-    fontSize: '12px',
-    fontWeight: 650,
+    fontSize: '13px',
+    fontWeight: 500,
     color: opptrixCssVars.textPrimary,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  folderHeadTrailing: {
+    position: 'relative',
+    flexShrink: 0,
+    width: '52px',
+    height: '18px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+  },
   folderCount: {
-    fontSize: '10px',
+    fontSize: '11px',
     fontWeight: 500,
     color: opptrixCssVars.textTertiary,
-    flexShrink: 0,
+    lineHeight: 1,
+    whiteSpace: 'nowrap',
+    transitionProperty: 'opacity',
+    transitionDuration: motion.fast,
+    '@media (hover: none)': {
+      display: 'none',
+    },
   },
-  folderActions: {
+  folderActionRename: {
+    ...nativeIconInteractive,
     display: 'inline-flex',
     alignItems: 'center',
-    gap: '0',
-    flexShrink: 0,
+    justifyContent: 'center',
+    lineHeight: 0,
+    position: 'absolute',
+    right: '18px',
+    top: '50%',
+    transform: 'translateY(-50%)',
     opacity: 0,
     pointerEvents: 'none',
     '@media (hover: none)': {
@@ -191,17 +222,38 @@ const useStyles = makeStyles({
       pointerEvents: 'auto',
     },
   },
-  iconAction: {
+  folderActionDelete: {
     ...nativeIconInteractive,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: '24px',
-    height: '24px',
     lineHeight: 0,
-    color: opptrixCssVars.textTertiary,
-    ':hover': {
-      color: opptrixCssVars.textPrimary,
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    opacity: 0,
+    pointerEvents: 'none',
+    '@media (hover: none)': {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+  },
+  folderActionClear: {
+    ...nativeIconInteractive,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    lineHeight: 0,
+    position: 'absolute',
+    right: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    opacity: 0,
+    pointerEvents: 'none',
+    '@media (hover: none)': {
+      opacity: 1,
+      pointerEvents: 'auto',
     },
   },
   sessionList: {
@@ -319,12 +371,16 @@ export default function SessionSidebarArchivePanel({
   const [deletingFolderId, setDeletingFolderId] = useState<string | null>(null)
   const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null)
   const [clearDialogOpen, setClearDialogOpen] = useState(false)
+  const [clearFolderId, setClearFolderId] = useState<string | null>(null)
 
   const createInputRef = useFocusOnMount(creatingFolder)
   const renameInputRef = useFocusOnMount(renamingFolderId != null)
 
-  const toggleFolder = useCallback((folderId: string) => {
-    setCollapsed(prev => ({ ...prev, [folderId]: !prev[folderId] }))
+  const toggleFolder = useCallback((folderId: string, isDefault: boolean) => {
+    setCollapsed(prev => {
+      const current = prev[folderId] ?? isDefault
+      return { ...prev, [folderId]: !current }
+    })
   }, [])
 
   const cancelCreate = useCallback(() => {
@@ -411,12 +467,17 @@ export default function SessionSidebarArchivePanel({
   }, [submitRename, cancelRename])
 
   const hasAnySession = groups.some(g => g.sessions.length > 0)
-  const otherFolderSessions = groups.find(g => g.folder.id === OTHER_ARCHIVE_FOLDER_ID)?.sessions.length ?? 0
+  const clearFolderGroup = clearFolderId
+    ? groups.find(g => g.folder.id === clearFolderId)
+    : undefined
+  const clearFolderTitle = clearFolderGroup?.folder.title ?? ''
+  const clearFolderSessions = clearFolderGroup?.sessions.length ?? 0
 
-  const confirmClearOtherFolder = useCallback(() => {
-    if (onClearFolder) void onClearFolder(OTHER_ARCHIVE_FOLDER_ID)
+  const confirmClearFolder = useCallback(() => {
+    if (onClearFolder && clearFolderId) void onClearFolder(clearFolderId)
     setClearDialogOpen(false)
-  }, [onClearFolder])
+    setClearFolderId(null)
+  }, [onClearFolder, clearFolderId])
 
   return (
     <div className={s.root}>
@@ -476,9 +537,13 @@ export default function SessionSidebarArchivePanel({
           <div className={s.emptyAll}>暂无归档对话<br />在对话列表中可将对话归档到此</div>
         )}
         {groups.map(({ folder, sessions }) => {
-          const isCollapsed = collapsed[folder.id] ?? false
+          const isCollapsed = collapsed[folder.id] ?? isSystemArchiveFolder(folder)
           const isRenaming = renamingFolderId === folder.id
           const isDeleting = deletingFolderId === folder.id
+          // 用户自建：重命名/删除；系统默认文件夹：清空
+          const hasUserFolderActions = !folder.isDefault
+          const hasFolderClear = folder.isDefault
+          const showFolderCountSwap = hasUserFolderActions || hasFolderClear
 
           return (
             <div key={folder.id} className={s.folderBlock}>
@@ -489,20 +554,27 @@ export default function SessionSidebarArchivePanel({
                   'opptrix-archive-folder-head',
                   !isRenaming && !isDeleting && 'opptrix-focusable',
                 )}
+                role={!isRenaming && !isDeleting ? 'button' : undefined}
+                tabIndex={!isRenaming && !isDeleting ? 0 : undefined}
+                aria-expanded={!isRenaming && !isDeleting ? !isCollapsed : undefined}
+                onClick={() => {
+                  if (!isRenaming && !isDeleting) toggleFolder(folder.id, isSystemArchiveFolder(folder))
+                }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && !isRenaming && !isDeleting) {
+                    e.preventDefault()
+                    toggleFolder(folder.id, isSystemArchiveFolder(folder))
+                  }
+                }}
               >
                 {!isRenaming && (
-                  <button
-                    type="button"
-                    className={s.folderToggle}
-                    aria-label={isCollapsed ? '展开' : '收起'}
-                    onClick={() => toggleFolder(folder.id)}
-                  >
+                  <span className={s.folderToggle} aria-hidden>
                     {isCollapsed
                       ? <ChevronRightRegular fontSize={14} />
                       : <ChevronDownRegular fontSize={14} />}
-                  </button>
+                  </span>
                 )}
-                {!isRenaming && <FolderRegular className={s.folderIcon} fontSize={15} />}
+                {!isRenaming && <FolderRegular className={s.folderIcon} fontSize={14} />}
                 {isRenaming ? (
                   <>
                     <Input
@@ -560,42 +632,64 @@ export default function SessionSidebarArchivePanel({
                 ) : (
                   <>
                     <span className={s.folderTitle}>{folder.title}</span>
-                    <span className={s.folderCount}>{sessions.length}</span>
-                    {!folder.isDefault && (
-                      <span className={mergeClasses(s.folderActions, 'opptrix-archive-folder-actions')}>
-                        <button
-                          type="button"
-                          className={mergeClasses(s.iconAction, 'opptrix-focusable')}
-                          aria-label="重命名文件夹"
-                          onClick={e => { e.stopPropagation(); startRename(folder) }}
-                        >
-                          <EditRegular fontSize={14} />
-                        </button>
-                        <button
-                          type="button"
-                          className={mergeClasses(s.iconAction, 'opptrix-focusable')}
-                          aria-label="删除文件夹"
-                          onClick={e => { e.stopPropagation(); startDeleteFolder(folder) }}
-                        >
-                          <DeleteRegular fontSize={14} />
-                        </button>
+                    <span className={s.folderHeadTrailing}>
+                      <span
+                        className={mergeClasses(
+                          s.folderCount,
+                          showFolderCountSwap && 'opptrix-archive-folder-count',
+                        )}
+                      >
+                        {sessions.length}
                       </span>
-                    )}
-                    {folder.id === OTHER_ARCHIVE_FOLDER_ID && onClearFolder && (
-                      <span className={mergeClasses(s.folderActions, 'opptrix-archive-folder-actions')}>
+                      {hasUserFolderActions && (
+                        <>
+                          <button
+                            type="button"
+                            className={mergeClasses(
+                              s.folderActionRename,
+                              'opptrix-archive-folder-rename',
+                              'opptrix-focusable',
+                            )}
+                            aria-label="重命名文件夹"
+                            onClick={e => { e.stopPropagation(); startRename(folder) }}
+                          >
+                            <EditRegular fontSize={14} />
+                          </button>
+                          <button
+                            type="button"
+                            className={mergeClasses(
+                              s.folderActionDelete,
+                              'opptrix-archive-folder-delete',
+                              'opptrix-focusable',
+                            )}
+                            aria-label="删除文件夹"
+                            onClick={e => { e.stopPropagation(); startDeleteFolder(folder) }}
+                          >
+                            <DeleteRegular fontSize={14} />
+                          </button>
+                        </>
+                      )}
+                      {hasFolderClear && (
                         <button
                           type="button"
-                          className={mergeClasses(s.iconAction, 'opptrix-focusable')}
+                          className={mergeClasses(
+                            s.folderActionClear,
+                            'opptrix-archive-folder-clear',
+                            'opptrix-focusable',
+                          )}
                           aria-label="清空文件夹"
                           onClick={e => {
                             e.stopPropagation()
-                            setClearDialogOpen(true)
+                            if (onClearFolder) {
+                              setClearFolderId(folder.id)
+                              setClearDialogOpen(true)
+                            }
                           }}
                         >
                           <BroomRegular fontSize={14} />
                         </button>
-                      </span>
-                    )}
+                      )}
+                    </span>
                   </>
                 )}
               </div>
@@ -672,17 +766,20 @@ export default function SessionSidebarArchivePanel({
 
       <OpptrixDialogAlert
         open={clearDialogOpen}
-        title="清空「其他」文件夹"
+        title={`清空「${clearFolderTitle}」`}
         message={
-          otherFolderSessions > 0
-            ? `将永久删除「其他」中的 ${otherFolderSessions} 条归档对话，此操作不可撤销。`
-            : '「其他」文件夹中暂无对话。'
+          clearFolderSessions > 0
+            ? `将永久删除「${clearFolderTitle}」中的 ${clearFolderSessions} 条归档对话，此操作不可撤销。`
+            : `「${clearFolderTitle}」中暂无对话。`
         }
         confirmLabel="清空"
         confirmTone="danger"
-        confirmDisabled={otherFolderSessions === 0}
-        onConfirm={confirmClearOtherFolder}
-        onCancel={() => setClearDialogOpen(false)}
+        confirmDisabled={clearFolderSessions === 0}
+        onConfirm={confirmClearFolder}
+        onCancel={() => {
+          setClearDialogOpen(false)
+          setClearFolderId(null)
+        }}
       />
     </div>
   )

--- a/client-ui/src/chat/SessionSidebarArchivePanel.tsx
+++ b/client-ui/src/chat/SessionSidebarArchivePanel.tsx
@@ -1,0 +1,689 @@
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent } from 'react'
+import { Input, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import {
+  AddRegular,
+  BroomRegular,
+  CheckmarkRegular,
+  ChevronDownRegular,
+  ChevronRightRegular,
+  DeleteRegular,
+  DismissRegular,
+  EditRegular,
+  FolderRegular,
+} from '@fluentui/react-icons'
+import type { SessionArchiveFolder, SessionMeta } from '../types/chat'
+import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
+import { ghostInteractive, nativeIconInteractive, sidebarItemSelected } from '../theme/mixins'
+import OpptrixButton from '../components/opptrix/OpptrixButton'
+import { OpptrixDialogAlert } from '../components/opptrix/OpptrixDialogAlert'
+
+const OTHER_ARCHIVE_FOLDER_ID = 'other'
+
+const useStyles = makeStyles({
+  root: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  toolbar: {
+    flexShrink: 0,
+    padding: '4px 8px 6px',
+  },
+  newFolderBtn: {
+    width: '100%',
+    justifyContent: 'flex-start',
+    minHeight: '30px',
+    fontSize: '13px',
+    fontWeight: 500,
+    color: opptrixCssVars.textSecondary,
+    borderRadius: opptrixTokens.radiusMd,
+  },
+  inlineRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    minHeight: '30px',
+    padding: '4px 6px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: 'transparent',
+  },
+  inlineEditRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    minHeight: '30px',
+    padding: '2px 4px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.surfaceHover,
+  },
+  inlineInput: {
+    flex: 1,
+    minWidth: 0,
+    height: '26px',
+    minHeight: '26px',
+    fontSize: '13px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.surfaceMuted,
+  },
+  inlineHint: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: '12px',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.35,
+    padding: '0 2px',
+  },
+  inlineConfirmText: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: '12px',
+    fontWeight: 500,
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.35,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  inlineActions: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '2px',
+    flexShrink: 0,
+  },
+  inlineBtn: {
+    ...nativeIconInteractive,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '26px',
+    height: '26px',
+    lineHeight: 0,
+    borderRadius: opptrixTokens.radiusMd,
+    color: opptrixCssVars.textSecondary,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      color: opptrixCssVars.textPrimary,
+    },
+  },
+  inlineBtnDanger: {
+    color: opptrixCssVars.error,
+    ':hover': {
+      backgroundColor: opptrixCssVars.errorSoft,
+      color: opptrixCssVars.error,
+    },
+  },
+  scroll: {
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    padding: '0 8px 8px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  folderBlock: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  folderHead: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    padding: '4px 6px',
+    borderRadius: opptrixTokens.radiusMd,
+    minHeight: '30px',
+    ...ghostInteractive,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+    },
+  },
+  folderHeadEditing: {
+    padding: '2px 4px',
+    gap: '4px',
+    backgroundColor: opptrixCssVars.surfaceHover,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+    },
+  },
+  folderToggle: {
+    ...nativeIconInteractive,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '22px',
+    height: '22px',
+    flexShrink: 0,
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 0,
+  },
+  folderIcon: {
+    color: opptrixCssVars.textSecondary,
+    flexShrink: 0,
+  },
+  folderTitle: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: '12px',
+    fontWeight: 650,
+    color: opptrixCssVars.textPrimary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  folderCount: {
+    fontSize: '10px',
+    fontWeight: 500,
+    color: opptrixCssVars.textTertiary,
+    flexShrink: 0,
+  },
+  folderActions: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '0',
+    flexShrink: 0,
+    opacity: 0,
+    pointerEvents: 'none',
+    '@media (hover: none)': {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+  },
+  iconAction: {
+    ...nativeIconInteractive,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '24px',
+    height: '24px',
+    lineHeight: 0,
+    color: opptrixCssVars.textTertiary,
+    ':hover': {
+      color: opptrixCssVars.textPrimary,
+    },
+  },
+  sessionList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    paddingLeft: '22px',
+  },
+  sessionItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    padding: '5px 8px',
+    minHeight: '30px',
+    borderRadius: opptrixTokens.radiusMd,
+    color: opptrixCssVars.textPrimary,
+    ...ghostInteractive,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+    },
+  },
+  sessionConfirm: {
+    padding: '4px 8px',
+  },
+  sessionActive: {
+    ...sidebarItemSelected,
+  },
+  sessionTitle: {
+    flex: 1,
+    fontSize: '13px',
+    fontWeight: 500,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  sessionDelete: {
+    ...nativeIconInteractive,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '24px',
+    height: '24px',
+    lineHeight: 0,
+    opacity: 0,
+    pointerEvents: 'none',
+    flexShrink: 0,
+    '@media (hover: none)': {
+      opacity: 1,
+      pointerEvents: 'auto',
+    },
+  },
+  emptyFolder: {
+    padding: '6px 8px 6px 22px',
+    fontSize: '12px',
+    color: opptrixCssVars.textTertiary,
+  },
+  emptyAll: {
+    padding: '32px 16px',
+    textAlign: 'center',
+    fontSize: '13px',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.6,
+  },
+})
+
+export interface ArchiveFolderGroup {
+  folder: SessionArchiveFolder
+  sessions: SessionMeta[]
+}
+
+interface Props {
+  groups: ArchiveFolderGroup[]
+  activeId: string | null
+  onSelect: (id: string) => void
+  onDeleteSession: (id: string) => void | Promise<void>
+  onCreateFolder: (title: string) => void | Promise<void>
+  onRenameFolder: (id: string, title: string) => void | Promise<void>
+  onDeleteFolder: (id: string) => void | Promise<void>
+  onClearFolder?: (id: string) => void | Promise<void>
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('zh-CN', { month: 'numeric', day: 'numeric' })
+}
+
+function useFocusOnMount(active: boolean) {
+  const ref = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (!active) return
+    const id = requestAnimationFrame(() => {
+      ref.current?.focus()
+      ref.current?.select()
+    })
+    return () => cancelAnimationFrame(id)
+  }, [active])
+  return ref
+}
+
+export default function SessionSidebarArchivePanel({
+  groups,
+  activeId,
+  onSelect,
+  onDeleteSession,
+  onCreateFolder,
+  onRenameFolder,
+  onDeleteFolder,
+  onClearFolder,
+}: Props) {
+  const s = useStyles()
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
+  const [creatingFolder, setCreatingFolder] = useState(false)
+  const [newFolderTitle, setNewFolderTitle] = useState('')
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null)
+  const [renameDraft, setRenameDraft] = useState('')
+  const [deletingFolderId, setDeletingFolderId] = useState<string | null>(null)
+  const [deletingSessionId, setDeletingSessionId] = useState<string | null>(null)
+  const [clearDialogOpen, setClearDialogOpen] = useState(false)
+
+  const createInputRef = useFocusOnMount(creatingFolder)
+  const renameInputRef = useFocusOnMount(renamingFolderId != null)
+
+  const toggleFolder = useCallback((folderId: string) => {
+    setCollapsed(prev => ({ ...prev, [folderId]: !prev[folderId] }))
+  }, [])
+
+  const cancelCreate = useCallback(() => {
+    setCreatingFolder(false)
+    setNewFolderTitle('')
+  }, [])
+
+  const submitCreate = useCallback(() => {
+    const trimmed = newFolderTitle.trim()
+    if (!trimmed) return
+    void onCreateFolder(trimmed)
+    setCreatingFolder(false)
+    setNewFolderTitle('')
+  }, [newFolderTitle, onCreateFolder])
+
+  const startRename = useCallback((folder: SessionArchiveFolder) => {
+    if (folder.isDefault) return
+    setDeletingFolderId(null)
+    setRenamingFolderId(folder.id)
+    setRenameDraft(folder.title)
+  }, [])
+
+  const cancelRename = useCallback(() => {
+    setRenamingFolderId(null)
+    setRenameDraft('')
+  }, [])
+
+  const submitRename = useCallback((folder: SessionArchiveFolder) => {
+    const trimmed = renameDraft.trim()
+    if (!trimmed || trimmed === folder.title) {
+      cancelRename()
+      return
+    }
+    void onRenameFolder(folder.id, trimmed)
+    cancelRename()
+  }, [renameDraft, onRenameFolder, cancelRename])
+
+  const startDeleteFolder = useCallback((folder: SessionArchiveFolder) => {
+    if (folder.isDefault) return
+    setRenamingFolderId(null)
+    setDeletingFolderId(folder.id)
+  }, [])
+
+  const cancelDeleteFolder = useCallback(() => {
+    setDeletingFolderId(null)
+  }, [])
+
+  const confirmDeleteFolder = useCallback((folderId: string) => {
+    void onDeleteFolder(folderId)
+    setDeletingFolderId(null)
+  }, [onDeleteFolder])
+
+  const startDeleteSession = useCallback((sessionId: string) => {
+    setDeletingSessionId(sessionId)
+  }, [])
+
+  const cancelDeleteSession = useCallback(() => {
+    setDeletingSessionId(null)
+  }, [])
+
+  const confirmDeleteSession = useCallback((sessionId: string) => {
+    void onDeleteSession(sessionId)
+    setDeletingSessionId(null)
+  }, [onDeleteSession])
+
+  const handleCreateKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submitCreate()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancelCreate()
+    }
+  }, [submitCreate, cancelCreate])
+
+  const handleRenameKeyDown = useCallback((e: KeyboardEvent, folder: SessionArchiveFolder) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submitRename(folder)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      cancelRename()
+    }
+  }, [submitRename, cancelRename])
+
+  const hasAnySession = groups.some(g => g.sessions.length > 0)
+  const otherFolderSessions = groups.find(g => g.folder.id === OTHER_ARCHIVE_FOLDER_ID)?.sessions.length ?? 0
+
+  const confirmClearOtherFolder = useCallback(() => {
+    if (onClearFolder) void onClearFolder(OTHER_ARCHIVE_FOLDER_ID)
+    setClearDialogOpen(false)
+  }, [onClearFolder])
+
+  return (
+    <div className={s.root}>
+      <div className={s.toolbar}>
+        {creatingFolder ? (
+          <div className={s.inlineEditRow}>
+            <Input
+              ref={createInputRef}
+              className={mergeClasses(s.inlineInput, 'opptrix-archive-inline-input', 'opptrix-focusable')}
+              appearance="filled-darker"
+              size="small"
+              placeholder="文件夹名称"
+              value={newFolderTitle}
+              onChange={(_, data) => setNewFolderTitle(data.value)}
+              onKeyDown={handleCreateKeyDown}
+            />
+            <span className={s.inlineActions}>
+              <button
+                type="button"
+                className={mergeClasses(s.inlineBtn, 'opptrix-focusable')}
+                aria-label="创建文件夹"
+                onClick={submitCreate}
+              >
+                <CheckmarkRegular fontSize={14} />
+              </button>
+              <button
+                type="button"
+                className={mergeClasses(s.inlineBtn, 'opptrix-focusable')}
+                aria-label="取消"
+                onClick={cancelCreate}
+              >
+                <DismissRegular fontSize={14} />
+              </button>
+            </span>
+          </div>
+        ) : (
+          <OpptrixButton
+            className={s.newFolderBtn}
+            variant="ghost"
+            size="small"
+            icon={<AddRegular fontSize={16} />}
+            onClick={() => {
+              setCreatingFolder(true)
+              setNewFolderTitle('')
+            }}
+          >
+            新建文件夹
+          </OpptrixButton>
+        )}
+      </div>
+
+      <div className={mergeClasses(s.scroll, 'opptrix-scroll', 'opptrix-scroll-hover')}>
+        {!groups.length && !creatingFolder && (
+          <div className={s.emptyAll}>还没有归档文件夹</div>
+        )}
+        {groups.length > 0 && !hasAnySession && (
+          <div className={s.emptyAll}>暂无归档对话<br />在对话列表中可将对话归档到此</div>
+        )}
+        {groups.map(({ folder, sessions }) => {
+          const isCollapsed = collapsed[folder.id] ?? false
+          const isRenaming = renamingFolderId === folder.id
+          const isDeleting = deletingFolderId === folder.id
+
+          return (
+            <div key={folder.id} className={s.folderBlock}>
+              <div
+                className={mergeClasses(
+                  s.folderHead,
+                  (isRenaming || isDeleting) && s.folderHeadEditing,
+                  'opptrix-archive-folder-head',
+                  !isRenaming && !isDeleting && 'opptrix-focusable',
+                )}
+              >
+                {!isRenaming && (
+                  <button
+                    type="button"
+                    className={s.folderToggle}
+                    aria-label={isCollapsed ? '展开' : '收起'}
+                    onClick={() => toggleFolder(folder.id)}
+                  >
+                    {isCollapsed
+                      ? <ChevronRightRegular fontSize={14} />
+                      : <ChevronDownRegular fontSize={14} />}
+                  </button>
+                )}
+                {!isRenaming && <FolderRegular className={s.folderIcon} fontSize={15} />}
+                {isRenaming ? (
+                  <>
+                    <Input
+                      ref={renameInputRef}
+                      className={mergeClasses(s.inlineInput, 'opptrix-archive-inline-input', 'opptrix-focusable')}
+                      appearance="filled-darker"
+                      size="small"
+                      value={renameDraft}
+                      onChange={(_, data) => setRenameDraft(data.value)}
+                      onKeyDown={e => handleRenameKeyDown(e, folder)}
+                    />
+                    <span className={s.inlineActions}>
+                      <button
+                        type="button"
+                        className={mergeClasses(s.inlineBtn, 'opptrix-focusable')}
+                        aria-label="保存名称"
+                        onClick={() => submitRename(folder)}
+                      >
+                        <CheckmarkRegular fontSize={14} />
+                      </button>
+                      <button
+                        type="button"
+                        className={mergeClasses(s.inlineBtn, 'opptrix-focusable')}
+                        aria-label="取消"
+                        onClick={cancelRename}
+                      >
+                        <DismissRegular fontSize={14} />
+                      </button>
+                    </span>
+                  </>
+                ) : isDeleting ? (
+                  <>
+                    <span className={s.inlineConfirmText}>
+                      删除「{folder.title}」？对话将移到「其他」
+                    </span>
+                    <span className={s.inlineActions}>
+                      <button
+                        type="button"
+                        className={mergeClasses(s.inlineBtn, s.inlineBtnDanger, 'opptrix-focusable')}
+                        aria-label="确认删除文件夹"
+                        onClick={() => confirmDeleteFolder(folder.id)}
+                      >
+                        <CheckmarkRegular fontSize={14} />
+                      </button>
+                      <button
+                        type="button"
+                        className={mergeClasses(s.inlineBtn, 'opptrix-focusable')}
+                        aria-label="取消"
+                        onClick={cancelDeleteFolder}
+                      >
+                        <DismissRegular fontSize={14} />
+                      </button>
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className={s.folderTitle}>{folder.title}</span>
+                    <span className={s.folderCount}>{sessions.length}</span>
+                    {!folder.isDefault && (
+                      <span className={mergeClasses(s.folderActions, 'opptrix-archive-folder-actions')}>
+                        <button
+                          type="button"
+                          className={mergeClasses(s.iconAction, 'opptrix-focusable')}
+                          aria-label="重命名文件夹"
+                          onClick={e => { e.stopPropagation(); startRename(folder) }}
+                        >
+                          <EditRegular fontSize={14} />
+                        </button>
+                        <button
+                          type="button"
+                          className={mergeClasses(s.iconAction, 'opptrix-focusable')}
+                          aria-label="删除文件夹"
+                          onClick={e => { e.stopPropagation(); startDeleteFolder(folder) }}
+                        >
+                          <DeleteRegular fontSize={14} />
+                        </button>
+                      </span>
+                    )}
+                    {folder.id === OTHER_ARCHIVE_FOLDER_ID && onClearFolder && (
+                      <span className={mergeClasses(s.folderActions, 'opptrix-archive-folder-actions')}>
+                        <button
+                          type="button"
+                          className={mergeClasses(s.iconAction, 'opptrix-focusable')}
+                          aria-label="清空文件夹"
+                          onClick={e => {
+                            e.stopPropagation()
+                            setClearDialogOpen(true)
+                          }}
+                        >
+                          <BroomRegular fontSize={14} />
+                        </button>
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
+              {!isCollapsed && !isRenaming && !isDeleting && (
+                sessions.length === 0
+                  ? <Text className={s.emptyFolder}>暂无对话</Text>
+                  : (
+                    <div className={s.sessionList}>
+                      {sessions.map(sess => {
+                        const active = sess.id === activeId
+                        const isDeletingSession = deletingSessionId === sess.id
+                        return isDeletingSession ? (
+                          <div
+                            key={sess.id}
+                            className={mergeClasses(s.inlineRow, s.sessionConfirm, 'opptrix-archive-session-item')}
+                          >
+                            <Text className={s.inlineHint}>删除此对话？</Text>
+                            <span className={s.inlineActions}>
+                              <button
+                                type="button"
+                                className={mergeClasses(s.inlineBtn, s.inlineBtnDanger, 'opptrix-focusable')}
+                                aria-label="确认删除对话"
+                                onClick={() => confirmDeleteSession(sess.id)}
+                              >
+                                <CheckmarkRegular fontSize={14} />
+                              </button>
+                              <button
+                                type="button"
+                                className={mergeClasses(s.inlineBtn, 'opptrix-focusable')}
+                                aria-label="取消"
+                                onClick={cancelDeleteSession}
+                              >
+                                <DismissRegular fontSize={14} />
+                              </button>
+                            </span>
+                          </div>
+                        ) : (
+                          <div
+                            key={sess.id}
+                            className={mergeClasses(
+                              s.sessionItem,
+                              'opptrix-archive-session-item',
+                              'opptrix-focusable',
+                              active && s.sessionActive,
+                            )}
+                            role="button"
+                            tabIndex={0}
+                            onClick={() => onSelect(sess.id)}
+                            onKeyDown={e => e.key === 'Enter' && onSelect(sess.id)}
+                          >
+                            <span className={s.sessionTitle}>{sess.title}</span>
+                            <span className={s.folderCount}>{formatDate(sess.updatedAt)}</span>
+                            <button
+                              type="button"
+                              className={mergeClasses(s.sessionDelete, 'opptrix-archive-session-delete', 'opptrix-focusable')}
+                              aria-label="删除对话"
+                              onClick={e => {
+                                e.stopPropagation()
+                                startDeleteSession(sess.id)
+                              }}
+                            >
+                              <DeleteRegular fontSize={14} />
+                            </button>
+                          </div>
+                        )
+                      })}
+                    </div>
+                  )
+              )}
+            </div>
+          )
+        })}
+      </div>
+
+      <OpptrixDialogAlert
+        open={clearDialogOpen}
+        title="清空「其他」文件夹"
+        message={
+          otherFolderSessions > 0
+            ? `将永久删除「其他」中的 ${otherFolderSessions} 条归档对话，此操作不可撤销。`
+            : '「其他」文件夹中暂无对话。'
+        }
+        confirmLabel="清空"
+        confirmTone="danger"
+        confirmDisabled={otherFolderSessions === 0}
+        onConfirm={confirmClearOtherFolder}
+        onCancel={() => setClearDialogOpen(false)}
+      />
+    </div>
+  )
+}

--- a/client-ui/src/chat/sessionExportMarkdown.ts
+++ b/client-ui/src/chat/sessionExportMarkdown.ts
@@ -1,0 +1,52 @@
+import type { ChatDisplayMessage, SessionMeta } from '../types/chat'
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function roleLabel(role: ChatDisplayMessage['role']): string {
+  return role === 'user' ? '用户' : '助手'
+}
+
+export function sanitizeSessionFilename(title: string): string {
+  const trimmed = title.replace(/[/\\?%*:|"<>]/g, '_').trim()
+  return trimmed || '对话'
+}
+
+/** 将完整对话导出为 Markdown 文本 */
+export function sessionToMarkdown(
+  session: Pick<SessionMeta, 'title' | 'createdAt' | 'updatedAt'>,
+  messages: ChatDisplayMessage[],
+): string {
+  const exportedAt = formatTimestamp(new Date().toISOString())
+  const lines: string[] = [
+    `# ${session.title || '新对话'}`,
+    '',
+    `> 导出时间：${exportedAt}`,
+    `> 创建：${formatTimestamp(session.createdAt)} · 更新：${formatTimestamp(session.updatedAt)}`,
+    '',
+    '---',
+    '',
+  ]
+
+  if (messages.length === 0) {
+    lines.push('_（暂无消息）_', '')
+    return lines.join('\n')
+  }
+
+  for (const msg of messages) {
+    lines.push(`## ${roleLabel(msg.role)} · ${formatTimestamp(msg.at)}`, '')
+    lines.push(msg.content.trim() || '_（空消息）_', '')
+    lines.push('')
+  }
+
+  return lines.join('\n').trimEnd() + '\n'
+}

--- a/client-ui/src/components/opptrix/OpptrixDialogAlert.tsx
+++ b/client-ui/src/components/opptrix/OpptrixDialogAlert.tsx
@@ -1,0 +1,171 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  Text,
+  makeStyles,
+  mergeClasses,
+} from '@fluentui/react-components'
+import { opptrixCssVars } from '../../theme/tokens'
+import OpptrixButton from './OpptrixButton'
+
+export type OpptrixDialogAlertTone = 'default' | 'danger'
+
+export interface OpptrixDialogAlertOptions {
+  title: string
+  message?: ReactNode
+  confirmLabel?: string
+  cancelLabel?: string
+  confirmTone?: OpptrixDialogAlertTone
+  confirmDisabled?: boolean
+}
+
+export interface OpptrixDialogAlertProps extends OpptrixDialogAlertOptions {
+  open: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+interface PendingAlert extends OpptrixDialogAlertOptions {
+  resolve: (confirmed: boolean) => void
+}
+
+interface OpptrixDialogAlertContextValue {
+  /** 二次确认，返回用户是否点击确认 */
+  confirm: (options: OpptrixDialogAlertOptions) => Promise<boolean>
+}
+
+const OpptrixDialogAlertContext = createContext<OpptrixDialogAlertContextValue | null>(null)
+
+const useStyles = makeStyles({
+  message: {
+    fontSize: '13px',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.55,
+    whiteSpace: 'pre-wrap',
+  },
+  actions: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '8px',
+    paddingTop: '2px',
+  },
+  confirmDanger: {
+    backgroundColor: opptrixCssVars.error,
+    color: '#FFFFFF',
+    ':hover': {
+      backgroundColor: opptrixCssVars.error,
+      opacity: 0.92,
+    },
+    ':active': {
+      opacity: 0.85,
+    },
+  },
+})
+
+export function OpptrixDialogAlert({
+  open,
+  title,
+  message,
+  confirmLabel = '确定',
+  cancelLabel = '取消',
+  confirmTone = 'default',
+  confirmDisabled = false,
+  onConfirm,
+  onCancel,
+}: OpptrixDialogAlertProps) {
+  const s = useStyles()
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(_, data) => {
+        if (!data.open) onCancel()
+      }}
+    >
+      <DialogSurface className="opptrix-glass-dialog-surface opptrix-dialog-alert-surface">
+        <DialogBody>
+          <DialogTitle>{title}</DialogTitle>
+          {message != null && message !== '' && (
+            <DialogContent>
+              {typeof message === 'string'
+                ? <Text className={s.message} block>{message}</Text>
+                : message}
+            </DialogContent>
+          )}
+          <div className={mergeClasses(s.actions, 'opptrix-dialog-alert-actions')}>
+            <OpptrixButton variant="ghost" onClick={onCancel}>
+              {cancelLabel}
+            </OpptrixButton>
+            <OpptrixButton
+              variant="primary"
+              disabled={confirmDisabled}
+              className={confirmTone === 'danger' ? s.confirmDanger : undefined}
+              onClick={onConfirm}
+            >
+              {confirmLabel}
+            </OpptrixButton>
+          </div>
+        </DialogBody>
+      </DialogSurface>
+    </Dialog>
+  )
+}
+
+export function OpptrixDialogAlertProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<PendingAlert | null>(null)
+
+  const confirm = useCallback((options: OpptrixDialogAlertOptions) => {
+    return new Promise<boolean>(resolve => {
+      setPending({ ...options, resolve })
+    })
+  }, [])
+
+  const finish = useCallback((confirmed: boolean) => {
+    setPending(current => {
+      current?.resolve(confirmed)
+      return null
+    })
+  }, [])
+
+  const value = useMemo<OpptrixDialogAlertContextValue>(() => ({ confirm }), [confirm])
+
+  return (
+    <OpptrixDialogAlertContext.Provider value={value}>
+      {children}
+      {pending && (
+        <OpptrixDialogAlert
+          open
+          title={pending.title}
+          message={pending.message}
+          confirmLabel={pending.confirmLabel}
+          cancelLabel={pending.cancelLabel}
+          confirmTone={pending.confirmTone}
+          confirmDisabled={pending.confirmDisabled}
+          onConfirm={() => finish(true)}
+          onCancel={() => finish(false)}
+        />
+      )}
+    </OpptrixDialogAlertContext.Provider>
+  )
+}
+
+export function useOpptrixDialogAlert(): OpptrixDialogAlertContextValue {
+  const ctx = useContext(OpptrixDialogAlertContext)
+  if (!ctx) {
+    throw new Error('useOpptrixDialogAlert must be used within OpptrixDialogAlertProvider')
+  }
+  return ctx
+}

--- a/client-ui/src/components/opptrix/OpptrixDialogAlert.tsx
+++ b/client-ui/src/components/opptrix/OpptrixDialogAlert.tsx
@@ -12,6 +12,7 @@ import {
   DialogBody,
   DialogTitle,
   DialogContent,
+  DialogActions,
   Text,
   makeStyles,
   mergeClasses,
@@ -54,25 +55,6 @@ const useStyles = makeStyles({
     lineHeight: 1.55,
     whiteSpace: 'pre-wrap',
   },
-  actions: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    gap: '8px',
-    paddingTop: '2px',
-  },
-  confirmDanger: {
-    backgroundColor: opptrixCssVars.error,
-    color: '#FFFFFF',
-    ':hover': {
-      backgroundColor: opptrixCssVars.error,
-      opacity: 0.92,
-    },
-    ':active': {
-      opacity: 0.85,
-    },
-  },
 })
 
 export function OpptrixDialogAlert({
@@ -91,33 +73,36 @@ export function OpptrixDialogAlert({
   return (
     <Dialog
       open={open}
+      modalType="alert"
       onOpenChange={(_, data) => {
         if (!data.open) onCancel()
       }}
     >
       <DialogSurface className="opptrix-glass-dialog-surface opptrix-dialog-alert-surface">
-        <DialogBody>
-          <DialogTitle>{title}</DialogTitle>
+        <DialogBody className="opptrix-dialog-alert-body">
+          <DialogTitle className="opptrix-dialog-alert-title">{title}</DialogTitle>
           {message != null && message !== '' && (
-            <DialogContent>
+            <DialogContent className="opptrix-dialog-alert-content">
               {typeof message === 'string'
                 ? <Text className={s.message} block>{message}</Text>
                 : message}
             </DialogContent>
           )}
-          <div className={mergeClasses(s.actions, 'opptrix-dialog-alert-actions')}>
+          <DialogActions className="opptrix-dialog-alert-actions">
             <OpptrixButton variant="ghost" onClick={onCancel}>
               {cancelLabel}
             </OpptrixButton>
             <OpptrixButton
               variant="primary"
               disabled={confirmDisabled}
-              className={confirmTone === 'danger' ? s.confirmDanger : undefined}
+              className={mergeClasses(
+                confirmTone === 'danger' && 'opptrix-btn-danger',
+              )}
               onClick={onConfirm}
             >
               {confirmLabel}
             </OpptrixButton>
-          </div>
+          </DialogActions>
         </DialogBody>
       </DialogSurface>
     </Dialog>

--- a/client-ui/src/components/opptrix/OpptrixSegmentedControl.tsx
+++ b/client-ui/src/components/opptrix/OpptrixSegmentedControl.tsx
@@ -1,0 +1,182 @@
+import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import { focusVisibleRing, motion } from '../../theme/mixins'
+import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
+
+const SEGMENTED_INSET = 2
+const SEGMENT_HEIGHT = 26
+
+const useStyles = makeStyles({
+  track: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'stretch',
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: `${SEGMENTED_INSET}px`,
+    borderRadius: opptrixTokens.radiusFull,
+    flexShrink: 0,
+    isolation: 'isolate',
+  },
+  trackEmbedded: {
+    borderRadius: opptrixTokens.radiusMd,
+  },
+  thumb: {
+    position: 'absolute',
+    top: `${SEGMENTED_INSET}px`,
+    left: 0,
+    height: `${SEGMENT_HEIGHT}px`,
+    borderRadius: opptrixTokens.radiusFull,
+    pointerEvents: 'none',
+    zIndex: 0,
+    willChange: 'transform, width',
+    transitionProperty: 'transform, width',
+    transitionDuration: motion.normal,
+    transitionTimingFunction: 'cubic-bezier(0.35, 1.12, 0.45, 1)',
+  },
+  thumbEmbedded: {
+    borderRadius: opptrixTokens.radiusMd,
+  },
+  segment: {
+    position: 'relative',
+    zIndex: 1,
+    flex: 1,
+    minWidth: 0,
+    border: 'none',
+    backgroundColor: 'transparent',
+    color: opptrixCssVars.textSecondary,
+    fontSize: '12px',
+    fontWeight: 600,
+    lineHeight: 1,
+    height: `${SEGMENT_HEIGHT}px`,
+    padding: '0 8px',
+    borderRadius: opptrixTokens.radiusFull,
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    transitionProperty: 'color, opacity',
+    transitionDuration: motion.fast,
+    transitionTimingFunction: motion.ease,
+    ...focusVisibleRing,
+    ':hover': {
+      color: opptrixCssVars.textPrimary,
+    },
+    ':active': {
+      opacity: opptrixTokens.activeOpacity,
+    },
+  },
+  segmentEmbedded: {
+    fontSize: '13px',
+    fontWeight: 500,
+    borderRadius: opptrixTokens.radiusMd,
+  },
+  segmentActive: {
+    color: opptrixCssVars.textPrimary,
+  },
+})
+
+export type SegmentedOption<T extends string> = {
+  value: T
+  label: ReactNode
+}
+
+interface OpptrixSegmentedControlProps<T extends string> {
+  value: T
+  options: SegmentedOption<T>[]
+  onChange: (value: T) => void
+  className?: string
+  variant?: 'default' | 'embedded'
+  'aria-label'?: string
+}
+
+export default function OpptrixSegmentedControl<T extends string>({
+  value,
+  options,
+  onChange,
+  className,
+  variant = 'default',
+  'aria-label': ariaLabel,
+}: OpptrixSegmentedControlProps<T>) {
+  const s = useStyles()
+  const embedded = variant === 'embedded'
+  const trackRef = useRef<HTMLDivElement>(null)
+  const segmentRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const [thumb, setThumb] = useState({ x: 0, width: 0, ready: false })
+
+  const activeIndex = Math.max(0, options.findIndex(opt => opt.value === value))
+
+  const measureThumb = useCallback(() => {
+    const track = trackRef.current
+    const btn = segmentRefs.current[activeIndex]
+    if (!track || !btn) return
+    setThumb({
+      x: btn.offsetLeft,
+      width: btn.offsetWidth,
+      ready: true,
+    })
+  }, [activeIndex])
+
+  useLayoutEffect(() => {
+    measureThumb()
+    const track = trackRef.current
+    if (!track || typeof ResizeObserver === 'undefined') return undefined
+    const ro = new ResizeObserver(() => measureThumb())
+    ro.observe(track)
+    for (const btn of segmentRefs.current) {
+      if (btn) ro.observe(btn)
+    }
+    return () => ro.disconnect()
+  }, [measureThumb, options.length, value])
+
+  return (
+    <div
+      ref={trackRef}
+      className={mergeClasses(
+        s.track,
+        'opptrix-segmented-control',
+        embedded && s.trackEmbedded,
+        embedded && 'opptrix-segmented-control-embedded',
+        className,
+      )}
+      role="tablist"
+      aria-label={ariaLabel}
+    >
+      <div
+        className={mergeClasses(
+          s.thumb,
+          'opptrix-segmented-thumb',
+          embedded && s.thumbEmbedded,
+          embedded && 'opptrix-segmented-thumb-embedded',
+        )}
+        aria-hidden
+        style={{
+          width: thumb.width || undefined,
+          transform: `translateX(${thumb.x}px)`,
+          opacity: thumb.ready ? 1 : 0,
+        }}
+      />
+      {options.map((opt, index) => {
+        const active = opt.value === value
+        return (
+          <button
+            key={opt.value}
+            ref={el => { segmentRefs.current[index] = el }}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            className={mergeClasses(
+              s.segment,
+              embedded && s.segmentEmbedded,
+              active && s.segmentActive,
+              'opptrix-focusable',
+            )}
+            onClick={() => {
+              if (opt.value !== value) onChange(opt.value)
+            }}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/client-ui/src/desktop/DesktopWindowChrome.tsx
+++ b/client-ui/src/desktop/DesktopWindowChrome.tsx
@@ -1,10 +1,10 @@
 import { createPortal } from 'react-dom'
-import type { CSSProperties } from 'react'
+import { cloneElement, isValidElement, useEffect, useState, type CSSProperties, type ReactNode } from 'react'
 import {
   ArrowLeftRegular,
   ArrowRightRegular,
 } from '@fluentui/react-icons'
-import { makeStyles, Text } from '@fluentui/react-components'
+import { makeStyles, mergeClasses, Text } from '@fluentui/react-components'
 import { isElectron } from '../platform/detect'
 import {
   DESKTOP_CHROME_BAND_HEIGHT,
@@ -17,10 +17,10 @@ import {
   DESKTOP_TOOL_GAP,
   DESKTOP_TOOL_ICON_SIZE,
   DESKTOP_Z_CHROME_TOOLS,
-  DESKTOP_Z_TITLE,
   DESKTOP_NEWS_TITLE_DRAG_CLIP_DARWIN,
   DESKTOP_NEWS_TITLE_DRAG_CLIP_WIN,
   SIDEBAR_INLINE_WIDTH,
+  DESKTOP_TITLE_BAR_ACTIONS_WIDTH,
 } from './constants'
 import {
   PanelLeftContractRegular,
@@ -31,8 +31,14 @@ import {
   ArrowMinimizeRegular,
 } from '../chat/chatIcons'
 import { electronPlatform } from '../platform/detect'
-import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
-import { desktopTitleLeft, desktopToolbarLeft, type DesktopViewMode } from './layout'
+import { opptrixCssVars } from '../theme/tokens'
+import {
+  desktopTitleLeft,
+  desktopTitleMaxWidth,
+  desktopTitleZoneRight,
+  desktopToolbarLeft,
+  type DesktopViewMode,
+} from './layout'
 import ChromeToolButton from './ChromeToolButton'
 import WindowControls from './WindowControls'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
@@ -49,7 +55,8 @@ const useStyles = makeStyles({
   },
   drag: {
     position: 'absolute',
-    inset: 0,
+    top: 0,
+    bottom: 0,
     WebkitAppRegion: 'drag',
     pointerEvents: 'auto',
   },
@@ -62,24 +69,37 @@ const useStyles = makeStyles({
     gap: `${DESKTOP_TOOL_GAP}px`,
     pointerEvents: 'auto',
     WebkitAppRegion: 'no-drag',
-    zIndex: 1,
+    zIndex: 4,
     transitionProperty: 'left',
     transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
     transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
   },
   title: {
-    position: 'fixed',
+    position: 'absolute',
     top: `${DESKTOP_CHROME_TOP_OFFSET}px`,
     height: `${DESKTOP_CHROME_BAND_HEIGHT}px`,
     display: 'flex',
     alignItems: 'center',
-    maxWidth: 'min(480px, 46vw)',
+    minWidth: 0,
     pointerEvents: 'none',
     WebkitAppRegion: 'drag',
-    zIndex: DESKTOP_Z_TITLE,
-    transitionProperty: 'left',
+    zIndex: 2,
+    transitionProperty: 'left, max-width',
     transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
     transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
+  },
+  titleInteractive: {
+    pointerEvents: 'auto',
+    WebkitAppRegion: 'no-drag',
+    zIndex: 5,
+  },
+  titleSlotWrap: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    minWidth: 0,
+    maxWidth: '100%',
+    pointerEvents: 'auto',
+    WebkitAppRegion: 'no-drag',
   },
   titleText: {
     fontSize: '13px',
@@ -106,11 +126,12 @@ const useStyles = makeStyles({
 
 interface DesktopWindowChromeProps {
   title: string
+  /** 可点击标题与工具菜单；未提供时使用纯文本标题 */
+  titleSlot?: ReactNode
   viewMode?: DesktopViewMode
   sidebarOpen?: boolean
   sidebarInline?: boolean
   showSidebarToggle?: boolean
-  /** Overlay mode: hover toolbar button to reveal sidebar */
   sidebarHoverReveal?: boolean
   canGoBack?: boolean
   canGoForward?: boolean
@@ -120,15 +141,47 @@ interface DesktopWindowChromeProps {
   onGoBack?: () => void
   onGoForward?: () => void
   rightPanelOpen?: boolean
-  /** Width of the open right panel — used to clip global drag off panel title bar. */
   rightPanelWidth?: number
+  chatColumnWidth?: number
+  chatAreaLeft?: number
   onToggleRightPanel?: () => void
   chatColumnVisible?: boolean
   onToggleChatColumn?: () => void
 }
 
+function resolveDragRightClip(
+  isNews: boolean,
+  isSettings: boolean,
+  rightPanelOpen: boolean,
+  chatColumnVisible: boolean,
+  sidebarInline: boolean,
+  rightPanelWidth: number,
+): Pick<CSSProperties, 'right' | 'width' | 'pointerEvents' | 'WebkitAppRegion'> {
+  if (isNews) {
+    const right = electronPlatform() === 'darwin'
+      ? DESKTOP_NEWS_TITLE_DRAG_CLIP_DARWIN
+      : DESKTOP_NEWS_TITLE_DRAG_CLIP_WIN
+    return { right: `${right}px` }
+  }
+  if (isSettings || !rightPanelOpen) return {}
+  if (!chatColumnVisible) {
+    if (sidebarInline) {
+      return { right: `calc(100% - ${SIDEBAR_INLINE_WIDTH}px)` }
+    }
+    return {
+      width: 0,
+      overflow: 'hidden',
+      pointerEvents: 'none',
+      WebkitAppRegion: 'no-drag',
+    }
+  }
+  if (rightPanelWidth > 0) return { right: `${rightPanelWidth}px` }
+  return {}
+}
+
 export default function DesktopWindowChrome({
   title,
+  titleSlot,
   viewMode = 'chat',
   sidebarOpen = false,
   sidebarInline = false,
@@ -143,12 +196,23 @@ export default function DesktopWindowChrome({
   onGoForward,
   rightPanelOpen = false,
   rightPanelWidth = 0,
+  chatColumnWidth,
+  chatAreaLeft = 0,
   onToggleRightPanel,
   chatColumnVisible = true,
   onToggleChatColumn,
 }: DesktopWindowChromeProps) {
   const s = useStyles()
   const macFullscreen = useElectronFullscreen()
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth : 1280,
+  )
+
+  useEffect(() => {
+    const onResize = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   if (!isElectron()) return null
 
@@ -157,33 +221,35 @@ export default function DesktopWindowChrome({
   const titleLeft = desktopTitleLeft(sidebarInline, viewMode, macFullscreen)
   const toolbarLeft = desktopToolbarLeft(macFullscreen)
   const titleBarActionsRight = electronPlatform() === 'darwin' ? 12 : 132
-
-  /** Clip global drag off interactive title bands (news actions, right panel, etc.). */
-  const dragLayerStyle: CSSProperties = (() => {
-    if (isNews) {
-      const right = electronPlatform() === 'darwin'
-        ? DESKTOP_NEWS_TITLE_DRAG_CLIP_DARWIN
-        : DESKTOP_NEWS_TITLE_DRAG_CLIP_WIN
-      return { right: `${right}px` }
-    }
-    if (isSettings || !rightPanelOpen) return {}
-    if (!chatColumnVisible) {
-      if (sidebarInline) {
-        return { right: `calc(100% - ${SIDEBAR_INLINE_WIDTH}px)` }
-      }
-      return {
-        width: 0,
-        overflow: 'hidden',
-        pointerEvents: 'none',
-        WebkitAppRegion: 'no-drag',
-      }
-    }
-    if (rightPanelWidth > 0) return { right: `${rightPanelWidth}px` }
-    return {}
-  })()
-
-  /** Page title in the chrome band (news uses its own in-page title bar). */
+  const showTitleBarActions = !isSettings && !rightPanelOpen && Boolean(onToggleRightPanel || onToggleChatColumn)
+  const titleMaxWidth = desktopTitleMaxWidth({
+    titleLeft,
+    viewportWidth,
+    rightPanelOpen,
+    rightPanelWidth,
+    chatColumnVisible,
+    reserveTitleBarActions: showTitleBarActions,
+    titleBarActionsRight,
+    titleBarActionsWidth: DESKTOP_TITLE_BAR_ACTIONS_WIDTH,
+    chatColumnWidth,
+    chatAreaLeft,
+  })
+  const titleZoneRight = desktopTitleZoneRight(titleLeft, titleMaxWidth)
   const showPageTitle = !isNews && !isSettings && chatColumnVisible
+  const interactiveTitle = showPageTitle && Boolean(titleSlot)
+
+  const titleSlotWithLayout = titleSlot && isValidElement(titleSlot)
+    ? cloneElement(titleSlot, { maxWidth: titleMaxWidth } as { maxWidth: number })
+    : titleSlot
+
+  const dragRightClip = resolveDragRightClip(
+    isNews,
+    isSettings,
+    rightPanelOpen,
+    chatColumnVisible,
+    sidebarInline,
+    rightPanelWidth,
+  )
 
   const handleSidebarPointer = () => {
     if (sidebarHoverReveal) {
@@ -204,14 +270,41 @@ export default function DesktopWindowChrome({
 
   return createPortal(
     <>
-      {showPageTitle && (
-        <div className={s.title} style={{ left: `${titleLeft}px` }}>
-          <Text className={s.titleText}>{title || (isNews ? '新闻中心' : '新对话')}</Text>
-        </div>
-      )}
-
       <header className={s.chromeBar} aria-label="窗口标题栏">
-        <div className={s.drag} style={dragLayerStyle} aria-hidden />
+        {interactiveTitle ? (
+          <>
+            <div
+              className={s.drag}
+              style={{ left: 0, width: `${titleLeft}px` }}
+              aria-hidden
+            />
+            <div
+              className={s.drag}
+              style={{ left: `${titleZoneRight}px`, right: 0, ...dragRightClip }}
+              aria-hidden
+            />
+          </>
+        ) : (
+          <div className={s.drag} style={{ left: 0, right: 0, ...dragRightClip }} aria-hidden />
+        )}
+
+        {showPageTitle && (
+          <div
+            className={mergeClasses(s.title, titleSlot && s.titleInteractive)}
+            style={{
+              left: `${titleLeft}px`,
+              maxWidth: `${titleMaxWidth}px`,
+            }}
+          >
+            {titleSlotWithLayout ? (
+              <div className={s.titleSlotWrap}>
+                {titleSlotWithLayout}
+              </div>
+            ) : (
+              <Text className={s.titleText}>{title || '新对话'}</Text>
+            )}
+          </div>
+        )}
 
         <div className={s.toolbar} style={{ left: `${toolbarLeft}px` }}>
           {showSidebarToggle && (onToggleSidebar || onRevealSidebar) && (

--- a/client-ui/src/desktop/DesktopWindowChrome.tsx
+++ b/client-ui/src/desktop/DesktopWindowChrome.tsx
@@ -1,5 +1,5 @@
 import { createPortal } from 'react-dom'
-import { cloneElement, isValidElement, useEffect, useState, type CSSProperties, type ReactNode } from 'react'
+import { cloneElement, isValidElement, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react'
 import {
   ArrowLeftRegular,
   ArrowRightRegular,
@@ -35,7 +35,6 @@ import { opptrixCssVars } from '../theme/tokens'
 import {
   desktopTitleLeft,
   desktopTitleMaxWidth,
-  desktopTitleZoneRight,
   desktopToolbarLeft,
   type DesktopViewMode,
 } from './layout'
@@ -89,8 +88,6 @@ const useStyles = makeStyles({
     transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
   },
   titleInteractive: {
-    pointerEvents: 'auto',
-    WebkitAppRegion: 'no-drag',
     zIndex: 5,
   },
   titleSlotWrap: {
@@ -204,17 +201,17 @@ export default function DesktopWindowChrome({
 }: DesktopWindowChromeProps) {
   const s = useStyles()
   const macFullscreen = useElectronFullscreen()
+  const titleMeasureRef = useRef<HTMLDivElement>(null)
   const [viewportWidth, setViewportWidth] = useState(() =>
     typeof window !== 'undefined' ? window.innerWidth : 1280,
   )
+  const [titleBlockWidth, setTitleBlockWidth] = useState(0)
 
   useEffect(() => {
     const onResize = () => setViewportWidth(window.innerWidth)
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
   }, [])
-
-  if (!isElectron()) return null
 
   const isSettings = viewMode === 'settings'
   const isNews = viewMode === 'news'
@@ -234,13 +231,36 @@ export default function DesktopWindowChrome({
     chatColumnWidth,
     chatAreaLeft,
   })
-  const titleZoneRight = desktopTitleZoneRight(titleLeft, titleMaxWidth)
   const showPageTitle = !isNews && !isSettings && chatColumnVisible
   const interactiveTitle = showPageTitle && Boolean(titleSlot)
 
   const titleSlotWithLayout = titleSlot && isValidElement(titleSlot)
     ? cloneElement(titleSlot, { maxWidth: titleMaxWidth } as { maxWidth: number })
     : titleSlot
+
+  useLayoutEffect(() => {
+    if (!isElectron() || !interactiveTitle) {
+      setTitleBlockWidth(0)
+      return
+    }
+    const el = titleMeasureRef.current
+    if (!el) return
+
+    const update = () => {
+      setTitleBlockWidth(Math.ceil(el.getBoundingClientRect().width))
+    }
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [interactiveTitle, title, titleMaxWidth, titleSlotWithLayout])
+
+  if (!isElectron()) return null
+
+  /** 仅让出可点击标题的实际宽度，其余标题栏带仍可拖拽 */
+  const dragResumeLeft = interactiveTitle
+    ? titleLeft + (titleBlockWidth > 0 ? titleBlockWidth : 0)
+    : titleLeft
 
   const dragRightClip = resolveDragRightClip(
     isNews,
@@ -280,7 +300,7 @@ export default function DesktopWindowChrome({
             />
             <div
               className={s.drag}
-              style={{ left: `${titleZoneRight}px`, right: 0, ...dragRightClip }}
+              style={{ left: `${dragResumeLeft}px`, right: 0, ...dragRightClip }}
               aria-hidden
             />
           </>
@@ -297,7 +317,7 @@ export default function DesktopWindowChrome({
             }}
           >
             {titleSlotWithLayout ? (
-              <div className={s.titleSlotWrap}>
+              <div ref={titleMeasureRef} className={s.titleSlotWrap}>
                 {titleSlotWithLayout}
               </div>
             ) : (

--- a/client-ui/src/desktop/constants.ts
+++ b/client-ui/src/desktop/constants.ts
@@ -83,6 +83,11 @@ export const DESKTOP_Z_PANEL_TITLE = 1200
 export const DESKTOP_Z_OVERLAY_SIDEBAR = 1150
 /** Global fixed toolbar / window controls — always above panel title bands */
 export const DESKTOP_Z_CHROME_TOOLS = 1300
+/** Clickable session title — above drag layer, below window controls hit targets */
+export const DESKTOP_Z_TITLE_INTERACTIVE = 1310
+
+/** Reserve for chat title-bar panel toggle buttons (2 × tool + gap) */
+export const DESKTOP_TITLE_BAR_ACTIONS_WIDTH = 60
 
 /** Clip global title-bar drag so news status + action buttons stay clickable */
 export const DESKTOP_NEWS_TITLE_DRAG_CLIP_DARWIN = 240

--- a/client-ui/src/desktop/layout.ts
+++ b/client-ui/src/desktop/layout.ts
@@ -2,6 +2,7 @@ import { electronPlatform } from '../platform/detect'
 import { opptrixTokens } from '../theme/tokens'
 import {
   DESKTOP_SETTINGS_SIDEBAR_WIDTH,
+  DESKTOP_TITLE_BAR_ACTIONS_WIDTH,
   DESKTOP_TITLE_GAP,
   DESKTOP_TITLEBAR_HEIGHT,
   DESKTOP_TOOL_GAP,
@@ -9,6 +10,7 @@ import {
   DESKTOP_TOOLBAR_TOOL_COUNT,
   DESKTOP_TRAFFIC_LIGHT_WIDTH,
   DESKTOP_TRAFFIC_LIGHT_WIDTH_FULLSCREEN,
+  DESKTOP_Z_TITLE_INTERACTIVE,
 } from './constants'
 
 export function desktopToolbarLeft(fullscreen = false): number {
@@ -39,6 +41,47 @@ export function desktopTitleLeft(
     return opptrixTokens.sidebarWidthPx + DESKTOP_TITLE_GAP
   }
   return afterToolbar
+}
+
+export function desktopTitleMaxWidth(opts: {
+  titleLeft: number
+  viewportWidth: number
+  rightPanelOpen?: boolean
+  rightPanelWidth?: number
+  chatColumnVisible?: boolean
+  reserveTitleBarActions?: boolean
+  titleBarActionsRight?: number
+  titleBarActionsWidth?: number
+  /** Measured chat column width — refines ellipsis when split layout is active */
+  chatColumnWidth?: number
+  /** Left edge of chat column in viewport (inline sidebar width, else 0) */
+  chatAreaLeft?: number
+}): number {
+  const trailingPad = DESKTOP_TITLE_GAP
+  let rightEdge = opts.viewportWidth - trailingPad
+
+  if (opts.rightPanelOpen && opts.chatColumnVisible !== false && (opts.rightPanelWidth ?? 0) > 0) {
+    rightEdge = opts.viewportWidth - (opts.rightPanelWidth ?? 0) - trailingPad
+  } else if (opts.reserveTitleBarActions) {
+    const actionsRight = opts.titleBarActionsRight ?? 12
+    const actionsWidth = opts.titleBarActionsWidth ?? DESKTOP_TITLE_BAR_ACTIONS_WIDTH
+    rightEdge = opts.viewportWidth - actionsRight - actionsWidth - trailingPad
+  }
+
+  let available = rightEdge - opts.titleLeft
+
+  if (opts.chatColumnWidth != null && opts.chatColumnWidth > 0) {
+    const chatAreaLeft = opts.chatAreaLeft ?? 0
+    const offsetInChat = Math.max(0, opts.titleLeft - chatAreaLeft)
+    available = Math.min(available, opts.chatColumnWidth - offsetInChat - trailingPad)
+  }
+
+  return Math.max(96, Math.min(480, available))
+}
+
+/** 可点击标题区右缘 — 用于在全局 drag 层上留出“洞” */
+export function desktopTitleZoneRight(titleLeft: number, titleMaxWidth: number): number {
+  return titleLeft + titleMaxWidth
 }
 
 export function desktopChromeToolbarReserve(fullscreen = false): number {

--- a/client-ui/src/main.tsx
+++ b/client-ui/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { FluentProvider } from '@fluentui/react-components'
 import App from './App'
+import { OpptrixDialogAlertProvider } from './components/opptrix/OpptrixDialogAlert'
 import { getOpptrixFluentTheme } from './theme/opptrixTheme'
 import { ThemeProvider, useTheme } from './theme/ThemeContext'
 import { isDesktopApp, isElectron } from './platform/detect'
@@ -23,7 +24,9 @@ function ThemedApp() {
   const { resolvedScheme } = useTheme()
   return (
     <FluentProvider theme={getOpptrixFluentTheme(resolvedScheme)}>
-      <App />
+      <OpptrixDialogAlertProvider>
+        <App />
+      </OpptrixDialogAlertProvider>
     </FluentProvider>
   )
 }

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import {
 } from '@fluentui/react-components'
 import { ChevronRightRegular, DeleteRegular, EditRegular, SystemRegular, WeatherMoonRegular, WeatherSunnyRegular } from '@fluentui/react-icons'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
+import { useOpptrixDialogAlert } from '../components/opptrix/OpptrixDialogAlert'
 import ProviderWizard from './ProviderWizard'
 import SettingsSidebar, {
   settingsSectionTitle, settingsSectionSubtitle, type SettingsSection,
@@ -302,6 +303,7 @@ function SettingsPageView({
   initialSection,
 }: SettingsPageProps) {
   const toast = useSettingsToast()
+  const { confirm } = useOpptrixDialogAlert()
   const { preference: themePreference, setPreference: setThemePreference } = useTheme()
   const s = useStyles()
   const sidebarOverlayMode = useSidebarOverlayMode(!isMobile)
@@ -400,7 +402,13 @@ function SettingsPageView({
   }, [])
 
   const handleDeleteProvider = async (p: PublicProvider) => {
-    if (!confirm(`确定删除提供商「${p.name}」？`)) return
+    const ok = await confirm({
+      title: `确定删除提供商「${p.name}」？`,
+      message: '删除后将无法使用该提供商下的模型。',
+      confirmLabel: '删除',
+      confirmTone: 'danger',
+    })
+    if (!ok) return
     try {
       await deleteProvider(p.id)
       await refresh()

--- a/client-ui/src/pages/settings/DiscoverStrategiesSettingsSection.tsx
+++ b/client-ui/src/pages/settings/DiscoverStrategiesSettingsSection.tsx
@@ -25,6 +25,7 @@ import {
   type StrategyDraft,
 } from './DiscoverStrategyDialogs'
 import { useSettingsToast } from './SettingsToast'
+import { useOpptrixDialogAlert } from '../../components/opptrix/OpptrixDialogAlert'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
 
 const CATEGORY_LABEL: Record<DiscoverStrategyPublic['category'], string> = {
@@ -185,6 +186,7 @@ function customFromBuiltin(detail: DiscoverStrategyDetail): CustomDiscoverStrate
 export default function DiscoverStrategiesSettingsSection() {
   const s = useStyles()
   const toast = useSettingsToast()
+  const { confirm } = useOpptrixDialogAlert()
   const [profile, setProfile] = useState<DiscoverStrategyProfile>(defaultDiscoverProfile())
   const [builtinList, setBuiltinList] = useState<DiscoverStrategyPublic[]>([])
   const [viewTarget, setViewTarget] = useState<ViewTarget>(null)
@@ -302,8 +304,16 @@ export default function DiscoverStrategiesSettingsSection() {
     toast.showSuccess(creating ? '自编策略已创建' : '策略已保存')
   }
 
-  const handleDeleteCustom = () => {
+  const handleDeleteCustom = async () => {
     if (editTarget?.mode !== 'edit') return
+    const name = draft.name.trim() || '该策略'
+    const ok = await confirm({
+      title: `确定删除「${name}」？`,
+      message: '删除后无法恢复。',
+      confirmLabel: '删除',
+      confirmTone: 'danger',
+    })
+    if (!ok) return
     const id = editTarget.id
     removeStrategy(id)
     setEditTarget(null)

--- a/client-ui/src/pages/settings/NewsFeedSettingsSection.tsx
+++ b/client-ui/src/pages/settings/NewsFeedSettingsSection.tsx
@@ -33,6 +33,7 @@ import {
   SettingsRow,
 } from './SettingsPrimitives'
 import { useSettingsToast } from './SettingsToast'
+import { useOpptrixDialogAlert } from '../../components/opptrix/OpptrixDialogAlert'
 import { useDebouncedEffect } from '../../hooks/useDebouncedEffect'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
 import { findDuplicateSubscription, formatSubscriptionUrlShort } from '../news/newsUtils'
@@ -275,6 +276,7 @@ type SaveState = 'idle' | 'pending' | 'saved' | 'error'
 export default function NewsFeedSettingsSection() {
   const s = useStyles()
   const toast = useSettingsToast()
+  const { confirm } = useOpptrixDialogAlert()
   const [loading, setLoading] = useState(true)
   const [settings, setSettings] = useState<NewsSettings>({
     refresh_interval_min: 15,
@@ -405,7 +407,13 @@ export default function NewsFeedSettingsSection() {
   }
 
   const handleDeleteGroup = async (id: string) => {
-    if (!confirm('删除分组后，其中订阅将移至未分组。确定删除？')) return
+    const ok = await confirm({
+      title: '确定删除此分组？',
+      message: '删除后，其中订阅将移至未分组。',
+      confirmLabel: '删除',
+      confirmTone: 'danger',
+    })
+    if (!ok) return
     try {
       const resp = await news.deleteGroup(id)
       setGroups(resp.groups)
@@ -496,9 +504,13 @@ export default function NewsFeedSettingsSection() {
   const handleDelete = async (id: string) => {
     const sub = subs.find(s => s.id === id)
     const label = sub?.title?.trim() || '该订阅源'
-    if (!confirm(
-      `确定删除「${label}」？\n\n删除后，该来源关联的历史文章将同步清除，无法恢复。`,
-    )) return
+    const ok = await confirm({
+      title: `确定删除「${label}」？`,
+      message: '删除后，该来源关联的历史文章将同步清除，无法恢复。',
+      confirmLabel: '删除',
+      confirmTone: 'danger',
+    })
+    if (!ok) return
     try {
       const resp = await news.deleteSubscription(id)
       setSubs(resp.subscriptions)

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -13,6 +13,14 @@ declare global {
         filename: string
         data: ArrayBuffer
       }) => Promise<string>
+      pickSaveFile?: (payload: {
+        defaultPath?: string
+        title?: string
+      }) => Promise<string | null>
+      writeTextFile?: (payload: {
+        filePath: string
+        text: string
+      }) => Promise<string>
       openExternalUrl?: (url: string) => Promise<boolean>
       clientVersion?: () => Promise<string>
       appUpdateGetStatus?: () => Promise<AppUpdateStatus>
@@ -37,6 +45,10 @@ declare global {
       signalShellReady?: () => void
     }
     showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<FileSystemDirectoryHandle>
+    showSaveFilePicker?: (options?: {
+      suggestedName?: string
+      types?: Array<{ description?: string; accept: Record<string, string[]> }>
+    }) => Promise<FileSystemFileHandle>
   }
 }
 

--- a/client-ui/src/platform/saveTextFile.ts
+++ b/client-ui/src/platform/saveTextFile.ts
@@ -1,0 +1,56 @@
+import { isElectron } from './detect'
+import { sanitizeSessionFilename } from '../chat/sessionExportMarkdown'
+
+export interface SaveTextFileResult {
+  filePath: string
+  bytes: number
+}
+
+/** 弹出保存对话框并将文本写入所选路径；用户取消时返回 null */
+export async function saveTextFileWithDialog(
+  text: string,
+  suggestedFilename: string,
+): Promise<SaveTextFileResult | null> {
+  const safeName = `${sanitizeSessionFilename(suggestedFilename.replace(/\.md$/i, ''))}.md`
+  const blob = new Blob([text], { type: 'text/markdown;charset=utf-8' })
+
+  if (isElectron() && window.electronAPI?.pickSaveFile && window.electronAPI?.writeTextFile) {
+    const filePath = await window.electronAPI.pickSaveFile({
+      defaultPath: safeName,
+      title: '导出对话',
+    })
+    if (!filePath) return null
+    const savedPath = await window.electronAPI.writeTextFile({ filePath, text })
+    return { filePath: savedPath, bytes: new TextEncoder().encode(text).length }
+  }
+
+  if (typeof window.showSaveFilePicker === 'function') {
+    try {
+      const handle = await window.showSaveFilePicker({
+        suggestedName: safeName,
+        types: [{
+          description: 'Markdown',
+          accept: { 'text/markdown': ['.md'] },
+        }],
+      })
+      const writable = await handle.createWritable()
+      await writable.write(blob)
+      await writable.close()
+      return { filePath: handle.name, bytes: blob.size }
+    } catch (e) {
+      if (e instanceof DOMException && e.name === 'AbortError') return null
+      throw e
+    }
+  }
+
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = safeName
+  anchor.rel = 'noopener'
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+  return { filePath: safeName, bytes: blob.size }
+}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -661,6 +661,77 @@ select:focus-visible {
   overflow: visible !important;
 }
 
+/* 二次确认 Dialog — 紧凑毛玻璃 */
+.opptrix-dialog-alert-surface.fui-DialogSurface {
+  max-width: min(360px, calc(100vw - 32px)) !important;
+  min-width: 280px;
+  border-radius: 14px !important;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1), 0 0 0 1px rgba(60, 60, 67, 0.06) !important;
+}
+
+.opptrix-dialog-alert-surface .opptrix-dialog-alert-body.fui-DialogBody {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 0 !important;
+  padding: 18px 18px 14px !important;
+}
+
+.opptrix-dialog-alert-surface .opptrix-dialog-alert-title.fui-DialogTitle {
+  font-size: 15px !important;
+  font-weight: 650 !important;
+  line-height: 1.35 !important;
+  letter-spacing: -0.02em;
+  color: var(--opptrix-text-primary, #1D1D1F) !important;
+  padding: 0 !important;
+  margin: 0 !important;
+}
+
+.opptrix-dialog-alert-surface .opptrix-dialog-alert-content.fui-DialogContent {
+  padding: 0 !important;
+  margin: 8px 0 0 !important;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--opptrix-text-secondary, #6B6B6B);
+}
+
+.opptrix-dialog-alert-surface .opptrix-dialog-alert-actions.fui-DialogActions {
+  display: flex !important;
+  flex-direction: row !important;
+  justify-content: flex-end !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
+  gap: 8px !important;
+  padding: 14px 0 0 !important;
+  margin: 0 !important;
+  width: 100% !important;
+  box-sizing: border-box;
+}
+
+.opptrix-dialog-alert-surface .opptrix-dialog-alert-actions .fui-Button {
+  min-width: 72px;
+  min-height: 32px;
+  margin: 0 !important;
+}
+
+.opptrix-btn-danger.fui-Button {
+  background-color: var(--opptrix-error, #D13438) !important;
+  color: #ffffff !important;
+  border: none !important;
+}
+
+.opptrix-btn-danger.fui-Button:hover {
+  background-color: var(--opptrix-error, #D13438) !important;
+  opacity: 0.92;
+}
+
+.opptrix-btn-danger.fui-Button:active {
+  opacity: 0.85;
+}
+
+[data-theme="dark"] .opptrix-dialog-alert-surface.fui-DialogSurface {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.36), 0 0 0 1px rgba(255, 255, 255, 0.08) !important;
+}
+
 .opptrix-dialog-alert-actions {
   width: 100%;
 }
@@ -940,6 +1011,332 @@ select:focus-visible {
   font-size: 12px;
   line-height: 1.45;
   color: var(--opptrix-text-tertiary, #9A9A9A);
+}
+
+html.opptrix-electron .opptrix-session-title-btn,
+html.opptrix-electron .opptrix-session-title-btn--clickable,
+html.opptrix-electron .opptrix-session-title-inline-edit,
+html.opptrix-electron .opptrix-session-title-inline-input {
+  -webkit-app-region: no-drag !important;
+  pointer-events: auto !important;
+}
+
+html.opptrix-electron .opptrix-session-title-btn:disabled {
+  pointer-events: none !important;
+}
+
+/* Chat session title — clickable tools trigger */
+.opptrix-session-title-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: 100%;
+  width: auto;
+  min-width: 0;
+  padding: 2px 6px;
+  margin: 0;
+  border: none;
+  border-radius: var(--opptrix-radius-md, 8px);
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: default;
+  text-align: left;
+  -webkit-app-region: no-drag;
+  box-sizing: border-box;
+}
+
+.opptrix-session-title-btn--clickable {
+  cursor: pointer;
+}
+
+.opptrix-session-title-btn--clickable:hover {
+  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.opptrix-session-title-btn--open {
+  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.opptrix-session-title-btn--chrome {
+  width: auto;
+  max-width: 100%;
+  margin: 0;
+  padding: 0 6px;
+  min-height: 28px;
+}
+
+.opptrix-session-title-btn__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+.opptrix-desktop-title-text {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--opptrix-text-primary, #1D1D1F);
+  letter-spacing: -0.01em;
+}
+
+.opptrix-session-title-btn__chevron {
+  flex-shrink: 0;
+  color: var(--opptrix-text-tertiary, #9A9A9A);
+  transition: transform 160ms ease;
+}
+
+.opptrix-session-title-btn__chevron--open {
+  transform: rotate(180deg);
+}
+
+.opptrix-session-title-inline-edit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+  max-width: 100%;
+  min-width: 0;
+  padding: 2px 4px;
+  border-radius: var(--opptrix-radius-md, 8px);
+  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.04));
+  box-sizing: border-box;
+  -webkit-app-region: no-drag;
+}
+
+.opptrix-session-title-inline-edit--chrome {
+  min-height: 28px;
+}
+
+.opptrix-session-title-inline-input {
+  flex: 1;
+  min-width: 72px;
+  height: 26px;
+  min-height: 26px;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.opptrix-session-title-inline-input.fui-Input,
+.opptrix-session-title-inline-input.fui-Input:hover,
+.opptrix-session-title-inline-input.fui-Input:focus-within {
+  background-color: var(--opptrix-surface-muted) !important;
+  border: none !important;
+  box-shadow: none !important;
+}
+
+.opptrix-session-title-inline-input.fui-Input::after {
+  display: none !important;
+}
+
+.opptrix-session-title-inline-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: var(--opptrix-radius-md, 8px);
+  background: transparent;
+  color: var(--opptrix-text-secondary, #6B6B6B);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+.opptrix-session-title-inline-btn:hover {
+  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.06));
+  color: var(--opptrix-text-primary, #1D1D1F);
+}
+
+html.opptrix-electron .opptrix-session-title-inline-edit,
+html.opptrix-electron .opptrix-session-title-inline-btn {
+  -webkit-app-region: no-drag !important;
+  pointer-events: auto !important;
+}
+
+/* Session title tools menus */
+.opptrix-session-tools-menu.opptrix-glass-panel,
+.opptrix-session-tools-archive.opptrix-glass-panel {
+  background: rgba(255, 255, 255, 0.48) !important;
+  backdrop-filter: blur(20px) saturate(170%);
+  -webkit-backdrop-filter: blur(20px) saturate(170%);
+  border-color: rgba(60, 60, 67, 0.09) !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 4px 12px rgba(0, 0, 0, 0.045) !important;
+}
+
+[data-theme="dark"] .opptrix-session-tools-menu.opptrix-glass-panel,
+[data-theme="dark"] .opptrix-session-tools-archive.opptrix-glass-panel {
+  background: rgba(44, 44, 46, 0.52) !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22), 0 4px 12px rgba(0, 0, 0, 0.26) !important;
+}
+
+.opptrix-session-tools-menu {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px;
+  box-sizing: border-box;
+  border-radius: var(--opptrix-radius-lg, 14px);
+  animation: opptrix-composer-tooltip-in 160ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+.opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item {
+  justify-content: flex-start;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--opptrix-text-primary, #1D1D1F);
+}
+
+.opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item svg {
+  flex-shrink: 0;
+  color: var(--opptrix-text-secondary, #6B6B6B);
+}
+
+.opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item:hover,
+.opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item--active {
+  background: rgba(255, 255, 255, 0.38);
+}
+
+[data-theme="dark"] .opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item:hover,
+[data-theme="dark"] .opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item--active {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.opptrix-session-tools-menu__archive-item {
+  justify-content: flex-start;
+}
+
+.opptrix-session-tools-menu__arrow {
+  margin-left: auto;
+  color: var(--opptrix-text-tertiary, #9A9A9A);
+}
+
+.opptrix-session-tools-menu__danger {
+  color: var(--opptrix-error, #D13438);
+}
+
+.opptrix-session-tools-menu__danger svg {
+  color: var(--opptrix-error, #D13438);
+}
+
+.opptrix-session-tools-menu__danger:hover,
+.opptrix-session-tools-menu__danger.opptrix-composer-tooltip-menu__item--active {
+  color: var(--opptrix-error, #D13438);
+}
+
+.opptrix-session-tools-archive {
+  display: flex;
+  flex-direction: column;
+  max-height: min(320px, 50vh);
+  box-sizing: border-box;
+  border-radius: var(--opptrix-radius-lg, 14px);
+  overflow: hidden;
+  animation: opptrix-composer-tooltip-in 160ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+.opptrix-session-tools-archive__head {
+  flex-shrink: 0;
+  padding: 10px 12px 8px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--opptrix-text-tertiary, #9A9A9A);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.opptrix-session-tools-archive__body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.opptrix-session-tools-archive__foot {
+  flex-shrink: 0;
+  padding: 4px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+.opptrix-session-tools-archive__folder,
+.opptrix-session-tools-archive__new {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--opptrix-text-primary, #1D1D1F);
+  text-align: left;
+  cursor: pointer;
+}
+
+.opptrix-session-tools-archive__folder:hover,
+.opptrix-session-tools-archive__new:hover {
+  background-color: rgba(255, 255, 255, 0.32);
+}
+
+.opptrix-session-tools-archive__empty {
+  padding: 12px 10px;
+  font-size: 12px;
+  color: var(--opptrix-text-tertiary, #9A9A9A);
+}
+
+.opptrix-session-tools-archive__inline {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 4px;
+  border-radius: 8px;
+  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.04));
+}
+
+.opptrix-session-tools-archive__inline-input {
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  min-height: 26px;
+  font-size: 13px;
+}
+
+.opptrix-session-tools-archive__inline-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--opptrix-text-secondary, #6B6B6B);
+  cursor: pointer;
+}
+
+.opptrix-session-tools-archive__inline-btn:hover {
+  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.06));
+  color: var(--opptrix-text-primary, #1D1D1F);
+}
+
+[data-theme="dark"] .opptrix-session-tools-archive__head,
+[data-theme="dark"] .opptrix-session-tools-archive__foot {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="dark"] .opptrix-session-tools-archive__folder:hover,
+[data-theme="dark"] .opptrix-session-tools-archive__new:hover {
+  background-color: rgba(255, 255, 255, 0.08);
 }
 
 .opptrix-composer-quick-add {

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -1682,7 +1682,24 @@ html.opptrix-electron .opptrix-session-title-inline-btn {
     pointer-events: auto;
   }
 
-  .opptrix-archive-folder-head:hover .opptrix-archive-folder-actions {
+  .opptrix-archive-folder-head:hover .opptrix-archive-folder-count {
+    opacity: 0;
+  }
+
+  .opptrix-archive-folder-head:hover .opptrix-archive-folder-rename,
+  .opptrix-archive-folder-head:hover .opptrix-archive-folder-delete,
+  .opptrix-archive-folder-head:hover .opptrix-archive-folder-clear {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .opptrix-archive-folder-head:focus-within .opptrix-archive-folder-count {
+    opacity: 0;
+  }
+
+  .opptrix-archive-folder-head:focus-within .opptrix-archive-folder-rename,
+  .opptrix-archive-folder-head:focus-within .opptrix-archive-folder-delete,
+  .opptrix-archive-folder-head:focus-within .opptrix-archive-folder-clear {
     opacity: 1;
     pointer-events: auto;
   }
@@ -1718,6 +1735,19 @@ html.opptrix-electron .opptrix-session-title-inline-btn {
   }
 
   .opptrix-follow-item:hover .opptrix-follow-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+@media (hover: none) {
+  .opptrix-archive-folder-head .opptrix-archive-folder-count {
+    display: none;
+  }
+
+  .opptrix-archive-folder-head .opptrix-archive-folder-rename,
+  .opptrix-archive-folder-head .opptrix-archive-folder-delete,
+  .opptrix-archive-folder-head .opptrix-archive-folder-clear {
     opacity: 1;
     pointer-events: auto;
   }

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -79,6 +79,9 @@ body {
   --opptrix-settings-panel-border-color: #E5E5EA;
   --opptrix-glass-surface-bg: rgba(255, 255, 255, 0.72);
   --opptrix-glass-surface-border: rgba(60, 60, 67, 0.12);
+  --opptrix-segmented-track: rgba(118, 118, 128, 0.12);
+  --opptrix-segmented-thumb-bg: rgba(255, 255, 255, 0.92);
+  --opptrix-segmented-thumb-shadow: 0 1px 2px rgba(0, 0, 0, 0.06), 0 2px 8px rgba(0, 0, 0, 0.08);
   --opptrix-overlay-sidebar-hover: #F2F2F7;
   --opptrix-overlay-sidebar-selected: #F2F2F7;
   --opptrix-motion-fast: 140ms;
@@ -143,6 +146,9 @@ body {
   --opptrix-settings-panel-border-color: #3A3A3C;
   --opptrix-glass-surface-bg: rgba(44, 44, 46, 0.72);
   --opptrix-glass-surface-border: rgba(255, 255, 255, 0.12);
+  --opptrix-segmented-track: rgba(118, 118, 128, 0.24);
+  --opptrix-segmented-thumb-bg: rgba(72, 72, 74, 0.96);
+  --opptrix-segmented-thumb-shadow: 0 1px 2px rgba(0, 0, 0, 0.32), 0 2px 8px rgba(0, 0, 0, 0.24);
   --opptrix-overlay-sidebar-hover: #3A3A3C;
   --opptrix-overlay-sidebar-selected: #48484A;
 }
@@ -655,6 +661,15 @@ select:focus-visible {
   overflow: visible !important;
 }
 
+.opptrix-dialog-alert-actions {
+  width: 100%;
+}
+
+[data-theme="dark"] .opptrix-glass-dialog-surface .fui-DialogTitle__action .fui-Button:hover,
+[data-theme="dark"] .opptrix-glass-dialog-surface .fui-DialogTitle__action button:hover {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
 /* ── Frosted glass panel / dropdown — 对齐 OpptrixDropdownPanel / 选股策略 ── */
 .opptrix-glass-panel {
   background: var(--opptrix-glass-surface-bg);
@@ -662,6 +677,61 @@ select:focus-visible {
   -webkit-backdrop-filter: blur(16px) saturate(160%);
   border: 1px solid var(--opptrix-glass-panel-border);
   box-shadow: var(--opptrix-glass-panel-shadow);
+}
+
+/* iOS-style segmented control — frosted capsule + sliding thumb */
+.opptrix-segmented-control {
+  background: var(--opptrix-segmented-track);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid var(--opptrix-glass-panel-border-color);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.opptrix-segmented-thumb {
+  background: var(--opptrix-segmented-thumb-bg);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: var(--opptrix-segmented-thumb-shadow);
+}
+
+/* Sidebar-embedded: recessed groove, flat thumb — aligns with list row hover height */
+.opptrix-segmented-control-embedded {
+  background: rgba(118, 118, 128, 0.1);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+  box-shadow:
+    inset 0 0 0 1px rgba(60, 60, 67, 0.07),
+    inset 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.opptrix-segmented-thumb-embedded {
+  background: var(--opptrix-glass-nav-selected);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border: none;
+  box-shadow: none;
+}
+
+[data-theme="dark"] .opptrix-segmented-control {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+[data-theme="dark"] .opptrix-segmented-thumb {
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="dark"] .opptrix-segmented-control-embedded {
+  background: rgba(118, 118, 128, 0.2);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.06),
+    inset 0 1px 2px rgba(0, 0, 0, 0.22);
+}
+
+[data-theme="dark"] .opptrix-segmented-thumb-embedded {
+  background: var(--opptrix-glass-nav-selected);
 }
 
 .fui-PopoverSurface.opptrix-glass-panel,
@@ -1211,6 +1281,31 @@ select:focus-visible {
   }
 
   .opptrix-session-item:hover .opptrix-session-archive {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .opptrix-archive-folder-head:hover .opptrix-archive-folder-actions {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .opptrix-archive-inline-input.fui-Input,
+  .opptrix-archive-inline-input.fui-Input:hover {
+    background-color: var(--opptrix-surface-muted) !important;
+    border: none !important;
+    box-shadow: none !important;
+  }
+
+  .opptrix-archive-inline-input.fui-Input:focus-within {
+    background-color: var(--opptrix-surface-hover) !important;
+  }
+
+  .opptrix-archive-inline-input.fui-Input::after {
+    display: none !important;
+  }
+
+  .opptrix-archive-session-item:hover .opptrix-archive-session-delete {
     opacity: 1;
     pointer-events: auto;
   }

--- a/docs/UI-DESIGN-SYSTEM.md
+++ b/docs/UI-DESIGN-SYSTEM.md
@@ -1,5 +1,7 @@
 # Opptrix UI Design System
 
+> 实现或修改 **任何** client-ui 可见界面前须先读本文与 [`UI-LAYOUT.md`](./UI-LAYOUT.md)。Agent 浮层/Dialog/Toast 规则： [`.cursor/rules/ui-overlay-components.mdc`](../.cursor/rules/ui-overlay-components.mdc)。
+
 > 参考 EchoBird 风格：**暖色浅色画布、陶土橙强调、圆角卡片、紧凑信息密度**。基于 Fluent UI v9 组件，自定义 Design Tokens。
 
 ## 1. 设计原则
@@ -113,11 +115,13 @@
 **实现**：
 
 - 全局类：`.opptrix-glass-panel`（`global.css`）
-- Dialog：`.opptrix-glass-dialog-surface`（Fluent `DialogSurface`）
+- 二次确认 Dialog：`.opptrix-glass-dialog-surface` + `OpptrixDialogAlert`（`components/opptrix/OpptrixDialogAlert.tsx`）
+- 复杂表单 Dialog：`.opptrix-dialog-surface`（Fluent `DialogSurface`）
 - Mixins：`glassDropdown`、`glassPanel`（`theme/mixins.ts`）
 - Tokens：`glass`、`glassBlur`、`surfaceGlass`（`theme/tokens.ts`）
 
-**原则**：面板与 Dialog **默认毛玻璃**；实体卡片（SurfaceCard、列表行）仍用 `surface` 实底 + 轻描边，不用毛玻璃。
+**原则**：浮层与二次确认 Dialog **默认毛玻璃**；实体卡片（SurfaceCard、列表行）仍用 `surface` 实底 + 轻描边，不用毛玻璃。  
+**Agent 规则**：`.cursor/rules/ui-overlay-components.mdc`（组件选型表与禁止项）。
 
 ## 6. Layout Constants
 
@@ -173,8 +177,22 @@
 - 发现页策略下拉、设置抽屉、Follow 对话框、SkillSheet 等浮层使用 **§5.1 毛玻璃**
 - 类名 `.opptrix-glass-panel` 或 mixin `glassDropdown`
 - 列表内选项 Hover：半透明白底 `rgba(255,255,255,0.45)`，不用实体灰块
+- 自定义锚定面板：`OpptrixDropdownPanel`；Fluent 下拉 listbox：`mergeOpptrixDropdownListboxProps`
 
-### 7.8 TabList
+### 7.8 浮层与反馈（统一组件）
+
+| 场景 | 组件 | 样式类 / Provider |
+|------|------|-------------------|
+| 二次确认（删除、清空等） | `OpptrixDialogAlert`、`useOpptrixDialogAlert()` | `.opptrix-glass-dialog-surface`；根节点 `OpptrixDialogAlertProvider`（`main.tsx`） |
+| 复杂表单 Dialog | Fluent `Dialog` + `OpptrixField` 等 | `.opptrix-dialog-surface` |
+| 操作结果 Toast | `useSettingsToast()` | `SettingsToastProvider`（设置页等）；mixin `glassPanel` |
+| 侧栏内联确认 | 列表行内 `inlineEditRow` + 按钮 | 与行同高，不用 Dialog |
+| 分段 Tab（胶囊） | `OpptrixSegmentedControl` | `.opptrix-segmented-control`；侧栏用 `variant="embedded"` |
+
+**禁止**：`window.confirm` / `alert` / `prompt`；无类名的裸 `DialogSurface`。  
+细则：`.cursor/rules/ui-overlay-components.mdc`。
+
+### 7.9 TabList
 
 - Fluent Tab `appearance="subtle"` 或自定义 pill
 - 选中：白底 + shadow-card + accent 下划线

--- a/docs/UI-LAYOUT.md
+++ b/docs/UI-LAYOUT.md
@@ -1,5 +1,7 @@
 # Opptrix UI Layout
 
+> 实现 UI 前请先读 [`UI-DESIGN-SYSTEM.md`](./UI-DESIGN-SYSTEM.md)（色彩、组件、毛玻璃）与本文件（布局）。浮层 / Dialog / Toast 选型见 [`.cursor/rules/ui-overlay-components.mdc`](../.cursor/rules/ui-overlay-components.mdc)。
+
 ## 1. 整体结构（EchoBird 三栏）
 
 ```
@@ -21,7 +23,7 @@
 - **Sidebar**：全高固定，不随主区滚动
 - **Main Canvas**：暖色 canvas 背景，内部卡片为 surface 白
 - **Agent Panel**：右侧滑入，与 EchoBird「会话记录」栏同位；关闭时主区占满
-- **浮层面板**：Dialog、下拉、抽屉统一毛玻璃（见 `UI-DESIGN-SYSTEM.md` §5.1）
+- **浮层面板**：Dialog、下拉、抽屉统一毛玻璃（见 `UI-DESIGN-SYSTEM.md` §5.1、§7.8）；二次确认用 `OpptrixDialogAlert`
 
 ### 1.1 Chat 主界面（当前默认入口）
 

--- a/packages/agent/src/archive-folders.ts
+++ b/packages/agent/src/archive-folders.ts
@@ -51,4 +51,26 @@ export class SessionArchiveFolderStore {
     this.save([...folders, folder])
     return folder
   }
+
+  rename(id: string, title: string): SessionArchiveFolder | null {
+    const folders = this.ensureDefaults()
+    const idx = folders.findIndex(f => f.id === id)
+    if (idx < 0) return null
+    if (folders[idx]!.isDefault) return null
+    const trimmed = title.trim()
+    if (!trimmed) return folders[idx]!
+    const next = folders.slice()
+    next[idx] = { ...next[idx]!, title: trimmed }
+    this.save(next)
+    return next[idx]!
+  }
+
+  /** 仅允许删除用户创建的文件夹 */
+  delete(id: string): boolean {
+    const folders = this.ensureDefaults()
+    const folder = folders.find(f => f.id === id)
+    if (!folder || folder.isDefault) return false
+    this.save(folders.filter(f => f.id !== id))
+    return true
+  }
 }

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -111,8 +111,28 @@ export class AgentEngine {
     return this.sessions.listArchivedGrouped()
   }
 
+  listAllArchivedByFolder() {
+    return this.sessions.listArchivedByFolderAll()
+  }
+
   listSessionArchiveFolders() {
     return this.sessions.listArchiveFolders()
+  }
+
+  createSessionArchiveFolder(title: string) {
+    return this.sessions.createArchiveFolder(title)
+  }
+
+  renameSessionArchiveFolder(id: string, title: string) {
+    return this.sessions.renameArchiveFolder(id, title)
+  }
+
+  deleteSessionArchiveFolder(id: string) {
+    return this.sessions.deleteArchiveFolder(id)
+  }
+
+  clearSessionArchiveFolder(id: string) {
+    return this.sessions.clearArchiveFolder(id)
   }
 
   archiveSession(id: string, folderId: string) {

--- a/packages/agent/src/sessions.ts
+++ b/packages/agent/src/sessions.ts
@@ -251,11 +251,14 @@ export class SessionStore {
 
   archive(id: string, folderId: string): SessionRecord | null {
     const record = this.get(id)
-    if (!record || isArchived(record)) return null
+    if (!record) return null
     const folder = this.folderStore.get(folderId) ?? this.folderStore.get('other')
     if (!folder) return null
-    record.archivedAt = new Date().toISOString()
+    if (!isArchived(record)) {
+      record.archivedAt = new Date().toISOString()
+    }
     record.archiveFolderId = folder.id
+    record.updatedAt = new Date().toISOString()
     writeRecord(record)
     return record
   }

--- a/packages/agent/src/sessions.ts
+++ b/packages/agent/src/sessions.ts
@@ -171,6 +171,54 @@ export class SessionStore {
     })).filter(g => g.sessions.length > 0)
   }
 
+  /** 归档侧栏：展示全部文件夹（含空文件夹） */
+  listArchivedByFolderAll(): Array<{ folder: import('./archive-folders.js').SessionArchiveFolder; sessions: SessionMeta[] }> {
+    const folders = this.folderStore.ensureDefaults()
+    const archived = this.listAll().filter(s => s.archivedAt)
+    return folders.map(folder => ({
+      folder,
+      sessions: archived
+        .filter(s => (s.archiveFolderId || 'other') === folder.id)
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+    }))
+  }
+
+  createArchiveFolder(title: string) {
+    return this.folderStore.create(title)
+  }
+
+  renameArchiveFolder(id: string, title: string) {
+    return this.folderStore.rename(id, title)
+  }
+
+  deleteArchiveFolder(id: string): { ok: boolean; movedCount: number } {
+    const folder = this.folderStore.get(id)
+    if (!folder || folder.isDefault) return { ok: false, movedCount: 0 }
+    let movedCount = 0
+    for (const meta of this.listAll()) {
+      if (!meta.archivedAt || (meta.archiveFolderId || 'other') !== id) continue
+      const record = this.get(meta.id)
+      if (!record) continue
+      record.archiveFolderId = 'other'
+      writeRecord(record)
+      movedCount += 1
+    }
+    const ok = this.folderStore.delete(id)
+    return { ok, movedCount }
+  }
+
+  clearArchiveFolder(id: string): { ok: boolean; deletedCount: number } {
+    const folder = this.folderStore.get(id)
+    if (!folder) return { ok: false, deletedCount: 0 }
+    let deletedCount = 0
+    for (const meta of this.listAll()) {
+      if (!meta.archivedAt || (meta.archiveFolderId || 'other') !== id) continue
+      this.delete(meta.id)
+      deletedCount += 1
+    }
+    return { ok: true, deletedCount }
+  }
+
   get(id: string): SessionRecord | null {
     const raw = getUserDataStore().getDocument<SessionRecord>(NAMESPACE, id)
     if (!raw) return null

--- a/tests/search-archive.test.mjs
+++ b/tests/search-archive.test.mjs
@@ -46,6 +46,44 @@ test('listActive hides archived sessions', async () => {
   getUserDataStore().close()
 })
 
+test('archived session can move to another folder', async () => {
+  const { SessionStore } = await import('../packages/agent/dist/sessions.js')
+  const { getUserDataStore } = await import('../packages/user-store/dist/index.js')
+
+  const sessions = new SessionStore()
+  const s = sessions.create('已归档')
+  sessions.archive(s.id, 'research')
+
+  const moved = sessions.archive(s.id, 'trades')
+  assert.ok(moved)
+  assert.equal(moved.archiveFolderId, 'trades')
+  assert.ok(moved.archivedAt)
+
+  const grouped = sessions.listArchivedByFolderAll()
+  const trades = grouped.find(g => g.folder.id === 'trades')
+  assert.ok(trades?.sessions.some(x => x.id === s.id))
+
+  getUserDataStore().close()
+})
+
+test('default folders can be cleared', async () => {
+  const { SessionStore } = await import('../packages/agent/dist/sessions.js')
+  const { getUserDataStore } = await import('../packages/user-store/dist/index.js')
+
+  const sessions = new SessionStore()
+  const a = sessions.create('A')
+  const b = sessions.create('B')
+  sessions.archive(a.id, 'review')
+  sessions.archive(b.id, 'review')
+
+  const result = sessions.clearArchiveFolder('review')
+  assert.equal(result.ok, true)
+  assert.equal(result.deletedCount, 2)
+  assert.equal(sessions.listArchivedByFolderAll().find(g => g.folder.id === 'review')?.sessions.length, 0)
+
+  getUserDataStore().close()
+})
+
 test('FTS indexes and searches session content', async () => {
   const { getUserDataStore } = await import('../packages/user-store/dist/index.js')
 


### PR DESCRIPTION
## Summary
- Add sidebar 对话/归档 tabs with folder CRUD, inline rename/delete, and hover trailing actions aligned to the session list
- Add chat title tools menu (rename, archive move, delete, export) with unified OpptrixDialogAlert confirmations
- Enable clear on all default archive folders; fix re-archiving archived sessions (move folder) instead of session not found
- Fix Electron title bar drag region to resume after measured title width

## Test plan
- [x] `npm run test:ci`
- [x] Sidebar archive tab: default folders collapsed, hover clear on 投研精选/操作记录/待复盘/其他
- [x] User folders: hover rename/delete icons
- [x] Re-archive an archived chat via title menu → moves folder without error
- [x] Title bar drag works in blank area right of chat title


Made with [Cursor](https://cursor.com)