### PR TITLE
fix(ui): Windows sidebar glass and title-bar alignment

### DIFF
--- a/client-ui/src/desktop/DesktopWindowChrome.tsx
+++ b/client-ui/src/desktop/DesktopWindowChrome.tsx
@@ -7,8 +7,6 @@ import {
 import { makeStyles, mergeClasses, Text } from '@fluentui/react-components'
 import { isElectron } from '../platform/detect'
 import {
-  DESKTOP_CHROME_BAND_HEIGHT,
-  DESKTOP_CHROME_TOP_OFFSET,
   DESKTOP_SIDEBAR_LAYOUT_EASE,
   DESKTOP_SIDEBAR_LAYOUT_MS,
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
@@ -33,6 +31,9 @@ import {
 import { electronPlatform } from '../platform/detect'
 import { opptrixCssVars } from '../theme/tokens'
 import {
+  desktopChromeBandHeight,
+  desktopChromeTopOffset,
+  desktopTitleBarActionsRight,
   desktopTitleLeft,
   desktopTitleMaxWidth,
   desktopToolbarLeft,
@@ -62,8 +63,6 @@ const useStyles = makeStyles({
   },
   toolbar: {
     position: 'absolute',
-    top: `${DESKTOP_CHROME_TOP_OFFSET}px`,
-    height: `${DESKTOP_CHROME_BAND_HEIGHT}px`,
     display: 'flex',
     alignItems: 'center',
     gap: `${DESKTOP_TOOL_GAP}px`,
@@ -76,8 +75,6 @@ const useStyles = makeStyles({
   },
   title: {
     position: 'absolute',
-    top: `${DESKTOP_CHROME_TOP_OFFSET}px`,
-    height: `${DESKTOP_CHROME_BAND_HEIGHT}px`,
     display: 'flex',
     alignItems: 'center',
     minWidth: 0,
@@ -111,8 +108,6 @@ const useStyles = makeStyles({
   },
   titleBarActions: {
     position: 'fixed',
-    top: `${DESKTOP_CHROME_TOP_OFFSET}px`,
-    height: `${DESKTOP_CHROME_BAND_HEIGHT}px`,
     display: 'flex',
     alignItems: 'center',
     gap: `${DESKTOP_TOOL_GAP}px`,
@@ -226,9 +221,11 @@ export default function DesktopWindowChrome({
   const isNews = viewMode === 'news'
   const isMarket = viewMode === 'market'
   const isStandalonePanel = isNews || isMarket
+  const chromeTop = desktopChromeTopOffset()
+  const chromeBand = desktopChromeBandHeight()
   const titleLeft = desktopTitleLeft(sidebarInline, viewMode, macFullscreen)
   const toolbarLeft = desktopToolbarLeft(macFullscreen)
-  const titleBarActionsRight = electronPlatform() === 'darwin' ? 12 : 132
+  const titleBarActionsRight = desktopTitleBarActionsRight()
   const showTitleBarActions = !isSettings && !rightPanelOpen && Boolean(onToggleRightPanel || onToggleChatColumn)
   const titleMaxWidth = desktopTitleMaxWidth({
     titleLeft,
@@ -323,6 +320,8 @@ export default function DesktopWindowChrome({
           <div
             className={mergeClasses(s.title, titleSlot != null && titleSlot !== false && s.titleInteractive)}
             style={{
+              top: `${chromeTop}px`,
+              height: `${chromeBand}px`,
               left: `${titleLeft}px`,
               maxWidth: `${titleMaxWidth}px`,
             }}
@@ -337,7 +336,14 @@ export default function DesktopWindowChrome({
           </div>
         )}
 
-        <div className={s.toolbar} style={{ left: `${toolbarLeft}px` }}>
+        <div
+          className={s.toolbar}
+          style={{
+            top: `${chromeTop}px`,
+            height: `${chromeBand}px`,
+            left: `${toolbarLeft}px`,
+          }}
+        >
           {showSidebarToggle && (onToggleSidebar || onRevealSidebar) && (
             <ChromeToolButton
               label={sidebarOpen ? '收起侧栏' : '展开侧栏'}
@@ -381,7 +387,11 @@ export default function DesktopWindowChrome({
       {!isSettings && !rightPanelOpen && (onToggleRightPanel || onToggleChatColumn) && (
         <div
           className={s.titleBarActions}
-          style={{ right: `${titleBarActionsRight}px` }}
+          style={{
+            top: `${chromeTop}px`,
+            height: `${chromeBand}px`,
+            right: `${titleBarActionsRight}px`,
+          }}
         >
           {onToggleChatColumn && (
             <ChromeToolButton

--- a/client-ui/src/desktop/WindowControls.tsx
+++ b/client-ui/src/desktop/WindowControls.tsx
@@ -1,15 +1,14 @@
 import { makeStyles } from '@fluentui/react-components'
 import { DismissRegular, SquareRegular, SubtractRegular } from '@fluentui/react-icons'
 import { isElectron } from '../platform/detect'
-import { DESKTOP_CHROME_BAND_HEIGHT, DESKTOP_CHROME_TOP_OFFSET, DESKTOP_Z_CHROME_TOOLS } from './constants'
+import { DESKTOP_Z_CHROME_TOOLS } from './constants'
+import { desktopChromeBandHeight, desktopChromeTopOffset } from './layout'
 import ChromeToolButton from './ChromeToolButton'
 
 const useStyles = makeStyles({
   controls: {
     position: 'fixed',
-    top: `${DESKTOP_CHROME_TOP_OFFSET}px`,
     right: 0,
-    height: `${DESKTOP_CHROME_BAND_HEIGHT}px`,
     display: 'flex',
     alignItems: 'center',
     paddingRight: '6px',
@@ -32,7 +31,13 @@ export default function WindowControls() {
   if (!isElectron() || !api || api.platform === 'darwin') return null
 
   return (
-    <div className={s.controls}>
+    <div
+      className={s.controls}
+      style={{
+        top: `${desktopChromeTopOffset()}px`,
+        height: `${desktopChromeBandHeight()}px`,
+      }}
+    >
       <ChromeToolButton label="Minimize" onClick={() => api.windowMinimize?.()}>
         <SubtractRegular fontSize={14} />
       </ChromeToolButton>

--- a/client-ui/src/desktop/constants.ts
+++ b/client-ui/src/desktop/constants.ts
@@ -1,10 +1,21 @@
 export const DESKTOP_TITLEBAR_HEIGHT = 43
 
-/** Vertical nudge for custom toolbar + title to align with macOS traffic lights */
+/**
+ * Vertical nudge for custom toolbar + title.
+ * macOS aligns with traffic lights; Windows sits slightly higher so panel
+ * toggles share a line with min/max/close.
+ */
 export const DESKTOP_CHROME_TOP_OFFSET = 5
+export const DESKTOP_CHROME_TOP_OFFSET_WIN = 2
 
-/** Usable band below the top inset inside the title bar */
+/** Usable band below the top inset inside the title bar (mac default). */
 export const DESKTOP_CHROME_BAND_HEIGHT = DESKTOP_TITLEBAR_HEIGHT - DESKTOP_CHROME_TOP_OFFSET
+
+/**
+ * Windows: width of custom min/max/close cluster + tight gap before it.
+ * 3×26 tools + 2×2 gaps + 6px end pad ≈ 88; +8px breathing room.
+ */
+export const DESKTOP_WIN_WINDOW_CONTROLS_RESERVE = 96
 
 /** macOS native traffic-light zone before app toolbar (windowed) */
 export const DESKTOP_TRAFFIC_LIGHT_WIDTH = 80

--- a/client-ui/src/desktop/layout.ts
+++ b/client-ui/src/desktop/layout.ts
@@ -1,6 +1,8 @@
 import { electronPlatform } from '../platform/detect'
 import { opptrixTokens } from '../theme/tokens'
 import {
+  DESKTOP_CHROME_TOP_OFFSET,
+  DESKTOP_CHROME_TOP_OFFSET_WIN,
   DESKTOP_SETTINGS_SIDEBAR_WIDTH,
   DESKTOP_TITLE_BAR_ACTIONS_WIDTH,
   DESKTOP_TITLE_GAP,
@@ -10,8 +12,24 @@ import {
   DESKTOP_TOOLBAR_TOOL_COUNT,
   DESKTOP_TRAFFIC_LIGHT_WIDTH,
   DESKTOP_TRAFFIC_LIGHT_WIDTH_FULLSCREEN,
+  DESKTOP_WIN_WINDOW_CONTROLS_RESERVE,
   DESKTOP_Z_TITLE_INTERACTIVE,
 } from './constants'
+
+/** Platform chrome inset — Windows sits higher to share a line with window buttons */
+export function desktopChromeTopOffset(): number {
+  return electronPlatform() === 'win32' ? DESKTOP_CHROME_TOP_OFFSET_WIN : DESKTOP_CHROME_TOP_OFFSET
+}
+
+export function desktopChromeBandHeight(): number {
+  return DESKTOP_TITLEBAR_HEIGHT - desktopChromeTopOffset()
+}
+
+/** Right inset for chat/panel toggles — flush to Windows min/max/close cluster */
+export function desktopTitleBarActionsRight(): number {
+  if (electronPlatform() === 'darwin') return 12
+  return DESKTOP_WIN_WINDOW_CONTROLS_RESERVE
+}
 
 export function desktopToolbarLeft(fullscreen = false): number {
   if (electronPlatform() !== 'darwin') return 12

--- a/client-ui/src/main.tsx
+++ b/client-ui/src/main.tsx
@@ -17,6 +17,11 @@ if (isElectron()) {
   document.documentElement.classList.add('opptrix-electron')
   document.documentElement.classList.add('opptrix-electron-startup')
   const platform = window.electronAPI?.platform
+  if (platform === 'win32') {
+    document.documentElement.classList.add('opptrix-platform-win32')
+  } else if (platform === 'darwin') {
+    document.documentElement.classList.add('opptrix-platform-darwin')
+  }
   // mac vibrancy / win acrylic — 侧栏透明穿透到系统毛玻璃
   if (platform === 'darwin' || platform === 'win32') {
     document.documentElement.classList.add('opptrix-electron-vibrancy')

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -337,7 +337,7 @@ export default function SettingsSidebar({
         width={opptrixTokens.settingsSidebarWidth}
         onClose={onClose}
       >
-        <div className={mergeClasses(s.sidebar, s.sidebarTopElectron)}>
+        <div className={mergeClasses(s.sidebar, s.sidebarTopElectron, 'opptrix-settings-sidebar')}>
           {body}
         </div>
       </OverlaySidebarShell>
@@ -354,6 +354,7 @@ export default function SettingsSidebar({
         sidebarSolidDark && s.sidebarElectronSolid,
         electronChrome && s.sidebarTopElectron,
         sidebarGlass && 'opptrix-glass-sidebar',
+        'opptrix-settings-sidebar',
         'opptrix-sidebar-edge',
       )}
     >

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -413,16 +413,60 @@ html.opptrix-electron-vibrancy .opptrix-glass-sidebar {
   -webkit-backdrop-filter: none !important;
 }
 
+/*
+ * Windows acrylic alone is too see-through through a fully clear sidebar.
+ * Keep material visible under a denser frosted tint (main chat sidebar only).
+ */
+html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar:not(.opptrix-settings-sidebar) {
+  background: rgba(255, 255, 255, 0.62) !important;
+}
+
 [data-theme="dark"] html.opptrix-electron:not(.opptrix-electron-vibrancy) .opptrix-glass-sidebar {
   background: var(--opptrix-canvas-alt) !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
 }
 
-[data-theme="dark"] html.opptrix-electron-vibrancy .opptrix-glass-sidebar {
+[data-theme="dark"] html.opptrix-electron-vibrancy .opptrix-glass-sidebar:not(.opptrix-settings-sidebar) {
   background: transparent !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
+}
+
+[data-theme="dark"] html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar:not(.opptrix-settings-sidebar) {
+  background: rgba(44, 44, 46, 0.72) !important;
+}
+
+/* ── Settings sidebar: ~85% opaque vs main glass, all platforms ── */
+html .opptrix-settings-sidebar {
+  --opptrix-settings-sidebar-fill: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, var(--opptrix-canvas-muted) 15%);
+}
+
+html:not(.opptrix-electron) .opptrix-settings-sidebar {
+  background: var(--opptrix-settings-sidebar-fill) !important;
+}
+
+html.opptrix-electron .opptrix-glass-sidebar.opptrix-settings-sidebar,
+html.opptrix-electron .opptrix-settings-sidebar {
+  background: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, transparent) !important;
+  backdrop-filter: blur(28px) saturate(150%);
+  -webkit-backdrop-filter: blur(28px) saturate(150%);
+}
+
+html.opptrix-electron-vibrancy .opptrix-glass-sidebar.opptrix-settings-sidebar {
+  /* Still denser than main; leftover 15% transparency lets a hint of OS material through */
+  background: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, transparent) !important;
+  backdrop-filter: none !important;
+  -webkit-backdrop-filter: none !important;
+}
+
+[data-theme="dark"] html.opptrix-electron .opptrix-glass-sidebar.opptrix-settings-sidebar,
+[data-theme="dark"] html.opptrix-electron .opptrix-settings-sidebar {
+  background: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, transparent) !important;
+}
+
+[data-theme="dark"] html:not(.opptrix-electron) .opptrix-settings-sidebar {
+  background: var(--opptrix-settings-sidebar-fill) !important;
 }
 
 /* Isolate top menu icons from backdrop-filter repaints triggered by chat-area animations */


### PR DESCRIPTION
## Summary
- Windows main sidebar: frosted tint over acrylic so it is less see-through
- Windows title bar: raise chrome slightly; hang chat/panel toggles flush left of min/max/close
- Settings sidebar (all platforms): ~85% opaque fill to distinguish from the main shell

## Test plan
- [ ] Windows: main chat sidebar opacity looks denser but still shows acrylic
- [ ] Windows: right panel toggle icons align with min/max/close and sit closer to them
- [ ] Settings (mac/Windows/web): left nav is clearly denser than main sidebar
- [ ] `npm run check:ui` passes


Made with [Cursor](https://cursor.com)