### PR TITLE
feat(agent): industry/market MCP tools and legacy tool cleanup

### DIFF
--- a/client-ui/src/chat/quickTaskCatalog.ts
+++ b/client-ui/src/chat/quickTaskCatalog.ts
@@ -10,7 +10,7 @@ export interface QuickTaskSection {
 
 /**
  * 推荐任务目录（始终展示，无需用户手动添加）
- * 文案面向非技术投资者；Agent 可映射到 evaluate_stock / screen_local_universe 等工具
+ * 文案面向非技术投资者；Agent 可映射到 evaluate_instrument / screen_stocks 等工具
  */
 export const QUICK_TASK_CATALOG: readonly QuickTaskSection[] = [
   {

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -118,6 +118,10 @@ Opptrix/
 - 工具元数据（何时使用、调用规范）：`packages/agent/src/tool-meta.ts`
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
 - **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（末项可自由输入），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
+- **行业分析**：`list_local_industries` → `get_industry_stats` / `get_local_industry_stocks` → `industry_mining`
+- **市场宏观**：`get_market_regime` / `get_market_dynamics` / `get_watchlist_radar` / `get_trend_brief`
+- **跨市场初选**：`screen_us_universe` / `screen_hk_universe` / `screen_crypto_universe` 或 `search_instruments`
+- 本地因子筛选（`screen_local_universe` 等）与 legacy 单市场工具（`evaluate_stock` 等）已从 Agent 移除，统一用 `get_instrument_*` / `evaluate_instrument`
 
 ### 4.3 数据层
 
@@ -132,9 +136,9 @@ Opptrix/
 
 **本地挖掘层** `@opptrix/market-data`：
 
-- SQLite 存储 A 股因子、K 线、行业映射等（ETF / 多市场 schema 见 DATA-LAYER §8）
-- `MarketDataSyncEngine` 从在线层同步；支持设置页触发与 Agent 工具 `trigger_market_db_sync`
-- 本地筛选、行业列表、决策雷达等 **优先走本地库**，降低延迟与源站压力
+- SQLite 存储 A 股行业映射、截面快照等（ETF / 多市场 schema 见 DATA-LAYER §8）
+- 本地因子筛选与全量同步已停用；`market_db_status` 返回名录/截面规模（`get_local_data_status` 工具）
+- 行业列表、决策雷达等只读能力仍可走本地库；选股用 `screen_stocks` 在线筛选
 
 ### 4.4 前端主界面
 

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -99,37 +99,27 @@ export interface ChatProgressOptions {
 // ── 工具中文标签映射 ──
 
 const TOOL_LABELS: Record<string, string> = {
-  evaluate_stock: '评估个股因子与评分',
+  get_market_regime: '分析宏观市场状态',
+  get_market_dynamics: '获取市场动态全景',
+  get_trend_brief: '生成趋势研判',
   screen_stocks: '按条件筛选股票',
-  local_screen_stocks: '本地因子初选',
-  screen_local_universe: '本地多维度筛选',
-  list_local_industries: '读取本地行业列表',
-  screen_local_industry_stocks: '行业内策略筛选',
-  get_local_industry_stocks: '读取行业成分股',
-  get_market_db_status: '查询本地数据库状态',
-  get_market_db_sync_state: '查看数据同步进度',
-  trigger_market_db_sync: '触发本地数据同步',
-  list_local_screen_factors: '读取可用筛选因子',
-  get_local_universe_screen_schema: '读取筛选维度说明',
-  batch_stock_snapshots: '批量获取候选股快照',
+  screen_us_universe: '筛选美股候选',
+  screen_hk_universe: '筛选港股候选',
+  screen_crypto_universe: '筛选 Crypto 交易对',
+  get_local_data_status: '查询本地数据状态',
+  get_etf_list: '读取 ETF 列表',
+  get_etf_scorecard: '评估 ETF 决策雷达',
   batch_instrument_snapshots: '批量获取候选标的快照',
-  get_stock_quotes: '获取实时行情',
+  list_local_industries: '读取本地行业列表',
+  get_local_industry_stocks: '读取行业成分股',
   get_watchlist: '读取关注列表',
   get_watchlist_radar: '生成关注股雷达摘要',
-  get_stock_kline: '获取 K 线数据',
-  get_stock_cyq: '分析筹码分布',
-  get_stock_chart: '获取图表数据',
-  get_stock_detail: '获取个股详情',
-  search_stocks: '搜索股票',
-  get_strategy_signal: '分析策略信号',
   institution_rating: '汇总机构评级',
   institution_report: '生成机构评级报告',
   analyze_portfolio: '分析组合因子暴露',
   get_closing_report: '生成收盘市场报告',
   get_morning_brief: '生成开盘早报',
   run_backtest: '运行因子回测',
-  strategy_verify: '验证策略历史表现',
-  strategy_verify_report: '生成策略验证报告',
   strategy_report: '生成策略分析报告',
   industry_mining: '梳理产业链与代表公司',
   industry_mermaid: '生成产业链图谱',
@@ -137,7 +127,6 @@ const TOOL_LABELS: Record<string, string> = {
   get_portfolio_holdings: '读取实盘持仓',
   portfolio_trades: '查询交易流水',
   portfolio_summary: '汇总持仓盈亏',
-  get_latest_evaluation: '读取缓存评估结果',
   get_news_center_status: '查询资讯中心状态',
   list_news_groups: '读取资讯分组',
   list_news_sources: '读取资讯订阅来源',
@@ -222,35 +211,22 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
   const ref = stockRef(args, result)
 
   switch (tool) {
-    case 'get_stock_kline':
-      return ref ? `获取 ${ref} K 线数据` : '获取 K 线数据'
-    case 'get_stock_chart':
-      return ref ? `获取 ${ref} 图表数据` : '获取图表数据'
-    case 'get_stock_cyq':
-      return ref ? `分析 ${ref} 筹码分布` : '分析筹码分布'
-    case 'get_stock_detail':
-      return ref ? `获取 ${ref} 详情` : '获取个股详情'
-    case 'evaluate_stock':
-      return ref ? `评估 ${ref} 因子与评分` : '评估个股因子与评分'
-    case 'get_strategy_signal':
-      return ref ? `分析 ${ref} 策略信号` : '分析策略信号'
+    case 'get_trend_brief':
+      return ref ? `${ref} · ${base}` : base
+    case 'get_market_regime':
+    case 'get_market_dynamics':
+      return base
+    case 'batch_instrument_snapshots': {
+      const n = instrumentsCount(args) ?? codesCount(args)
+      return n != null ? `批量获取 ${n} 只候选标的快照` : '批量获取候选标的快照'
+    }
     case 'institution_rating':
     case 'institution_report':
     case 'get_instrument_institution_rating':
     case 'get_instrument_institution_report':
       return ref ? `汇总 ${ref} 机构观点` : base
-    case 'strategy_verify':
-    case 'strategy_verify_report':
     case 'strategy_report':
       return ref ? `${ref} · ${base}` : base
-    case 'batch_stock_snapshots': {
-      const n = codesCount(args)
-      return n != null ? `批量获取 ${n} 只候选股快照` : '批量获取候选股快照'
-    }
-    case 'batch_instrument_snapshots': {
-      const n = instrumentsCount(args) ?? codesCount(args)
-      return n != null ? `批量获取 ${n} 只候选标的快照` : '批量获取候选标的快照'
-    }
     case 'get_instrument_snapshot':
     case 'get_instrument_chart':
     case 'get_instrument_quotes':
@@ -262,10 +238,6 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
       const iref = instrumentRefFromArgs(args) ?? ref
       return iref ? `${base} · ${iref}` : base
     }
-    case 'get_stock_quotes': {
-      const n = codesCount(args)
-      return n != null ? `获取 ${n} 只股票实时行情` : '获取实时行情'
-    }
     case 'get_watchlist_radar': {
       const n = codesCount(args)
       return n != null ? `生成 ${n} 只股票雷达摘要` : '生成关注股雷达摘要'
@@ -274,32 +246,34 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
       const n = codesCount(args)
       return n != null ? `对 ${n} 只股票运行回测` : '运行因子回测'
     }
-    case 'search_stocks': {
+    case 'screen_stocks':
+    case 'screen_us_universe':
+    case 'screen_hk_universe':
+    case 'screen_crypto_universe': {
+      const conds = Array.isArray(args.conditions)
+        ? args.conditions.length
+        : Array.isArray(args.factor_conditions)
+          ? args.factor_conditions.length
+          : null
       const kw = typeof args.keyword === 'string' ? args.keyword.trim() : ''
-      return kw ? `搜索「${kw}」` : '搜索股票'
+      if (kw) return `${base} · ${kw}`
+      return conds != null ? `${base}（${conds} 条条件）` : base
     }
     case 'industry_mining':
     case 'industry_mermaid': {
       const industry = typeof args.industry === 'string' ? args.industry.trim() : ''
       return industry ? `${industry} · ${base}` : base
     }
-    case 'screen_stocks':
-    case 'local_screen_stocks':
-    case 'screen_local_universe':
-    case 'screen_local_industry_stocks': {
-      const conds = Array.isArray(args.conditions)
-        ? args.conditions.length
-        : Array.isArray(args.factor_conditions)
-          ? args.factor_conditions.length
-          : null
-      const industry = typeof args.industry === 'string' ? args.industry.trim() : ''
-      if (industry) return `${industry} · ${base}`
-      return conds != null ? `${base}（${conds} 条条件）` : base
-    }
     case 'list_local_industries': {
       const kw = typeof args.keyword === 'string' ? args.keyword.trim() : ''
       return kw ? `${base} · ${kw}` : base
     }
+    case 'get_local_industry_stocks': {
+      const industry = typeof args.industry === 'string' ? args.industry.trim() : ''
+      return industry ? `${base} · ${industry}` : base
+    }
+    case 'get_industry_stats':
+      return base
     case 'ask_user': {
       const q = typeof args.prompt === 'string'
         ? args.prompt.trim()
@@ -535,6 +509,36 @@ function summarizeToolResult(tool: string, result: unknown): string | null {
         : []
       if (labels.length) return `已选择：${labels.join('、')}`
       return '已收到你的确认'
+    }
+    case 'list_local_industries': {
+      const payload = envelope?.data ?? result
+      if (!payload || typeof payload !== 'object') return null
+      const p = payload as Record<string, unknown>
+      const n = Array.isArray(p.industries) ? p.industries.length : null
+      return n != null ? `共 ${n} 个行业` : null
+    }
+    case 'get_industry_stats': {
+      const payload = envelope?.data ?? result
+      if (!payload || typeof payload !== 'object') return null
+      const p = payload as Record<string, unknown>
+      const n = Array.isArray(p.items) ? p.items.length : null
+      return n != null ? `${n} 个行业统计` : null
+    }
+    case 'get_local_industry_stocks': {
+      const payload = envelope?.data ?? result
+      if (!payload || typeof payload !== 'object') return null
+      const p = payload as Record<string, unknown>
+      const industry = typeof p.industry === 'string' ? p.industry : ''
+      const n = Array.isArray(p.items) ? p.items.length : null
+      if (industry && n != null) return `${industry} · ${n} 只成分股`
+      return n != null ? `${n} 只成分股` : null
+    }
+    case 'industry_mining': {
+      const payload = envelope?.data ?? result
+      if (!payload || typeof payload !== 'object') return null
+      const p = payload as Record<string, unknown>
+      const name = typeof p.industry === 'string' ? p.industry : ''
+      return name ? `${name} 产业链分析完成` : '产业链分析完成'
     }
     default:
       return null

--- a/packages/agent/src/mcp/broker.ts
+++ b/packages/agent/src/mcp/broker.ts
@@ -11,16 +11,14 @@ export const MCP_SLOW_TOOL_CALL_TIMEOUT_MS = 900_000
 
 const SLOW_TOOLS = new Set([
   'screen_stocks',
-  'local_screen_stocks',
-  'screen_local_universe',
-  'screen_local_industry_stocks',
-  'trigger_market_db_sync',
-  'evaluate_stock',
-  'get_stock_detail',
+  'screen_us_universe',
+  'screen_hk_universe',
+  'screen_crypto_universe',
   'get_watchlist_radar',
+  'get_market_dynamics',
   'run_backtest',
-  'strategy_verify',
   'industry_mining',
+  'verify_instrument_strategy',
 ])
 
 export interface McpToolCallOptions {
@@ -34,7 +32,7 @@ function toolCallTimeoutMs(name: string, override?: number): number {
 }
 
 function formatToolTimeoutError(name: string): string {
-  return `工具 ${name} 执行超时（数据拉取或计算耗时较长）。请确认本地初选库已就绪，或缩小筛选范围后重试。`
+  return `工具 ${name} 执行超时（数据拉取或计算耗时较长）。请缩小筛选范围或稍后重试。`
 }
 
 /**

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -1,6 +1,5 @@
 /** 数据层 / 分析工具元数据：用途说明与调用规范（OpenAI tools + MCP 共用） */
 import { discoverMiningToolNamesForProfile, INSTRUMENT_HUB_FEATURE, isDiscoverStrategyProfile } from '@opptrix/shared'
-import { UNIFIED_MINING_INSTRUMENT_TOOLS } from './unified-mcp-tools.js'
 
 /**
  * 工具元数据 — 每个 Agent 工具的使用指南和调用规范。
@@ -19,8 +18,6 @@ export interface ToolMeta {
   miningEligible?: boolean
   /** 对应 ResearchHub.dispatch feature 名称，用于 hub 层路由 */
   hubFeature?: string
-  /** 已由跨市场统一工具替代时标记为 true，聊天场景默认隐藏 */
-  deprecated?: boolean
 }
 
 const INSTRUMENT_REF_USAGE = [
@@ -34,91 +31,71 @@ const INSTRUMENT_REF_USAGE = [
 ].join(' ')
 
 export const TOOL_META: Record<string, ToolMeta> = {
-  get_market_db_status: {
-    hubFeature: 'market_db_status',
+  get_market_regime: {
+    hubFeature: 'market_regime',
     miningEligible: true,
-    usageGuide: '任何依赖本地因子/初选的任务开始前先调用，确认 is_ready、因子日期与覆盖率；数据不足时决定是否改用在线工具或缩小范围。',
-    compliance: '无参数；只读；不要重复调用（同一轮对话调用一次即可）。',
+    usageGuide: '判断 A 股/美股宏观环境（牛熊、风险偏好、建议策略方向）；挖掘或组合分析前先了解大盘背景时使用。',
+    compliance: '只读；profile_scope 默认 cn；us 需 TickFlow/在线 K 线可用；勿重复调用。',
   },
-  get_market_db_sync_state: {
-    hubFeature: 'market_db_sync_state',
+  get_market_dynamics: {
+    hubFeature: 'market_dynamics',
     miningEligible: true,
-    usageGuide: '本地库未就绪或因子过旧时查看同步进度；向用户说明数据时效性。',
-    compliance: '只读；不可用于触发同步（使用 trigger_market_db_sync）。',
+    usageGuide: '需要市场全景（指数、全球市场、涨跌榜、龙虎榜）时使用；适合开盘/收盘复盘或解释板块异动背景。',
+    compliance: '只读；无参数；响应较大，同一轮对话调用一次即可。',
   },
-  trigger_market_db_sync: {
-    hubFeature: 'market_db_sync',
+  get_trend_brief: {
+    hubFeature: 'trend_brief',
     miningEligible: true,
-    usageGuide: '仅当 get_market_db_status 显示未就绪且挖掘强依赖本地因子时，可后台触发 resume/bootstrap 同步。',
-    compliance: '写操作、耗时长；同一任务最多调用 1 次；须先检查 status；勿在候选已充足时调用。',
-  },
-  list_local_screen_factors: {
-    hubFeature: 'list_screen_factors',
-    miningEligible: true,
-    usageGuide: '快速查看可用因子字段名；构造筛选条件前更推荐 get_local_universe_screen_schema 获取完整维度、单位与示例。',
-    compliance: '只读；factor 名须与 schema 一致。',
-  },
-  get_local_universe_screen_schema: {
-    hubFeature: 'local_universe_screen_schema',
-    miningEligible: true,
-    usageGuide: '本地初选组合筛选前必读：返回因子列表、单位、典型区间、行业/板块/评分/市值等过滤字段与查询示例。',
-    compliance: '只读；同一任务调用一次即可；按 schema 构造 screen_local_universe 参数。',
-  },
-  screen_local_universe: {
-    hubFeature: 'local_universe_screen',
-    miningEligible: true,
-    usageGuide: '本地 L0 库已就绪时，按多维度组合筛选股票列表（因子 AND + 行业/板块/评分/估值/市值 + 排序）。选股挖掘扩大/收紧候选池的首选工具。',
-    compliance: '须先 get_market_db_status 与 get_local_universe_screen_schema；factor_conditions ≤8；top_n ≤200；至少一项条件或过滤；本地库未就绪时勿调用。',
-  },
-  list_local_industries: {
-    hubFeature: 'local_industry_list',
-    miningEligible: true,
-    usageGuide: '行业选股前获取可用行业名称列表；可用 keyword 模糊查找（如「半导体」「银行」）。返回 industries 数组供 screen_local_industry_stocks 精确匹配。',
-    compliance: '只读；须本地库 is_ready；行业名须原样传入后续筛选工具，勿臆造。',
-  },
-  screen_local_industry_stocks: {
-    hubFeature: 'local_industry_screen',
-    miningEligible: true,
-    usageGuide: '在单一或少数行业内按策略因子/评分/估值筛选候选股；适合「先定行业、再选股」流程。不知行业名时先 list_local_industries。',
-    compliance: '须 industry / industries / industry_contains 至少一项；factor_conditions ≤8；top_n ≤200；行业名与 list_local_industries 一致。',
-  },
-  get_local_industry_stocks: {
-    hubFeature: 'market_industry_stocks',
-    miningEligible: true,
-    usageGuide: '快速列出某行业全部成分股（价量、评分），不做因子过滤；需要策略条件时用 screen_local_industry_stocks。',
-    compliance: 'industry 必填且为精确名称；limit ≤200；不替代因子筛选。',
-  },
-  local_screen_stocks: {
-    hubFeature: 'screening',
-    miningEligible: true,
-    usageGuide: '本地 L0 库已就绪时，按因子条件快速扩大或收紧候选池（比在线全市场扫描更快）。',
-    compliance: 'conditions 1-5 条；top_n ≤ 120；优先于 screen_stocks（本地路径）。',
+    usageGuide: 'A 股单股趋势一句话研判（均线、相对沪深300、可选持仓盈亏）；用户问「走势怎么看」且已有代码时使用。',
+    compliance: '仅 CN 股票；code 必填；holding_cost 可选；深度分析仍须 get_instrument_snapshot / evaluate_instrument。',
   },
   screen_stocks: {
     hubFeature: 'screening',
     miningEligible: true,
-    usageGuide: '本地库不可用或需要评分卡排序的全市场扫描时使用。',
-    compliance: 'conditions 必填；top_n 默认 20、挖掘场景建议 ≤ 80；避免与 local_screen_stocks 重复调用相同条件。',
+    usageGuide: 'A 股在线因子条件筛选；扩大/收紧候选池的首选工具（本地因子筛选已停用）。',
+    compliance: 'conditions 必填；top_n 默认 20、挖掘建议 ≤ 80；勿编造 factor 名。',
+  },
+  screen_us_universe: {
+    hubFeature: 'local_us_screen',
+    miningEligible: true,
+    usageGuide: '美股名录在线 keyword 筛选；挖掘或主题研究扩大美股候选时使用。',
+    compliance: 'top_n ≤ 200；结果 symbol 用于 get_instrument_snapshot；勿与 search_instruments 重复相同 keyword。',
+  },
+  screen_hk_universe: {
+    hubFeature: 'local_hk_screen',
+    miningEligible: true,
+    usageGuide: '港股名录在线 keyword 筛选；挖掘或主题研究扩大港股候选时使用。',
+    compliance: 'top_n ≤ 200；结果 code 用于 get_instrument_snapshot（market=HK）；勿调用 A 股专用工具。',
+  },
+  screen_crypto_universe: {
+    hubFeature: 'local_crypto_screen',
+    miningEligible: true,
+    usageGuide: 'Crypto 交易对名录筛选（keyword/quote/base_contains）；7×24 市场初选时使用。',
+    compliance: 'top_n ≤ 200；结果 pair 用于 get_instrument_snapshot（market=CRYPTO）。',
+  },
+  list_local_industries: {
+    hubFeature: 'local_industry_list',
+    miningEligible: true,
+    usageGuide: '行业主题分析前获取可用行业名称；keyword 模糊查找（如「半导体」「银行」）。',
+    compliance: '只读；行业名须原样传入 get_local_industry_stocks / industry_mining；无数据时改 search_instruments + screen_stocks。',
+  },
+  get_local_industry_stocks: {
+    hubFeature: 'market_industry_stocks',
+    miningEligible: true,
+    usageGuide: '列出某行业成分股（价量、综合评分）；行业对比后锁定龙头或扩散分析时使用。',
+    compliance: 'industry 必填且为精确名称；limit ≤200；深度分析再对单股 evaluate_instrument / get_instrument_snapshot。',
   },
   get_industry_stats: {
     hubFeature: 'market_industry_stats',
     miningEligible: true,
-    usageGuide: '行业对比、估值分位判断、解释候选股所处行业位置。',
-    compliance: '可选 trade_date；行业级聚合，不替代单股 detail。',
+    usageGuide: '行业涨跌对比、估值水平、均评分；解释候选股所处行业强弱或选强势/弱势行业时使用。',
+    compliance: '只读；可选 trade_date；行业级聚合，不替代单股 get_instrument_snapshot。',
   },
-  batch_stock_snapshots: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.batch_snapshots,
+  batch_instrument_snapshots: {
+    hubFeature: 'instrument_batch_snapshots',
     miningEligible: true,
-    deprecated: true,
-    usageGuide: '初选后批量获取候选截面（行业、评分、PE/PB、关键因子）；挖掘前首选批量工具。',
-    compliance: 'codes 数组一次传入，建议 ≤ 80；禁止对同一 codes 列表重复调用；跨市场请用 batch_instrument_snapshots。',
-  },
-  get_stock_quotes: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.quotes,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '需要最新价、涨跌幅、量比等盘中字段；snapshots 不含实时价时补充。',
-    compliance: '批量 codes；勿逐只循环调用。',
+    usageGuide: `初选后批量获取候选截面（行业、评分、PE/PB、关键因子）；A 股挖掘首选。${INSTRUMENT_REF_USAGE}`,
+    compliance: 'instruments 或 codes 一次传入，建议 ≤ 80；禁止对同一列表重复调用。',
   },
   get_watchlist: {
     hubFeature: 'watchlist_list',
@@ -130,41 +107,19 @@ export const TOOL_META: Record<string, ToolMeta> = {
     hubFeature: 'watchlist_radar',
     miningEligible: true,
     usageGuide: '快速获取关注股或多股雷达摘要（估值分位、主力净流入、评分卡）；codes 省略则自动使用用户关注列表。',
-    compliance: 'codes 批量或省略；适合 5–30 只；深度分析仍须 get_stock_detail。',
+    compliance: 'codes 批量或省略；适合 5–30 只 A 股；深度分析仍须 get_instrument_snapshot。',
   },
-  get_stock_kline: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.chart,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '验证趋势、动量、技术形态；策略含动量/突破/均线逻辑时使用。',
-    compliance: '单股；count ≤ 240；勿对全部候选逐只拉取，仅对 shortlisted 使用。',
-  },
-  get_stock_cyq: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.cyq,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '筹码分布、获利盘、成本区分析；适合短线/博弈或估值辅助。',
-    compliance: '单股深度；仅对最终 3–8 只候选调用；请改用 get_instrument_cyq。',
-  },
-  get_stock_chart: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.chart,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '需要多周期 K 线（周/月/分钟）时使用；日 K 优先 get_instrument_chart。',
-    compliance: '单股；指定 period；控制 count 避免超大响应。',
-  },
-  get_stock_detail: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.snapshot,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: 'snapshots/雷达信息不足时的深度聚合：财务、新闻、资金流、股东、F10 摘要等。',
-    compliance: '单股重量级；仅对拟入选标的调用；禁止对 20+ 只批量 detail。',
+  get_local_data_status: {
+    hubFeature: 'market_db_status',
+    miningEligible: false,
+    usageGuide: '需确认本地行业名录/截面是否就绪时使用；local_offline_screening_enabled 恒为 false。',
+    compliance: '只读；勿用于触发同步；选股请用 screen_stocks / search_instruments。',
   },
   get_etf_list: {
-    hubFeature: 'local_etf_list',
+    hubFeature: 'etf_list',
     miningEligible: true,
-    usageGuide: '获取 A 股 ETF 列表；本地库已同步时优先读本地，否则在线拉取。',
-    compliance: '只读；可选 code 过滤单只；列表用于 ETF 主题筛选或验证代码。',
+    usageGuide: '获取 A 股 ETF 全量列表或按 code 验证；ETF 主题挖掘前定位标的。',
+    compliance: '只读；可选 code 过滤；列表结果用 code 调用 get_etf_snapshot / get_etf_scorecard。',
   },
   search_etfs: {
     hubFeature: 'search_etfs',
@@ -179,177 +134,22 @@ export const TOOL_META: Record<string, ToolMeta> = {
     compliance: '单只 code；深度持仓/历史净值用 get_etf_holdings / get_etf_nav。',
   },
   get_etf_nav: {
-    hubFeature: 'local_etf_nav',
+    hubFeature: 'etf_nav',
     miningEligible: true,
     usageGuide: 'ETF 历史净值与溢价率序列；判断折溢价、净值趋势时使用。',
-    compliance: '单只 code；本地无数据时自动在线回退。',
+    compliance: '单只 code；在线拉取。',
   },
   get_etf_holdings: {
-    hubFeature: 'local_etf_holdings',
+    hubFeature: 'etf_holdings',
     miningEligible: true,
     usageGuide: 'ETF 最新披露持仓与权重；了解底层资产或行业暴露时使用。',
     compliance: '单只 code；持仓按季报更新，勿臆造成分股。',
   },
-  get_local_etf_screen_schema: {
-    hubFeature: 'local_etf_screen_schema',
-    miningEligible: false,
-    usageGuide: 'screen_local_etfs 前先读维度说明（溢价率%、规模亿元）。',
-    compliance: '只读 schema；需 etf_list/etf_nav 已同步。',
-  },
-  screen_local_etfs: {
-    hubFeature: 'local_etf_screen',
-    miningEligible: true,
-    usageGuide: '按折溢价率、规模、跟踪指数筛选本地 ETF；适合找低溢价宽基/行业 ETF。',
-    compliance: 'top_n ≤200；本地 etf_count=0 时勿调用。',
-  },
   get_etf_scorecard: {
     hubFeature: 'etf_scorecard',
     miningEligible: true,
-    usageGuide: '单只 ETF 决策雷达：折溢价、规模流动性、费率、净值波动与同类对比（0–100 分）。',
-    compliance: '单只 code；需 etf_list/etf_nav 已同步；缺数据时部分维度为空。',
-  },
-  get_etf_scorecard_schema: {
-    hubFeature: 'etf_scorecard_schema',
-    miningEligible: false,
-    usageGuide: 'get_etf_scorecard 前先读维度与权重说明。',
-    compliance: '只读 schema。',
-  },
-  get_us_stock_quote: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.quotes,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '获取单只美股实时/近收盘行情（价量、涨跌幅）；需 symbol 如 AAPL。',
-    compliance: 'symbol 为美股 ticker；需 TickFlow 已配置。',
-  },
-  get_us_stock_kline: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.chart,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '美股日 K 线序列；验证趋势或动量时使用。',
-    compliance: '单只 symbol；count ≤ 500；勿批量循环。',
-  },
-  get_us_stock_profile: {
-    hubFeature: 'us_profile',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '美股公司概况（交易所、行业、市值等）；需 TickFlow 已配置。',
-    compliance: '单只 symbol；无 Profile 时说明数据源限制。',
-  },
-  get_us_stock_financials: {
-    hubFeature: 'us_financials',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '美股财报摘要（TickFlow financials）；annual/quarter 可选。',
-    compliance: '单只 symbol；需 TickFlow API Key；YoY 字段暂为空。',
-  },
-  get_us_stock_snapshot: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.snapshot,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '单只美股聚合快照：概况 + 行情 + 近期 K 线；分析美股首选入口。',
-    compliance: '单只 symbol；深度财报另待后续 capability。',
-  },
-  search_us_stocks: {
-    hubFeature: 'search_us_stocks',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '按 ticker 或公司名搜索美股；本地库已同步时优先本地。',
-    compliance: 'keyword ≥1 字符；结果 symbol 用于 get_instrument_snapshot。',
-  },
-  get_crypto_quote: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.quotes,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: 'Crypto 交易对实时行情（7×24）；如 BTC/USDT。',
-    compliance: 'pair 必填；支持 BTC/USDT、BTC-USDT、BTCUSDT 写法。',
-  },
-  get_crypto_kline: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.chart,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: 'Crypto 日 K 线；7×24 市场，缓存 TTL 较短。',
-    compliance: 'pair 必填；count 默认 180。',
-  },
-  get_crypto_snapshot: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.snapshot,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: 'Crypto 聚合快照：行情 + 近期 K 线；分析 Crypto 首选入口。',
-    compliance: 'pair 必填；无 Profile 层（Crypto MVP）。',
-  },
-  search_crypto_pairs: {
-    hubFeature: 'search_crypto_pairs',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '搜索 Crypto 交易对；本地 instruments 已同步时优先本地。',
-    compliance: 'keyword ≥1 字符；结果 pair 用于 get_instrument_snapshot。',
-  },
-  get_local_us_screen_schema: {
-    hubFeature: 'local_us_screen_schema',
-    miningEligible: false,
-    usageGuide: 'screen_local_us_stocks 前先读本地美股筛选维度说明。',
-    compliance: '只读 schema；需 us_list 已同步。',
-  },
-  screen_local_us_stocks: {
-    hubFeature: 'local_us_screen',
-    miningEligible: true,
-    usageGuide: '按 ticker/公司名、行业关键词筛选本地美股列表。',
-    compliance: 'top_n ≤200；本地 us_count=0 时勿调用。',
-  },
-  get_local_crypto_screen_schema: {
-    hubFeature: 'local_crypto_screen_schema',
-    miningEligible: false,
-    usageGuide: 'screen_local_crypto_pairs 前先读本地 Crypto 筛选维度说明。',
-    compliance: '只读 schema；需 crypto_list 已同步。',
-  },
-  screen_local_crypto_pairs: {
-    hubFeature: 'local_crypto_screen',
-    miningEligible: true,
-    usageGuide: '按 keyword、quote（USDT/USDC/BTC 等）、base_contains 筛选本地交易对。',
-    compliance: 'top_n ≤200；本地 crypto_count=0 时勿调用。',
-  },
-  get_local_jp_screen_schema: {
-    hubFeature: 'local_jp_screen_schema',
-    miningEligible: false,
-    usageGuide: '日股暂未接入，勿调用。',
-    compliance: 'prescreenMode=blocked；仅保留兼容。',
-  },
-  screen_local_jp_stocks: {
-    hubFeature: 'local_jp_screen',
-    miningEligible: false,
-    usageGuide: '日股暂未接入，勿调用。',
-    compliance: 'prescreenMode=blocked。',
-  },
-  get_local_kr_screen_schema: {
-    hubFeature: 'local_kr_screen_schema',
-    miningEligible: false,
-    usageGuide: '韩股暂未接入，勿调用。',
-    compliance: 'prescreenMode=blocked；仅保留兼容。',
-  },
-  screen_local_kr_stocks: {
-    hubFeature: 'local_kr_screen',
-    miningEligible: false,
-    usageGuide: '韩股暂未接入，勿调用。',
-    compliance: 'prescreenMode=blocked。',
-  },
-  get_local_hk_screen_schema: {
-    hubFeature: 'local_hk_screen_schema',
-    miningEligible: false,
-    usageGuide: 'screen_local_hk_stocks 前先读本地港股筛选维度说明。',
-    compliance: '只读 schema；需 hk_list 已同步。',
-  },
-  screen_local_hk_stocks: {
-    hubFeature: 'local_hk_screen',
-    miningEligible: true,
-    usageGuide: '按代码/公司名、行业关键词筛选本地港股列表。',
-    compliance: 'top_n ≤200；本地 hk_count=0 时勿调用。',
-  },
-  search_local_instruments: {
-    hubFeature: 'instrument_search',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '已合并至 search_instruments；跨市场在线搜索 keyword，可用 markets 过滤。',
-    compliance: 'keyword 必填；优先 search_instruments；勿替代 screen_local_* 初选。',
+    usageGuide: '单只 ETF 决策雷达：折溢价、规模流动性、费率、净值波动与同类对比（0–100 分）；与 evaluate_instrument(ETF) 等价。',
+    compliance: '单只 code；缺数据时部分维度为空。',
   },
   search_instruments: {
     hubFeature: 'instrument_search',
@@ -374,12 +174,6 @@ export const TOOL_META: Record<string, ToolMeta> = {
     miningEligible: true,
     usageGuide: `批量最新价、涨跌幅、量比等；初选后快速更新多只候选行情。${INSTRUMENT_REF_USAGE}`,
     compliance: 'instruments 数组一次传入，建议 ≤ 30；禁止逐只循环调用。',
-  },
-  batch_instrument_snapshots: {
-    hubFeature: 'instrument_batch_snapshots',
-    miningEligible: true,
-    usageGuide: `初选后批量获取候选截面（行业、评分、PE/PB、关键因子）；A 股挖掘首选。可用 instruments 数组或 codes+market（默认 CN）。${INSTRUMENT_REF_USAGE}`,
-    compliance: 'instruments 或 codes 一次传入，建议 ≤ 80；禁止对同一列表重复调用。',
   },
   get_instrument_chart: {
     hubFeature: 'instrument_chart',
@@ -409,7 +203,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
     hubFeature: 'instrument_strategy_verify',
     miningEligible: false,
     usageGuide: `验证历史策略信号胜率与 forward 收益，支撑 thesis 可信度。${INSTRUMENT_REF_USAGE}`,
-    compliance: '单只；计算较重；仅对核心 1–3 只候选使用；跨市场请用本工具替代 strategy_verify。',
+    compliance: '单只；计算较重；仅对核心 1–3 只候选使用。',
   },
   get_instrument_latest_evaluation: {
     hubFeature: 'latest_evaluation',
@@ -435,64 +229,16 @@ export const TOOL_META: Record<string, ToolMeta> = {
     usageGuide: `机构评级完整文本报告；仅 A 股。${INSTRUMENT_REF_USAGE}`,
     compliance: '长文本；仅用户明确要求深度报告时调用；market 须为 CN。',
   },
-  search_stocks: {
-    hubFeature: 'search_stocks',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '根据名称/代码/行业关键词在本地 universe 中定位标的；需先完成 universe 同步。',
-    compliance: 'keyword 必填；优先 StockIndex 在线检索，A 股空结果时腾讯备用；可用 markets 限定市场。',
-  },
-  evaluate_stock: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.evaluation,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '对单股做评分卡因子评估与综合打分；需要量化 match_score 依据时使用。',
-    compliance: '单股；可指定 scorecard；评估会写本地快照，同股同卡避免重复评估。',
-  },
-  get_latest_evaluation: {
-    hubFeature: 'latest_evaluation',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '读取已缓存的最近一次因子评估，避免重复 evaluate_stock；跨市场请用 get_instrument_latest_evaluation。',
-    compliance: '单股只读；无缓存时再调用 evaluate_stock。',
-  },
-  get_strategy_signal: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.strategy_signal,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '9 策略融合方向信号，辅助判断多空倾向与策略匹配度。',
-    compliance: '单股；信号为研究参考，非买卖指令。',
-  },
-  strategy_verify: {
-    hubFeature: INSTRUMENT_HUB_FEATURE.strategy_verify,
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '验证历史信号胜率与 forward 收益，支撑 thesis 可信度；跨市场请用 verify_instrument_strategy。',
-    compliance: '单股；计算较重；仅对核心 1–3 只候选使用。',
-  },
-  strategy_verify_report: {
-    hubFeature: 'strategy_verify_report',
-    miningEligible: true,
-    deprecated: true,
-    usageGuide: '需要可读文本版验证报告时使用；跨市场策略验证请用 verify_instrument_strategy。',
-    compliance: '单股；文本较长，挖掘 JSON 输出阶段慎用。',
-  },
-  strategy_report: {
-    hubFeature: 'strategy_report',
-    miningEligible: true,
-    usageGuide: '单股 T 策略综合分析长文。',
-    compliance: '文本报告；非结构化挖掘首选。',
-  },
   institution_rating: {
     hubFeature: INSTRUMENT_HUB_FEATURE.institution_rating,
     miningEligible: true,
-    usageGuide: '28 家机构风格共识；基本面/估值研究需外部观点时使用。',
-    compliance: '单股；可选 groups 过滤；勿编造机构观点。',
+    usageGuide: 'A 股 28 家机构风格共识（CN 六位 code 快捷写法）；跨市场请用 get_instrument_institution_rating。',
+    compliance: '单股 CN code；可选 groups 过滤；勿编造机构观点。',
   },
   institution_report: {
     hubFeature: INSTRUMENT_HUB_FEATURE.institution_report,
     miningEligible: true,
-    usageGuide: '机构评级完整文本报告。',
+    usageGuide: 'A 股机构评级完整文本报告（CN 六位 code 快捷写法）。',
     compliance: '长文本；仅用户明确要求深度报告时调用。',
   },
   analyze_portfolio: {
@@ -522,14 +268,20 @@ export const TOOL_META: Record<string, ToolMeta> = {
   industry_mining: {
     hubFeature: 'industry_mining',
     miningEligible: true,
-    usageGuide: '产业链透视、上下游代表公司；行业主题策略时补充候选理解。',
-    compliance: 'industry 名称需具体；不替代单股财务核实。',
+    usageGuide: '产业链透视、上下游代表公司；配合 list_local_industries / get_industry_stats 做行业主题深度分析。',
+    compliance: 'industry 名称需具体；不替代单股财务核实；可与 get_local_industry_stocks 交叉验证代表公司。',
   },
   industry_mermaid: {
     hubFeature: 'industry_mermaid',
     miningEligible: true,
-    usageGuide: '输出产业链 mindmap 源码。',
-    compliance: '展示用；挖掘 JSON 不必调用。',
+    usageGuide: '输出产业链 Mermaid mindmap 源码；用户需要可视化产业链结构时使用。',
+    compliance: '展示用；分析逻辑仍须 industry_mining 或单股工具支撑。',
+  },
+  strategy_report: {
+    hubFeature: 'strategy_report',
+    miningEligible: true,
+    usageGuide: '单股 T 策略综合分析长文（A 股 CN code）。',
+    compliance: '文本报告；非结构化挖掘首选；跨市场策略验证用 verify_instrument_strategy。',
   },
   get_portfolio_holdings: {
     hubFeature: 'portfolio_holdings',
@@ -552,38 +304,38 @@ export const TOOL_META: Record<string, ToolMeta> = {
   get_news_center_status: {
     hubFeature: 'news_center_status',
     miningEligible: false,
-    usageGuide: '用户询问订阅资讯、RSS 要闻或新闻中心内容前调用；确认数据是否已刷新、订阅规模与文章总量。有标的上下文时，下一步按标的 market 选分组。',
+    usageGuide: '用户询问订阅资讯、RSS 要闻或新闻中心内容前调用；确认数据是否已刷新、订阅规模与文章总量。',
     compliance: '只读；无参数；stale=true 时告知用户列表可能不是最新，勿编造文章。',
   },
   list_news_groups: {
     hubFeature: 'news_groups_list',
     miningEligible: false,
-    usageGuide: '按标的类型选资讯分组：阅读返回的 market_hints 与 relevance，优先与标的 market 一致的分组（如 CN 标的→含「A股/沪深」分组）；不足时交叉查 MACRO/GLOBAL 分组。',
+    usageGuide: '按标的类型选资讯分组：阅读返回的 market_hints 与 relevance，优先与标的 market 一致的分组。',
     compliance: '只读；分组 id 须原样传入 list_news_articles；未分组订阅用 group_id=__ungrouped__；同一任务最多调用 1 次。',
   },
   list_news_sources: {
     hubFeature: 'news_sources_list',
     miningEligible: false,
-    usageGuide: '在已选分组内按 market_hints / title 关键词筛选 enabled 来源；与 list_news_articles(view=source) 配合；优先 relevance 高的来源。',
+    usageGuide: '在已选分组内按 market_hints / title 关键词筛选 enabled 来源。',
     compliance: '只读；subscription_id 须来自本工具返回；同一任务最多调用 1 次。',
   },
   list_news_articles: {
     hubFeature: 'news_articles_list',
     miningEligible: false,
-    usageGuide: '标的相关资讯：优先 view=group + 最匹配 group_id；信息不足时交叉调阅 MACRO/GLOBAL 分组或 view=timeline 兜底。用户问「订阅里有什么」且无标的时用 timeline。',
-    compliance: '只读；limit ≤50；view=group 须 group_id，view=source 须 subscription_id；列表无正文，禁止臆造 article_id；翻页用 cursor。',
+    usageGuide: '标的相关资讯：优先 view=group + 最匹配 group_id；信息不足时交叉调阅 MACRO/GLOBAL 分组或 view=timeline 兜底。',
+    compliance: '只读；limit ≤50；view=group 须 group_id，view=source 须 subscription_id；列表无正文，禁止臆造 article_id。',
   },
   get_news_article: {
     hubFeature: 'news_article_detail',
     miningEligible: false,
     usageGuide: '仅对 list 筛出的最相关 1–3 篇拉正文做深度解读；用户点名某条资讯时使用。',
-    compliance: 'article_id 必填且须来自 list_news_articles；只读；正文已压缩空白；无正文时可能仅返回标题。',
+    compliance: 'article_id 必填且须来自 list_news_articles；只读；正文已压缩空白。',
   },
   get_notice_content: {
     hubFeature: 'notice_content',
     miningEligible: false,
     usageGuide: '用户要读某条上市公司公告/年报全文时使用；url 来自 get_instrument_snapshot 公告列表或用户提供的链接。',
-    compliance: 'url 必填；支持新浪/巨潮/SSE 等 HTML 与 PDF；正文已压缩；truncated=true 时可增大 max_chars；只读。',
+    compliance: 'url 必填；支持 HTML 与 PDF；正文已压缩；truncated=true 时可增大 max_chars；只读。',
   },
   get_current_time: {
     miningEligible: true,
@@ -613,7 +365,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
   ask_user: {
     miningEligible: false,
     usageGuide: '分析前需用户确认方向、范围或偏好，且上下文无法推断时调用；会在聊天输入框上方展示选择题，用户点选或自行输入后继续。',
-    compliance: 'prompt 必填、面向投资者；options 2–5 项且 id 唯一；allow_multiple 默认 false；同一轮对话最多 1 次；禁止索要密钥；调用后须等待工具返回再续分析。',
+    compliance: 'prompt 必填、面向投资者；options 2–5 项且 id 唯一；allow_multiple 默认 false；同一轮对话最多 1 次；禁止索要密钥。',
   },
   list_enabled_providers: {
     hubFeature: 'provider_list',
@@ -631,29 +383,13 @@ export const TOOL_META: Record<string, ToolMeta> = {
     hubFeature: 'provider_invoke_custom',
     miningEligible: false,
     usageGuide: '执行 list_provider_custom_methods 查到的自定义方法；标准 get_instrument_* 能覆盖的需求勿调用。',
-    compliance: 'provider_id + method 必填；args 为 JSON 数组；code/symbol 可传 InstrumentRef 或 CN:600519 / 600519.SH / sh600519，引擎自动转为 Provider 格式；同一 method 每任务最多 1 次。',
+    compliance: 'provider_id + method 必填；args 为 JSON 数组；code/symbol 可传 InstrumentRef 或 CN:600519；同一 method 每任务最多 1 次。',
   },
 }
 
 export const DATA_LAYER_MINING_TOOL_NAMES = Object.entries(TOOL_META)
   .filter(([, m]) => m.miningEligible)
   .map(([name]) => name) as readonly string[]
-
-const US_MINING_TOOL_NAMES = [
-  'get_market_db_status',
-  'get_local_us_screen_schema',
-  'screen_local_us_stocks',
-  'search_local_instruments',
-  ...UNIFIED_MINING_INSTRUMENT_TOOLS,
-] as const
-
-const CRYPTO_MINING_TOOL_NAMES = [
-  'get_market_db_status',
-  'get_local_crypto_screen_schema',
-  'screen_local_crypto_pairs',
-  'search_local_instruments',
-  ...UNIFIED_MINING_INSTRUMENT_TOOLS,
-] as const
 
 export function discoverMiningToolNames(profile: string): readonly string[] {
   if (isDiscoverStrategyProfile(profile)) {

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -178,20 +178,31 @@ export class ToolRegistry {
 
     const tools: Omit<ToolDef, 'meta'>[] = [
       {
-        name: 'evaluate_stock', category: '个股分析',
-        description: '对单只股票做全面因子评估与评分卡打分',
+        name: 'get_market_regime', category: '市场',
+        description: '获取宏观市场状态（牛熊/风险偏好、建议策略方向）；A 股默认沪深300，美股用 SPY',
         parameters: S({
-          code: { type: 'string', description: '6位股票代码，如 600519' },
-          scorecard: { type: 'string', description: '评分卡名称，默认综合评估' },
-        }, ['code']),
-        handler: (a: Record<string, unknown>) => d('instrument_evaluation', {
-          ...normalizeInstrumentHubParams({ code: a.code, market: 'CN' }),
-          scorecard: a.scorecard ?? '综合评估',
+          profile_scope: { type: 'string', description: 'cn（默认 A 股）| us（美股）' },
         }),
+        handler: (a: Record<string, unknown>) => d('market_regime', a),
+      },
+      {
+        name: 'get_market_dynamics', category: '市场',
+        description: '获取市场动态全景：A 股/全球指数、涨跌榜、龙虎榜摘要',
+        parameters: S({}),
+        handler: () => d('market_dynamics', {}),
+      },
+      {
+        name: 'get_trend_brief', category: '个股分析',
+        description: 'A 股单股趋势研判：均线结构、相对强弱、可选持仓成本盈亏',
+        parameters: S({
+          code: { type: 'string', description: '6 位 A 股代码' },
+          holding_cost: { type: 'number', description: '可选，持仓成本价（元）' },
+        }, ['code']),
+        handler: (a: Record<string, unknown>) => d('trend_brief', a),
       },
       {
         name: 'screen_stocks', category: '选股',
-        description: '按因子条件在线筛选股票',
+        description: '按因子条件在线筛选 A 股',
         parameters: S({
           conditions: { type: 'array', description: '条件数组 [{factor, op, value}]，op 为 > >= < <= =' },
           scorecard: { type: 'string', description: '评分卡' },
@@ -200,10 +211,53 @@ export class ToolRegistry {
         handler: (a: Record<string, unknown>) => d('screening', { conditions: a.conditions, scorecard: a.scorecard, top_n: a.top_n ?? 20 }),
       },
       {
+        name: 'screen_us_universe', category: '选股',
+        description: '按关键词在线筛选美股名录（StockIndex）',
+        parameters: S({
+          keyword: { type: 'string', description: 'ticker 或公司名关键词' },
+          top_n: { type: 'number', description: '返回条数，默认 50，最大 200' },
+        }),
+        handler: (a: Record<string, unknown>) => d('local_us_screen', a),
+      },
+      {
+        name: 'screen_hk_universe', category: '选股',
+        description: '按关键词在线筛选港股名录（StockIndex）',
+        parameters: S({
+          keyword: { type: 'string', description: '代码或公司名关键词' },
+          top_n: { type: 'number', description: '返回条数，默认 50，最大 200' },
+        }),
+        handler: (a: Record<string, unknown>) => d('local_hk_screen', a),
+      },
+      {
+        name: 'screen_crypto_universe', category: '选股',
+        description: '按关键词/计价币筛选 Crypto 交易对名录',
+        parameters: S({
+          keyword: { type: 'string', description: '可选，匹配 pair 或 base' },
+          quote: { type: 'string', description: '可选，计价币如 USDT' },
+          base_contains: { type: 'string', description: '可选，base 币种包含' },
+          top_n: { type: 'number', description: '返回条数，默认 50，最大 200' },
+        }),
+        handler: (a: Record<string, unknown>) => d('local_crypto_screen', a),
+      },
+      {
         name: 'get_watchlist', category: '组合管理',
         description: '读取用户关注列表（代码、名称、行业、备注、加入价）',
         parameters: S({}),
         handler: () => d('watchlist_list', {}),
+      },
+      {
+        name: 'get_watchlist_radar', category: '组合管理',
+        description: '关注股或多股雷达摘要（估值分位、主力净流入、评分）；省略 codes 则用用户关注列表',
+        parameters: S({
+          codes: { type: 'array', description: '可选，A 股 6 位代码数组；省略则读取关注列表' },
+        }),
+        handler: (a: Record<string, unknown>) => d('watchlist_radar', { codes: a.codes }),
+      },
+      {
+        name: 'get_local_data_status', category: '基础',
+        description: '查询本地 SQLite 数据规模与就绪状态（行业名录、截面等；不含因子筛选）',
+        parameters: S({}),
+        handler: () => d('market_db_status', {}),
       },
       {
         name: 'search_etfs', category: '通用',
@@ -212,6 +266,20 @@ export class ToolRegistry {
           keyword: { type: 'string', description: '搜索关键词' },
         }, ['keyword']),
         handler: (a: Record<string, unknown>) => d('search_etfs', { keyword: a.keyword }),
+      },
+      {
+        name: 'get_etf_list', category: '通用',
+        description: '获取 A 股 ETF 全量列表，或按 code 过滤单只',
+        parameters: S({
+          code: { type: 'string', description: '可选，6 位 ETF 代码过滤' },
+        }),
+        handler: (a: Record<string, unknown>) => d('etf_list', a),
+      },
+      {
+        name: 'get_etf_scorecard', category: '通用',
+        description: '单只 A 股 ETF 决策雷达（折溢价、规模流动性、费率、波动与同类对比）',
+        parameters: S({ code: { type: 'string', description: '6 位 ETF 代码' } }, ['code']),
+        handler: (a: Record<string, unknown>) => d('etf_scorecard', { code: a.code }),
       },
       {
         name: 'get_etf_snapshot', category: '通用',
@@ -232,24 +300,6 @@ export class ToolRegistry {
         handler: (a: Record<string, unknown>) => d('etf_holdings', { code: a.code }),
       },
       {
-        name: 'search_us_stocks', category: '通用',
-        description: '搜索美股（ticker 或公司名）',
-        parameters: S({ keyword: { type: 'string', description: '搜索关键词' } }, ['keyword']),
-        handler: (a: Record<string, unknown>) => d('instrument_search', {
-          keyword: a.keyword,
-          markets: ['US'],
-        }),
-      },
-      {
-        name: 'search_crypto_pairs', category: '通用',
-        description: '搜索 Crypto 交易对（base 或 pair 名）',
-        parameters: S({ keyword: { type: 'string', description: '搜索关键词' } }, ['keyword']),
-        handler: (a: Record<string, unknown>) => d('instrument_search', {
-          keyword: a.keyword,
-          markets: ['CRYPTO'],
-        }),
-      },
-      {
         name: 'analyze_portfolio', category: '组合管理',
         description: '分析持仓组合的因子暴露与综合评分',
         parameters: S({
@@ -257,21 +307,6 @@ export class ToolRegistry {
           scorecard: { type: 'string', description: '评分卡' },
         }, ['holdings']),
         handler: (a: Record<string, unknown>) => d('portfolio_analysis', { holdings: a.holdings, scorecard: a.scorecard }),
-      },
-      {
-        name: 'search_stocks', category: '通用',
-        description: '按代码或名称关键词在线搜索 A 股标的',
-        parameters: S({ keyword: { type: 'string', description: '搜索关键词' } }, ['keyword']),
-        handler: (a: Record<string, unknown>) => d('instrument_search', {
-          keyword: a.keyword,
-          markets: ['CN'],
-        }),
-      },
-      {
-        name: 'get_strategy_signal', category: '策略',
-        description: '获取单股 9 策略融合信号（看多/看空/中性）',
-        parameters: S({ code: { type: 'string', description: '股票代码' } }, ['code']),
-        handler: (a: Record<string, unknown>) => d('instrument_strategy_signal', normalizeInstrumentHubParams({ code: a.code, market: 'CN' })),
       },
       {
         name: 'institution_rating', category: '个股分析',
@@ -308,29 +343,6 @@ export class ToolRegistry {
         handler: (a: Record<string, unknown>) => d('backtest', { codes: a.codes, scorecard: a.scorecard, periods: a.periods ?? 5 }),
       },
       {
-        name: 'strategy_verify', category: '策略',
-        description: '验证策略历史信号胜率与 forward 收益',
-        parameters: S({
-          code: { type: 'string', description: '股票代码' },
-          checkpoints: { type: 'number', description: '验证点数' },
-          forward_days: { type: 'number', description: '持有天数' },
-        }, ['code']),
-        handler: (a: Record<string, unknown>) => d('instrument_strategy_verify', {
-          ...normalizeInstrumentHubParams({ code: a.code, market: 'CN' }),
-          checkpoints: a.checkpoints ?? 30,
-          forward_days: a.forward_days ?? 5,
-        }),
-      },
-      {
-        name: 'strategy_verify_report', category: '策略',
-        description: '策略验证的格式化文本报告',
-        parameters: S({
-          code: { type: 'string', description: '股票代码' },
-          checkpoints: { type: 'number', description: '验证点数' },
-        }, ['code']),
-        handler: (a: Record<string, unknown>) => d('strategy_verify_report', { code: a.code, checkpoints: a.checkpoints ?? 30 }),
-      },
-      {
         name: 'strategy_report', category: '策略',
         description: '单股 T 策略综合分析文本报告',
         parameters: S({ code: { type: 'string', description: '股票代码' } }, ['code']),
@@ -359,6 +371,34 @@ export class ToolRegistry {
         description: '产业链 Mermaid mindmap 源码',
         parameters: S({ industry: { type: 'string', description: '行业名称' } }, ['industry']),
         handler: (a: Record<string, unknown>) => d('industry_mermaid', { industry: a.industry }),
+      },
+      {
+        name: 'list_local_industries', category: '行业',
+        description: '列出 A 股可用行业名称（可 keyword 模糊过滤），供查成分股或产业链分析',
+        parameters: S({
+          keyword: { type: 'string', description: '可选，模糊匹配行业名，如 半导体、银行' },
+          trade_date: { type: 'string', description: '可选，截面日 YYYY-MM-DD' },
+          limit: { type: 'number', description: '返回条数，默认 200，最大 500' },
+        }),
+        handler: (a: Record<string, unknown>) => d('local_industry_list', a),
+      },
+      {
+        name: 'get_industry_stats', category: '行业',
+        description: 'A 股行业维度统计：成分数量、均评分、PE/PB、涨跌家数对比',
+        parameters: S({
+          trade_date: { type: 'string', description: '可选，截面日 YYYY-MM-DD' },
+        }),
+        handler: (a: Record<string, unknown>) => d('market_industry_stats', a),
+      },
+      {
+        name: 'get_local_industry_stocks', category: '行业',
+        description: '列出指定行业的 A 股成分股（最新价、涨跌幅、综合评分）',
+        parameters: S({
+          industry: { type: 'string', description: '行业名称，须与 list_local_industries 返回一致' },
+          trade_date: { type: 'string', description: '可选，截面日 YYYY-MM-DD' },
+          limit: { type: 'number', description: '返回条数，默认 120，最大 200' },
+        }, ['industry']),
+        handler: (a: Record<string, unknown>) => d('market_industry_stocks', a),
       },
       {
         name: 'get_news_center_status', category: '资讯中心',
@@ -422,12 +462,6 @@ export class ToolRegistry {
           url: a.url,
           max_chars: a.max_chars ?? a.maxChars,
         }),
-      },
-      {
-        name: 'get_latest_evaluation', category: '通用',
-        description: '读取最近一次评估缓存（会话内 evaluate 结果）',
-        parameters: S({ code: { type: 'string', description: '股票代码' } }, ['code']),
-        handler: (a: Record<string, unknown>) => d('latest_evaluation', normalizeInstrumentHubParams({ code: a.code, market: 'CN' })),
       },
       {
         name: 'get_portfolio_holdings', category: '组合管理',

--- a/packages/agent/src/unified-mcp-tools.ts
+++ b/packages/agent/src/unified-mcp-tools.ts
@@ -108,37 +108,8 @@ export const UNIFIED_MINING_INSTRUMENT_TOOLS = [
   'get_instrument_indicators',
 ] as const
 
-export const LEGACY_MARKET_DATA_TOOL_NAMES = [
-  'get_us_stock_quote',
-  'get_us_stock_kline',
-  'get_us_stock_snapshot',
-  'get_us_stock_profile',
-  'get_us_stock_financials',
-  'get_crypto_quote',
-  'get_crypto_kline',
-  'get_crypto_snapshot',
-  'get_stock_quotes',
-  'get_stock_kline',
-  'get_stock_chart',
-  'get_stock_detail',
-  'search_us_stocks',
-  'search_crypto_pairs',
-  'evaluate_stock',
-  'get_strategy_signal',
-  'strategy_verify',
-  'strategy_verify_report',
-  'get_latest_evaluation',
-  'batch_stock_snapshots',
-  'get_stock_cyq',
-  'search_stocks',
-] as const
-
-const LEGACY_MARKET_DATA_TOOL_SET = new Set<string>(LEGACY_MARKET_DATA_TOOL_NAMES)
-
 export function CHAT_MCP_TOOL_NAMES(registry: { list: () => Array<{ name: string }> }): readonly string[] {
-  return registry.list()
-    .map(t => t.name)
-    .filter(name => !LEGACY_MARKET_DATA_TOOL_SET.has(name))
+  return registry.list().map(t => t.name)
 }
 
 type DispatchFn = (feature: string, params: Record<string, unknown>) => Promise<unknown>

--- a/packages/market-data/src/query/screen-schema.ts
+++ b/packages/market-data/src/query/screen-schema.ts
@@ -162,7 +162,7 @@ export function buildLocalUniverseScreenSchema(latestTradeDate?: string | null):
   return {
     version: '1.0',
     data_source: '本地 L0 初选库（SQLite stock_factors / stock_scores / stock_quotes_daily）',
-    prerequisite: '先调用 get_market_db_status 确认 is_ready=true；未就绪时勿调用本筛选，改用 screen_stocks 或 trigger_market_db_sync。',
+    prerequisite: '本地因子筛选已停用；请使用 screen_stocks 或 search_instruments 在线初选。',
     trade_date: {
       format: 'YYYY-MM-DD',
       default: latestTradeDate ?? '最新因子交易日',

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -461,7 +461,12 @@ export class ResearchHub {
   }
 
   private marketDbStatus(t0: number) {
-    return this.failLocalOffline(t0)
+    const status = this.marketData.status()
+    return ok({
+      ...status,
+      local_offline_screening_enabled: false,
+      guidance: '本地因子筛选已停用；行业名录/截面仍可读本地 SQLite；选股请用 screen_stocks 或 search_instruments',
+    }, '本地数据状态', t0)
   }
 
   private marketDbSyncState(t0: number) {
@@ -528,24 +533,46 @@ export class ResearchHub {
     return this.failLocalOffline(t0)
   }
 
+  private industrySnapshotUnavailable(t0: number) {
+    const { stock_count: stockCount } = this.marketData.status()
+    if (stockCount > 0) return null
+    return fail('本地行业库暂无数据，请使用 search_instruments、screen_stocks 等在线能力', t0)
+  }
+
   private marketIndustryStats(params: Record<string, unknown>, t0: number) {
-    void params
-    return this.failLocalOffline(t0)
+    const unavailable = this.industrySnapshotUnavailable(t0)
+    if (unavailable) return unavailable
+    const tradeDate = params.trade_date != null ? String(params.trade_date).trim() : undefined
+    const data = this.marketData.industryStats(tradeDate || undefined)
+    return ok(data, `A 股 ${data.items.length} 个行业统计`, t0)
   }
 
   private marketIndustryStocks(params: Record<string, unknown>, t0: number) {
-    void params
-    return this.failLocalOffline(t0)
+    const industry = String(params.industry ?? '').trim()
+    if (!industry) return fail('industry 必填', t0)
+    const unavailable = this.industrySnapshotUnavailable(t0)
+    if (unavailable) return unavailable
+    const tradeDate = params.trade_date != null ? String(params.trade_date).trim() : undefined
+    const limitRaw = params.limit != null ? Number(params.limit) : 120
+    const limit = Number.isFinite(limitRaw) ? limitRaw : 120
+    const data = this.marketData.industryStocks(industry, tradeDate || undefined, limit)
+    return ok(data, `${industry} 成分股 ${data.items.length} 只`, t0)
   }
 
   private localIndustryList(params: Record<string, unknown>, t0: number) {
-    void params
-    return this.failLocalOffline(t0)
+    const unavailable = this.industrySnapshotUnavailable(t0)
+    if (unavailable) return unavailable
+    const keyword = params.keyword != null ? String(params.keyword).trim() : undefined
+    const tradeDate = params.trade_date != null ? String(params.trade_date).trim() : undefined
+    const limitRaw = params.limit != null ? Number(params.limit) : undefined
+    const limit = limitRaw != null && Number.isFinite(limitRaw) ? limitRaw : undefined
+    const data = this.marketData.industryList(keyword || undefined, tradeDate || undefined, limit)
+    return ok(data, `行业列表 ${data.industries.length} 项`, t0)
   }
 
   private localIndustryScreen(params: Record<string, unknown>, t0: number) {
     void params
-    return this.failLocalOffline(t0)
+    return fail('本地因子行业内筛选已停用，请用 get_local_industry_stocks 列出成分股后结合 screen_stocks / evaluate_instrument 在线分析', t0)
   }
 
   private listScreenFactors(t0: number) {

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -18,7 +18,7 @@ export function buildStandardInstrumentApiPlaybook(): string {
     '- 能力探测：get_instrument_capabilities → 仅调用返回 capabilities 中的工具',
     '- 行情：get_instrument_quotes；快照：get_instrument_snapshot；K 线：get_instrument_chart',
     '- A 股批量截面：batch_instrument_snapshots；评估/信号：evaluate_instrument、get_instrument_strategy_signal',
-    '- ETF：search_etfs / get_etf_snapshot / get_etf_nav / get_etf_holdings（或 instrument ETF ref）',
+    '- ETF：search_etfs / get_etf_list / get_etf_snapshot / get_etf_nav / get_etf_holdings / get_etf_scorecard（或 instrument ETF ref + evaluate_instrument）',
     '- 日股/韩股（JP/KR）暂未接入标准 API，勿调用行情/快照/K 线类工具',
   ].join('\n')
 }
@@ -109,6 +109,31 @@ export function buildUserInteractionPlaybook(): string {
   ].join('\n')
 }
 
+/** 聊天 Agent — 市场宏观与关注池 */
+export function buildMarketContextPlaybook(): string {
+  return [
+    '【市场与关注 — get_market_regime / get_market_dynamics / get_watchlist_radar / get_trend_brief】',
+    '1) 宏观背景：get_market_regime（A 股默认 cn，美股 profile_scope=us）→ 解读牛熊/风险偏好后再谈个股',
+    '2) 市场全景：get_market_dynamics → 指数、全球市场、涨跌榜、龙虎榜；适合复盘或解释板块轮动',
+    '3) 关注池速览：get_watchlist → get_watchlist_radar（可省略 codes 用关注列表）→ 对重点标的 get_instrument_snapshot',
+    '4) A 股趋势一句话：get_trend_brief（code 必填，可选 holding_cost）→ 需要深度时 evaluate_instrument / get_instrument_chart',
+    '5) 跨市场名录初选：screen_us_universe / screen_hk_universe / screen_crypto_universe 或 search_instruments（markets 过滤）',
+  ].join('\n')
+}
+
+/** 聊天 Agent — 行业分析路径（列表 → 统计 → 成分股 → 产业链） */
+export function buildIndustryAnalysisPlaybook(): string {
+  return [
+    '【A 股行业分析 — list_local_industries / get_industry_stats / get_local_industry_stocks / industry_mining】',
+    '1) 不确定行业名：list_local_industries（keyword 模糊，如「半导体」）→ 用返回的精确 industry 名继续',
+    '2) 行业强弱/估值对比：get_industry_stats → 读涨跌家数、均 PE/PB、均评分',
+    '3) 行业成分与龙头：get_local_industry_stocks（industry 须与列表一致）→ 对重点标的 get_instrument_snapshot / evaluate_instrument',
+    '4) 产业链与代表公司：industry_mining；需 mindmap 展示时用 industry_mermaid',
+    '5) 条件选股：screen_stocks（在线因子筛选）；本地因子筛选已停用',
+    '6) 本地行业库无数据时：get_local_data_status 确认后改 search_instruments + screen_stocks，并告知用户',
+  ].join('\n')
+}
+
 /** 聊天 Agent 完整 system 规则正文（不含角色行） */
 export function buildAgentSystemRules(): string {
   return [
@@ -117,14 +142,16 @@ export function buildAgentSystemRules(): string {
     '- 跨市场标的统一用 InstrumentRef（market + symbol）；不熟悉代码时 search_instruments',
     buildStandardInstrumentApiPlaybook(),
     buildInstrumentAnalysisPlaybook(),
+    buildIndustryAnalysisPlaybook(),
+    buildMarketContextPlaybook(),
     buildProviderCustomMethodPlaybook(),
     buildUserInteractionPlaybook(),
-    '- A 股在线初选：screen_stocks；本地因子库可选 get_market_db_status + screen_local_universe（库未就绪时勿强依赖）',
+    '- A 股在线初选：screen_stocks；跨市场初选：search_instruments 或 screen_us_universe / screen_hk_universe / screen_crypto_universe',
     buildNewsRetrievalPlaybook(),
     '- 每个工具描述含【何时使用】【调用规范】，严格遵守',
     '- 不推荐具体买卖，仅提供研究与数据解读',
     '- 可组合多个工具由浅入深补全数据',
-    '- 用户关注列表用 get_watchlist；实盘持仓用 get_portfolio_holdings / portfolio_summary（含 A/HK/US，返回带 market）；交易流水用 portfolio_trades（过滤港/美须带 market）',
+    '- 用户关注列表用 get_watchlist；关注池雷达用 get_watchlist_radar；实盘持仓用 get_portfolio_holdings / portfolio_summary（含 A/HK/US，返回带 market）；交易流水用 portfolio_trades（过滤港/美须带 market）',
     '- 报告日期与时区用 get_current_time；环境/版本用 get_system_info；默认评分卡与模型用 get_app_settings',
     '- 外部集成（Tushare）状态用 get_integration_status',
     '- 禁止 Shell 执行、任意文件读写或未提供的工具能力',

--- a/packages/shared/src/discover-mining-prompt.ts
+++ b/packages/shared/src/discover-mining-prompt.ts
@@ -7,21 +7,23 @@ import { buildInstrumentAnalysisPlaybook, buildNewsRetrievalPlaybook, buildProvi
 /** 策略解析 / 执行提示中的资产类型描述 */
 export function discoverProfileAssetLabel(profile: DiscoverStrategyProfile): string {
   const def = getDiscoverProfileDefinition(profile)
-  if (!def) return 'A 股股票（本地因子库）'
+  if (!def) return 'A 股股票（在线因子筛选）'
   if (profile === 'cn_etf') return 'A 股 ETF（折溢价%、规模亿元）'
   if (def.prescreenMode === 'list_filter') {
     const online = def.readinessCountKey == null
     return `${def.label}（${online ? 'StockIndex 在线列表' : '本地列表'} keyword / industry_contains）`
   }
-  return 'A 股股票（本地因子库）'
+  return 'A 股股票（在线因子筛选）'
 }
 
 const CN_EQUITY_FORBIDDEN = [
-  'evaluate_stock', 'get_strategy_signal', 'batch_stock_snapshots', 'batch_instrument_snapshots',
-  'get_stock_cyq', 'search_stocks',
-  'get_stock_detail', 'get_stock_chart', 'screen_local_universe',
+  'batch_stock_snapshots',
+  'get_stock_cyq', 'get_stock_detail', 'get_stock_chart', 'get_stock_kline', 'get_stock_quotes',
+  'evaluate_stock', 'get_strategy_signal', 'search_stocks',
   'get_us_stock_snapshot', 'get_us_stock_quote', 'get_us_stock_kline',
   'get_crypto_snapshot', 'get_crypto_quote', 'get_crypto_kline',
+  'screen_local_universe', 'local_screen_stocks', 'screen_local_industry_stocks',
+  'get_market_db_status', 'trigger_market_db_sync',
 ].join('、')
 
 /** Agent 挖掘阶段 system prompt — 由 registry + miningToolGroup 驱动 */
@@ -86,14 +88,13 @@ export function buildDiscoverMiningSystemPrompt(input: {
 
   if (mode === 'factor_screen') {
     return [
-      '你是 Opptrix 选股页 Agent。策略条件已由 AI 解析并完成因子初选。',
+      '你是 Opptrix 选股页 Agent。策略条件已由 AI 解析并完成在线初选。',
       '你可调用数据层 MCP 工具（见各工具【何时使用】【调用规范】）由浅入深补全数据：',
-      '1) search_instruments / screen_stocks → batch_instrument_snapshots（在线初选优先）',
+      '1) get_market_regime（可选宏观背景）→ search_instruments / screen_stocks → batch_instrument_snapshots',
       '2) 不足时对 shortlisted 单股：get_instrument_snapshot / evaluate_instrument / get_instrument_strategy_signal / institution_rating',
-      '3) 本地因子库（可选）：get_market_db_status → screen_local_universe；未就绪时勿强依赖 trigger_market_db_sync',
-      '4) 策略涉及用户持仓/关注：get_watchlist、get_portfolio_holdings、portfolio_trades',
-      '5) 需要资讯背景：先确定候选为 A 股，再按【资讯调阅】规则 list_news_groups 选 CN/MACRO 相关分组',
-      '6) 板块/宏观/情绪等非标准数据：list_provider_custom_methods → invoke_provider_custom_method',
+      '3) 策略涉及用户持仓/关注：get_watchlist、get_watchlist_radar、get_portfolio_holdings、portfolio_trades',
+      '4) 需要资讯背景：先确定候选为 A 股，再按【资讯调阅】规则 list_news_groups 选 CN/MACRO 相关分组',
+      '5) 板块/宏观/情绪等非标准数据：list_provider_custom_methods → invoke_provider_custom_method',
       buildInstrumentAnalysisPlaybook(),
       buildProviderCustomMethodPlaybook(),
       buildNewsRetrievalPlaybook(),

--- a/packages/shared/src/discover-mining-tools.ts
+++ b/packages/shared/src/discover-mining-tools.ts
@@ -25,6 +25,7 @@ export const UNIFIED_CN_ANALYTICS_TOOLS = [
 ] as const
 
 const CN_EQUITY_ONLINE_TOOLS = [
+  'get_market_regime',
   'screen_stocks',
   'search_instruments',
   'batch_instrument_snapshots',
@@ -33,6 +34,9 @@ const CN_EQUITY_ONLINE_TOOLS = [
   'verify_instrument_strategy',
   'get_instrument_cyq',
   'get_instrument_latest_evaluation',
+  'list_local_industries',
+  'get_industry_stats',
+  'get_local_industry_stocks',
 ] as const
 
 const REGIONAL_MINING_TOOLS = [
@@ -45,25 +49,32 @@ export const DISCOVER_MINING_TOOL_GROUPS = {
   cn_equity_full: [...CN_EQUITY_ONLINE_TOOLS],
   cn_etf: [
     'search_etfs',
+    'get_etf_list',
     'get_etf_snapshot',
     'get_etf_nav',
     'get_etf_holdings',
+    'get_etf_scorecard',
     'search_instruments',
     'get_instrument_snapshot',
     'evaluate_instrument',
     'get_instrument_strategy_signal',
   ],
   us_equity: [
+    'screen_us_universe',
     'search_instruments',
     ...UNIFIED_INSTRUMENT_MINING_TOOLS,
   ],
   crypto_spot: [
+    'screen_crypto_universe',
     'search_instruments',
     ...UNIFIED_INSTRUMENT_MINING_TOOLS,
   ],
   jp_equity: [] as const,
   kr_equity: [] as const,
-  hk_equity: [...REGIONAL_MINING_TOOLS],
+  hk_equity: [
+    'screen_hk_universe',
+    ...REGIONAL_MINING_TOOLS,
+  ],
   none: [] as const,
 } as const satisfies Record<string, readonly string[]>
 

--- a/tests/agent-industry-tools.test.mjs
+++ b/tests/agent-industry-tools.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { ToolRegistry } from '../packages/agent/dist/tools.js'
+import { ResearchHub } from '../packages/research-hub/dist/hub.js'
+import { buildIndustryAnalysisPlaybook } from '../packages/shared/dist/agent-prompt-guide.js'
+import { DATA_LAYER_MINING_TOOL_NAMES } from '../packages/agent/dist/tool-meta.js'
+
+const INDUSTRY_TOOLS = [
+  'list_local_industries',
+  'get_industry_stats',
+  'get_local_industry_stocks',
+  'industry_mining',
+  'industry_mermaid',
+]
+
+test('ToolRegistry registers industry analysis tools', () => {
+  const hub = new ResearchHub()
+  const registry = new ToolRegistry(hub)
+  const names = registry.list().map(t => t.name)
+  for (const name of INDUSTRY_TOOLS) {
+    assert.ok(names.includes(name), `missing tool: ${name}`)
+  }
+  assert.equal(registry.get('screen_local_industry_stocks'), undefined)
+})
+
+test('industry tools are chat-visible via CHAT_MCP_TOOL_NAMES', async () => {
+  const { CHAT_MCP_TOOL_NAMES } = await import('../packages/agent/dist/unified-mcp-tools.js')
+  const hub = new ResearchHub()
+  const registry = new ToolRegistry(hub)
+  const chatTools = new Set(CHAT_MCP_TOOL_NAMES(registry))
+  for (const name of INDUSTRY_TOOLS) {
+    assert.ok(chatTools.has(name), `chat tool missing: ${name}`)
+  }
+})
+
+test('mining whitelist includes industry read tools but not deprecated screen_local_industry_stocks', () => {
+  assert.ok(DATA_LAYER_MINING_TOOL_NAMES.includes('list_local_industries'))
+  assert.ok(DATA_LAYER_MINING_TOOL_NAMES.includes('get_industry_stats'))
+  assert.ok(!DATA_LAYER_MINING_TOOL_NAMES.includes('screen_local_industry_stocks'))
+})
+
+test('agent prompt includes industry analysis playbook', () => {
+  const text = buildIndustryAnalysisPlaybook()
+  assert.match(text, /list_local_industries/)
+  assert.match(text, /screen_stocks/)
+  assert.match(text, /get_local_data_status/)
+})

--- a/tests/agent-tool-integration.test.mjs
+++ b/tests/agent-tool-integration.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { ToolRegistry } from '../packages/agent/dist/tools.js'
+import { ResearchHub } from '../packages/research-hub/dist/hub.js'
+import { DATA_LAYER_MINING_TOOL_NAMES } from '../packages/agent/dist/tool-meta.js'
+import { buildMarketContextPlaybook } from '../packages/shared/dist/agent-prompt-guide.js'
+
+const P0_TOOLS = [
+  'get_watchlist_radar',
+  'get_market_regime',
+  'get_market_dynamics',
+  'get_trend_brief',
+]
+
+const P1_TOOLS = [
+  'get_etf_list',
+  'get_etf_scorecard',
+  'screen_us_universe',
+  'screen_hk_universe',
+  'screen_crypto_universe',
+]
+
+const REMOVED_LEGACY = [
+  'evaluate_stock',
+  'search_stocks',
+  'search_us_stocks',
+  'search_crypto_pairs',
+  'get_strategy_signal',
+  'strategy_verify',
+  'strategy_verify_report',
+  'get_latest_evaluation',
+  'screen_local_universe',
+  'local_screen_stocks',
+  'trigger_market_db_sync',
+  'get_market_db_status',
+]
+
+test('ToolRegistry registers P0/P1 market and screening tools', () => {
+  const registry = new ToolRegistry(new ResearchHub())
+  const names = new Set(registry.list().map(t => t.name))
+  for (const name of [...P0_TOOLS, ...P1_TOOLS]) {
+    assert.ok(names.has(name), `missing tool: ${name}`)
+  }
+  for (const name of REMOVED_LEGACY) {
+    assert.ok(!names.has(name), `legacy tool should be removed: ${name}`)
+  }
+})
+
+test('P0 tools are mining-eligible where appropriate', () => {
+  for (const name of P0_TOOLS) {
+    assert.ok(DATA_LAYER_MINING_TOOL_NAMES.includes(name), `${name} should be mining eligible`)
+  }
+  assert.ok(!DATA_LAYER_MINING_TOOL_NAMES.includes('get_local_data_status'))
+})
+
+test('market_db_status hub returns real status not offline stub', async () => {
+  const hub = new ResearchHub()
+  const resp = await hub.dispatch('market_db_status', {})
+  assert.equal(resp.success, true)
+  const data = resp.data
+  assert.ok(data && typeof data === 'object')
+  assert.equal(data.local_offline_screening_enabled, false)
+  assert.ok('stock_count' in data)
+  assert.ok('guidance' in data)
+})
+
+test('agent prompt includes market context playbook', () => {
+  const text = buildMarketContextPlaybook()
+  assert.match(text, /get_market_regime/)
+  assert.match(text, /get_watchlist_radar/)
+  assert.match(text, /screen_us_universe/)
+})

--- a/tests/multi-market-architecture.test.mjs
+++ b/tests/multi-market-architecture.test.mjs
@@ -61,13 +61,15 @@ test('discover profile registry drives prescreen mode and mining tools', () => {
 
   const hkTools = discoverMiningToolNamesForProfile('hk_equity')
   assert.ok(hkTools.includes('search_instruments'))
+  assert.ok(hkTools.includes('screen_hk_universe'))
   assert.ok(!hkTools.includes('get_local_hk_screen_schema'))
 
   assert.deepEqual(discoverFactorsForProfile('hk_equity'), ['keyword', 'industry_contains'])
 })
 
-test('discover mining tools for cn_equity start with online screening', () => {
-  assert.deepEqual(discoverMiningToolNamesForProfile('cn_equity').slice(0, 2), [
+test('discover mining tools for cn_equity start with market regime and online screening', () => {
+  assert.deepEqual(discoverMiningToolNamesForProfile('cn_equity').slice(0, 3), [
+    'get_market_regime',
     'screen_stocks',
     'search_instruments',
   ])
@@ -167,28 +169,17 @@ test('cn_equity_full mining uses unified instrument batch and evaluation tools',
   assert.ok(!cnTools.includes('evaluate_stock'))
 })
 
-test('CHAT_MCP_TOOL_NAMES excludes legacy per-market tools', async () => {
-  const { CHAT_MCP_TOOL_NAMES, LEGACY_MARKET_DATA_TOOL_NAMES } = await import(
-    '../packages/agent/dist/unified-mcp-tools.js'
-  )
-  const registry = {
-    list: () => [
-      ...LEGACY_MARKET_DATA_TOOL_NAMES.map(name => ({ name })),
-      { name: 'batch_instrument_snapshots' },
-      { name: 'get_instrument_snapshot' },
-      { name: 'get_instrument_indicators' },
-      { name: 'search_instruments' },
-    ],
-  }
-  const chatTools = CHAT_MCP_TOOL_NAMES(registry)
-  assert.ok(chatTools.includes('get_instrument_snapshot'))
-  assert.ok(chatTools.includes('get_instrument_indicators'))
-  assert.ok(chatTools.includes('search_instruments'))
-  assert.ok(!chatTools.includes('get_us_stock_quote'))
-  assert.ok(!chatTools.includes('get_crypto_quote'))
-  assert.ok(!chatTools.includes('strategy_verify'))
-  assert.ok(!chatTools.includes('batch_stock_snapshots'))
-  assert.ok(chatTools.includes('batch_instrument_snapshots'))
+test('CHAT_MCP_TOOL_NAMES exposes all registered tools', async () => {
+  const { CHAT_MCP_TOOL_NAMES } = await import('../packages/agent/dist/unified-mcp-tools.js')
+  const { ToolRegistry } = await import('../packages/agent/dist/tools.js')
+  const { ResearchHub } = await import('../packages/research-hub/dist/hub.js')
+  const registry = new ToolRegistry(new ResearchHub())
+  const chatTools = new Set(CHAT_MCP_TOOL_NAMES(registry))
+  assert.ok(chatTools.has('get_instrument_snapshot'))
+  assert.ok(chatTools.has('get_market_regime'))
+  assert.ok(chatTools.has('get_watchlist_radar'))
+  assert.ok(!chatTools.has('evaluate_stock'))
+  assert.ok(!chatTools.has('search_stocks'))
 })
 
 test('discoverMiningToolNames in agent aligns with shared registry', async () => {


### PR DESCRIPTION
## Summary
- Register P0 tools: `get_watchlist_radar`, `get_market_regime`, `get_market_dynamics`, `get_trend_brief`
- Register P1 tools: `get_etf_list`, `get_etf_scorecard`, `screen_us/hk/crypto_universe`
- Wire industry read tools: `list_local_industries`, `get_industry_stats`, `get_local_industry_stocks`
- Remove deprecated legacy MCP tools (`evaluate_stock`, `search_stocks`, local-factor screening, etc.) in favor of `get_instrument_*` / `screen_stocks`
- Fix Hub `market_db_status` to return real SQLite status; trim `TOOL_META` and mining prompts to match

## Test plan
- [x] `node --test --test-force-exit tests/agent-tool-integration.test.mjs tests/agent-industry-tools.test.mjs` (8/8 pass)
- [x] `npm run build -w @opptrix/shared -w @opptrix/research-hub -w @opptrix/agent`


Made with [Cursor](https://cursor.com)