### PR TITLE
feat(desktop): R2 update feed, CDN purge, and About update UX

### DIFF
--- a/.cursor/rules/backward-compatibility.mdc
+++ b/.cursor/rules/backward-compatibility.mdc
@@ -1,0 +1,51 @@
+---
+description: 硬性规则 — 数据库/数据架构/升级必须兼容旧客户端，禁止断代
+alwaysApply: true
+---
+
+# 向后兼容与迁移（硬性规则）
+
+**禁止断代**：任何已发布客户端（桌面/Web 自托管、旧版安装包）在升级后仍须能 **打开、读数据、逐步迁移**；不得因 schema/架构/配置格式变更导致 **数据丢失、白屏、无法启动或无法更新**。
+
+涉及 **SQLite schema**、**本地/用户数据格式**、**Hub/API 契约**、**自动更新源/安装包**、**Provider/数据层路由** 替换时，必须先设计 **兼容 + 迁移**，再改实现。
+
+## 动手前必读（按场景）
+
+| 场景 | 参考 |
+|------|------|
+| 用户 SQLite（`~/.opptrix/opptrix.db`） | `packages/user-store/src/store.ts`（`meta` 迁移标记、`migrateFromLegacyFiles`） |
+| 本地因子库 / market-data | `packages/market-data-store`（`SCHEMA_VERSION`、`MIGRATION_SQL`） |
+| 新闻/订阅/文档 JSON | `packages/news-feed/src/store.ts`（`ensureMigrated`、懒迁移） |
+| Provider / 设置迁移 | `packages/user-store` → `providerSettings.migrateFromLegacy` |
+| 桌面自动更新 | `docs/DESKTOP-RELEASE.md`；旧包更新源与 R2/CDN 切换须有过渡说明 |
+| 对外 API / Agent tools | 旧字段保留或双读；破坏性变更须版本化或 feature flag |
+
+## 必须遵守
+
+1. **可升级路径**：新版本启动时 **自动检测** 旧格式/schema，**幂等** 迁移（重复运行安全）；用 `meta` 键或 `SCHEMA_VERSION` 记录已完成步骤。
+2. **双读 / 双写（过渡期）**：读逻辑优先新格式，**回退读旧格式**；写可双写或迁移后单写，直到确认无旧数据残留（或文档声明弃用版本下限）。
+3. **只增不破（默认）**：SQLite 优先 `ALTER TABLE` / 新表 + 回填；**禁止**无迁移地 `DROP`/重命名列/改 namespace 导致旧客户端或旧 server 读失败。
+4. **降级友好**：迁移失败须 **可诊断**（日志/用户可见提示），尽量 **保留原数据** 不静默覆盖；禁止「失败就删库重建」作为唯一路径。
+5. **跨版本客户端**：旧桌面/Web 客户端连 **新 server** 时，API 不得返回无法解析的结构；新客户端连 **旧 server** 时应有降级或明确错误提示。
+6. **自动更新不断链**：改 `app-update.yml` / 更新 CDN / 文件名规则时，须保证 **已发布旧版** 仍能完成 **至少一次** 升级到过渡版或新版（或文档 + Release 说明手动升级路径）。
+7. **数据层架构替换**：换 Provider、Hub feature、存储位置时，须 **映射旧 capability/旧路径** 或提供一次性 import/migrate；不得让旧配置静默失效。
+
+## 禁止（反模式）
+
+- ❌ 改 schema/JSON 结构却不写迁移，依赖用户删 `opptrix.db` 或重装
+- ❌ 重命名 `documents.namespace` / 配置 key / env 名且无读取旧 key 的兼容层
+- ❌ 仅在新版本写数据，旧版本打开即空数据或崩溃
+- ❌ 更换更新 URL/渠道后，旧安装包 **永久无法** 自动更新且无说明
+- ❌ 「开发环境清库即可」作为对 **已发布用户** 的解决方案
+
+## 改动自检（PR / 提交前）
+
+- [ ] 是否动到 DB schema、本地文件格式、API 响应或更新元数据？
+- [ ] 是否有 **幂等迁移** + 版本/标记记录？
+- [ ] 旧数据是否能在 **不手动干预** 下被新版本读取并转换？
+- [ ] 旧客户端（低 1～2 个小版本）是否仍可启动或收到可理解的升级提示？
+- [ ] 是否更新 `docs/` 或 Release Notes 中的 **最低兼容版本 / 手动步骤**（若无法自动迁移）？
+
+## 无法自动迁移时
+
+须 **显式** 在 PR 与面向用户的 Release 说明中写清：影响范围、备份建议、手动步骤、支持的最低旧版本；**不得** 默认用户可接受数据清空。

--- a/.cursor/rules/engineering-guidelines.mdc
+++ b/.cursor/rules/engineering-guidelines.mdc
@@ -20,6 +20,7 @@ alwaysApply: true
 
 ## 改动原则
 
+- **向后兼容与迁移（硬性）**：数据库结构变动、数据架构更换、本地存储/配置格式升级、自动更新源变更等，**必须** 设计旧版客户端/旧数据的兼容与迁移机制，**禁止断代**。细则见 `.cursor/rules/backward-compatibility.mdc`。
 - **数据层标准 API（强制）**：任何新功能、数据调用或 Hub/前后端改动前，必须先查阅已有标准方法与架构（`docs/PROVIDER-STANDARD-API.md`、`docs/DATA-LAYER.md`、`instrument-query.ts`）；优先 `queryInstrumentData(ref, capability)` 复用，标准能力不足时再扩展标准层（计划路由 → Provider 标准方法 → 自定义方法），**禁止**直连 Provider / 重复造轮子。细则见 `.cursor/rules/data-layer-standard-api.mdc`。
 - **Data Provider 文档**：在 `a-stock-layer` 新增/修改 Provider 方法时，须按 `.cursor/rules/data-provider-docs.mdc` 完善 JSDoc 与 `custom-method-docs.ts`（含 sourceUrl、入参/出参、usage、维护备注）；不得只实现逻辑不写文档。
 - **基于上一版实现与用户最新指示**做增量修改；不要臆测需求或“顺便优化”未提及的行为。

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Build desktop package
         shell: bash
         env:
+          OPPTRIX_UPDATE_BASE_URL: ${{ secrets.OPPTRIX_UPDATE_BASE_URL }}
           SIGN_MODE: ${{ steps.signcfg.outputs.mode }}
           CSC_LINK_SECRET: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD_SECRET: ${{ secrets.CSC_KEY_PASSWORD }}
@@ -324,3 +325,60 @@ jobs:
 
           gh release upload "$TAG" "$WORK/latest-mac.yml" --clobber
           echo "Published merged latest-mac.yml to $TAG"
