### PR TITLE
feat(agent): ask_user 交互确认工具与毛玻璃选择题面板

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -911,8 +911,56 @@ app.post<{ Params: { id: string }; Body: { message: string; selected_text: strin
 app.post<{ Params: { id: string } }>('/api/sessions/:id/chat/cancel', async (req, reply) => {
   const cancelled = cancelSessionChat(req.params.id)
   if (!cancelled) return reply.code(404).send({ error: 'no active chat' })
+  agent.userPromptBridge.cancelSession(req.params.id)
   return { cancelled: true }
 })
+
+app.post<{
+  Params: { id: string }
+  Body: {
+    prompt_id: string
+    kind: 'option' | 'custom'
+    selected_ids?: string[]
+    selected_labels?: string[]
+    custom_text?: string
+  }
+}>(
+  '/api/sessions/:id/chat/user-prompt',
+  async (req, reply) => {
+    const promptId = req.body?.prompt_id?.trim()
+    if (!promptId) return reply.code(400).send({ error: 'prompt_id required' })
+
+    const kind = req.body?.kind
+    if (kind !== 'option' && kind !== 'custom') {
+      return reply.code(400).send({ error: 'kind must be option or custom' })
+    }
+
+    const selectedIds = Array.isArray(req.body.selected_ids)
+      ? req.body.selected_ids.map(id => String(id).trim()).filter(Boolean)
+      : []
+    const selectedLabels = Array.isArray(req.body.selected_labels)
+      ? req.body.selected_labels.map(label => String(label).trim()).filter(Boolean)
+      : []
+    const customText = typeof req.body.custom_text === 'string'
+      ? req.body.custom_text.trim()
+      : ''
+
+    if (kind === 'custom') {
+      if (!customText) return reply.code(400).send({ error: 'custom_text required for kind=custom' })
+    } else if (!selectedIds.length || !selectedLabels.length) {
+      return reply.code(400).send({ error: 'selected_ids and selected_labels required for kind=option' })
+    }
+
+    const ok = agent.resolveUserPrompt(req.params.id, promptId, {
+      kind,
+      selected_ids: selectedIds,
+      selected_labels: selectedLabels,
+      custom_text: kind === 'custom' ? customText : undefined,
+    })
+    if (!ok) return reply.code(404).send({ error: 'no pending user prompt' })
+    return { ok: true }
+  },
+)
 
 app.post<{ Params: { id: string }; Body: { message: string; model?: string } }>(
   '/api/sessions/:id/chat/stream',

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1423,6 +1423,26 @@ export async function cancelSessionChat(sessionId: string) {
   })
 }
 
+export async function submitUserPromptResponse(
+  sessionId: string,
+  promptId: string,
+  answer: {
+    kind: 'option' | 'custom'
+    selected_ids?: string[]
+    selected_labels?: string[]
+    custom_text?: string
+  },
+) {
+  return jsonFetch<{ ok: boolean }>(`/sessions/${sessionId}/chat/user-prompt`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      prompt_id: promptId,
+      ...answer,
+    }),
+  }, CHAT_REQUEST_TIMEOUT)
+}
+
 export async function streamSessionChat(
   sessionId: string,
   message: string,

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -14,6 +14,7 @@ import {
   listSessions, createSession, getSession, deleteSession, forkSession, clearSessionContext,
   setSessionContext, ephemeralAsk,
   streamSessionChat, cancelSessionChat, getHealth, listAvailableModels, setSessionModel,
+  submitUserPromptResponse,
   archiveSession,
   listArchivedSessions, createSessionArchiveFolder, renameSessionArchiveFolder, deleteSessionArchiveFolder,
   clearSessionArchiveFolder, renameSession,
@@ -22,7 +23,7 @@ import type {
   ChatDisplayMessage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
   SessionMeta, AvailableModel,
 } from '../types/chat'
-import type { ChatLiveTrace } from '../types/chatProgress'
+import type { ChatLiveTrace, ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
 import type { FeedArticle } from '../types/schemas'
 import { previewSelectionText } from '../utils/formatContextRefPreview'
 import { feedArticleToContextRef } from '../pages/news/newsUtils'
@@ -232,6 +233,8 @@ export default function ChatApp() {
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)
   const [liveTrace, setLiveTrace] = useState<ChatLiveTrace | null>(null)
+  const [pendingUserPrompt, setPendingUserPrompt] = useState<ChatUserPromptPayload | null>(null)
+  const [userPromptSubmitting, setUserPromptSubmitting] = useState(false)
   const [error, setError] = useState('')
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
   const [sessionModel, setSessionModelState] = useState<string | undefined>()
@@ -644,6 +647,8 @@ export default function ChatApp() {
     setInput('')
     setLoading(true)
     setLiveTrace({ steps: [], thinkingLabel: '模型正在思考…' })
+    setPendingUserPrompt(null)
+    setUserPromptSubmitting(false)
     setError('')
 
     const optimistic: ChatDisplayMessage = {
@@ -668,6 +673,15 @@ export default function ChatApp() {
           }))
           return
         }
+        if (event.type === 'user_prompt') {
+          setPendingUserPrompt(event.prompt)
+          setLiveTrace(prev => ({
+            steps: prev?.steps ?? [],
+            thinkingLabel: '等待你的确认…',
+            thinkingSnippet: prev?.thinkingSnippet,
+          }))
+          return
+        }
         if (event.type === 'tool_start') {
           setLiveTrace(prev => ({
             thinkingLabel: prev?.thinkingLabel,
@@ -677,6 +691,9 @@ export default function ChatApp() {
           return
         }
         if (event.type === 'tool_done') {
+          if (event.step.tool === 'ask_user') {
+            setPendingUserPrompt(null)
+          }
           setLiveTrace(prev => ({
             thinkingLabel: prev?.thinkingLabel ?? '模型正在整理结果…',
             thinkingSnippet: prev?.thinkingSnippet,
@@ -743,9 +760,27 @@ export default function ChatApp() {
       chatAbortRef.current = null
       stoppingRef.current = false
       setLiveTrace(null)
+      setPendingUserPrompt(null)
+      setUserPromptSubmitting(false)
       setLoading(false)
     }
   }
+
+  const handleUserPromptSubmit = useCallback(async (answer: UserPromptAnswerPayload) => {
+    const sid = activeId
+    const prompt = pendingUserPrompt
+    if (!sid || !prompt || userPromptSubmitting) return
+    setUserPromptSubmitting(true)
+    setError('')
+    try {
+      await submitUserPromptResponse(sid, prompt.id, answer)
+      setPendingUserPrompt(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '提交失败，请重试')
+    } finally {
+      setUserPromptSubmitting(false)
+    }
+  }, [activeId, pendingUserPrompt, userPromptSubmitting])
 
   const handleForkFromMessage = async (messageIndex: number) => {
     if (!activeId) return
@@ -1144,6 +1179,9 @@ export default function ChatApp() {
                     chatColumnVisible={chatVisible}
                     onToggleRightPanel={!isMobile ? handleToggleRightPanel : undefined}
                     onToggleChatColumn={!isMobile && canToggleChatColumn ? handleToggleChatColumn : undefined}
+                    userPrompt={pendingUserPrompt}
+                    userPromptSubmitting={userPromptSubmitting}
+                    onUserPromptSubmit={pendingUserPrompt ? handleUserPromptSubmit : undefined}
                   />
                 </div>
               </div>

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -6,10 +6,12 @@ import ComposerContextRefTag from './ComposerContextRefTag'
 import ComposerStockRefTag from './ComposerStockRefTag'
 import ComposerQuickTasks from './ComposerQuickTasks'
 import ComposerStockMentionList from './ComposerStockMentionList'
+import ComposerAgentUserPromptPanel from './ComposerAgentUserPromptPanel'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import { useWatchlist } from '../market/useWatchlist'
 import { useStockMention } from './useStockMention'
 import type { AvailableModel, SessionContextRef } from '../types/chat'
+import type { ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
 import type { WatchlistItem } from '../types/market'
 import { composeComposerMessage, mergeStockRef, stockRefKey } from './composerMessage'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
@@ -248,6 +250,9 @@ interface ChatComposerProps {
   onStop?: () => void
   onModelChange?: (ref: string) => void
   onClearContextRef?: () => void
+  userPrompt?: ChatUserPromptPayload | null
+  userPromptSubmitting?: boolean
+  onUserPromptSubmit?: (answer: UserPromptAnswerPayload) => void
 }
 
 export default function ChatComposer({
@@ -266,6 +271,9 @@ export default function ChatComposer({
   onStop,
   onModelChange,
   onClearContextRef,
+  userPrompt = null,
+  userPromptSubmitting = false,
+  onUserPromptSubmit,
 }: ChatComposerProps) {
   const s = useStyles()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -344,7 +352,8 @@ export default function ChatComposer({
     setStockRefs([])
   }, [input, loading, onSubmit, stockRefs])
 
-  const canSend = Boolean(input.trim() || stockRefs.length) && !loading
+  const canSend = Boolean(input.trim() || stockRefs.length) && !loading && !userPrompt
+  const composerLocked = loading || Boolean(userPrompt)
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (mentionState.open && mentionMatches.length) {
@@ -419,6 +428,13 @@ export default function ChatComposer({
 
       <div className={s.panelWrap}>
         <div className={s.panelGround} aria-hidden />
+        {userPrompt && onUserPromptSubmit && (
+          <ComposerAgentUserPromptPanel
+            prompt={userPrompt}
+            submitting={userPromptSubmitting}
+            onSubmit={onUserPromptSubmit}
+          />
+        )}
         <div className={mergeClasses(s.panel, 'opptrix-composer-shell')}>
           <div className={s.inputRow}>
             <span ref={mentionAnchorRef} className={s.mentionAnchor} aria-hidden />
@@ -450,14 +466,14 @@ export default function ChatComposer({
               onKeyUp={handleTextareaSelect}
               placeholder={isMobile ? '输入问题，@ 选择股票…' : '输入问题，@ 选择关注股票，Enter 发送…'}
               rows={ROWS}
-              disabled={loading}
+              disabled={composerLocked}
               enterKeyHint="send"
             />
           </div>
           <div className={s.toolbar}>
             <div className={s.toolbarLeft}>
               <ComposerQuickTasks
-                disabled={loading}
+                disabled={composerLocked}
                 onApply={handleApplyQuickTask}
               />
             </div>
@@ -466,7 +482,7 @@ export default function ChatComposer({
                 <ModelSelector
                   models={availableModels}
                   value={sessionModel}
-                  disabled={loading}
+                  disabled={composerLocked}
                   isMobile={isMobile}
                   compact
                   onChange={onModelChange}

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -6,7 +6,7 @@ import type {
   ChatDisplayMessage, EphemeralAskTurn, MessageSelection, SessionContextRef,
   AvailableModel,
 } from '../types/chat'
-import type { ChatLiveTrace } from '../types/chatProgress'
+import type { ChatLiveTrace, ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
 import MobileTopBar from './MobileTopBar'
 import ChatComposer from './ChatComposer'
 import ChatMessageItem from './ChatMessageItem'
@@ -262,6 +262,9 @@ interface ChatViewProps {
   onToggleRightPanel?: () => void
   chatColumnVisible?: boolean
   onToggleChatColumn?: () => void
+  userPrompt?: ChatUserPromptPayload | null
+  userPromptSubmitting?: boolean
+  onUserPromptSubmit?: (answer: UserPromptAnswerPayload) => void
 }
 
 export default function ChatView({
@@ -277,6 +280,9 @@ export default function ChatView({
   onToggleRightPanel,
   chatColumnVisible = true,
   onToggleChatColumn,
+  userPrompt = null,
+  userPromptSubmitting = false,
+  onUserPromptSubmit,
 }: ChatViewProps) {
   const s = useStyles()
   const chatBoxRef = useRef<HTMLDivElement>(null)
@@ -635,6 +641,9 @@ export default function ChatView({
               onStop={onStop}
               onModelChange={onModelChange}
               onClearContextRef={onClearContextRef}
+              userPrompt={userPrompt}
+              userPromptSubmitting={userPromptSubmitting}
+              onUserPromptSubmit={onUserPromptSubmit}
             />
           </div>
         </div>

--- a/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
+++ b/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useState } from 'react'
+import { mergeClasses } from '@fluentui/react-components'
+import OpptrixButton from '../components/opptrix/OpptrixButton'
+import OpptrixInput from '../components/opptrix/OpptrixInput'
+import type { ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
+import { OPPTRIX_GLASS_PANEL_CLASS } from '../theme/mixins'
+
+interface ComposerAgentUserPromptPanelProps {
+  prompt: ChatUserPromptPayload
+  submitting?: boolean
+  onSubmit: (answer: UserPromptAnswerPayload) => void
+}
+
+export default function ComposerAgentUserPromptPanel({
+  prompt,
+  submitting = false,
+  onSubmit,
+}: ComposerAgentUserPromptPanelProps) {
+  const [customText, setCustomText] = useState('')
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+
+  useEffect(() => {
+    setCustomText('')
+    setSelectedIds([])
+  }, [prompt.id])
+
+  const submitOption = useCallback((id: string, label: string) => {
+    if (submitting) return
+    onSubmit({
+      kind: 'option',
+      selected_ids: [id],
+      selected_labels: [label],
+    })
+  }, [onSubmit, submitting])
+
+  const submitCustom = useCallback(() => {
+    const text = customText.trim()
+    if (!text || submitting) return
+    onSubmit({
+      kind: 'custom',
+      selected_ids: [],
+      selected_labels: [],
+      custom_text: text,
+    })
+  }, [customText, onSubmit, submitting])
+
+  const toggleMulti = useCallback((id: string) => {
+    setSelectedIds(prev => (
+      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
+    ))
+  }, [])
+
+  const submitMultiple = useCallback(() => {
+    if (submitting || !selectedIds.length) return
+    const labels = prompt.options
+      .filter(opt => selectedIds.includes(opt.id))
+      .map(opt => opt.label)
+    onSubmit({
+      kind: 'option',
+      selected_ids: selectedIds,
+      selected_labels: labels,
+    })
+  }, [onSubmit, prompt.options, selectedIds, submitting])
+
+  const handleCustomKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      submitCustom()
+    }
+  }
+
+  return (
+    <div
+      className={mergeClasses(
+        'opptrix-composer-user-prompt-panel',
+        OPPTRIX_GLASS_PANEL_CLASS,
+      )}
+      role="region"
+      aria-label="Agent 确认问题"
+    >
+      <div className="opptrix-composer-user-prompt-panel__head">
+        <span className="opptrix-composer-user-prompt-panel__title">
+          {prompt.title?.trim() || '请确认'}
+        </span>
+        <p className="opptrix-composer-user-prompt-panel__prompt">{prompt.prompt}</p>
+      </div>
+
+      <div className="opptrix-composer-user-prompt-panel__options">
+        {prompt.options.map(opt => (
+          <button
+            key={opt.id}
+            type="button"
+            className={mergeClasses(
+              'opptrix-composer-user-prompt-panel__option',
+              'opptrix-focusable',
+              prompt.allowMultiple && selectedIds.includes(opt.id)
+                && 'opptrix-composer-user-prompt-panel__option--selected',
+            )}
+            disabled={submitting}
+            onClick={() => {
+              if (prompt.allowMultiple) {
+                toggleMulti(opt.id)
+                return
+              }
+              submitOption(opt.id, opt.label)
+            }}
+          >
+            {opt.label}
+          </button>
+        ))}
+
+        <div className="opptrix-composer-user-prompt-panel__custom">
+          <OpptrixInput
+            className="opptrix-composer-user-prompt-panel__custom-input"
+            value={customText}
+            disabled={submitting}
+            placeholder="其他，输入后按 Enter 提交"
+            onChange={(_e, data) => setCustomText(data.value)}
+            onKeyDown={handleCustomKeyDown}
+            aria-label="自行输入答案"
+          />
+          <span className="opptrix-composer-user-prompt-panel__custom-hint">Enter</span>
+        </div>
+      </div>
+
+      {prompt.allowMultiple && (
+        <div className="opptrix-composer-user-prompt-panel__confirm">
+          <OpptrixButton
+            variant="primary"
+            size="small"
+            disabled={submitting || selectedIds.length === 0}
+            onClick={submitMultiple}
+          >
+            确认选择
+          </OpptrixButton>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -898,6 +898,123 @@ select:focus-visible {
   border-radius: var(--opptrix-radius-lg, 14px);
 }
 
+/* Composer agent user prompt — ask_user 选择题面板（输入框上方） */
+.opptrix-composer-user-prompt-panel {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 12px 14px;
+  margin-bottom: 8px;
+  border-radius: var(--opptrix-radius-lg, 14px);
+  overflow: hidden;
+  animation: opptrix-composer-tooltip-in 220ms cubic-bezier(0, 0, 0.2, 1) both;
+  transform-origin: bottom center;
+}
+
+.opptrix-composer-user-prompt-panel__head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.opptrix-composer-user-prompt-panel__title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--opptrix-text-tertiary, #9A9A9A);
+}
+
+.opptrix-composer-user-prompt-panel__prompt {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.45;
+  color: var(--opptrix-text, #1A1A1A);
+}
+
+.opptrix-composer-user-prompt-panel__options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.opptrix-composer-user-prompt-panel__option {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--opptrix-text, #1A1A1A);
+  transition: background-color 140ms ease, box-shadow 140ms ease;
+}
+
+.opptrix-composer-user-prompt-panel__option:hover:not(:disabled) {
+  background: rgba(60, 60, 67, 0.08);
+}
+
+.opptrix-composer-user-prompt-panel__option:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.opptrix-composer-user-prompt-panel__option--selected {
+  background: rgba(60, 60, 67, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(60, 60, 67, 0.14);
+}
+
+[data-theme="dark"] .opptrix-composer-user-prompt-panel__option:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme="dark"] .opptrix-composer-user-prompt-panel__option--selected {
+  background: rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+}
+
+.opptrix-composer-user-prompt-panel__custom {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin-top: 4px;
+  padding-top: 8px;
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+
+[data-theme="dark"] .opptrix-composer-user-prompt-panel__custom {
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.opptrix-composer-user-prompt-panel__custom-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.opptrix-composer-user-prompt-panel__custom-hint {
+  flex-shrink: 0;
+  font-size: 12px;
+  color: var(--opptrix-text-tertiary, #9A9A9A);
+  user-select: none;
+}
+
+.opptrix-composer-user-prompt-panel__confirm {
+  display: flex;
+  justify-content: flex-end;
+}
+
 /* Composer tooltip menus — @ mention, quick tasks, model picker */
 .opptrix-composer-tooltip-menu {
   display: flex;

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -1,5 +1,20 @@
 export type ChatToolStepStatus = 'running' | 'done' | 'error'
 
+export interface ChatUserPromptPayload {
+  id: string
+  title?: string
+  prompt: string
+  options: Array<{ id: string; label: string }>
+  allowMultiple?: boolean
+}
+
+export interface UserPromptAnswerPayload {
+  kind: 'option' | 'custom'
+  selected_ids: string[]
+  selected_labels: string[]
+  custom_text?: string
+}
+
 export interface ChatToolStep {
   id: string
   tool: string
@@ -17,6 +32,7 @@ export type ChatProgressEvent =
   | { type: 'thinking'; round: number; label: string; snippet?: string }
   | { type: 'tool_start'; step: ChatToolStep }
   | { type: 'tool_done'; step: ChatToolStep }
+  | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
   | { type: 'reply'; content: string }
   | {
     type: 'done'

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -114,9 +114,10 @@ Opptrix/
     ResearchHub / MarketDataService / AshareEngine
 ```
 
-- 工具定义：`packages/agent/src/tools.ts`（约 **43** 个 MCP 工具，含本地数据层）
+- 工具定义：`packages/agent/src/tools.ts`（MCP 投研工具 + 内置 `ask_user` 交互确认）
 - 工具元数据（何时使用、调用规范）：`packages/agent/src/tool-meta.ts`
-- 系统提示与引擎：`packages/agent/src/engine.ts`
+- 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
+- **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（末项可自由输入），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
 
 ### 4.3 数据层
 

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -53,10 +53,19 @@ export interface ChatToolStep {
  *   - done:        全部完成（reply=最终回复、tools_used=使用的工具列表、title=会话标题）
  *   - error:       出错（message=错误信息）
  */
+export interface ChatUserPromptPayload {
+  id: string
+  title?: string
+  prompt: string
+  options: Array<{ id: string; label: string }>
+  allowMultiple?: boolean
+}
+
 export type ChatProgressEvent =
   | { type: 'thinking'; round: number; label: string; snippet?: string }
   | { type: 'tool_start'; step: ChatToolStep }
   | { type: 'tool_done'; step: ChatToolStep }
+  | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
   | { type: 'reply'; content: string }
   | {
     type: 'done'
@@ -140,6 +149,7 @@ const TOOL_LABELS: Record<string, string> = {
   get_app_settings: '读取应用设置',
   get_project_info: '读取项目路径信息',
   get_integration_status: '检查外部集成状态',
+  ask_user: '向你确认问题',
   get_instrument_capabilities: '查询标的能力',
   get_instrument_snapshot: '获取标的快照',
   get_instrument_quotes: '获取标的行情',
@@ -289,6 +299,16 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
     case 'list_local_industries': {
       const kw = typeof args.keyword === 'string' ? args.keyword.trim() : ''
       return kw ? `${base} · ${kw}` : base
+    }
+    case 'ask_user': {
+      const q = typeof args.prompt === 'string'
+        ? args.prompt.trim()
+        : typeof args.question === 'string'
+          ? args.question.trim()
+          : ''
+      if (!q) return base
+      const short = q.length > 36 ? `${q.slice(0, 36)}…` : q
+      return `等待你的确认：${short}`
     }
     default:
       return ref ? `${base} · ${ref}` : base
@@ -504,6 +524,18 @@ function summarizeToolResult(tool: string, result: unknown): string | null {
     case 'get_instrument_latest_evaluation':
     case 'get_latest_evaluation':
       return summarizeInstrumentEvaluation(data, message)
+    case 'ask_user': {
+      if (!result || typeof result !== 'object') return null
+      const r = result as Record<string, unknown>
+      if (r.kind === 'custom' && typeof r.custom_text === 'string' && r.custom_text.trim()) {
+        return `已选择：${r.custom_text.trim()}`
+      }
+      const labels = Array.isArray(r.selected_labels)
+        ? r.selected_labels.filter((l): l is string => typeof l === 'string' && l.trim().length > 0)
+        : []
+      if (labels.length) return `已选择：${labels.join('、')}`
+      return '已收到你的确认'
+    }
     default:
       return null
   }

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -14,6 +14,13 @@ import {
   formatArgsPreview,
   formatToolLabel,
 } from './chat-progress.js'
+import {
+  UserPromptBridge,
+  createUserPromptId,
+  parseAskUserArgs,
+  type UserPromptAnswer,
+  UserPromptCancelledError,
+} from './user-prompt.js'
 import { SessionStore, type SessionRecord, type SessionContextRef } from './sessions.js'
 
 export interface AgentSettings {
@@ -54,6 +61,7 @@ export class AgentEngine {
   private registry = new ProviderRegistry()
   private settings: AgentSettings
   private mcpBrokerPromise: Promise<McpToolBroker> | null = null
+  readonly userPromptBridge = new UserPromptBridge()
 
   constructor(
     private hub: ResearchHub,
@@ -148,6 +156,7 @@ export class AgentEngine {
   }
 
   deleteSession(id: string) {
+    this.userPromptBridge.cancelSession(id)
     this.sessions.delete(id)
   }
 
@@ -232,6 +241,10 @@ export class AgentEngine {
     return { reply: turn.message.content?.trim() || '（无回复内容）' }
   }
 
+  resolveUserPrompt(sessionId: string, promptId: string, answer: UserPromptAnswer) {
+    return this.userPromptBridge.submit(sessionId, promptId, answer)
+  }
+
   async chat(
     sessionId: string,
     message: string,
@@ -270,6 +283,7 @@ export class AgentEngine {
     const signal = progress?.signal
 
     const finalizeCancelled = (partialTools: string[], partialSteps: ChatToolStep[]): ChatResult => {
+      this.userPromptBridge.cancelSession(sessionId)
       record!.messages = record!.messages.slice(0, messagesBeforeAssistant)
       if (record!.turns) {
         record!.turns = record!.turns.slice(0, turnsBeforeAssistant + 1)
@@ -395,10 +409,27 @@ export class AgentEngine {
 
           let result: unknown
           try {
-            result = await broker.call(fn, args, { signal })
+            if (fn === 'ask_user') {
+              const parsed = parseAskUserArgs(args)
+              if (parsed.error || !parsed.payload) {
+                result = { error: parsed.error ?? 'ask_user 参数无效' }
+              } else {
+                const promptId = createUserPromptId()
+                const answerPromise = this.userPromptBridge.waitForAnswer(sessionId, promptId, signal)
+                emit({
+                  type: 'user_prompt',
+                  prompt: { id: promptId, ...parsed.payload },
+                })
+                const answer = await answerPromise
+                result = { ok: true, ...answer }
+              }
+            } else {
+              result = await broker.call(fn, args, { signal })
+            }
           } catch (e) {
             if (
               e instanceof ChatCancelledError
+              || e instanceof UserPromptCancelledError
               || signal?.aborted
               || (e instanceof DOMException && e.name === 'AbortError')
             ) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4,8 +4,19 @@ export {
   type ChatProgressOptions,
   type ChatToolStep,
   type ChatToolStepStatus,
+  type ChatUserPromptPayload,
   formatToolLabel,
 } from './chat-progress.js'
+export {
+  type UserPromptAnswer,
+  type UserPromptOption,
+  type UserPromptPayload,
+  UserPromptBridge,
+  UserPromptCancelledError,
+  createUserPromptId,
+  normalizeUserPromptOptions,
+  parseAskUserArgs,
+} from './user-prompt.js'
 export {
   type AgentAppContext,
   type PublicAppSettings,

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -610,6 +610,11 @@ export const TOOL_META: Record<string, ToolMeta> = {
     usageGuide: '需要确认 Tushare 等外部集成是否已配置时调用。',
     compliance: '只读；不返回 Token/Secret。',
   },
+  ask_user: {
+    miningEligible: false,
+    usageGuide: '分析前需用户确认方向、范围或偏好，且上下文无法推断时调用；会在聊天输入框上方展示选择题，用户点选或自行输入后继续。',
+    compliance: 'prompt 必填、面向投资者；options 2–5 项且 id 唯一；allow_multiple 默认 false；同一轮对话最多 1 次；禁止索要密钥；调用后须等待工具返回再续分析。',
+  },
   list_enabled_providers: {
     hubFeature: 'provider_list',
     miningEligible: false,

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -161,6 +161,7 @@ export class ToolRegistry {
   systemPrompt() {
     return [
       '你是 Opptrix 专业多市场投研助手。仅通过已注册的 MCP 投研工具获取真实数据，再基于结果用中文给出简洁、专业的分析。',
+      '需要用户确认分析方向或偏好时，使用 ask_user 工具在界面展示选择题（含自行输入项），勿让用户在聊天里自行罗列选项。',
       buildAgentSystemRules(),
     ].join('\n')
   }
@@ -515,6 +516,21 @@ export class ToolRegistry {
           const tushare = await d('tushare_config', {})
           return { tushare: tushare.data ?? tushare }
         },
+      },
+      {
+        name: 'ask_user',
+        category: '交互',
+        description: '向用户发起选择题确认；会在输入框上方展示题目与选项，最后一项可自由输入后回车提交，作答后继续分析',
+        parameters: S({
+          title: { type: 'string', description: '可选面板标题，如「分析范围确认」' },
+          prompt: { type: 'string', description: '要向用户提出的具体问题（面向投资者，避免技术术语）' },
+          options: {
+            type: 'array',
+            description: '2–5 个预置选项，每项为 { id, label }；id 为稳定标识，label 为展示文案',
+          },
+          allow_multiple: { type: 'boolean', description: '是否允许多选，默认 false' },
+        }, ['prompt', 'options']),
+        handler: async () => ({ error: 'ask_user 由 Agent 引擎直接处理' }),
       },
     ].map(t => ({ ...t, meta: TOOL_META[t.name] }))
   }

--- a/packages/agent/src/user-prompt.ts
+++ b/packages/agent/src/user-prompt.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from 'node:crypto'
+
+export class UserPromptCancelledError extends Error {
+  constructor() {
+    super('已取消')
+    this.name = 'UserPromptCancelledError'
+  }
+}
+
+/** 问答题选项 — Agent ask_user 工具预置选项 */
+export interface UserPromptOption {
+  id: string
+  label: string
+}
+
+/** 推送给客户端的问答面板载荷 */
+export interface UserPromptPayload {
+  id: string
+  title?: string
+  prompt: string
+  options: UserPromptOption[]
+  allowMultiple?: boolean
+}
+
+/** 用户作答结果 — 回传给 Agent 工具输出 */
+export interface UserPromptAnswer {
+  kind: 'option' | 'custom'
+  selected_ids: string[]
+  selected_labels: string[]
+  custom_text?: string
+}
+
+interface PendingPrompt {
+  resolve: (answer: UserPromptAnswer) => void
+  reject: (err: Error) => void
+  abortCleanup?: () => void
+}
+
+function sessionPrefix(sessionId: string) {
+  return `${sessionId}:`
+}
+
+/**
+ * 进程内问答桥 — Agent 调用 ask_user 时挂起，待客户端 POST 作答后恢复。
+ * 每个 AgentEngine 实例持有一个 bridge；按 sessionId + promptId 匹配 pending。
+ */
+export class UserPromptBridge {
+  private readonly pending = new Map<string, PendingPrompt>()
+
+  waitForAnswer(
+    sessionId: string,
+    promptId: string,
+    signal?: AbortSignal,
+  ): Promise<UserPromptAnswer> {
+    const key = `${sessionId}:${promptId}`
+    if (this.pending.has(key)) {
+      return Promise.reject(new Error('duplicate user prompt id'))
+    }
+
+    return new Promise((resolve, reject) => {
+      const onAbort = () => {
+        this.pending.delete(key)
+        reject(new UserPromptCancelledError())
+      }
+      if (signal) {
+        if (signal.aborted) {
+          reject(new UserPromptCancelledError())
+          return
+        }
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+
+      this.pending.set(key, {
+        resolve: (answer) => {
+          if (signal) signal.removeEventListener('abort', onAbort)
+          resolve(answer)
+        },
+        reject: (err) => {
+          if (signal) signal.removeEventListener('abort', onAbort)
+          reject(err)
+        },
+        abortCleanup: signal ? () => signal.removeEventListener('abort', onAbort) : undefined,
+      })
+    })
+  }
+
+  submit(sessionId: string, promptId: string, answer: UserPromptAnswer): boolean {
+    const key = `${sessionId}:${promptId}`
+    const entry = this.pending.get(key)
+    if (!entry) return false
+    this.pending.delete(key)
+    entry.resolve(answer)
+    return true
+  }
+
+  cancelSession(sessionId: string) {
+    const prefix = sessionPrefix(sessionId)
+    for (const [key, entry] of this.pending) {
+      if (!key.startsWith(prefix)) continue
+      entry.abortCleanup?.()
+      entry.reject(new UserPromptCancelledError())
+      this.pending.delete(key)
+    }
+  }
+}
+
+export function createUserPromptId() {
+  return randomUUID()
+}
+
+export function normalizeUserPromptOptions(raw: unknown): UserPromptOption[] | null {
+  if (!Array.isArray(raw) || raw.length < 2 || raw.length > 5) return null
+  const options: UserPromptOption[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') return null
+    const id = String((item as { id?: unknown }).id ?? '').trim()
+    const label = String((item as { label?: unknown }).label ?? '').trim()
+    if (!id || !label) return null
+    options.push({ id, label })
+  }
+  const ids = new Set(options.map(o => o.id))
+  if (ids.size !== options.length) return null
+  return options
+}
+
+export function parseAskUserArgs(args: Record<string, unknown>): {
+  payload?: Omit<UserPromptPayload, 'id'>
+  error?: string
+} {
+  const prompt = String(args.prompt ?? args.question ?? '').trim()
+  if (!prompt) return { error: 'prompt 不能为空' }
+
+  const options = normalizeUserPromptOptions(args.options)
+  if (!options) {
+    return { error: 'options 须为 2–5 个对象数组，每项含 id 与 label' }
+  }
+
+  const titleRaw = args.title
+  const title = titleRaw == null ? undefined : String(titleRaw).trim() || undefined
+
+  return {
+    payload: {
+      prompt,
+      title,
+      options,
+      allowMultiple: Boolean(args.allow_multiple ?? args.allowMultiple),
+    },
+  }
+}

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -97,6 +97,18 @@ export function newsCrossReadHintForRef(ref: InstrumentRef): string {
   return `主市场优先 ${ref.market} 分组；不足时可交叉查阅：${hints.join('、')}`
 }
 
+/** 聊天 Agent — 用户交互确认（ask_user 工具） */
+export function buildUserInteractionPlaybook(): string {
+  return [
+    '【用户确认 — ask_user 内置交互工具】',
+    '- 当分析方向、标的范围、时间窗口、偏好（短线/中线、是否含资讯等）存在多种合理路径且无法从上下文推断时，调用 ask_user 而非在正文里罗列选项让用户打字回复',
+    '- 参数：prompt 写一句面向投资者的问题；options 提供 2–5 个互斥或常见选项（id 英文/数字，label 中文简短）；allow_multiple 仅在「可多选」时设为 true',
+    '- 界面会在输入框上方展示题目；最后一项为「自行输入」，用户可直接打字后按 Enter 提交',
+    '- 收到返回的 selected_labels / custom_text 后再继续拉数与分析；同一轮对话最多调用 1 次 ask_user',
+    '- 禁止用于索要 API Key、密码等敏感信息；禁止在已有明确用户指令时重复确认',
+  ].join('\n')
+}
+
 /** 聊天 Agent 完整 system 规则正文（不含角色行） */
 export function buildAgentSystemRules(): string {
   return [
@@ -106,6 +118,7 @@ export function buildAgentSystemRules(): string {
     buildStandardInstrumentApiPlaybook(),
     buildInstrumentAnalysisPlaybook(),
     buildProviderCustomMethodPlaybook(),
+    buildUserInteractionPlaybook(),
     '- A 股在线初选：screen_stocks；本地因子库可选 get_market_db_status + screen_local_universe（库未就绪时勿强依赖）',
     buildNewsRetrievalPlaybook(),
     '- 每个工具描述含【何时使用】【调用规范】，严格遵守',

--- a/tests/agent-ask-user.test.mjs
+++ b/tests/agent-ask-user.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  UserPromptBridge,
+  parseAskUserArgs,
+  normalizeUserPromptOptions,
+  UserPromptCancelledError,
+} from '../packages/agent/src/user-prompt.ts'
+
+test('normalizeUserPromptOptions accepts 2–5 unique options', () => {
+  const ok = normalizeUserPromptOptions([
+    { id: 'a', label: '选项 A' },
+    { id: 'b', label: '选项 B' },
+  ])
+  assert.deepEqual(ok, [
+    { id: 'a', label: '选项 A' },
+    { id: 'b', label: '选项 B' },
+  ])
+
+  assert.equal(normalizeUserPromptOptions([{ id: 'a', label: '仅一项' }]), null)
+  assert.equal(normalizeUserPromptOptions([
+    { id: 'a', label: 'A' },
+    { id: 'a', label: '重复' },
+  ]), null)
+})
+
+test('parseAskUserArgs validates prompt and options', () => {
+  assert.match(parseAskUserArgs({ prompt: '', options: [] }).error ?? '', /prompt/)
+  const parsed = parseAskUserArgs({
+    prompt: '你想分析哪类标的？',
+    title: '分析范围',
+    options: [
+      { id: 'cn', label: 'A 股' },
+      { id: 'us', label: '美股' },
+    ],
+  })
+  assert.equal(parsed.error, undefined)
+  assert.equal(parsed.payload?.title, '分析范围')
+  assert.equal(parsed.payload?.options.length, 2)
+})
+
+test('UserPromptBridge resolves submitted answers', async () => {
+  const bridge = new UserPromptBridge()
+  const sessionId = 'sess-1'
+  const promptId = 'prompt-1'
+
+  const answerPromise = bridge.waitForAnswer(sessionId, promptId)
+  const submitted = bridge.submit(sessionId, promptId, {
+    kind: 'option',
+    selected_ids: ['cn'],
+    selected_labels: ['A 股'],
+  })
+  assert.equal(submitted, true)
+  const answer = await answerPromise
+  assert.equal(answer.selected_labels[0], 'A 股')
+})
+
+test('UserPromptBridge rejects on session cancel', async () => {
+  const bridge = new UserPromptBridge()
+  const sessionId = 'sess-2'
+  const promptId = 'prompt-2'
+
+  const answerPromise = bridge.waitForAnswer(sessionId, promptId)
+  bridge.cancelSession(sessionId)
+  await assert.rejects(answerPromise, UserPromptCancelledError)
+})


### PR DESCRIPTION
## Summary
- 新增 Agent 内置 MCP 工具 `ask_user`：分析前需用户确认时，通过 SSE `user_prompt` 事件在输入框上方展示选择题面板（含自由输入 + Enter 提交），作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
- 前端 `ComposerAgentUserPromptPanel` 采用与 composer 浮层一致的 `opptrix-glass-panel` 毛玻璃样式
- 提示词集成：`buildUserInteractionPlaybook()`、tool-meta、`systemPrompt` 引导 Agent 优先用工具确认而非让用户在聊天里打字选

## Test plan
- [x] `node --test tests/agent-ask-user.test.mjs`（参数校验与 UserPromptBridge）
- [x] `npm run build -w @opptrix/agent -w client-ui -w @opptrix/server`
- [x] 启动应用，触发 Agent 调用 `ask_user`，确认毛玻璃面板展示、点选/Enter 提交后分析继续
- [x] 取消生成时会话内 pending prompt 正确清理


Made with [Cursor](https://cursor.com)