### PR TITLE
fix(instrument-ref): disambiguate A/H same-code numeric inputs

### DIFF
--- a/client-ui/src/layout/MainHeader.tsx
+++ b/client-ui/src/layout/MainHeader.tsx
@@ -4,7 +4,7 @@ import {
 } from '@fluentui/react-components'
 import { BotRegular, DismissRegular, ArrowSyncRegular } from '@fluentui/react-icons'
 import { research } from '../api/client'
-import { hitToWatchlistItem, parseInstrumentInput, toStockContext, marketDisplayName } from '../market/instrument'
+import { hitToWatchlistItem, isAmbiguousNumericCode, isUnambiguousCnDigits, parseInstrumentInput, tryParseInstrumentInput, toStockContext, marketDisplayName } from '../market/instrument'
 import { useApp } from '../context/AppContext'
 import type { FeatureRoute } from '../types/schemas'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
@@ -51,14 +51,27 @@ export default function MainHeader({ onNavigate, onRefresh }: Props) {
     try {
       const resp = await research.searchInstruments(q, 10)
       if (resp.success && resp.data?.items?.length) {
-        setGlobalStock(toStockContext(hitToWatchlistItem(resp.data.items[0])))
+        // 对纯数字短码，选择"symbol 精确匹配"的命中优先（避免 700 → 含 "700" 的名称匹配）；
+        // 若有多个市场精确同码（A/H 同时存在），默认取第一条（搜索已按 CN→HK 排序，
+        // 用户可从结果列表里再选港股，下方股票 chip 会显示市场后缀）。
+        const items = resp.data.items
+        const digits = q.replace(/\D/g, '')
+        let pick = items[0]!
+        if (digits && digits.length <= 5) {
+          const exact = items.find(it => it.instrument.symbol.replace(/^0+/, '') === digits
+            || it.instrument.symbol === digits.padStart(5, '0'))
+          if (exact) pick = exact
+        }
+        setGlobalStock(toStockContext(hitToWatchlistItem(pick)))
       } else {
-        const ref = parseInstrumentInput(q)
+        // 无搜索结果：明确 6 位 A 股/带前缀代码可本地解析；短数字码歧义保守兜底为 CN，
+        // 但保留原始长度（不 padStart 到 6 位），避免把 "700" 误当 "000700"。
+        const ref = tryParseInstrumentInput(q) ?? parseInstrumentInput(q)
         setGlobalStock({ code: q, name: '', instrument: ref })
       }
       onNavigate('stock_research')
     } catch {
-      const ref = parseInstrumentInput(q)
+      const ref = tryParseInstrumentInput(q) ?? parseInstrumentInput(q)
       setGlobalStock({ code: q, name: '', instrument: ref })
       onNavigate('stock_research')
     }

--- a/client-ui/src/market/instrument.ts
+++ b/client-ui/src/market/instrument.ts
@@ -9,6 +9,21 @@ const HK_PREFIX = /^HK:/i
 const JP_PREFIX = /^JP:/i
 const KR_PREFIX = /^KR:/i
 
+/**
+ * 裸数字代码跨市场歧义检测（与 @opptrix/shared 对齐）：
+ * - 6 位纯数字 → A 股（无歧义）
+ * - 1-5 位纯数字 → 可能是港股 5 位码、日韩代码、或省略前导 0 的 A 股短写，
+ *   需要经 instrument_search 跨市场搜索消歧，不能直接判为 A 股。
+ */
+export function isUnambiguousCnDigits(raw: string): boolean {
+  return /^\d{6}$/.test(raw.trim())
+}
+
+export function isAmbiguousNumericCode(raw: string): boolean {
+  const s = raw.trim()
+  return /^\d{1,5}$/.test(s)
+}
+
 export function parseInstrumentInput(raw: string): InstrumentRef {
   const input = raw.trim()
   if (!input) {
@@ -47,7 +62,10 @@ export function parseInstrumentInput(raw: string): InstrumentRef {
     const symbol = digits ? digits.padStart(6, '0') : sym.toUpperCase()
     return { market: 'KR', assetClass: 'EQUITY', symbol }
   }
-  if (/^\d+$/.test(input) && input.length <= 6) {
+  // 6 位纯数字 → A 股（无歧义）。1-5 位数字仍兜底为 A 股以保持调用方非空约定，
+  // 但入口（主搜索/聊天 @ 提及等）应先用 isAmbiguousNumericCode 判断，
+  // 短码必须先走跨市场 instrument_search 获取带正确 market 的 ref。
+  if (/^\d{6}$/.test(input)) {
     const sym = normalizeCode(input)
     const assetClass = isCnEtfCode(sym) ? 'ETF' : isCnIndexCode(sym) ? 'INDEX' : 'EQUITY'
     return { market: 'CN', assetClass, symbol: sym }
@@ -62,7 +80,36 @@ export function parseInstrumentInput(raw: string): InstrumentRef {
       return { market: 'CRYPTO', assetClass: 'CRYPTO_SPOT', symbol: base, quote }
     }
   }
+  // 短数字码兜底：不 padStart 到 6 位，保留原始长度作为 CN symbol，
+  // 避免把 "700" 错当 "000700"（不存在的 A 股），让上层至少能看出异常。
+  if (/^\d+$/.test(input)) {
+    return { market: 'CN', assetClass: 'EQUITY', symbol: input }
+  }
   return { market: 'CN', assetClass: 'EQUITY', symbol: normalizeCode(input) }
+}
+
+/**
+ * 严格解析：可明确判定 market 的输入才返回 InstrumentRef；
+ * 跨市场歧义（1-5 位纯数字等）返回 null，调用方应走 instrument_search 消歧。
+ */
+export function tryParseInstrumentInput(raw: string): InstrumentRef | null {
+  const input = raw.trim()
+  if (!input) return null
+  // 带前缀 / 6 位纯数字 / 字母 ticker / crypto 对 → 复用 parseInstrumentInput 判定
+  if (US_PREFIX.test(input) || CRYPTO_PREFIX.test(input) || HK_PREFIX.test(input)
+    || JP_PREFIX.test(input) || KR_PREFIX.test(input)) {
+    return parseInstrumentInput(input)
+  }
+  if (isUnambiguousCnDigits(input)) return parseInstrumentInput(input)
+  if (/^[A-Z][A-Z0-9.-]{0,11}$/i.test(input) && !/^\d+$/.test(input)) {
+    return parseInstrumentInput(input)
+  }
+  if ((input.includes('/') || input.includes('-'))
+    && /^[A-Z0-9]+[\/\-][A-Z0-9]+$/i.test(input)) {
+    return parseInstrumentInput(input)
+  }
+  // 1-5 位纯数字等歧义场景 → null，交给搜索层
+  return null
 }
 
 /** CN A-share / ETF instrument ref from a bare code or alias string. */
@@ -88,7 +135,8 @@ export function isLikelyCnEquityInput(raw: string): boolean {
   if (/^(US|HK|JP|KR|CRYPTO|NYSE|NASDAQ|AMEX|BINANCE|OKX):/i.test(s)) return false
   if (s.includes('/')) return false
   if (/^[A-Z][A-Z0-9.-]{0,11}$/i.test(s) && !/^\d+$/.test(s)) return false
-  return /^\d{1,6}$/.test(s)
+  // 仅 6 位纯数字无歧义判为 A 股；1-5 位交由跨市场搜索消歧
+  return isUnambiguousCnDigits(s)
 }
 
 /** 与 @opptrix/shared instrumentRefKey 保持一致：symbol → quote → exchange */

--- a/packages/a-stock-layer/src/core/instrument.ts
+++ b/packages/a-stock-layer/src/core/instrument.ts
@@ -96,13 +96,17 @@ export function toInstrumentRef(
   return normalizeInstrumentRef({ market: 'US', assetClass: 'EQUITY', symbol: raw })
 }
 
-/** Heuristic: crypto pair → US ticker → CN 6-digit */
+/** Heuristic: crypto pair → US ticker → CN 6-digit.
+ *  1-5 位纯数字有跨市场歧义（港股 5 位码/日韩/省略前导 0 的 A 股短写），
+ *  不在这里武断归 CN；返回 'CN' 仅作为兜底，上层应优先经 parseCanonicalInstrumentInput
+ *  与 instrument_search 消歧后再构造 InstrumentRef。 */
 export function inferMarketFromSymbol(raw: string): Market {
   if (/^(US|NYSE|NASDAQ|AMEX):/i.test(raw.trim())) return 'US'
   if (/^(CRYPTO|BINANCE|OKX):/i.test(raw.trim())) return 'CRYPTO'
   if (isCryptoPairNotation(raw)) return 'CRYPTO'
   const s = raw.trim()
-  if (/^\d+$/.test(s) && s.length <= 6) return 'CN'
+  // 仅 6 位纯数字可无歧义判为 A 股；短数字码交由上层搜索消歧。
+  if (/^\d{6}$/.test(s)) return 'CN'
   if (isValidUsSymbol(s)) return 'US'
   return 'CN'
 }

--- a/packages/shared/src/instrument-ref.ts
+++ b/packages/shared/src/instrument-ref.ts
@@ -61,5 +61,7 @@ export function isLikelyCnEquityInput(raw: string): boolean {
   if (/^(US|HK|JP|KR|CRYPTO|NYSE|NASDAQ|AMEX|BINANCE|OKX):/i.test(s)) return false
   if (s.includes('/')) return false
   if (/^[A-Z][A-Z0-9.-]{0,11}$/i.test(s) && !/^\d+$/.test(s)) return false
+  // 保守兜底：1-6 位数字都可能是 A 股（含省略前导 0 的短写），但 1-5 位存在跨市场歧义，
+  // 调用方应用 isAmbiguousNumericCode 进一步判断并走 instrument_search 消歧。
   return /^\d{1,6}$/.test(s)
 }

--- a/packages/shared/src/instrument-symbol.ts
+++ b/packages/shared/src/instrument-symbol.ts
@@ -17,6 +17,21 @@ export function canonicalCnSymbol(symbol: string): string {
   return digits.padStart(6, '0')
 }
 
+/**
+ * 裸数字代码存在跨市场歧义：A 股固定 6 位，港股为 5 位（含前导 0），
+ * 日韩也使用 4-6 位数字。只有输入为精确 6 位纯数字时才能无歧义判为 A 股；
+ * 1-5 位数字需要上层经 instrument_search 跨市场搜索消歧，不能本地直接归 CN。
+ */
+export function isUnambiguousCnDigits(raw: string): boolean {
+  return /^\d{6}$/.test(raw.trim())
+}
+
+/** 1-5 位纯数字 — 可能是港股（00700）、日韩股票、或省略前导 0 的 A 股简写，需要搜索消歧 */
+export function isAmbiguousNumericCode(raw: string): boolean {
+  const s = raw.trim()
+  return /^\d{1,5}$/.test(s)
+}
+
 /** 美股 ticker — 大写、去交易所前缀 */
 export function canonicalUsSymbol(symbol: string): string {
   let s = symbol.trim().toUpperCase().replace(/^(US|NYSE|NASDAQ|AMEX):/i, '')
@@ -173,13 +188,28 @@ export function parseCanonicalInstrumentInput(raw: string): InstrumentRef | null
     })
   }
 
-  if (/^\d{1,6}$/.test(text)) {
+  // 6 位纯数字 → A 股（A 股代码段固定 6 位，CN 内部可继续区分 SH/SZ/BJ/ETF/INDEX），
+  // 本地解析无歧义。1-5 位数字属于跨市场歧义码（港股 5 位码如 00700、日韩代码、省略前导 0 的
+  // A 股短写）：不直接当错，兜底按 A 股原样 symbol 构造（不 padStart 到 6 位），
+  // 但调用方应优先经 instrument_search 跨市场搜索拿到带正确 market 的 ref。
+  // 可用 isAmbiguousNumericCode(text) 判断并走搜索路径。
+  if (isUnambiguousCnDigits(text)) {
     const symbol = canonicalCnSymbol(text)
     return normalizeInstrumentRef({
       market: 'CN',
       assetClass: inferCnAssetClassFromSymbol(symbol),
       symbol,
     })
+  }
+  if (isAmbiguousNumericCode(text)) {
+    // 跨市场歧义的短数字码（1-5 位）：不经过 canonicalCnSymbol 规范化（避免 padStart 到 6 位
+    // 把 "700" 错当 "000700"），返回一个 symbol 为原码的 CN EQUITY ref 作为兜底。
+    // 调用方应优先用 isAmbiguousNumericCode(text) 判断并经 instrument_search 消歧。
+    return {
+      market: 'CN',
+      assetClass: 'EQUITY',
+      symbol: text.trim(),
+    }
   }
 
   if (/^[A-Z][A-Z0-9.-]{0,11}$/i.test(text) && !/^\d+$/.test(text)) {


### PR DESCRIPTION
## Summary

When users typed short numeric codes like `002851`, `700`, `2851`, `9988`, all parser layers (`parseCanonicalInstrumentInput`, `inferMarketFromSymbol`, client `parseInstrumentInput`) unconditionally left-padded them to 6 digits and classified them as CN A-shares. HK 5-digit codes (e.g. 00700 Tencent, 02851 HK 002851 counterpart) could only be reached via an explicit `HK:` prefix or by picking a cross-market search result — bare numeric short codes silently routed to the wrong market.

**Fix:**
- Add `isUnambiguousCnDigits` (exactly 6 digits) and `isAmbiguousNumericCode` (1-5 digits) helpers in shared/client layers
- 6-digit bare codes still parse as CN A-shares (A-share codes are fixed-length 6, internally unambiguous)
- 1-5 digit bare codes treated as cross-market ambiguous: parser returns a CN EQUITY ref with the raw (un-padded) symbol as a conservative fallback so existing call sites don't break, but search-capable callers (main header search, @-mention picker) MUST run the code through `instrument_search` first to get the correct market-qualified ref
- Client `parseInstrumentInput` no longer left-pads sub-6-digit numeric input (so `700` stays `700` instead of becoming the non-existent A-share `000700`)
- Add strict `tryParseInstrumentInput` that returns null for ambiguous codes for callers that want to force a search round-trip
- MainHeader search: for short numeric queries, prefer exact symbol matches from cross-market results over CN-first ordering so `700` resolves to `00700.HK` rather than an unrelated name hit; only fall back to local parse when online search returns nothing

This keeps existing Agent/Hub CN paths working (they still get a CN ref as a safety net) while ensuring primary user-facing entry points resolve HK and other regional codes correctly when users type the bare number.

## Files changed

- `client-ui/src/layout/MainHeader.tsx` — main header search disambiguation logic
- `client-ui/src/market/instrument.ts` — client parser helpers + `tryParseInstrumentInput`
- `packages/a-stock-layer/src/core/instrument.ts` — `inferMarketFromSymbol` guards
- `packages/shared/src/instrument-ref.ts` — `isLikelyCnEquityInput` updated
- `packages/shared/src/instrument-symbol.ts` — `parseCanonicalInstrumentInput` guards + exported helpers

## Test plan

- [ ] Type `700` in main header search → resolves to `00700.HK` (Tencent)
- [ ] Type `00700` in main header search → resolves to `00700.HK`
- [ ] Type `9988` in main header search → resolves to `09988.HK` (Alibaba)
- [ ] Type `002851` → resolves to CN `002851` (not padded/converted)
- [ ] Type `600519` → resolves to CN `600519` (Maotai, 6-digit unambiguous)
- [ ] Agent/Hub paths still get CN ref as fallback when search unavailable
- [ ] No TypeScript errors (`tsc --noEmit` clean for modified files)

Made with [Cursor](https://cursor.com)