+
+  sync-r2:
+    name: Sync release to Cloudflare R2
+    needs: finalize-release
+    runs-on: ubuntu-latest
+    if: ${{ needs.finalize-release.result == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          WORK="$RUNNER_TEMP/r2-sync"
+          mkdir -p "$WORK"
+          gh release download "$TAG" -D "$WORK"
+          echo "ASSET_DIR=$WORK" >> "$GITHUB_ENV"
+          ls -la "$WORK"
+
+      - name: Sync to Cloudflare R2 (purge old + upload current)
+        shell: bash
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          OPPTRIX_UPDATE_BASE_URL: ${{ secrets.OPPTRIX_UPDATE_BASE_URL }}
+        run: node apps/desktop/scripts/sync-release-to-r2.mjs "$ASSET_DIR"
+
+      - name: Verify public update metadata
+        shell: bash
+        env:
+          OPPTRIX_UPDATE_BASE_URL: ${{ secrets.OPPTRIX_UPDATE_BASE_URL }}
+        run: |
+          if [[ -z "${OPPTRIX_UPDATE_BASE_URL:-}" ]]; then
+            echo "OPPTRIX_UPDATE_BASE_URL not set — skip public verify"
+            exit 0
+          fi
+          BASE="${OPPTRIX_UPDATE_BASE_URL%/}/"
+          for yml in latest-mac.yml latest.yml latest-linux.yml; do
+            url="${BASE}${yml}"
+            echo "Checking $url"
+            curl -fsSL --retry 3 --retry-delay 2 "$url" -o /dev/null
+          done
+          echo "Public update metadata reachable on R2"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -382,3 +382,11 @@ jobs:
             curl -fsSL --retry 3 --retry-delay 2 "$url" -o /dev/null
           done
           echo "Public update metadata reachable on R2"
+
+      - name: Purge Cloudflare CDN cache (latest-*.yml)
+        shell: bash
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+          OPPTRIX_UPDATE_BASE_URL: ${{ secrets.OPPTRIX_UPDATE_BASE_URL }}
+        run: node apps/desktop/scripts/purge-update-cdn-cache.mjs

--- a/apps/desktop/electron/updater.cjs
+++ b/apps/desktop/electron/updater.cjs
@@ -91,7 +91,7 @@ function initUpdater({ version }) {
       currentVersion: version,
       version: null,
       percent: 0,
-      message: null,
+      message: '当前已是最新版本',
     })
   })
 
