### PR TITLE
feat(desktop): use native window vibrancy under transparent sidebar

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -83,9 +83,34 @@ function setOpaqueWindowBackground(win) {
   win.setBackgroundColor(SPLASH_CANVAS)
 }
 
+/** macOS vibrancy / Windows acrylic — 勿开 BrowserWindow.transparent，否则缩放动画会漏出桌面空透明。 */
+function enableWindowBlurBackground(win) {
+  if (win.isDestroyed()) return
+  if (process.platform === 'darwin') {
+    try {
+      win.setVibrancy('sidebar')
+    } catch {
+      /* older Electron */
+    }
+    // 透明网页区域露的是 vibrancy 材质层，不是裸桌面；背景色用 0 alpha 才能看见材质
+    win.setBackgroundColor('#00000000')
+    return
+  }
+  if (process.platform === 'win32') {
+    try {
+      if (typeof win.setBackgroundMaterial === 'function') {
+        win.setBackgroundMaterial('acrylic')
+      }
+    } catch {
+      /* unsupported on older Windows */
+    }
+    win.setBackgroundColor('#00000000')
+  }
+}
+
+/** @deprecated use enableWindowBlurBackground */
 function enableMacWindowTransparency(win) {
-  if (process.platform !== 'darwin' || win.isDestroyed()) return
-  win.setBackgroundColor('#00000000')
+  enableWindowBlurBackground(win)
 }
 
 async function fadeSplashOut(win) {
@@ -467,7 +492,8 @@ function buildMainWindowOptions() {
     minWidth: MIN_WIDTH,
     minHeight: MIN_HEIGHT,
     title: APP_TITLE,
-    backgroundColor: '#F5F5F7',
+    // Splash / Linux 默认实色；mac/win 有原生毛玻璃时启动阶段仍先用不透明底防闪
+    backgroundColor: SPLASH_CANVAS,
     show: false,
     center,
     webPreferences: mainWindowWebPreferences({
@@ -480,9 +506,13 @@ function buildMainWindowOptions() {
   if (process.platform === 'darwin') {
     options.titleBarStyle = 'hiddenInset'
     options.trafficLightPosition = { x: 16, y: 16 }
+    // 系统侧栏毛玻璃。不要设 transparent:true —— 缩放时新区域会短暂变成「空透明」漏桌面。
     options.vibrancy = 'sidebar'
     options.visualEffectState = 'active'
-    options.transparent = true
+  } else if (process.platform === 'win32') {
+    options.frame = false
+    // 同 mac：用系统材料，避免整窗 transparent 导致缩放漏底
+    options.backgroundMaterial = 'acrylic'
   } else {
     options.frame = false
   }
@@ -598,7 +628,7 @@ async function loadAppInMainWindow(win, { enforceMinSplash = true } = {}) {
   })
 
   await shellReady
-  enableMacWindowTransparency(win)
+  enableWindowBlurBackground(win)
 
   if (!win.isVisible()) {
     await new Promise((resolve) => {

--- a/client-ui/src/chat/SessionSidebar.tsx
+++ b/client-ui/src/chat/SessionSidebar.tsx
@@ -10,7 +10,7 @@ import { ghostInteractive, motion, nativeIconInteractive, sidebarItemSelected, s
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import OpptrixSegmentedControl from '../components/opptrix/OpptrixSegmentedControl'
 import ThinkingDots from '../components/ThinkingDots'
-import { isElectron } from '../platform/detect'
+import { isElectron, supportsNativeWindowVibrancy } from '../platform/detect'
 import { useTheme } from '../theme/ThemeContext'
 import { DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT } from '../desktop/constants'
 import OverlaySidebarShell from '../desktop/OverlaySidebarShell'
@@ -312,7 +312,10 @@ function SessionSidebar({
   const isDrawer = mode === 'drawer'
   const isOverlay = mode === 'overlay'
   const electronChrome = isElectron() && !isDrawer
-  const sidebarGlass = electronChrome && resolvedScheme !== 'dark'
+  const nativeVibrancy = supportsNativeWindowVibrancy()
+  // 原生毛玻璃时深浅色都透明穿透；无原生时仅浅色用 CSS glass，深色实底
+  const sidebarGlass = electronChrome && (nativeVibrancy || resolvedScheme !== 'dark')
+  const sidebarSolidDark = electronChrome && !nativeVibrancy && resolvedScheme === 'dark'
   const [listTabState, setListTabState] = useState<SidebarListTab>('chat')
   const listTab = listTabProp ?? listTabState
   const setListTab = useCallback((tab: SidebarListTab) => {
@@ -532,7 +535,7 @@ function SessionSidebar({
         isDrawer && drawerOpen && s.sidebarDrawerOpen,
         !electronChrome && !isDrawer && s.sidebarWeb,
         electronChrome && s.sidebarElectron,
-        electronChrome && resolvedScheme === 'dark' && s.sidebarElectronSolid,
+        sidebarSolidDark && s.sidebarElectronSolid,
         electronChrome && s.sidebarTopElectron,
         sidebarGlass && 'opptrix-glass-sidebar',
         !isDrawer && 'opptrix-sidebar-edge',

--- a/client-ui/src/main.tsx
+++ b/client-ui/src/main.tsx
@@ -16,6 +16,11 @@ if (isDesktopApp()) {
 if (isElectron()) {
   document.documentElement.classList.add('opptrix-electron')
   document.documentElement.classList.add('opptrix-electron-startup')
+  const platform = window.electronAPI?.platform
+  // mac vibrancy / win acrylic — 侧栏透明穿透到系统毛玻璃
+  if (platform === 'darwin' || platform === 'win32') {
+    document.documentElement.classList.add('opptrix-electron-vibrancy')
+  }
   window.setTimeout(() => {
     document.documentElement.classList.remove('opptrix-electron-startup')
     window.electronAPI?.signalShellReady?.()

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -12,7 +12,7 @@ import {
 } from '@fluentui/react-icons'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
 import { ghostInteractive, inputShellInteractive, motion, sidebarItemSelected, sidebarTopMenuIcon, sidebarTopMenuRow, SIDEBAR_TOP_MENU_ICON_SIZE } from '../../theme/mixins'
-import { isElectron } from '../../platform/detect'
+import { isElectron, supportsNativeWindowVibrancy } from '../../platform/detect'
 import { useTheme } from '../../theme/ThemeContext'
 import { DESKTOP_TITLEBAR_HEIGHT } from '../../desktop/constants'
 import OverlaySidebarShell from '../../desktop/OverlaySidebarShell'
@@ -218,7 +218,9 @@ export default function SettingsSidebar({
   const { resolvedScheme } = useTheme()
   const isOverlay = mode === 'overlay'
   const electronChrome = isElectron() && !isMobile && !isOverlay
-  const sidebarGlass = electronChrome && resolvedScheme !== 'dark'
+  const nativeVibrancy = supportsNativeWindowVibrancy()
+  const sidebarGlass = electronChrome && (nativeVibrancy || resolvedScheme !== 'dark')
+  const sidebarSolidDark = electronChrome && !nativeVibrancy && resolvedScheme === 'dark'
 
   const searchActive = Boolean(search.trim()) && !isMobile
 
@@ -349,7 +351,7 @@ export default function SettingsSidebar({
         isMobile && s.sidebarMobile,
         !electronChrome && !isMobile && s.sidebarWeb,
         electronChrome && s.sidebarElectron,
-        electronChrome && resolvedScheme === 'dark' && s.sidebarElectronSolid,
+        sidebarSolidDark && s.sidebarElectronSolid,
         electronChrome && s.sidebarTopElectron,
         sidebarGlass && 'opptrix-glass-sidebar',
         'opptrix-sidebar-edge',

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -204,3 +204,10 @@ export function isDesktopRuntime(): boolean {
 export function useElectronChrome(): boolean {
   return isElectron()
 }
+
+/** macOS vibrancy / Windows acrylic — sidebar can punch through to OS blur */
+export function supportsNativeWindowVibrancy(): boolean {
+  if (!isElectron()) return false
+  const platform = electronPlatform()
+  return platform === 'darwin' || platform === 'win32'
+}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -160,7 +160,9 @@ html.opptrix-desktop {
   --opptrix-chrome-top-offset: 5px;
 }
 
-/* ── Electron: fully transparent shell, glass sidebars ── */
+/* ── Electron: 壳层透明以露出窗口材质（vibrancy/acrylic），主内容区自行实底 ──
+ * 注意：BrowserWindow 本身不应 transparent:true，否则缩放动画漏出桌面。
+ */
 html.opptrix-electron {
   --opptrix-app-bg: transparent;
   --opptrix-chrome-bg: transparent;
@@ -395,14 +397,30 @@ html.opptrix-electron .opptrix-right-panel {
   background: var(--opptrix-canvas) !important;
 }
 
+/* ── Electron shell glass ──
+ * 有原生毛玻璃（mac vibrancy / win acrylic）时侧栏透明穿透窗口层；
+ * 否则（Linux 等）保留 CSS backdrop-filter 毛玻璃。
+ */
 html.opptrix-electron .opptrix-glass-sidebar {
   background: var(--opptrix-sidebar-glass) !important;
   backdrop-filter: blur(40px) saturate(180%);
   -webkit-backdrop-filter: blur(40px) saturate(180%);
 }
 
-[data-theme="dark"] html.opptrix-electron .opptrix-glass-sidebar {
+html.opptrix-electron-vibrancy .opptrix-glass-sidebar {
+  background: transparent !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+[data-theme="dark"] html.opptrix-electron:not(.opptrix-electron-vibrancy) .opptrix-glass-sidebar {
   background: var(--opptrix-canvas-alt) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+[data-theme="dark"] html.opptrix-electron-vibrancy .opptrix-glass-sidebar {
+  background: transparent !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
 }
@@ -414,6 +432,7 @@ html.opptrix-electron .opptrix-overlay-sidebar .opptrix-sidebar-menu {
   will-change: transform;
 }
 
+/* Overlay 浮在实色主内容上，仍用 CSS 毛玻璃（无法穿透到窗口 vibrancy） */
 html.opptrix-electron .opptrix-overlay-sidebar {
   background: var(--opptrix-sidebar-glass) !important;
   backdrop-filter: blur(40px) saturate(180%);

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -89,6 +89,16 @@ The release app loads `http://127.0.0.1:8711` (UI + API same origin).
 
 In Electron, the client forces **desktop layout** (sidebar visible, no mobile drawer) via `client-ui/src/platform/detect.ts`.
 
+### Window blur + sidebar
+
+| 平台 | 窗口层 | 固定左侧栏 |
+|------|--------|------------|
+| macOS | `vibrancy: 'sidebar'`（**不开** `transparent`） | CSS 透明，露的是系统毛玻璃材质；缩放时不会漏裸桌面 |
+| Windows | `backgroundMaterial: 'acrylic'`（**不开** `transparent`） | 同上 |
+| Linux | 实色窗口底 | 保留 CSS `.opptrix-glass-sidebar` 毛玻璃（无原生 acrylic） |
+
+窄窗浮层侧栏仍盖在实色主内容上，继续用 CSS 毛玻璃。文档标记类：`html.opptrix-electron-vibrancy`。
+
 ### Title bar z-index
 
 Stacking order (low → high), defined in `client-ui/src/desktop/constants.ts` as `DESKTOP_Z_*`:

--- a/docs/UI-DESIGN-SYSTEM.md
+++ b/docs/UI-DESIGN-SYSTEM.md
@@ -121,6 +121,7 @@
 - Tokens：`glass`、`glassBlur`、`surfaceGlass`（`theme/tokens.ts`）
 
 **原则**：浮层与二次确认 Dialog **默认毛玻璃**；实体卡片（SurfaceCard、列表行）仍用 `surface` 实底 + 轻描边，不用毛玻璃。  
+Electron **固定左侧栏**：macOS / Windows 走窗口原生毛玻璃（侧栏透明穿透）；Linux 与窄窗浮层侧栏仍用 CSS `.opptrix-glass-sidebar` / `.opptrix-overlay-sidebar`。  
 **Agent 规则**：`.cursor/rules/ui-overlay-components.mdc`（组件选型表与禁止项）。
 
 ## 6. Layout Constants


### PR DESCRIPTION
## Summary
- Apply macOS `vibrancy: sidebar` / Windows acrylic without `BrowserWindow.transparent`, fixing resize leaks of clear desktop
- Keep docked left sidebar CSS-transparent so it shows the system material instead of CSS `backdrop-filter`
- Linux keeps CSS glass; overlay sidebars still use CSS blur over opaque content

## Test plan
- [x] `npm run check:ui`
- [ ] macOS: docked sidebar looks frosted; window resize does not flash clear desktop
- [ ] Windows: acrylic under transparent sidebar (where supported)
- [ ] Narrow-window overlay sidebar still uses CSS glass


Made with [Cursor](https://cursor.com)