@@ -156,7 +156,23 @@ function registerUpdaterIpc(ipcMain) {
   ipcMain.handle('app-update-get-status', async () => status)
 
   ipcMain.handle('app-update-check', async () => {
-    if (!app.isPackaged || !autoUpdater) return status
+    if (!autoUpdater) {
+      setStatus({
+        state: 'error',
+        message: '更新组件不可用，请重新安装应用或从 GitHub Releases 下载最新版。',
+      })
+      return status
+    }
+    if (!app.isPackaged) {
+      setStatus({
+        state: 'not-available',
+        currentVersion: status.currentVersion,
+        version: null,
+        percent: 0,
+        message: '开发模式不支持自动更新，请从 GitHub Releases 下载正式安装包。',
+      })
+      return status
+    }
     setStatus({ state: 'checking', message: '正在检查更新…' })
     try {
       await autoUpdater.checkForUpdates()

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,10 +45,8 @@
     ],
     "publish": [
       {
-        "provider": "github",
-        "owner": "Travisun",
-        "repo": "Opptrix",
-        "vPrefixedTagName": false
+        "provider": "generic",
+        "url": "https://updates.opptrix.example/desktop/"
       }
     ],
     "directories": {
@@ -173,6 +171,7 @@
     }
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.888.0",
     "electron": "^35.0.0",
     "electron-builder": "^25.1.8",
     "to-ico": "^1.1.5"

--- a/apps/desktop/scripts/build-package.mjs
+++ b/apps/desktop/scripts/build-package.mjs
@@ -5,14 +5,18 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { appendDesktopArtifactNameArgs } from './lib/desktop-artifact-names.mjs'
 import { NPM_CMD, NPM_SHELL } from './lib/commands.mjs'
+import { resolveUpdateFeedUrl } from './lib/update-feed-url.mjs'
 
 const DESKTOP_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const platformArgs = process.argv.slice(2)
 const publishToGitHub = platformArgs.includes('--publish')
+const updateFeedUrl = resolveUpdateFeedUrl()
 
 const ebArgs = [
   '--config.npmRebuild=false',
   ...(publishToGitHub ? [] : ['--publish', 'never']),
+  '-c.publish.0.provider=generic',
+  `-c.publish.0.url=${updateFeedUrl}`,
   ...platformArgs,
 ]
 appendDesktopArtifactNameArgs(ebArgs, platformArgs)

--- a/apps/desktop/scripts/lib/r2-client.mjs
+++ b/apps/desktop/scripts/lib/r2-client.mjs
@@ -1,0 +1,92 @@
+import fs from 'node:fs'
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3'
+
+export function requireR2Env() {
+  const names = [
+    'R2_ACCOUNT_ID',
+    'R2_ACCESS_KEY_ID',
+    'R2_SECRET_ACCESS_KEY',
+    'R2_BUCKET',
+  ]
+  const missing = names.filter((name) => !process.env[name]?.trim())
+  if (missing.length > 0) {
+    throw new Error(`Missing R2 env: ${missing.join(', ')}`)
+  }
+  return {
+    accountId: process.env.R2_ACCOUNT_ID.trim(),
+    accessKeyId: process.env.R2_ACCESS_KEY_ID.trim(),
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY.trim(),
+    bucket: process.env.R2_BUCKET.trim(),
+  }
+}
+
+export function createR2Client({ accountId, accessKeyId, secretAccessKey }) {
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: { accessKeyId, secretAccessKey },
+  })
+}
+
+export async function listObjectKeys(client, bucket, prefix) {
+  const keys = []
+  let continuationToken
+  const normalized = prefix ? `${prefix.replace(/\/+$/, '')}/` : ''
+
+  do {
+    const resp = await client.send(new ListObjectsV2Command({
+      Bucket: bucket,
+      Prefix: normalized || undefined,
+      ContinuationToken: continuationToken,
+    }))
+    for (const item of resp.Contents ?? []) {
+      if (item.Key) keys.push(item.Key)
+    }
+    continuationToken = resp.IsTruncated ? resp.NextContinuationToken : undefined
+  } while (continuationToken)
+
+  return keys
+}
+
+export async function deleteObjectKeys(client, bucket, keys) {
+  if (keys.length === 0) return 0
+  let deleted = 0
+  for (let i = 0; i < keys.length; i += 1000) {
+    const chunk = keys.slice(i, i + 1000)
+    await client.send(new DeleteObjectsCommand({
+      Bucket: bucket,
+      Delete: {
+        Objects: chunk.map((Key) => ({ Key })),
+        Quiet: true,
+      },
+    }))
+    deleted += chunk.length
+  }
+  return deleted
+}
+
+export async function putObjectFile(client, bucket, key, filePath, contentType) {
+  await client.send(new PutObjectCommand({
+    Bucket: bucket,
+    Key: key,
+    Body: fs.readFileSync(filePath),
+    ContentType: contentType,
+  }))
+}
+
+export function contentTypeForFileName(name) {
+  const lower = name.toLowerCase()
+  if (lower.endsWith('.yml')) return 'text/yaml; charset=utf-8'
+  if (lower.endsWith('.blockmap')) return 'application/octet-stream'
+  if (lower.endsWith('.exe')) return 'application/vnd.microsoft.portable-executable'
+  if (lower.endsWith('.dmg')) return 'application/x-apple-diskimage'
+  if (lower.endsWith('.zip')) return 'application/zip'
+  if (lower.endsWith('.appimage')) return 'application/x-executable'
+  if (lower.endsWith('.deb')) return 'application/vnd.debian.binary-package'
+  return 'application/octet-stream'
+}

--- a/apps/desktop/scripts/lib/update-feed-url.mjs
+++ b/apps/desktop/scripts/lib/update-feed-url.mjs
@@ -1,0 +1,14 @@
+/** Public base URL for electron-updater generic provider (must end with `/`). */
+export const DEFAULT_UPDATE_FEED_URL = 'https://updates.opptrix.example/desktop/'
+
+export function resolveUpdateFeedUrl() {
+  const raw = (process.env.OPPTRIX_UPDATE_BASE_URL ?? DEFAULT_UPDATE_FEED_URL).trim()
+  if (!raw) return DEFAULT_UPDATE_FEED_URL
+  return raw.endsWith('/') ? raw : `${raw}/`
+}
+
+/** Object key prefix inside the R2 bucket, derived from the public URL path. */
+export function r2KeyPrefixFromFeedUrl(feedUrl = resolveUpdateFeedUrl()) {
+  const pathname = new URL(feedUrl).pathname.replace(/^\/+|\/+$/g, '')
+  return pathname || 'desktop'
+}

--- a/apps/desktop/scripts/purge-update-cdn-cache.mjs
+++ b/apps/desktop/scripts/purge-update-cdn-cache.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Purge Cloudflare edge cache for desktop update metadata (latest-*.yml).
+ *
+ * Env: CLOUDFLARE_API_TOKEN, CLOUDFLARE_ZONE_ID, OPPTRIX_UPDATE_BASE_URL
+ */
+import { resolveUpdateFeedUrl } from './lib/update-feed-url.mjs'
+
+const YML_FILES = ['latest-mac.yml', 'latest.yml', 'latest-linux.yml']
+
+function requireEnv(name) {
+  const value = process.env[name]?.trim()
+  if (!value) throw new Error(`Missing ${name}`)
+  return value
+}
+
+async function purgeFiles(zoneId, token, urls) {
+  const resp = await fetch(`https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ files: urls }),
+  })
+
+  const data = await resp.json()
+  if (!resp.ok || !data.success) {
+    const detail = data.errors?.map((e) => e.message).join('; ') || resp.statusText
+    throw new Error(`Cloudflare purge failed: ${detail}`)
+  }
+
+  return data
+}
+
+async function main() {
+  if (!process.env.CLOUDFLARE_API_TOKEN?.trim()) {
+    console.log('[cdn] CLOUDFLARE_API_TOKEN not set — skipping cache purge')
+    return
+  }
+
+  const zoneId = requireEnv('CLOUDFLARE_ZONE_ID')
+  const token = requireEnv('CLOUDFLARE_API_TOKEN')
+  const base = resolveUpdateFeedUrl()
+  const urls = YML_FILES.map((name) => new URL(name, base).href)
+
+  console.log(`[cdn] purging ${urls.length} URL(s) on zone ${zoneId}`)
+  for (const url of urls) console.log(`  - ${url}`)
+
+  const result = await purgeFiles(zoneId, token, urls)
+  console.log(`[cdn] purge OK (${result.result?.id ?? 'done'})`)
+}
+
+main().catch((err) => {
+  console.error('[cdn] purge failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/apps/desktop/scripts/sync-release-to-r2.mjs
+++ b/apps/desktop/scripts/sync-release-to-r2.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * Purge prior desktop release objects on Cloudflare R2, then upload the current
+ * GitHub Release artifacts + latest-*.yml for electron-updater (generic provider).
+ *
+ * Env: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET,
+ *      OPPTRIX_UPDATE_BASE_URL (public CDN URL, e.g. https://pub-xxx.r2.dev/desktop/)
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { r2KeyPrefixFromFeedUrl, resolveUpdateFeedUrl } from './lib/update-feed-url.mjs'
+import {
+  contentTypeForFileName,
+  createR2Client,
+  deleteObjectKeys,
+  listObjectKeys,
+  putObjectFile,
+  requireR2Env,
+} from './lib/r2-client.mjs'
+
+const RELEASE_FILE = /\.(dmg|zip|exe|AppImage|deb|yml|blockmap)$/i
+
+function usage() {
+  console.error('Usage: sync-release-to-r2.mjs <release-assets-dir>')
+  process.exit(1)
+}
+
+function shouldUpload(name) {
+  if (!RELEASE_FILE.test(name)) return false
+  if (/^latest-mac-(arm64|x64)\.yml$/i.test(name)) return false
+  return true
+}
+
+function collectUploadFiles(dir) {
+  const names = fs.readdirSync(dir).filter(shouldUpload).sort()
+  if (names.length === 0) {
+    throw new Error(`No release artifacts to upload under ${dir}`)
+  }
+  const required = ['latest-mac.yml', 'latest.yml', 'latest-linux.yml']
+  for (const yml of required) {
+    if (!names.includes(yml)) {
+      throw new Error(`Missing ${yml} in ${dir} — finalize-release must complete first`)
+    }
+  }
+  return names.map((name) => ({
+    name,
+    filePath: path.join(dir, name),
+    size: fs.statSync(path.join(dir, name)).size,
+  }))
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 ** 3) return `${(bytes / 1024 ** 2).toFixed(1)} MB`
+  return `${(bytes / 1024 ** 3).toFixed(2)} GB`
+}
+
+async function main() {
+  const sourceDir = process.argv[2]
+  if (!sourceDir) usage()
+
+  if (!process.env.R2_ACCESS_KEY_ID?.trim()) {
+    console.log('[r2] R2_ACCESS_KEY_ID not set — skipping sync')
+    return
+  }
+
+  const feedUrl = resolveUpdateFeedUrl()
+  const prefix = r2KeyPrefixFromFeedUrl(feedUrl)
+  const r2Env = requireR2Env()
+  const client = createR2Client(r2Env)
+  const files = collectUploadFiles(sourceDir)
+  const totalBytes = files.reduce((sum, f) => sum + f.size, 0)
+
+  console.log(`[r2] feed URL: ${feedUrl}`)
+  console.log(`[r2] bucket: ${r2Env.bucket}  prefix: ${prefix}/`)
+  console.log(`[r2] uploading ${files.length} file(s), ${formatBytes(totalBytes)} total`)
+
+  const existingKeys = await listObjectKeys(client, r2Env.bucket, prefix)
+  if (existingKeys.length > 0) {
+    console.log(`[r2] purging ${existingKeys.length} existing object(s) under ${prefix}/`)
+    await deleteObjectKeys(client, r2Env.bucket, existingKeys)
+  }
+
+  for (const file of files) {
+    const key = `${prefix}/${file.name}`
+    await putObjectFile(
+      client,
+      r2Env.bucket,
+      key,
+      file.filePath,
+      contentTypeForFileName(file.name),
+    )
+    console.log(`[r2] uploaded ${key} (${formatBytes(file.size)})`)
+  }
+
+  console.log('[r2] sync complete — clients should read update metadata from:')
+  console.log(`  macOS:   ${feedUrl}latest-mac.yml`)
+  console.log(`  Windows: ${feedUrl}latest.yml`)
+  console.log(`  Linux:   ${feedUrl}latest-linux.yml`)
+}
+
+main().catch((err) => {
+  console.error('[r2] sync failed:', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/client-ui/src/hooks/useAppUpdate.ts
+++ b/client-ui/src/hooks/useAppUpdate.ts
@@ -20,8 +20,20 @@ export function useAppUpdate() {
 
   const checkNow = useCallback(async () => {
     if (!isElectron()) return
-    const res = await window.electronAPI?.appUpdateCheck?.()
-    if (res) setStatus(res)
+    setStatus(prev => ({
+      ...prev,
+      state: 'checking',
+      message: '正在检查更新…',
+    }))
+    try {
+      const res = await window.electronAPI?.appUpdateCheck?.()
+      if (res) setStatus(res)
+    } catch {
+      setStatus({
+        state: 'error',
+        message: '无法连接更新服务器',
+      })
+    }
   }, [])
 
   const installUpdate = useCallback(async () => {

--- a/client-ui/src/pages/settings/AboutSettingsSection.tsx
+++ b/client-ui/src/pages/settings/AboutSettingsSection.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
-import { Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { useCallback, useEffect, useState } from 'react'
+import { ProgressBar, Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import {
+  ArrowSyncRegular,
   BugRegular,
   ChevronRightRegular,
   ShieldRegular,
@@ -11,6 +12,10 @@ import { useAppUpdate } from '../../hooks/useAppUpdate'
 import { isElectron } from '../../platform/detect'
 import { openExternalUrl } from '../../platform/openUrl'
 import { opptrixCssVars } from '../../theme/tokens'
+import {
+  buildAppUpdatePanel,
+  isAppUpdateCheckBusy,
+} from '../../utils/appUpdateUi'
 import {
   OPPTRIX_GITHUB_HOME,
   OPPTRIX_GITHUB_ISSUES,
@@ -76,6 +81,28 @@ const useStyles = makeStyles({
     lineHeight: 1.55,
     paddingLeft: '2px',
   },
+  updatePanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    width: '100%',
+  },
+  updateDesc: {
+    fontSize: '13px',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.55,
+  },
+  progressMeta: {
+    fontSize: '12px',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.4,
+  },
+  updateActions: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    paddingTop: '2px',
+  },
 })
 
 type AboutSettingsSectionProps = {
@@ -86,6 +113,7 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
   const s = useStyles()
   const { status: updateStatus, checkNow, installUpdate } = useAppUpdate()
   const [versionLabel, setVersionLabel] = useState<string | null>(null)
+  const [checkedOnce, setCheckedOnce] = useState(false)
 
   useEffect(() => {
     if (isElectron()) {
@@ -99,10 +127,16 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
       .catch(() => setVersionLabel(null))
   }, [])
 
+  const handleCheckUpdate = useCallback(() => {
+    setCheckedOnce(true)
+    void checkNow()
+  }, [checkNow])
+
   const versionDesc = versionLabel ?? '读取版本中…'
   const showUpdateBlock = isElectron()
-  const hasUpdateFollowUp = updateStatus.state === 'ready'
-    || (updateStatus.state === 'error' && Boolean(updateStatus.message))
+  const checkBusy = isAppUpdateCheckBusy(updateStatus)
+  const updatePanel = buildAppUpdatePanel(updateStatus, { checkedOnce })
+  const showUpdateStatusRow = Boolean(updatePanel?.visible)
 
   return (
     <div className={mergeClasses(s.root, contentFlush && s.rootFlush)}>
@@ -126,28 +160,58 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
             title="当前版本"
             desc={versionDesc}
             control={showUpdateBlock ? (
-              <OpptrixButton variant="secondary" onClick={() => { void checkNow() }}>
-                检查更新
+              <OpptrixButton
+                variant="secondary"
+                disabled={checkBusy}
+                icon={checkBusy ? <Spinner size="tiny" /> : undefined}
+                onClick={handleCheckUpdate}
+              >
+                {checkBusy ? '检查中…' : '检查更新'}
               </OpptrixButton>
             ) : undefined}
-            last={!showUpdateBlock || !hasUpdateFollowUp}
+            last={!showUpdateStatusRow}
           />
-          {showUpdateBlock && updateStatus.state === 'ready' && (
+          {showUpdateStatusRow && updatePanel && (
             <SettingsRow
-              title={`新版本 v${updateStatus.version ?? ''} 已就绪`}
-              desc="重启应用即可完成更新"
-              control={(
-                <OpptrixButton variant="primary" onClick={() => { void installUpdate() }}>
-                  重启更新
-                </OpptrixButton>
+              stack
+              title={updatePanel.title}
+              desc={(
+                <div className={s.updatePanel}>
+                  <Text className={s.updateDesc} block>{updatePanel.desc}</Text>
+                  {updatePanel.showProgress && (
+                    <>
+                      <ProgressBar
+                        value={
+                          updatePanel.percent != null && updatePanel.percent > 0
+                            ? updatePanel.percent / 100
+                            : undefined
+                        }
+                        max={1}
+                        thickness="medium"
+                        shape="rounded"
+                      />
+                      <Text className={s.progressMeta} block>
+                        {updateStatus.state === 'available'
+                          ? '正在连接下载…'
+                          : updatePanel.percent != null && updatePanel.percent > 0
+                            ? `已完成 ${updatePanel.percent}%`
+                            : '正在准备下载…'}
+                      </Text>
+                    </>
+                  )}
+                  {updatePanel.showInstall && (
+                    <div className={s.updateActions}>
+                      <OpptrixButton
+                        variant="primary"
+                        icon={<ArrowSyncRegular />}
+                        onClick={() => { void installUpdate() }}
+                      >
+                        重启更新
+                      </OpptrixButton>
+                    </div>
+                  )}
+                </div>
               )}
-              last={!(updateStatus.state === 'error' && updateStatus.message)}
-            />
-          )}
-          {showUpdateBlock && updateStatus.state === 'error' && updateStatus.message && (
-            <SettingsRow
-              title="暂时无法检查更新"
-              desc={updateStatus.message}
               last
             />
           )}

--- a/client-ui/src/utils/appUpdateUi.ts
+++ b/client-ui/src/utils/appUpdateUi.ts
@@ -1,0 +1,79 @@
+import type { AppUpdateStatus } from '../platform/detect'
+
+export type AppUpdatePanelModel = {
+  visible: boolean
+  title: string
+  desc: string
+  showProgress: boolean
+  /** 0–100；undefined 表示不确定进度 */
+  percent?: number
+  showInstall: boolean
+}
+
+export function buildAppUpdatePanel(
+  status: AppUpdateStatus,
+  opts: { checkedOnce: boolean },
+): AppUpdatePanelModel | null {
+  const { checkedOnce } = opts
+
+  switch (status.state) {
+    case 'checking':
+      return {
+        visible: true,
+        title: '正在检查更新',
+        desc: status.message ?? '正在连接更新服务器，请稍候…',
+        showProgress: false,
+        showInstall: false,
+      }
+    case 'available':
+      return {
+        visible: true,
+        title: status.version ? `发现新版本 v${status.version}` : '发现新版本',
+        desc: status.message ?? '正在准备下载，请稍候…',
+        showProgress: true,
+        percent: 0,
+        showInstall: false,
+      }
+    case 'downloading':
+      return {
+        visible: true,
+        title: status.version ? `正在下载 v${status.version}` : '正在下载更新',
+        desc: status.message ?? '下载完成后可重启安装',
+        showProgress: true,
+        percent: status.percent ?? 0,
+        showInstall: false,
+      }
+    case 'ready':
+      return {
+        visible: true,
+        title: status.version ? `新版本 v${status.version} 已就绪` : '新版本已就绪',
+        desc: status.message ?? '重启应用即可完成更新，对话与本地数据不会丢失。',
+        showProgress: false,
+        percent: 100,
+        showInstall: true,
+      }
+    case 'error':
+      return {
+        visible: true,
+        title: '暂时无法完成更新',
+        desc: status.message ?? '请检查网络后重试，或稍后再试。',
+        showProgress: false,
+        showInstall: false,
+      }
+    case 'not-available':
+      if (!checkedOnce) return null
+      return {
+        visible: true,
+        title: '当前已是最新版本',
+        desc: status.message ?? '暂无可用更新。你可以稍后再检查，或到项目主页查看发布说明。',
+        showProgress: false,
+        showInstall: false,
+      }
+    default:
+      return null
+  }
+}
+
+export function isAppUpdateCheckBusy(status: AppUpdateStatus): boolean {
+  return status.state === 'checking'
+}

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -31,8 +31,23 @@
 | 在 UI 中面向投资者写易懂文案 | 在界面裸露技术词（MCP、hydrate、F10）而不解释 |
 | 小步增量 PR | 未经讨论的大范围重构、擅自改导航/布局模式 |
 | 数据层走 `queryInstrumentData` 标准 API | Hub/UI 直连 Provider |
+| **向后兼容与迁移**（硬性，禁止断代） | 无迁移改 DB/schema/API/更新源导致旧客户端不可用或丢数据 |
 
 **免责声明**：本软件输出仅供参考与学习，**不构成投资建议**；协作者不得在文案或逻辑中暗示「保证盈利」。详见 [README.md](../README.md) 风险提示。
+
+### 1.2 向后兼容与迁移（硬性）
+
+任何 **SQLite schema**、**本地/用户数据格式**、**Hub/API 契约**、**自动更新源/安装包**、**Provider/数据层路由** 变更，必须先设计 **旧版兼容 + 幂等迁移**，**禁止断代**（旧客户端无法打开、丢数据、或永久无法更新）。
+
+| 必须 | 禁止 |
+|------|------|
+| 启动时自动检测旧格式并幂等迁移（`meta` / `SCHEMA_VERSION`） | 无迁移 `DROP`/重命名导致旧数据不可读 |
+| 过渡期双读旧格式；更新 URL 变更须保证旧包至少能升一次 | 让用户删 `opptrix.db` 或重装作为唯一方案 |
+| 迁移失败可诊断、尽量保留原数据 | 旧安装包永久无法自动更新且无说明 |
+
+**参考实现**：`packages/user-store`（`migrateFromLegacyFiles`）、`packages/market-data-store`（`SCHEMA_VERSION`）、`packages/news-feed`（`ensureMigrated`）、桌面更新见 [DESKTOP-RELEASE.md](./DESKTOP-RELEASE.md)。
+
+完整规则：`.cursor/rules/backward-compatibility.mdc`。
 
 ---
 
@@ -169,7 +184,7 @@ Opptrix/
 
 ### 5.1 开始任务前
 
-1. 阅读本文件与 `.cursor/rules/engineering-guidelines.mdc`
+1. 阅读本文件与 `.cursor/rules/engineering-guidelines.mdc`、`.cursor/rules/backward-compatibility.mdc`
 2. 若涉及 UI：阅读 `docs/UI-DESIGN-SYSTEM.md`、`docs/UI-LAYOUT.md`；桌面行为见 `docs/DESKTOP.md`
 3. 若涉及 API：阅读 `docs/API.md`
 4. 用 `rg` / 语义搜索定位现有实现，**模仿邻近代码风格**
@@ -210,6 +225,7 @@ npm run serve               # 生产预览
 - [ ] 未提交密钥、`.env`、`apps/server/data/config.json` 中的 API Key
 - [ ] UI 文案面向投资者、符合设计 Token
 - [ ] 改动范围最小，无无关格式化或重构
+- [ ] 若改 DB/本地存储/API/更新元数据：已做兼容与迁移，旧客户端可升级（见 §1.2）
 - [ ] 若改 API/feature，已更新 `docs/API.md`（如适用）
 
 ---
@@ -289,6 +305,7 @@ npm run serve               # 生产预览
 | [UI-LAYOUT.md](./UI-LAYOUT.md) | 布局与页面模板 |
 | [packages/README.md](../packages/README.md) | 各 npm 包职责 |
 | `.cursor/rules/engineering-guidelines.mdc` | Cursor 自动应用的工程规则 |
+| `.cursor/rules/backward-compatibility.mdc` | **硬性** — 数据库/数据架构/升级兼容与迁移 |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ Electron main
 ```
 
 - 生产 bundle：`runtime-stage` 含 server、packages、原生 `.node`（按架构编译）。
-- **electron-updater**：启动后检查 GitHub Release；用户确认后 `quitAndInstall`。
+- **electron-updater**：启动后检查 **Cloudflare R2** 上的 `latest-*.yml`；用户确认后 `quitAndInstall`（GitHub Release 仍供手动下载）。
 - 详见 [DESKTOP.md](./DESKTOP.md)、[DESKTOP-RELEASE.md](./DESKTOP-RELEASE.md)。
 
 ## 本地持久化

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -152,52 +152,138 @@ latest-linux.yml
 
 编辑 Release 说明，补充 **面向用户** 的更新内容。
 
-### 4.4 Cloudflare R2 更新加速（CI 自动）
+### 4.4 Cloudflare R2 + CDN（`update.opptrix.org`）
 
-桌面客户端的 **检查更新 / 下载更新** 走 Cloudflare R2（免费 10 GB 存储），GitHub Release 仍用于手动下载与 Release Notes。
+桌面客户端的 **检查更新 / 下载更新** 走 R2 + 自定义域名 CDN；GitHub Release 仍用于手动下载与 Release Notes。
 
 CI 在 `finalize-release` 成功后执行 **`sync-r2`** job：
 
 1. 从 GitHub Release 下载当前标签的全部安装包与 `latest-*.yml`；
-2. **删除** R2 bucket 内 `desktop/` 前缀下的旧对象（仅保留最新一版，避免超出 10 GB 配额）；
+2. **删除** R2 bucket 内 `desktop/` 前缀下的旧对象（仅保留最新一版）；
 3. 上传当前版本全部产物到 R2；
-4. 校验公网 URL 可访问 `latest-mac.yml` / `latest.yml` / `latest-linux.yml`。
+4. 校验 `update.opptrix.org` 上 yml 可访问；
+5. **Purge** Cloudflare 边缘缓存中的三个 `latest-*.yml`（安装包文件名带版本号，无需 purge）。
 
-#### 一次性配置（Cloudflare Dashboard）
+---
 
-1. **R2 → Create bucket**（例如 `opptrix-desktop-releases`）。
-2. **R2 → Manage R2 API Tokens → Create API token**：Object Read & Write，限定上述 bucket。
-3. **启用公网访问**（二选一）：
-   - **R2.dev 子域**：bucket → Settings → Public access → Allow Access，获得 `https://pub-xxxx.r2.dev`；
-   - **自定义域名**：R2 → bucket → Custom Domains，绑定如 `updates.example.com`（推荐，可开 Cloudflare CDN）。
-4. 公网 base URL 须包含路径前缀，例如：`https://pub-xxxx.r2.dev/desktop/`（**末尾斜杠必填**）。
+#### 第一步：Cloudflare R2（存储 + 自定义域名）
 
-#### GitHub Actions Secrets
+1. **R2 → Create bucket**  
+   名称示例：`opptrix-desktop-releases`
 
-在 **Settings → Secrets and variables → Actions** 添加：
+2. **Settings → Custom Domains → Connect Domain**  
+   - 域名：`update.opptrix.org`（`opptrix.org` 须在同一 Cloudflare 账号）  
+   - 等待状态 **Active**
 
-| Secret | 说明 |
-|--------|------|
-| `R2_ACCOUNT_ID` | Cloudflare 账户 ID（Dashboard 右侧） |
-| `R2_ACCESS_KEY_ID` | R2 API Token Access Key ID |
-| `R2_SECRET_ACCESS_KEY` | R2 API Token Secret Access Key |
-| `R2_BUCKET` | Bucket 名称，如 `opptrix-desktop-releases` |
-| `OPPTRIX_UPDATE_BASE_URL` | 公网更新根 URL，如 `https://pub-xxxx.r2.dev/desktop/` |
+3. **Settings → Public Development URL → Disable**  
+   输入 `disallow`，避免攻击者绕过 CDN 直打 `r2.dev`
 
-未配置 R2 secrets 时：`sync-r2` 会跳过上传（构建仍成功）；`OPPTRIX_UPDATE_BASE_URL` 未设置时，安装包内 `app-update.yml` 使用占位 URL，**自动更新不可用**。
+4. **Manage R2 API Tokens → Create API token**（给 GitHub 上传用）  
+   | 项 | 值 |
+   |----|-----|
+   | Token name | `github-opptrix-release` |
+   | Permissions | **Object Read & Write** |
+   | Specify bucket | 仅 `opptrix-desktop-releases` |
+   | TTL | 可选「无过期」或 1 年 |
+
+   创建后**立即复制**（Secret 只显示一次）：
+   - **Access Key ID** → GitHub `R2_ACCESS_KEY_ID`
+   - **Secret Access Key** → GitHub `R2_SECRET_ACCESS_KEY`
+
+5. **Account ID**（Dashboard 右侧 Overview）→ GitHub `R2_ACCOUNT_ID`
+
+---
+
+#### 第二步：Cloudflare API Token（给 GitHub 刷新 CDN 缓存）
+
+与 R2 Token **分开**创建（权限不同）：
+
+1. **My Profile → API Tokens → Create Token**
+2. 可用模板 **「Edit zone DNS」** 改权限，或 **Create Custom Token**：
+   | 项 | 值 |
+   |----|-----|
+   | Token name | `github-opptrix-cdn-purge` |
+   | Permissions | **Zone → Cache Purge → Purge** |
+   | Zone Resources | **Include → Specific zone → opptrix.org** |
+
+3. 创建后复制 Token → GitHub `CLOUDFLARE_API_TOKEN`
+
+4. **Zone ID**（`opptrix.org` → Overview 右侧）→ GitHub `CLOUDFLARE_ZONE_ID`  
+   > 注意：Zone 是 **`opptrix.org`**，不是 `update.opptrix.org` 子域。
+
+---
+
+#### 第三步：GitHub Repository Secrets
+
+打开：**https://github.com/Travisun/Opptrix/settings/secrets/actions → New repository secret**
+
+| Secret 名称 | 填什么 | 示例 |
+|-------------|--------|------|
+| `R2_ACCOUNT_ID` | Cloudflare Account ID | `a1b2c3d4e5f6...` |
+| `R2_ACCESS_KEY_ID` | R2 API Token Access Key ID | `abc123...` |
+| `R2_SECRET_ACCESS_KEY` | R2 API Token Secret Access Key | `xyz789...`（仅创建时可见） |
+| `R2_BUCKET` | Bucket 名称 | `opptrix-desktop-releases` |
+| `OPPTRIX_UPDATE_BASE_URL` | 公网更新根 URL，**末尾带 `/`** | `https://update.opptrix.org/desktop/` |
+| `CLOUDFLARE_API_TOKEN` | Zone Cache Purge Token | `Bearer` 后面的整串 |
+| `CLOUDFLARE_ZONE_ID` | `opptrix.org` 的 Zone ID | `32 位 hex` |
+
+**已有、无需新增**（CI 自带）：`GITHUB_TOKEN`（上传 Release、下载资产）。
+
+**构建阶段也会读** `OPPTRIX_UPDATE_BASE_URL`（写入安装包内 `app-update.yml`），因此 **打 `desktop-v*` 标签前** 必须已配置该 Secret。
+
+---
+
+#### 第四步：验证配置
+
+Secrets 配好后，可本地抽查（勿把 Secret 提交到仓库）：
+
+```bash
+# R2 公网 yml（应 200）
+curl -I "https://update.opptrix.org/desktop/latest-mac.yml"
+
+# Cloudflare Purge API（替换 ZONE_ID 与 TOKEN）
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/purge_cache" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"files":["https://update.opptrix.org/desktop/latest-mac.yml"]}'
+# 期望 JSON 中 "success": true
+```
+
+正式验证：合并含 `sync-r2` 的 workflow 后，打 `desktop-v*` 标签，在 Actions 查看 **Sync release to Cloudflare R2** job 三步均绿：
+- Sync to Cloudflare R2  
+- Verify public update metadata  
+- Purge Cloudflare CDN cache  
+
+---
+
+#### 跳过行为（便于排查）
+
+| 未配置的 Secret | CI 行为 |
+|-----------------|---------|
+| `R2_ACCESS_KEY_ID` 等 R2 四项 | 跳过 R2 上传 |
+| `OPPTRIX_UPDATE_BASE_URL` | 安装包用占位 URL；跳过公网 verify |
+| `CLOUDFLARE_API_TOKEN` | 跳过 CDN purge（R2 上传仍成功） |
 
 #### 客户端如何指向 R2
 
 - CI 构建时通过 `OPPTRIX_UPDATE_BASE_URL` 注入 `electron-builder` 的 `generic` publish URL；
-- 打包产物内嵌 `app-update.yml`，`electron-updater` 从 R2 拉取 `latest-*.yml` 与安装包；
-- **已发布且仍使用 GitHub 更新源的旧客户端**，需先手动安装一版切换至 R2 源的新包后，后续才能走 R2 加速更新。
+- 打包产物内嵌 `app-update.yml`，`electron-updater` 从 `update.opptrix.org` 拉取 yml 与安装包；
+- **仍走 GitHub 更新源的旧客户端**，需先手动安装一版新包后，后续才走 R2/CDN。
 
-本地调试 R2 同步（需已下载 Release 资源目录）：
+本地调试 R2 同步：
 
 ```bash
 export R2_ACCOUNT_ID=… R2_ACCESS_KEY_ID=… R2_SECRET_ACCESS_KEY=… R2_BUCKET=…
-export OPPTRIX_UPDATE_BASE_URL=https://pub-xxxx.r2.dev/desktop/
+export OPPTRIX_UPDATE_BASE_URL=https://update.opptrix.org/desktop/
 node apps/desktop/scripts/sync-release-to-r2.mjs /path/to/release-assets
+```
+
+本地调试 CDN purge：
+
+```bash
+export CLOUDFLARE_API_TOKEN=… CLOUDFLARE_ZONE_ID=…
+export OPPTRIX_UPDATE_BASE_URL=https://update.opptrix.org/desktop/
+node apps/desktop/scripts/purge-update-cdn-cache.mjs
 ```
 
 ---

--- a/docs/DESKTOP-RELEASE.md
+++ b/docs/DESKTOP-RELEASE.md
@@ -11,7 +11,8 @@
 | 项目 | 说明 |
 |------|------|
 | 更新方式 | `electron-updater` 全量更新（按平台下载完整安装包，用户确认后重启安装） |
-| 更新源 | GitHub Releases（`apps/desktop/package.json` → `build.publish`） |
+| 更新源 | **Cloudflare R2**（`generic` provider；CI 构建时写入 `app-update.yml`） |
+| 手动下载 | GitHub Releases（安装包与 Release Notes 仍发布在 GitHub） |
 | 版本真源 | `apps/desktop/package.json` 的 `version` 字段 |
 | Git 标签 | `desktop-v{version}`，例如 `desktop-v0.6.1` |
 | CI 工作流 | [.github/workflows/release-desktop.yml](../.github/workflows/release-desktop.yml) |
@@ -109,6 +110,8 @@ git push origin desktop-v0.6.1
 1. **prepare-release**：创建 GitHub Release（`desktop-v{version}`）
 2. **4 个并行 job** 打包（macOS x64 / arm64、Windows、Linux）
 3. 各 job 用 `gh release upload` 上传安装包（`electron-builder --publish never`，避免 CI 内自动 publish/签名冲突）
+4. **finalize-release** 合并 macOS 双架构 `latest-mac.yml` 并校验 yml 与 Release 附件一致
+5. **sync-r2** 将当前 Release 产物同步至 Cloudflare R2（purge 旧版 + 上传），供客户端加速更新
 
 Sidecar 原生依赖由 `apps/desktop/scripts/stage-runtime.mjs` staging；`-dev` 标签默认跳过代码签名。
 
@@ -148,6 +151,54 @@ latest-linux.yml
 （另可有 `.blockmap` 等辅助文件。）
 
 编辑 Release 说明，补充 **面向用户** 的更新内容。
+
+### 4.4 Cloudflare R2 更新加速（CI 自动）
+
+桌面客户端的 **检查更新 / 下载更新** 走 Cloudflare R2（免费 10 GB 存储），GitHub Release 仍用于手动下载与 Release Notes。
+
+CI 在 `finalize-release` 成功后执行 **`sync-r2`** job：
+
+1. 从 GitHub Release 下载当前标签的全部安装包与 `latest-*.yml`；
+2. **删除** R2 bucket 内 `desktop/` 前缀下的旧对象（仅保留最新一版，避免超出 10 GB 配额）；
+3. 上传当前版本全部产物到 R2；
+4. 校验公网 URL 可访问 `latest-mac.yml` / `latest.yml` / `latest-linux.yml`。
+
+#### 一次性配置（Cloudflare Dashboard）
+
+1. **R2 → Create bucket**（例如 `opptrix-desktop-releases`）。
+2. **R2 → Manage R2 API Tokens → Create API token**：Object Read & Write，限定上述 bucket。
+3. **启用公网访问**（二选一）：
+   - **R2.dev 子域**：bucket → Settings → Public access → Allow Access，获得 `https://pub-xxxx.r2.dev`；
+   - **自定义域名**：R2 → bucket → Custom Domains，绑定如 `updates.example.com`（推荐，可开 Cloudflare CDN）。
+4. 公网 base URL 须包含路径前缀，例如：`https://pub-xxxx.r2.dev/desktop/`（**末尾斜杠必填**）。
+
+#### GitHub Actions Secrets
+
+在 **Settings → Secrets and variables → Actions** 添加：
+
+| Secret | 说明 |
+|--------|------|
+| `R2_ACCOUNT_ID` | Cloudflare 账户 ID（Dashboard 右侧） |
+| `R2_ACCESS_KEY_ID` | R2 API Token Access Key ID |
+| `R2_SECRET_ACCESS_KEY` | R2 API Token Secret Access Key |
+| `R2_BUCKET` | Bucket 名称，如 `opptrix-desktop-releases` |
+| `OPPTRIX_UPDATE_BASE_URL` | 公网更新根 URL，如 `https://pub-xxxx.r2.dev/desktop/` |
+
+未配置 R2 secrets 时：`sync-r2` 会跳过上传（构建仍成功）；`OPPTRIX_UPDATE_BASE_URL` 未设置时，安装包内 `app-update.yml` 使用占位 URL，**自动更新不可用**。
+
+#### 客户端如何指向 R2
+
+- CI 构建时通过 `OPPTRIX_UPDATE_BASE_URL` 注入 `electron-builder` 的 `generic` publish URL；
+- 打包产物内嵌 `app-update.yml`，`electron-updater` 从 R2 拉取 `latest-*.yml` 与安装包；
+- **已发布且仍使用 GitHub 更新源的旧客户端**，需先手动安装一版切换至 R2 源的新包后，后续才能走 R2 加速更新。
+
+本地调试 R2 同步（需已下载 Release 资源目录）：
+
+```bash
+export R2_ACCOUNT_ID=… R2_ACCESS_KEY_ID=… R2_SECRET_ACCESS_KEY=… R2_BUCKET=…
+export OPPTRIX_UPDATE_BASE_URL=https://pub-xxxx.r2.dev/desktop/
+node apps/desktop/scripts/sync-release-to-r2.mjs /path/to/release-assets
+```
 
 ---
 
@@ -190,8 +241,8 @@ npm run build:desktop -- --publish always
 
 已安装的打包版客户端（非 `npm run dev`）会：
 
-1. 启动约 10 秒后后台检查 GitHub Release；
-2. 读取嵌入在安装包内的 `app-update.yml`（构建时由 `publish.github` 生成）；
+1. 启动约 10 秒后后台检查 **R2 上的 `latest-*.yml`**；
+2. 读取嵌入在安装包内的 `app-update.yml`（构建时由 `generic` publish + `OPPTRIX_UPDATE_BASE_URL` 生成）；
 3. 对比 `latest-*.yml` 中的 `version` 与本地 `apps/desktop/package.json` 版本；
 4. 若有新版本：`autoDownload` 后台下载 **当前平台** 整包；
 5. 侧栏「设置」上方提示 → 用户点 **重启更新** → `quitAndInstall` 完成替换。

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,13 +21,14 @@
     },
     "apps/desktop": {
       "name": "@opptrix/desktop",
-      "version": "0.6.0-dev.10",
+      "version": "0.6.0-dev.14",
       "license": "Apache-2.0",
       "dependencies": {
         "electron-updater": "^6.6.2",
         "node-llama-cpp": "^3.19.0"
       },
       "devDependencies": {
+        "@aws-sdk/client-s3": "^3.888.0",
         "electron": "^35.0.0",
         "electron-builder": "^25.1.8",
         "to-ico": "^1.1.5"
@@ -2317,10 +2318,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "client-ui/node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
-    },
     "client-ui/node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "dev": true,
@@ -2444,6 +2441,332 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.16",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/checksums/-/checksums-3.1000.16.tgz",
+      "integrity": "sha512-EKnvkXSmz3IpA99tCNuI+dLFXyZyClSm8zns9sB/elvkU+MTuomAs6toJMPMBf98/fICG/urXDkzGz0/c3yyAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1084.0",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/client-s3/-/client-s3-3.1084.0.tgz",
+      "integrity": "sha512-W8KZlbU3vL4N0rZnXqryH5Ft3fkBnGypaorZmFxBoZRMGkwtvRBGiSnNXu1/1a/j/qZNwwt6LLNBWQQysB/pRg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.16",
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-node": "^3.972.66",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.62",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.1",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/core/-/core-3.975.1.tgz",
+      "integrity": "sha512-8qh/6EYb7hl/ZwVfQufhbMEZs1gQIc7GbdrIf4eprQJ7cv042+74nE6l3YDfyWNzb9iPXb8fRyYSHkNIk5eE6Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@aws-sdk/xml-builder": "^3.972.34",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.57.tgz",
+      "integrity": "sha512-1RfJaF7SW1TOnvNGU7kaYjwUf5H3sfm+synGH1bHhRlqcnxCt3szebH3dmKEyY4tuGcbQ6ffzUT89cRitBV8OQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.59.tgz",
+      "integrity": "sha512-sRCkpTiFnCdQvuaRVjQ6SVoHu6i7RUpurVo1c4F81HWhPvUJ7Wdp5MNtSdX1O29CNXc8em3O5m52hCjVtAD9SA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.1.tgz",
+      "integrity": "sha512-6d8H6ZAh3ZPKZ6fe1nG2OWeZEZPtt9ravoD1dezPdPtsSkJRoxGAnFSHwKT3E/Te6fHE30zRzjV6TD12rvF6yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-login": "^3.972.63",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.63.tgz",
+      "integrity": "sha512-GREWRrMj0XnNKMaVa/Mauoaui26qBEHu71WWqXbwZOu/jFQOnPZjTf7u0KtGKC8VGa6VUs9kDWGgocrKNLS9vw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.66",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.66.tgz",
+      "integrity": "sha512-f+qjRXZpz7sgzbc4QB+6nLKfyKFgRRXzWdXbsKPv/VhVRyHsDyq4yBWC/B75BAJpFIcUeI2XR/3gdWJ677zB4A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.57",
+        "@aws-sdk/credential-provider-http": "^3.972.59",
+        "@aws-sdk/credential-provider-ini": "^3.973.1",
+        "@aws-sdk/credential-provider-process": "^3.972.57",
+        "@aws-sdk/credential-provider-sso": "^3.973.1",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.63",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/credential-provider-imds": "^4.4.7",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.57",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.57.tgz",
+      "integrity": "sha512-TiVQhuU0pbhIZAUZacbPHMyzrIdiH+lnx+PMY/Pu/b93dJrq3wdZwzUJ0TPpvNxaqbHsxJvQZW3/h/beLiKq7Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.1",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.1.tgz",
+      "integrity": "sha512-3foTZUJ4821Ij60X7K3NJroygiZLnbBmarN+T//O2cjkISan90zElN3NBmgSlDrTQ7Gs6z/yO8V7h60QNcDZHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/token-providers": "3.1083.0",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.63",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.63.tgz",
+      "integrity": "sha512-8qZLFhM69eKcS37m459ctPR05Qimycm/74OPVioe6wNZabMT54GYhwBju0+J656RkMasNSawWQu+c8CmBe3TUQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.62.tgz",
+      "integrity": "sha512-k8JJwYXVYlOOjWnPZDThQS1xDFJgi5Dokt73qFlDtrZAbdcint5aIdjB9XgJAAQVP5OoqcefQmh1FYXiPpvsvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.31",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/nested-clients/-/nested-clients-3.997.31.tgz",
+      "integrity": "sha512-BDHTpwcsZHEBNEJzOg/B1BkFYJxAXY50dau/NyVWs3d51F0WgIUGSWZot/Os+N3KpDhXeaXnz37mWffAvduREw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.39",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/fetch-http-handler": "^5.6.4",
+        "@smithy/node-http-handler": "^4.9.4",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.39",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
+      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/signature-v4": "^5.6.3",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1083.0",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1083.0.tgz",
+      "integrity": "sha512-s0woKnxuHrExLc5L2ArIH5BMkbonHPtt+5hSBM8oknp9M6QTuUmmAmJ2E0EdzCGONrO+8+ADPqvv6UX0nNcc7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.1",
+        "@aws-sdk/nested-clients": "^3.997.31",
+        "@aws-sdk/types": "^3.974.0",
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.0",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/types/-/types-3.974.0.tgz",
+      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmmirror.com/@aws-sdk/xml-builder/-/xml-builder-3.972.34.tgz",
+      "integrity": "sha512-wHhWL1y7sN3enBA8POrPpQM5jCcmu2ozyhbRei4c8OjVcEaEs6yLucLa/pla457ggS/ysuy7bosagz3HaJkZXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmmirror.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -3810,6 +4133,93 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.29.2",
+      "resolved": "https://registry.npmmirror.com/@smithy/core/-/core-3.29.2.tgz",
+      "integrity": "sha512-DXUk6yU0C1Q1tYvJh1VCtl8QOBcSoZpKwjTPkxT6A4MUQYHvgeKGByL8mrEdxnvhdf9nq5GyzmRb5n/vPgu3Lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.7",
+      "resolved": "https://registry.npmmirror.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.7.tgz",
+      "integrity": "sha512-UEMLOoA0Fl4uYBxh6l0uN0H6EJe/A89OGeDNTteQeXpJ20BcpfIr4wlCY9pel1jEAUHAxaYwuqrYlrKdXE1GKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmmirror.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.4.tgz",
+      "integrity": "sha512-psnst7NZWdAEvJvyW8YZEE7xNVMyLrQFfHtyrVFrxNyy+dKWkQ+rqC6oI5ZhxThpUy9RSfEshgm34zqbOxzsRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.4",
+      "resolved": "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.4.tgz",
+      "integrity": "sha512-BNTop/fSOptmoVk8g+efwHCofFh37g70OWGAFES1TeAAJja1K5aAI8rTE26ETSc5k8IQuWY2kAIoPla01NgYrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.6.3.tgz",
+      "integrity": "sha512-8qVKKzqh7naF27ePmx0SkUfnGP/wBI9dyaeAmhHvopnbIlItUAmB/e6PkPCU3rRb2v9BY8D4EZXSoydSibatvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.2",
+        "@smithy/types": "^4.16.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.0",
+      "resolved": "https://registry.npmmirror.com/@smithy/types/-/types-4.16.0.tgz",
+      "integrity": "sha512-aVUabzlBBmY0PfvVgLKQSOGFIL5/7R54JE3uD9a5Ay/jSED61SkuAcCYENNXJzYUvJ1NPrWO0P+rAXHCkbBUKw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "dev": true,
@@ -4838,6 +5248,13 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmmirror.com/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.6",
@@ -12700,11 +13117,6 @@
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "0BSD"
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "funding": [
@@ -13735,6 +14147,12 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.22.4",


### PR DESCRIPTION
## Summary
- Sync desktop release artifacts to Cloudflare R2 with generic electron-updater feed at `update.opptrix.org/desktop/`
- Purge CDN cache for `latest-*.yml` after R2 sync in GitHub Actions
- Improve settings About page update check UX (spinner, progress, restart when ready)
- Add backward-compatibility Cursor rule and sync AGENT-GUIDE

## Test plan
- [ ] Merge and tag `desktop-v0.6.0-dev.15` to trigger Release Desktop workflow
- [ ] Verify R2 upload + CDN purge jobs succeed
- [ ] Install previous dev build and check update from settings About
- [ ] Confirm `latest-mac.yml` / `latest-win.yml` served from update CDN


Made with [Cursor](https://cursor.com)