### PR TITLE
feat(agent): external MCP servers with priority failover

### DIFF
--- a/.cursor/rules/external-mcp-servers.mdc
+++ b/.cursor/rules/external-mcp-servers.mdc
@@ -1,0 +1,28 @@
+---
+description: 外部 MCP Server 接入约束（优先级链、密钥、Agent 权限）
+globs:
+  - packages/agent/src/mcp/external/**
+  - packages/shared/src/mcp-servers.ts
+  - packages/user-store/src/mcp-servers.ts
+  - apps/server/src/mcp-server-routes.ts
+  - client-ui/src/pages/settings/McpServersSettingsSection.tsx
+---
+
+# 外部 MCP Server
+
+## 路由
+
+- LLM 见**稳定本地工具名**；执行层按 `sortOrder` 试已启用且未 pause 的外部源，再回落本地 `ToolRegistry`
+- 外部独有工具：`serverId__toolName`；业务错误不 failover；429/超时/网络错误才 failover + 熔断
+- 本地健康时不抢主路径（仅外部全部失败/暂停时成为结果来源）
+
+## 安全与权限
+
+- API / Agent 列表**永不回传** secrets 明文
+- Agent 可 `list` / `enable` / `pause` / `reorder`；`install` / `uninstall` 须 `ask_user` + `confirmed=true`
+- **禁止**经 Agent 修改已有服务器的 `command` / `url` / env 明文（设置页或 install 确认载荷一次写入）
+- stdio 子进程勿在渲染进程 spawn；HTTP 须超时
+
+## 持久化
+
+- user-store documents 命名空间 `mcp_servers`；类型在 `@opptrix/shared` 的 `mcp-servers.ts`

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -27,6 +27,7 @@ import { isDiscoverStrategyProfile, listDiscoverProfileMeta, type DiscoverStrate
 import { registerNewsRoutes } from './news-routes.js'
 import { registerEnrichmentRoutes } from './enrichment-routes.js'
 import { registerSearchRoutes } from './search-routes.js'
+import { registerMcpServerRoutes } from './mcp-server-routes.js'
 import {
   startNewsFeedScheduler,
   getNewsSettings,
@@ -1216,6 +1217,7 @@ async function bootstrap() {
 
   await registerNewsRoutes(app)
   await registerEnrichmentRoutes(app)
+  await registerMcpServerRoutes(app)
   registerSearchRoutes(app, hub, agent)
   startNewsFeedScheduler()
   startEnrichmentScheduler(90_000, resolveProjectRoot())

--- a/apps/server/src/mcp-server-routes.ts
+++ b/apps/server/src/mcp-server-routes.ts
@@ -1,0 +1,207 @@
+/**
+ * 外部 MCP Server CRUD / 测试连接 / 重排 — REST API。
+ * 响应永不包含明文 secrets。
+ */
+
+import type { FastifyInstance } from 'fastify'
+import {
+  getExternalMcpRegistry,
+  type ExternalMcpRegistry,
+} from '@opptrix/agent'
+import type {
+  McpCapabilityBindings,
+  McpServerCreateInput,
+  McpServerPatch,
+  McpTransportConfig,
+} from '@opptrix/shared'
+import { isValidMcpServerId } from '@opptrix/shared'
+
+function parseTransportConfig(raw: unknown): McpTransportConfig | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const o = raw as Record<string, unknown>
+  const transport = String(o.transport ?? '').trim().toLowerCase()
+  if (transport === 'stdio') {
+    const command = String(o.command ?? '').trim()
+    if (!command) return null
+    return {
+      transport: 'stdio',
+      command,
+      args: Array.isArray(o.args) ? o.args.map(String) : undefined,
+      cwd: o.cwd != null ? String(o.cwd) : undefined,
+      env: o.env && typeof o.env === 'object' && !Array.isArray(o.env)
+        ? Object.fromEntries(
+          Object.entries(o.env as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+        )
+        : undefined,
+    }
+  }
+  if (transport === 'http') {
+    const url = String(o.url ?? '').trim()
+    if (!url) return null
+    return {
+      transport: 'http',
+      url,
+      headers: o.headers && typeof o.headers === 'object' && !Array.isArray(o.headers)
+        ? Object.fromEntries(
+          Object.entries(o.headers as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+        )
+        : undefined,
+    }
+  }
+  return null
+}
+
+function parseSecrets(raw: unknown): Record<string, string> | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  return Object.fromEntries(
+    Object.entries(raw as Record<string, unknown>).map(([k, v]) => [k, String(v ?? '')]),
+  )
+}
+
+function parseBindings(raw: unknown): McpCapabilityBindings | undefined {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  return Object.fromEntries(
+    Object.entries(raw as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+  )
+}
+
+function publicList(reg: ExternalMcpRegistry) {
+  return { servers: reg.listPublic() }
+}
+
+export async function registerMcpServerRoutes(app: FastifyInstance) {
+  app.get('/api/mcp-servers', async () => {
+    const reg = getExternalMcpRegistry()
+    await reg.hydrate()
+    return publicList(reg)
+  })
+
+  app.get<{ Params: { id: string } }>('/api/mcp-servers/:id', async (req, reply) => {
+    const reg = getExternalMcpRegistry()
+    await reg.hydrate()
+    const row = reg.listPublic().find(s => s.id === req.params.id)
+    if (!row) return reply.status(404).send({ error: 'MCP Server 不存在' })
+    return { server: row }
+  })
+
+  app.post<{
+    Body: {
+      id?: string
+      title?: string
+      enabled?: boolean
+      paused?: boolean
+      sortOrder?: number
+      transportConfig?: unknown
+      secrets?: unknown
+      capabilityBindings?: unknown
+      installSource?: 'manual' | 'registry'
+    }
+  }>('/api/mcp-servers', async (req, reply) => {
+    const title = String(req.body?.title ?? '').trim()
+    if (!title) return reply.status(400).send({ error: 'title 必填' })
+    const transportConfig = parseTransportConfig(req.body?.transportConfig)
+    if (!transportConfig) {
+      return reply.status(400).send({ error: 'transportConfig 无效（stdio 需 command，http 需 url）' })
+    }
+    const id = req.body?.id != null ? String(req.body.id).trim().toLowerCase() : undefined
+    if (id && !isValidMcpServerId(id)) {
+      return reply.status(400).send({ error: '无效的 id（须小写字母开头，仅 a-z0-9_-）' })
+    }
+    const input: McpServerCreateInput = {
+      id,
+      title,
+      enabled: req.body?.enabled,
+      paused: req.body?.paused,
+      sortOrder: req.body?.sortOrder,
+      transportConfig,
+      secrets: parseSecrets(req.body?.secrets),
+      capabilityBindings: parseBindings(req.body?.capabilityBindings),
+      installSource: req.body?.installSource === 'registry' ? 'registry' : 'manual',
+    }
+    try {
+      const reg = getExternalMcpRegistry()
+      const row = reg.create(input)
+      await reg.hydrate()
+      const server = reg.listPublic().find(s => s.id === row.id)
+      return reply.status(201).send({ server })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      return reply.status(400).send({ error: msg })
+    }
+  })
+
+  app.patch<{
+    Params: { id: string }
+    Body: {
+      title?: string
+      enabled?: boolean
+      paused?: boolean
+      sortOrder?: number
+      transportConfig?: unknown
+      secrets?: unknown
+      capabilityBindings?: unknown
+    }
+  }>('/api/mcp-servers/:id', async (req, reply) => {
+    const reg = getExternalMcpRegistry()
+    if (!reg.getRecord(req.params.id)) {
+      return reply.status(404).send({ error: 'MCP Server 不存在' })
+    }
+    const patch: McpServerPatch = {}
+    if (req.body?.title !== undefined) patch.title = String(req.body.title)
+    if (req.body?.enabled !== undefined) patch.enabled = Boolean(req.body.enabled)
+    if (req.body?.paused !== undefined) patch.paused = Boolean(req.body.paused)
+    if (req.body?.sortOrder !== undefined) patch.sortOrder = Number(req.body.sortOrder)
+    if (req.body?.transportConfig !== undefined) {
+      const cfg = parseTransportConfig(req.body.transportConfig)
+      if (!cfg) return reply.status(400).send({ error: 'transportConfig 无效' })
+      patch.transportConfig = cfg
+    }
+    if (req.body?.secrets !== undefined) {
+      const secrets = parseSecrets(req.body.secrets)
+      if (secrets) patch.secrets = secrets
+    }
+    if (req.body?.capabilityBindings !== undefined) {
+      const bindings = parseBindings(req.body.capabilityBindings)
+      if (bindings) patch.capabilityBindings = bindings
+    }
+    try {
+      reg.save(req.params.id, patch)
+      await reg.hydrate()
+      const server = reg.listPublic().find(s => s.id === req.params.id)
+      return { server }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      return reply.status(400).send({ error: msg })
+    }
+  })
+
+  app.delete<{ Params: { id: string } }>('/api/mcp-servers/:id', async (req, reply) => {
+    const reg = getExternalMcpRegistry()
+    if (!reg.delete(req.params.id)) {
+      return reply.status(404).send({ error: 'MCP Server 不存在' })
+    }
+    return { ok: true, deleted: req.params.id }
+  })
+
+  app.post<{ Params: { id: string } }>('/api/mcp-servers/:id/test', async (req, reply) => {
+    const reg = getExternalMcpRegistry()
+    if (!reg.getRecord(req.params.id)) {
+      return reply.status(404).send({ error: 'MCP Server 不存在' })
+    }
+    const result = await reg.testConnection(req.params.id)
+    return { ...result, server: reg.listPublic().find(s => s.id === req.params.id) }
+  })
+
+  app.post<{ Body: { server_ids?: string[]; serverIds?: string[] } }>(
+    '/api/mcp-servers/reorder',
+    async (req, reply) => {
+      const raw = req.body?.server_ids ?? req.body?.serverIds
+      const ids = Array.isArray(raw) ? raw.map(String) : []
+      if (!ids.length) return reply.status(400).send({ error: 'server_ids 必填' })
+      const reg = getExternalMcpRegistry()
+      reg.reorder(ids)
+      await reg.hydrate()
+      return publicList(reg)
+    },
+  )
+}

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1659,3 +1659,58 @@ export const news = {
       total: number
     }>('/news/refresh', { method: 'POST' }),
 }
+
+// ─── External MCP Servers ───
+
+import type {
+  McpServerCreatePayload,
+  McpServerPatchPayload,
+  PublicMcpServer,
+} from '../types/mcpServer'
+
+export async function listMcpServers() {
+  const resp = await jsonFetch<{ servers: PublicMcpServer[] }>('/mcp-servers')
+  return resp.servers
+}
+
+export async function createMcpServer(payload: McpServerCreatePayload) {
+  return jsonFetch<{ server: PublicMcpServer }>('/mcp-servers', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function updateMcpServer(id: string, payload: McpServerPatchPayload) {
+  return jsonFetch<{ server: PublicMcpServer }>(`/mcp-servers/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function deleteMcpServer(id: string) {
+  return jsonFetch<{ ok: boolean; deleted: string }>(`/mcp-servers/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  })
+}
+
+export async function testMcpServer(id: string) {
+  return jsonFetch<{
+    ok: boolean
+    message: string
+    tools?: string[]
+    server?: PublicMcpServer
+  }>(`/mcp-servers/${encodeURIComponent(id)}/test`, {
+    method: 'POST',
+  }, 60_000)
+}
+
+export async function reorderMcpServers(serverIds: string[]) {
+  const resp = await jsonFetch<{ servers: PublicMcpServer[] }>('/mcp-servers/reorder', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ server_ids: serverIds }),
+  })
+  return resp.servers
+}

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -14,6 +14,7 @@ import { normalizeSettingsSection } from './settings/settingsTypes'
 import type { SettingsSearchEntry } from './settings/settingsSearchIndex'
 import SettingsBackRow from './settings/SettingsBackRow'
 import DataProvidersSettingsSection from './settings/DataProvidersSettingsSection'
+import McpServersSettingsSection from './settings/McpServersSettingsSection'
 import NewsFeedSettingsSection from './settings/NewsFeedSettingsSection'
 import TranslationSettingsSection from './settings/TranslationSettingsSection'
 import MultimodalSettingsSection from './settings/MultimodalSettingsSection'
@@ -597,6 +598,9 @@ function SettingsPageView({
 
       case 'data_providers':
         return <DataProvidersSettingsSection />
+
+      case 'mcp_servers':
+        return <McpServersSettingsSection />
 
       case 'news_feed':
         return <NewsFeedSettingsSection />

--- a/client-ui/src/pages/settings/McpServersSettingsSection.tsx
+++ b/client-ui/src/pages/settings/McpServersSettingsSection.tsx
@@ -1,0 +1,550 @@
+/**
+ * 设置页 — 外部 MCP Server 列表（启用/暂停/排序/测试/增删改；密钥掩码）。
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Input,
+  Switch,
+  Text,
+  makeStyles,
+  mergeClasses,
+} from '@fluentui/react-components'
+import {
+  AddRegular,
+  ArrowDownRegular,
+  ArrowUpRegular,
+  DeleteRegular,
+  PlugConnectedRegular,
+} from '@fluentui/react-icons'
+import {
+  createMcpServer,
+  deleteMcpServer,
+  listMcpServers,
+  reorderMcpServers,
+  testMcpServer,
+  updateMcpServer,
+} from '../../api/client'
+import type { PublicMcpServer } from '../../types/mcpServer'
+import OpptrixButton from '../../components/opptrix/OpptrixButton'
+import { useOpptrixDialogAlert } from '../../components/opptrix/OpptrixDialogAlert'
+import { SettingsGroup, SettingsRow } from './SettingsPrimitives'
+import { useSettingsToast } from './SettingsToast'
+import { SettingsListPanelSkeleton } from './SettingsListPanelSkeleton'
+import { opptrixCssVars, opptrixTokens } from '../../theme/tokens'
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  tabHint: {
+    fontSize: '12px',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.45,
+    padding: '0 2px 4px',
+  },
+  listPanel: {
+    border: opptrixCssVars.settingsPanelBorder,
+    borderRadius: opptrixTokens.radiusLg,
+    backgroundColor: opptrixCssVars.canvas,
+    overflow: 'hidden',
+  },
+  row: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '12px 14px',
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    ':last-child': { borderBottom: 'none' },
+  },
+  rowTop: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: '12px',
+  },
+  rowMain: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  title: {
+    fontSize: '14px',
+    fontWeight: 600,
+    color: opptrixCssVars.textPrimary,
+  },
+  meta: {
+    fontSize: '12px',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.45,
+    wordBreak: 'break-all',
+  },
+  actions: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: '6px',
+    justifyContent: 'flex-end',
+  },
+  healthOk: { color: opptrixCssVars.success },
+  healthBad: { color: opptrixCssVars.error },
+  healthMuted: { color: opptrixCssVars.textTertiary },
+  dialogBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    minWidth: '320px',
+  },
+  fieldLabel: {
+    fontSize: '12px',
+    color: opptrixCssVars.textSecondary,
+  },
+  dialogActions: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    marginTop: '8px',
+  },
+  empty: {
+    padding: '24px 14px',
+    textAlign: 'center',
+    color: opptrixCssVars.textTertiary,
+    fontSize: '13px',
+  },
+})
+
+function healthLabel(s: PublicMcpServer): { text: string; className: 'ok' | 'bad' | 'muted' } {
+  if (s.paused) return { text: '已暂停', className: 'muted' }
+  if (!s.enabled) return { text: '未启用', className: 'muted' }
+  switch (s.health) {
+    case 'healthy':
+      return { text: '健康', className: 'ok' }
+    case 'degraded':
+      return { text: '降级', className: 'bad' }
+    case 'open':
+      return { text: '熔断中', className: 'bad' }
+    default:
+      return { text: '未知', className: 'muted' }
+  }
+}
+
+type FormState = {
+  title: string
+  transport: 'stdio' | 'http'
+  command: string
+  args: string
+  url: string
+  bearer: string
+  bindings: string
+}
+
+const emptyForm = (): FormState => ({
+  title: '',
+  transport: 'stdio',
+  command: '',
+  args: '',
+  url: '',
+  bearer: '',
+  bindings: '',
+})
+
+function parseBindingsJson(raw: string): Record<string, string> | undefined {
+  const t = raw.trim()
+  if (!t) return undefined
+  try {
+    const parsed = JSON.parse(t) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+    )
+  } catch {
+    return undefined
+  }
+}
+
+export default function McpServersSettingsSection() {
+  const s = useStyles()
+  const { showToast } = useSettingsToast()
+  const { confirm } = useOpptrixDialogAlert()
+  const [servers, setServers] = useState<PublicMcpServer[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      setServers(await listMcpServers())
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : '加载失败', 'error')
+      setServers([])
+    } finally {
+      setLoading(false)
+    }
+  }, [showToast])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const openCreate = () => {
+    setEditingId(null)
+    setForm(emptyForm())
+    setDialogOpen(true)
+  }
+
+  const openEdit = (row: PublicMcpServer) => {
+    setEditingId(row.id)
+    setForm({
+      title: row.title,
+      transport: row.transport,
+      command: row.transport === 'stdio' ? row.endpointPreview.split(' ')[0] ?? '' : '',
+      args: row.transport === 'stdio'
+        ? row.endpointPreview.split(' ').slice(1).join(' ')
+        : '',
+      url: row.transport === 'http' ? row.endpointPreview : '',
+      bearer: '',
+      bindings: Object.keys(row.capabilityBindings).length
+        ? JSON.stringify(row.capabilityBindings, null, 2)
+        : '',
+    })
+    setDialogOpen(true)
+  }
+
+  const handleSave = async () => {
+    const title = form.title.trim()
+    if (!title) {
+      showToast('请填写名称', 'error')
+      return
+    }
+    const bindings = parseBindingsJson(form.bindings)
+    if (form.bindings.trim() && !bindings) {
+      showToast('能力绑定须为合法 JSON 对象', 'error')
+      return
+    }
+    setSaving(true)
+    try {
+      if (editingId) {
+        const secrets: Record<string, string> = {}
+        if (form.bearer.trim()) secrets.authorization = form.bearer.trim()
+        await updateMcpServer(editingId, {
+          title,
+          secrets: Object.keys(secrets).length ? secrets : undefined,
+          capabilityBindings: bindings,
+          transportConfig: form.transport === 'stdio'
+            ? {
+                transport: 'stdio',
+                command: form.command.trim(),
+                args: form.args.trim() ? form.args.trim().split(/\s+/) : [],
+              }
+            : { transport: 'http', url: form.url.trim() },
+        })
+        showToast('已保存', 'success')
+      } else {
+        if (form.transport === 'stdio' && !form.command.trim()) {
+          showToast('stdio 须填写 command', 'error')
+          return
+        }
+        if (form.transport === 'http' && !form.url.trim()) {
+          showToast('http 须填写 URL', 'error')
+          return
+        }
+        const secrets: Record<string, string> = {}
+        if (form.bearer.trim()) secrets.authorization = form.bearer.trim()
+        await createMcpServer({
+          title,
+          transportConfig: form.transport === 'stdio'
+            ? {
+                transport: 'stdio',
+                command: form.command.trim(),
+                args: form.args.trim() ? form.args.trim().split(/\s+/) : [],
+              }
+            : { transport: 'http', url: form.url.trim() },
+          secrets: Object.keys(secrets).length ? secrets : undefined,
+          capabilityBindings: bindings,
+        })
+        showToast('已添加 MCP 服务器', 'success')
+      }
+      setDialogOpen(false)
+      await refresh()
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : '保存失败', 'error')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const move = async (id: string, dir: -1 | 1) => {
+    if (!servers) return
+    const ids = servers.map(x => x.id)
+    const i = ids.indexOf(id)
+    const j = i + dir
+    if (i < 0 || j < 0 || j >= ids.length) return
+    ;[ids[i], ids[j]] = [ids[j], ids[i]]
+    setBusyId(id)
+    try {
+      setServers(await reorderMcpServers(ids))
+      showToast('优先级已更新', 'success')
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : '排序失败', 'error')
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  if (loading && !servers) {
+    return (
+      <div className={s.root}>
+        <Text className={s.tabHint} block>
+          接入外部 MCP 作为更高优先级数据源；不可用时自动回退下一外部源，最后使用本地工具。
+        </Text>
+        <SettingsListPanelSkeleton />
+      </div>
+    )
+  }
+
+  return (
+    <div className={s.root}>
+      <Text className={s.tabHint} block>
+        接入外部 MCP 作为更高优先级数据源；不可用时自动回退下一外部源，最后使用本地工具。
+        密钥仅保存在本地用户库，列表不展示明文。
+      </Text>
+
+      <div className={s.listPanel}>
+        {!servers?.length ? (
+          <div className={s.empty}>尚未配置外部 MCP 服务器</div>
+        ) : (
+          servers.map((row, index) => {
+            const h = healthLabel(row)
+            const healthClass = h.className === 'ok'
+              ? s.healthOk
+              : h.className === 'bad'
+                ? s.healthBad
+                : s.healthMuted
+            return (
+              <div key={row.id} className={s.row}>
+                <div className={s.rowTop}>
+                  <div className={s.rowMain}>
+                    <Text className={s.title}>{row.title}</Text>
+                    <Text className={s.meta} block>
+                      {row.id} · {row.transport} · {row.endpointPreview}
+                    </Text>
+                    <Text className={mergeClasses(s.meta, healthClass)} block>
+                      {h.text}
+                      {row.toolCount > 0 ? ` · ${row.toolCount} 工具` : ''}
+                      {row.lastError ? ` · ${row.lastError}` : ''}
+                    </Text>
+                  </div>
+                  <div className={s.actions}>
+                    <Switch
+                      checked={row.enabled && !row.paused}
+                      disabled={busyId === row.id}
+                      onChange={(_, d) => {
+                        void (async () => {
+                          setBusyId(row.id)
+                          try {
+                            await updateMcpServer(row.id, {
+                              enabled: d.checked,
+                              paused: !d.checked,
+                            })
+                            await refresh()
+                          } catch (e) {
+                            showToast(e instanceof Error ? e.message : '更新失败', 'error')
+                          } finally {
+                            setBusyId(null)
+                          }
+                        })()
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className={s.actions}>
+                  <OpptrixButton
+                    variant="ghost"
+                    size="small"
+                    icon={<ArrowUpRegular />}
+                    disabled={index === 0 || busyId === row.id}
+                    onClick={() => { void move(row.id, -1) }}
+                    aria-label="提高优先级"
+                  />
+                  <OpptrixButton
+                    variant="ghost"
+                    size="small"
+                    icon={<ArrowDownRegular />}
+                    disabled={index === servers.length - 1 || busyId === row.id}
+                    onClick={() => { void move(row.id, 1) }}
+                    aria-label="降低优先级"
+                  />
+                  <OpptrixButton
+                    variant="secondary"
+                    size="small"
+                    icon={<PlugConnectedRegular />}
+                    disabled={busyId === row.id}
+                    onClick={() => {
+                      void (async () => {
+                        setBusyId(row.id)
+                        try {
+                          const r = await testMcpServer(row.id)
+                          showToast(r.message, r.ok ? 'success' : 'error')
+                          await refresh()
+                        } catch (e) {
+                          showToast(e instanceof Error ? e.message : '测试失败', 'error')
+                        } finally {
+                          setBusyId(null)
+                        }
+                      })()
+                    }}
+                  >
+                    测试
+                  </OpptrixButton>
+                  <OpptrixButton
+                    variant="secondary"
+                    size="small"
+                    onClick={() => openEdit(row)}
+                  >
+                    编辑
+                  </OpptrixButton>
+                  <OpptrixButton
+                    variant="ghost"
+                    size="small"
+                    icon={<DeleteRegular />}
+                    disabled={busyId === row.id}
+                    onClick={() => {
+                      void (async () => {
+                        const ok = await confirm({
+                          title: '卸载 MCP 服务器',
+                          message: `确定删除「${row.title}」？将断开连接并移除配置。`,
+                          confirmLabel: '删除',
+                          confirmTone: 'danger',
+                        })
+                        if (!ok) return
+                        setBusyId(row.id)
+                        try {
+                          await deleteMcpServer(row.id)
+                          showToast('已删除', 'success')
+                          await refresh()
+                        } catch (e) {
+                          showToast(e instanceof Error ? e.message : '删除失败', 'error')
+                        } finally {
+                          setBusyId(null)
+                        }
+                      })()
+                    }}
+                    aria-label={`删除 ${row.title}`}
+                  />
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+
+      <SettingsGroup>
+        <SettingsRow
+          title="添加 MCP 服务器"
+          desc="配置 stdio 命令或 Streamable HTTP URL；可设置本地工具名到远程工具的绑定"
+          control={(
+            <OpptrixButton variant="primary" size="small" icon={<AddRegular />} onClick={openCreate}>
+              添加
+            </OpptrixButton>
+          )}
+          last
+        />
+      </SettingsGroup>
+
+      <Dialog open={dialogOpen} onOpenChange={(_, d) => { if (!d.open) setDialogOpen(false) }}>
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>{editingId ? '编辑 MCP 服务器' : '添加 MCP 服务器'}</DialogTitle>
+            <DialogContent className={s.dialogBody}>
+              <Text className={s.fieldLabel} block>名称</Text>
+              <Input
+                value={form.title}
+                onChange={(_, d) => setForm(f => ({ ...f, title: d.value }))}
+                placeholder="显示名称"
+              />
+              <Text className={s.fieldLabel} block>传输</Text>
+              <div className={s.actions}>
+                <OpptrixButton
+                  variant={form.transport === 'stdio' ? 'primary' : 'secondary'}
+                  size="small"
+                  onClick={() => setForm(f => ({ ...f, transport: 'stdio' }))}
+                >
+                  stdio
+                </OpptrixButton>
+                <OpptrixButton
+                  variant={form.transport === 'http' ? 'primary' : 'secondary'}
+                  size="small"
+                  onClick={() => setForm(f => ({ ...f, transport: 'http' }))}
+                >
+                  HTTP
+                </OpptrixButton>
+              </div>
+              {form.transport === 'stdio' ? (
+                <>
+                  <Text className={s.fieldLabel} block>Command</Text>
+                  <Input
+                    value={form.command}
+                    onChange={(_, d) => setForm(f => ({ ...f, command: d.value }))}
+                    placeholder="npx"
+                  />
+                  <Text className={s.fieldLabel} block>Args（空格分隔）</Text>
+                  <Input
+                    value={form.args}
+                    onChange={(_, d) => setForm(f => ({ ...f, args: d.value }))}
+                    placeholder="-y @example/mcp-server"
+                  />
+                </>
+              ) : (
+                <>
+                  <Text className={s.fieldLabel} block>URL</Text>
+                  <Input
+                    value={form.url}
+                    onChange={(_, d) => setForm(f => ({ ...f, url: d.value }))}
+                    placeholder="https://…"
+                  />
+                  <Text className={s.fieldLabel} block>
+                    Bearer Token（可选；已配置不显示明文，留空表示不改）
+                  </Text>
+                  <Input
+                    type="password"
+                    value={form.bearer}
+                    onChange={(_, d) => setForm(f => ({ ...f, bearer: d.value }))}
+                    placeholder="••••"
+                    autoComplete="off"
+                  />
+                </>
+              )}
+              <Text className={s.fieldLabel} block>能力绑定 JSON（可选）</Text>
+              <Input
+                value={form.bindings}
+                onChange={(_, d) => setForm(f => ({ ...f, bindings: d.value }))}
+                placeholder='{"get_instrument_quotes":"get_quotes"}'
+              />
+              <div className={s.dialogActions}>
+                <OpptrixButton variant="ghost" disabled={saving} onClick={() => setDialogOpen(false)}>
+                  取消
+                </OpptrixButton>
+                <OpptrixButton variant="primary" disabled={saving} onClick={() => { void handleSave() }}>
+                  {saving ? '保存中…' : '保存'}
+                </OpptrixButton>
+              </div>
+            </DialogContent>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+    </div>
+  )
+}

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -9,6 +9,7 @@ import {
   SettingsRegular,
   TranslateRegular,
   ServerRegular,
+  PlugConnectedRegular,
 } from '@fluentui/react-icons'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
 import { ghostInteractive, inputShellInteractive, motion, sidebarItemSelected, sidebarTopMenuIcon, sidebarTopMenuRow, SIDEBAR_TOP_MENU_ICON_SIZE } from '../../theme/mixins'
@@ -33,6 +34,7 @@ const NAV: { id: SettingsSection; label: string; icon: typeof SettingsRegular }[
   { id: 'general', label: '常规', icon: SettingsRegular },
   { id: 'models', label: '模型', icon: BotRegular },
   { id: 'data_providers', label: '数据源', icon: ServerRegular },
+  { id: 'mcp_servers', label: 'MCP 服务器', icon: PlugConnectedRegular },
   { id: 'news_feed', label: '新闻订阅', icon: NewsRegular },
   { id: 'translation', label: '翻译', icon: TranslateRegular },
   { id: 'multimodal', label: '多模态', icon: ImageRegular },
@@ -375,6 +377,8 @@ export function settingsSectionSubtitle(section: SettingsSection): string {
       return '配置 LLM 提供商与可用模型'
     case 'data_providers':
       return '管理各市场行情与资讯数据提供商'
+    case 'mcp_servers':
+      return '接入外部 MCP，按优先级故障转移，本地工具兜底'
     case 'news_feed':
       return '管理 RSS 订阅与资讯更新频率'
     case 'translation':

--- a/client-ui/src/pages/settings/settingsSearchIndex.ts
+++ b/client-ui/src/pages/settings/settingsSearchIndex.ts
@@ -26,6 +26,7 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   { section: 'general', title: '常规', desc: '管理默认评分卡与后端连接状态' },
   { section: 'models', title: '模型', desc: '配置 LLM 提供商与可用模型' },
   { section: 'data_providers', title: '数据源', desc: '管理行情与资讯数据提供商、拖拽回退顺序', keywords: ['priority', '回退', '拖拽', '排序'] },
+  { section: 'mcp_servers', title: 'MCP 服务器', desc: '外部 MCP 接入与优先级故障转移', keywords: ['mcp', 'stdio', 'http', '外部工具'] },
   { section: 'news_feed', title: '新闻订阅', desc: '管理 RSS 订阅与资讯更新频率' },
   { section: 'translation', title: '翻译', desc: '配置新闻阅读的离线翻译与远程大模型回退' },
   { section: 'multimodal', title: '多模态', desc: '配置图片 OCR、语音转写与文章媒体自动提取策略' },
@@ -54,6 +55,12 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   { section: 'data_providers', group: 'A 股', title: 'Tushare Pro', keywords: ['tushare', '行情源', 'token'] },
   { section: 'data_providers', group: 'A 股', title: 'API Token', desc: '粘贴 Token', keywords: ['token', '密钥'] },
   { section: 'data_providers', title: '能力绑定', keywords: ['binding', 'override'] },
+
+  // MCP 服务器
+  { section: 'mcp_servers', title: '外部 MCP', desc: 'stdio / Streamable HTTP', keywords: ['model context protocol', '故障转移', '熔断'] },
+  { section: 'mcp_servers', title: '测试连接', keywords: ['探活', 'tools/list'] },
+  { section: 'mcp_servers', title: '优先级排序', keywords: ['sortOrder', '回退', 'failover'] },
+  { section: 'mcp_servers', title: '能力绑定', desc: '本地工具名映射到远程工具', keywords: ['capabilityBindings'] },
 
   // 新闻订阅
   { section: 'news_feed', title: 'RSS 订阅', desc: '添加订阅源', keywords: ['订阅', 'RSSHub', 'Atom', '资讯', '新闻中心'] },
@@ -88,6 +95,7 @@ const SECTION_LABEL: Record<SettingsSection, string> = {
   general: '常规',
   models: '模型',
   data_providers: '数据源',
+  mcp_servers: 'MCP 服务器',
   news_feed: '新闻订阅',
   translation: '翻译',
   multimodal: '多模态',

--- a/client-ui/src/pages/settings/settingsTypes.ts
+++ b/client-ui/src/pages/settings/settingsTypes.ts
@@ -2,6 +2,7 @@ export type SettingsSection =
   | 'general'
   | 'models'
   | 'data_providers'
+  | 'mcp_servers'
   | 'news_feed'
   | 'translation'
   | 'multimodal'
@@ -11,6 +12,7 @@ const SETTINGS_SECTION_IDS: readonly SettingsSection[] = [
   'general',
   'models',
   'data_providers',
+  'mcp_servers',
   'news_feed',
   'translation',
   'multimodal',

--- a/client-ui/src/types/mcpServer.ts
+++ b/client-ui/src/types/mcpServer.ts
@@ -1,0 +1,44 @@
+/** 外部 MCP Server 公开视图（API 永不回传明文密钥） */
+
+export type McpServerTransport = 'stdio' | 'http'
+export type McpServerHealthState = 'unknown' | 'healthy' | 'degraded' | 'open' | 'paused'
+
+export interface PublicMcpServer {
+  id: string
+  title: string
+  enabled: boolean
+  paused: boolean
+  sortOrder: number
+  transport: McpServerTransport
+  endpointPreview: string
+  secretsConfigured: Record<string, boolean>
+  capabilityBindings: Record<string, string>
+  installSource: 'manual' | 'registry'
+  health: McpServerHealthState
+  toolCount: number
+  lastError?: string
+  lastHealthyAt?: string
+  updatedAt: string
+}
+
+export interface McpServerCreatePayload {
+  id?: string
+  title: string
+  enabled?: boolean
+  paused?: boolean
+  transportConfig:
+    | { transport: 'stdio'; command: string; args?: string[]; cwd?: string; env?: Record<string, string> }
+    | { transport: 'http'; url: string; headers?: Record<string, string> }
+  secrets?: Record<string, string>
+  capabilityBindings?: Record<string, string>
+}
+
+export interface McpServerPatchPayload {
+  title?: string
+  enabled?: boolean
+  paused?: boolean
+  sortOrder?: number
+  transportConfig?: McpServerCreatePayload['transportConfig']
+  secrets?: Record<string, string>
+  capabilityBindings?: Record<string, string>
+}

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -129,20 +129,27 @@ Opptrix/
                 ↓
          activeNames = core+meta+播种+会话激活
                 ↓
-         McpToolBroker（本轮子集）→ LLM tools
+         AggregatingToolBroker（外部 MCP 优先级链 → 本地 McpToolBroker）→ LLM tools
                 ↓
          activate_tool_pack → 同会话累积 → 同轮刷新 Broker
                 ↓
-         ToolRegistry → ResearchHub / MarketDataService
+         ToolRegistry / External MCP Client → ResearchHub / MarketDataService
 ```
 
-- 工具定义：`packages/agent/src/tools.ts`（MCP 投研工具 + 内置 `ask_user` 交互确认 + 工具包元工具）
+- 工具定义：`packages/agent/src/tools.ts`（MCP 投研工具 + 内置 `ask_user` 交互确认 + 工具包元工具 + 外部 MCP 运维工具）
 - 工具元数据（何时使用、调用规范、`packId`）：`packages/agent/src/tool-meta.ts`
 - **工具包路由（Tool Pack Router）**：
   - 包定义：`packages/shared/src/tool-packs.ts`（`TOOL_PACK_DEFS` / `TOOL_PACK_MEMBERSHIP`）
   - 意图播种：`packages/agent/src/mcp/tool-pack-resolver.ts`（关键词/上下文 → ≤2 业务 pack）
   - 会话激活：`list_tool_packs` / `activate_tool_pack`；同 session 累积 active packs
-  - 引擎每轮按 `core`+`meta`+播种+已激活 子集创建 `McpToolBroker`；激活后同轮刷新 tools
+  - 引擎每轮按 `core`+`meta`+播种+已激活 子集创建 `AggregatingToolBroker`（内含本地 `McpToolBroker` + 外部 MCP 注册表）；激活后同轮刷新 tools
+  - **外部 MCP（优先级故障转移）**：
+    - 配置：`packages/shared/src/mcp-servers.ts`；持久化 user-store `mcp_servers`；设置页 **MCP 服务器** / REST `/api/mcp-servers*`
+    - 运行时：`packages/agent/src/mcp/external/`（`ExternalMcpRegistry` / Health / AggregatingToolBroker）
+    - 传输：stdio + Streamable HTTP；LLM 仍见稳定本地工具名；有 `capabilityBindings` 时按 `sortOrder` 试外部再本地兜底
+    - 外部独有工具：`serverId__toolName` 命名空间注入 catalog
+    - meta 运维：`list_mcp_servers` / `enable_mcp_server` / `pause_mcp_server` / `reorder_mcp_servers`；`install_mcp_server` / `uninstall_mcp_server` **须 ask_user 后 `confirmed=true`**；禁止经 Agent 改已有 server 的 command/url/env
+    - 单测：`tests/external-mcp-failover.test.mjs`
   - **分层精排**：`resolveToolRoutePlan` 将用户意图映射为首选工具顺序与研究档位（L1 事实快答 / L2 结构化解读 / L3 深度备忘录），注入「本轮工具选型卡」与证据纪律/输出骨架，并把首选工具排到 tools schema 前列
   - 默认角色为**投研研究员**：事实与推断分层、标注时效、工具失败不编造、L3 声明数据缺口；配合 MCP 取证后按档位写结论
   - **基本面事实表（`fundamentals` pack）**：`get_instrument_profile` / `get_instrument_financials` / `get_instrument_income_statement` / `get_instrument_balance_sheet` / `get_instrument_cash_flow` / `get_instrument_financial_indicators` / `get_instrument_shareholders` / `get_instrument_institution_holdings` / `get_instrument_dividend`

--- a/docs/API.md
+++ b/docs/API.md
@@ -193,6 +193,22 @@ POST /api/research
 | GET | `/api/news/articles/:id` | 单篇文章 |
 | POST | `/api/news/refresh` | 强制刷新全部 enabled 源 |
 
+### 外部 MCP Server
+
+用户可配置的外部 MCP（stdio / Streamable HTTP）。列表与写操作**永不回传明文密钥**（仅 `secretsConfigured` 布尔掩码）。执行路由：已启用且未 pause 的外部源按 `sortOrder` 优先；熔断/超时/429 后 failover；本地 ToolRegistry 始终最终兜底。
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | `/api/mcp-servers` | `{ servers: PublicMcpServer[] }` |
+| GET | `/api/mcp-servers/:id` | 单条公开视图 |
+| POST | `/api/mcp-servers` | 创建（`title` + `transportConfig`；可选 `secrets` / `capabilityBindings`） |
+| PATCH | `/api/mcp-servers/:id` | 更新启用/暂停/传输/绑定/密钥合入 |
+| DELETE | `/api/mcp-servers/:id` | 删除配置并断开 |
+| POST | `/api/mcp-servers/:id/test` | 探活（`tools/list`）；超时较长 |
+| POST | `/api/mcp-servers/reorder` | `{ server_ids: string[] }` 重排优先级 |
+
+`PublicMcpServer` 含：`id`/`title`/`enabled`/`paused`/`sortOrder`/`transport`/`endpointPreview`/`secretsConfigured`/`capabilityBindings`/`health`/`toolCount` 等。
+
 订阅地址须为完整 `http(s)://` 链接。文章持久化在本地 SQLite，默认保留 **3 年内**按 `pub_date` 排序的文章；可在设置中调整保留年限与数量上限（不限上限时仅按年限清理）。写入超出策略时自动删除最旧文章。
 
 ### Writer 端点

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -7,6 +7,8 @@ import { ProviderRegistry, type ProviderProfile, type AvailableModel } from './l
 import { DiscoverRunner } from './discover.js'
 import { ToolRegistry } from './tools.js'
 import { McpToolBroker } from './mcp/broker.js'
+import { AggregatingToolBroker } from './mcp/external/index.js'
+import { getExternalMcpRegistry } from './mcp/external/registry.js'
 import {
   ToolPackSessionStore,
   listToolPacksPayload,
@@ -20,7 +22,7 @@ import {
   orderToolsByPreference,
   type ToolRoutePlan,
 } from './mcp/tool-route-plan.js'
-import { buildSessionClockPlaybook } from '@opptrix/shared'
+import { buildSessionClockPlaybook, parseNamespacedMcpTool } from '@opptrix/shared'
 import {
   type ChatProgressEvent,
   type ChatProgressOptions,
@@ -100,9 +102,12 @@ export class AgentEngine {
 
   get llmConfigured() { return this.registry.configured }
 
-  /** 按本轮 active tool names 创建进程内 MCP broker（每轮可重建） */
+  /** 按本轮 active tool names 创建聚合 MCP broker（本地 + 外部优先级链） */
   private async createRoundBroker(activeNames: readonly string[]) {
-    return McpToolBroker.create(this.tools, activeNames)
+    return AggregatingToolBroker.create(
+      () => McpToolBroker.create(this.tools, activeNames),
+      getExternalMcpRegistry(),
+    )
   }
 
   private resolveRoundPackIds(sessionId: string) {
@@ -519,11 +524,18 @@ export class AgentEngine {
                 const answer = await answerPromise
                 result = { ok: true, ...answer }
               }
-            } else if (!activeSet.has(fn)) {
+            } else if (!activeSet.has(fn) && !parseNamespacedMcpTool(fn)) {
               result = { error: unloadedToolHint(fn) }
             } else {
               result = await broker.call(fn, args, { signal })
-              if (fn === 'activate_tool_pack') {
+              if (
+                fn === 'activate_tool_pack'
+                || fn === 'enable_mcp_server'
+                || fn === 'pause_mcp_server'
+                || fn === 'install_mcp_server'
+                || fn === 'uninstall_mcp_server'
+                || fn === 'reorder_mcp_servers'
+              ) {
                 refreshTools = true
               }
             }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -53,6 +53,13 @@ export {
 export { createMcpServer, runMcpStdio } from './mcp/server.js'
 export { McpToolBroker } from './mcp/broker.js'
 export {
+  AggregatingToolBroker,
+  getExternalMcpRegistry,
+  resetExternalMcpRegistry,
+  ExternalMcpRegistry,
+  ExternalMcpHealth,
+} from './mcp/external/index.js'
+export {
   ToolPackSessionStore,
   resolveActivePackIds,
   toolNamesForPacks,

--- a/packages/agent/src/mcp/external/connection.ts
+++ b/packages/agent/src/mcp/external/connection.ts
@@ -1,0 +1,139 @@
+/**
+ * 单个外部 MCP Server 的 Client 封装（stdio / Streamable HTTP）。
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { McpServerRecord } from '@opptrix/shared'
+import type { OpenAiTool, JsonSchema } from '../../tools.js'
+
+export interface ExternalToolDef {
+  name: string
+  description: string
+  inputSchema: JsonSchema
+}
+
+export class ExternalMcpConnection {
+  private client: Client | null = null
+  private toolsCache: ExternalToolDef[] = []
+  private connected = false
+
+  constructor(readonly record: McpServerRecord) {}
+
+  get tools(): readonly ExternalToolDef[] {
+    return this.toolsCache
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return
+    const client = new Client({ name: 'opptrix-host', version: '0.7.0' })
+    const cfg = this.record.transportConfig
+
+    if (cfg.transport === 'stdio') {
+      const env: Record<string, string> = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter((e): e is [string, string] => typeof e[1] === 'string'),
+        ),
+        ...(cfg.env ?? {}),
+        ...this.record.secrets,
+      }
+      const transport = new StdioClientTransport({
+        command: cfg.command,
+        args: cfg.args ?? [],
+        cwd: cfg.cwd,
+        env,
+        stderr: 'pipe',
+      })
+      await client.connect(transport)
+    } else {
+      const headers: Record<string, string> = { ...(cfg.headers ?? {}) }
+      const bearer = this.record.secrets.authorization
+        ?? this.record.secrets.bearer
+        ?? this.record.secrets.api_key
+        ?? ''
+      if (bearer && !headers.Authorization) {
+        headers.Authorization = bearer.startsWith('Bearer ') ? bearer : `Bearer ${bearer}`
+      }
+      const transport = new StreamableHTTPClientTransport(new URL(cfg.url), {
+        requestInit: { headers },
+      })
+      await client.connect(transport)
+    }
+
+    this.client = client
+    this.connected = true
+    await this.refreshTools()
+  }
+
+  async refreshTools(): Promise<ExternalToolDef[]> {
+    if (!this.client) throw new Error(`MCP ${this.record.id} 未连接`)
+    const { tools } = await this.client.listTools()
+    this.toolsCache = tools.map(t => ({
+      name: t.name,
+      description: t.description ?? '',
+      inputSchema: (t.inputSchema ?? { type: 'object', properties: {} }) as JsonSchema,
+    }))
+    return this.toolsCache
+  }
+
+  async callTool(name: string, args: Record<string, unknown>, opts?: {
+    signal?: AbortSignal
+    timeoutMs?: number
+  }): Promise<unknown> {
+    if (!this.client) throw new Error(`MCP ${this.record.id} 未连接`)
+    const timeout = opts?.timeoutMs ?? 120_000
+    const result = await this.client.callTool(
+      { name, arguments: args },
+      undefined,
+      { timeout, maxTotalTimeout: timeout * 2, signal: opts?.signal },
+    )
+    const content = Array.isArray(result.content) ? result.content : []
+    const text = content
+      .filter((c): c is { type: 'text'; text: string } =>
+        typeof c === 'object' && c !== null && (c as { type?: string }).type === 'text'
+        && typeof (c as { text?: unknown }).text === 'string',
+      )
+      .map(c => c.text)
+      .join('\n')
+    if (result.isError) {
+      if (!text) throw new Error(`MCP ${this.record.id}/${name} failed`)
+      try {
+        const parsed = JSON.parse(text) as unknown
+        if (parsed && typeof parsed === 'object' && 'error' in parsed) {
+          throw new Error(String((parsed as { error: unknown }).error))
+        }
+        throw new Error(text)
+      } catch (e) {
+        if (e instanceof Error && e.message !== text) throw e
+        throw new Error(text)
+      }
+    }
+    if (!text) return { ok: true, source: this.record.id }
+    try {
+      return JSON.parse(text) as unknown
+    } catch {
+      return text
+    }
+  }
+
+  toOpenAiTools(prefix: boolean): OpenAiTool[] {
+    return this.toolsCache.map(t => ({
+      type: 'function' as const,
+      function: {
+        name: prefix ? `${this.record.id}__${t.name}` : t.name,
+        description: `[MCP:${this.record.id}] ${t.description}`,
+        parameters: t.inputSchema,
+      },
+    }))
+  }
+
+  async close(): Promise<void> {
+    if (this.client && this.connected) {
+      await this.client.close().catch(() => {})
+    }
+    this.client = null
+    this.connected = false
+    this.toolsCache = []
+  }
+}

--- a/packages/agent/src/mcp/external/health.ts
+++ b/packages/agent/src/mcp/external/health.ts
@@ -1,0 +1,91 @@
+/**
+ * 外部 MCP Server 健康 / 熔断（per-server）。
+ */
+
+import type { McpServerHealthState } from '@opptrix/shared'
+import { isMcpServerFailoverError } from '@opptrix/shared'
+
+const FAILURE_THRESHOLD = 3
+const BASE_COOLDOWN_MS = 30_000
+const MAX_COOLDOWN_MS = 15 * 60_000
+
+interface HealthEntry {
+  consecutiveFails: number
+  cooldownUntil: number
+  state: McpServerHealthState
+  lastError: string
+}
+
+export class ExternalMcpHealth {
+  private entries = new Map<string, HealthEntry>()
+
+  getState(serverId: string, paused: boolean): McpServerHealthState {
+    if (paused) return 'paused'
+    const e = this.entries.get(serverId)
+    if (!e) return 'unknown'
+    if (e.state === 'open' && e.cooldownUntil > Date.now()) return 'open'
+    if (e.state === 'open' && e.cooldownUntil <= Date.now()) return 'degraded'
+    return e.state
+  }
+
+  shouldSkip(serverId: string, paused: boolean): boolean {
+    if (paused) return true
+    const e = this.entries.get(serverId)
+    if (!e) return false
+    if (e.state === 'open' && e.cooldownUntil > Date.now()) return true
+    return false
+  }
+
+  recordSuccess(serverId: string): void {
+    this.entries.set(serverId, {
+      consecutiveFails: 0,
+      cooldownUntil: 0,
+      state: 'healthy',
+      lastError: '',
+    })
+  }
+
+  recordFailure(serverId: string, error: unknown): void {
+    if (!isMcpServerFailoverError(error)) {
+      // 业务错误：不升熔断，仅记 degraded
+      const prev = this.entries.get(serverId)
+      this.entries.set(serverId, {
+        consecutiveFails: prev?.consecutiveFails ?? 0,
+        cooldownUntil: prev?.cooldownUntil ?? 0,
+        state: prev?.state === 'open' ? 'open' : 'degraded',
+        lastError: error instanceof Error ? error.message : String(error),
+      })
+      return
+    }
+
+    const prev = this.entries.get(serverId)
+    const fails = (prev?.consecutiveFails ?? 0) + 1
+    const msg = error instanceof Error ? error.message : String(error)
+    if (fails >= FAILURE_THRESHOLD || /429|quota|额度/i.test(msg)) {
+      const level = Math.max(1, fails - FAILURE_THRESHOLD + 1)
+      const cooldown = Math.min(BASE_COOLDOWN_MS * 2 ** (level - 1), MAX_COOLDOWN_MS)
+      this.entries.set(serverId, {
+        consecutiveFails: fails,
+        cooldownUntil: Date.now() + cooldown,
+        state: 'open',
+        lastError: msg.slice(0, 200),
+      })
+      return
+    }
+    this.entries.set(serverId, {
+      consecutiveFails: fails,
+      cooldownUntil: 0,
+      state: 'degraded',
+      lastError: msg.slice(0, 200),
+    })
+  }
+
+  reset(serverId?: string): void {
+    if (serverId) this.entries.delete(serverId)
+    else this.entries.clear()
+  }
+
+  lastError(serverId: string): string {
+    return this.entries.get(serverId)?.lastError ?? ''
+  }
+}

--- a/packages/agent/src/mcp/external/index.ts
+++ b/packages/agent/src/mcp/external/index.ts
@@ -1,0 +1,88 @@
+/**
+ * 聚合工具 Broker：本地 InMemory MCP + 外部 MCP 优先级故障转移。
+ */
+
+import {
+  isMcpServerFailoverError,
+  parseNamespacedMcpTool,
+} from '@opptrix/shared'
+import type { OpenAiTool } from '../../tools.js'
+import { McpToolBroker, type McpToolCallOptions } from '../broker.js'
+import {
+  annotateMcpResult,
+  getExternalMcpRegistry,
+  type ExternalMcpRegistry,
+} from './registry.js'
+
+export class AggregatingToolBroker {
+  private constructor(
+    private readonly local: McpToolBroker,
+    private readonly external: ExternalMcpRegistry,
+  ) {}
+
+  static async create(
+    createLocal: () => Promise<McpToolBroker>,
+    external: ExternalMcpRegistry = getExternalMcpRegistry(),
+  ): Promise<AggregatingToolBroker> {
+    await external.hydrate()
+    const local = await createLocal()
+    return new AggregatingToolBroker(local, external)
+  }
+
+  async openAiTools(): Promise<OpenAiTool[]> {
+    const localTools = await this.local.openAiTools()
+    const ext = this.external.listNamespacedOpenAiTools()
+    return [...localTools, ...ext]
+  }
+
+  async call(
+    name: string,
+    args: Record<string, unknown> = {},
+    opts?: McpToolCallOptions,
+  ): Promise<unknown> {
+    if (parseNamespacedMcpTool(name)) {
+      try {
+        const result = await this.external.callNamespaced(name, args, opts)
+        const parsed = parseNamespacedMcpTool(name)!
+        return annotateMcpResult(result, parsed.serverId)
+      } catch (e) {
+        return { error: e instanceof Error ? e.message : String(e) }
+      }
+    }
+
+    const chain = this.external.resolveBindingChain(name)
+    const tried: string[] = []
+    for (const cand of chain) {
+      tried.push(cand.serverId)
+      try {
+        const result = await this.external.callExternal(
+          cand.serverId,
+          cand.remoteTool,
+          args,
+          opts,
+        )
+        return annotateMcpResult(result, cand.serverId)
+      } catch (e) {
+        if (isMcpServerFailoverError(e)) continue
+        // 业务错误：不换源，直接返回
+        return { error: e instanceof Error ? e.message : String(e), _mcp: { source: cand.serverId } }
+      }
+    }
+
+    const localResult = await this.local.call(name, args, opts)
+    return annotateMcpResult(localResult, 'local', { degraded: tried.length > 0 })
+  }
+
+  async close(): Promise<void> {
+    await this.local.close()
+  }
+}
+
+export {
+  annotateMcpResult,
+  getExternalMcpRegistry,
+  resetExternalMcpRegistry,
+  ExternalMcpRegistry,
+} from './registry.js'
+export { ExternalMcpHealth } from './health.js'
+export { ExternalMcpConnection } from './connection.js'

--- a/packages/agent/src/mcp/external/registry.ts
+++ b/packages/agent/src/mcp/external/registry.ts
@@ -1,0 +1,276 @@
+/**
+ * 外部 MCP Server 注册表：连接池、工具 catalog、绑定解析。
+ */
+
+import {
+  isMcpServerFailoverError,
+  namespacedMcpTool,
+  parseNamespacedMcpTool,
+  type McpServerCreateInput,
+  type McpServerPatch,
+  type McpServerRecord,
+  type PublicMcpServer,
+} from '@opptrix/shared'
+import { getUserDataStore } from '@opptrix/user-store'
+import type { OpenAiTool } from '../../tools.js'
+import { ExternalMcpConnection } from './connection.js'
+import { ExternalMcpHealth } from './health.js'
+
+export interface BindingCandidate {
+  serverId: string
+  remoteTool: string
+}
+
+export class ExternalMcpRegistry {
+  private connections = new Map<string, ExternalMcpConnection>()
+  readonly health = new ExternalMcpHealth()
+  private hydratePromise: Promise<void> | null = null
+
+  private get repo() {
+    return getUserDataStore().mcpServers
+  }
+
+  listRecords(): McpServerRecord[] {
+    return this.repo.listAll()
+  }
+
+  getRecord(id: string): McpServerRecord | null {
+    return this.repo.get(id)
+  }
+
+  async hydrate(): Promise<void> {
+    if (this.hydratePromise) return this.hydratePromise
+    this.hydratePromise = this.doHydrate()
+    try {
+      await this.hydratePromise
+    } finally {
+      this.hydratePromise = null
+    }
+  }
+
+  private async doHydrate(): Promise<void> {
+    const rows = this.repo.listAll().filter(r => r.enabled && !r.paused)
+    const want = new Set(rows.map(r => r.id))
+    for (const id of [...this.connections.keys()]) {
+      if (!want.has(id)) {
+        await this.connections.get(id)?.close()
+        this.connections.delete(id)
+      }
+    }
+    await Promise.all(rows.map(row => this.ensureConnected(row)))
+  }
+
+  private async ensureConnected(row: McpServerRecord): Promise<ExternalMcpConnection | null> {
+    let conn = this.connections.get(row.id)
+    if (conn) {
+      // 配置可能已更新：若 endpoint 变化则重建
+      const prev = conn.record
+      const same = JSON.stringify(prev.transportConfig) === JSON.stringify(row.transportConfig)
+        && JSON.stringify(prev.secrets) === JSON.stringify(row.secrets)
+      if (same) return conn
+      await conn.close()
+      this.connections.delete(row.id)
+    }
+    conn = new ExternalMcpConnection(row)
+    try {
+      await conn.connect()
+      this.connections.set(row.id, conn)
+      this.health.recordSuccess(row.id)
+      const cur = this.repo.get(row.id)
+      if (cur) {
+        getUserDataStore().setDocument('mcp_servers', row.id, {
+          ...cur,
+          lastError: undefined,
+          lastHealthyAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        })
+      }
+      return conn
+    } catch (e) {
+      this.health.recordFailure(row.id, e)
+      const msg = e instanceof Error ? e.message : String(e)
+      const cur = this.repo.get(row.id)
+      if (cur) {
+        getUserDataStore().setDocument('mcp_servers', row.id, {
+          ...cur,
+          lastError: msg.slice(0, 200),
+          updatedAt: new Date().toISOString(),
+        })
+      }
+      await conn.close().catch(() => {})
+      return null
+    }
+  }
+
+  listPublic(): PublicMcpServer[] {
+    return this.repo.listAll().map(row => {
+      const conn = this.connections.get(row.id)
+      return this.repo.toPublic(row, {
+        health: this.health.getState(row.id, row.paused),
+        toolCount: conn?.tools.length ?? 0,
+      })
+    })
+  }
+
+  create(input: McpServerCreateInput): McpServerRecord {
+    return this.repo.create(input)
+  }
+
+  save(id: string, patch: McpServerPatch): McpServerRecord {
+    const row = this.repo.save(id, patch)
+    // 热更新：下轮 hydrate 会重建；若 pause/disable 立即断开
+    if (!row.enabled || row.paused) {
+      void this.connections.get(id)?.close().then(() => this.connections.delete(id))
+      this.health.reset(id)
+    }
+    return row
+  }
+
+  delete(id: string): boolean {
+    void this.connections.get(id)?.close()
+    this.connections.delete(id)
+    this.health.reset(id)
+    return this.repo.delete(id)
+  }
+
+  reorder(ids: string[]): McpServerRecord[] {
+    return this.repo.reorder(ids)
+  }
+
+  /** 已启用且健康的服务器上的 namespaced 独有工具（未出现在 bindings 值中的） */
+  listNamespacedOpenAiTools(): OpenAiTool[] {
+    const out: OpenAiTool[] = []
+    const rows = this.repo.listAll()
+      .filter(r => r.enabled && !r.paused)
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+
+    for (const row of rows) {
+      if (this.health.shouldSkip(row.id, row.paused)) continue
+      const conn = this.connections.get(row.id)
+      if (!conn) continue
+      const boundRemotes = new Set(Object.values(row.capabilityBindings))
+      for (const t of conn.tools) {
+        if (boundRemotes.has(t.name)) continue
+        out.push({
+          type: 'function',
+          function: {
+            name: namespacedMcpTool(row.id, t.name),
+            description: `[MCP:${row.id}] ${t.description}`,
+            parameters: t.inputSchema,
+          },
+        })
+      }
+    }
+    return out
+  }
+
+  /** 本地工具名 → 按优先级的外部候选链 */
+  resolveBindingChain(localToolName: string): BindingCandidate[] {
+    const rows = this.repo.listAll()
+      .filter(r => r.enabled && !r.paused)
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+    const out: BindingCandidate[] = []
+    for (const row of rows) {
+      if (this.health.shouldSkip(row.id, row.paused)) continue
+      const remote = row.capabilityBindings[localToolName]
+      if (!remote) continue
+      if (!this.connections.has(row.id)) continue
+      out.push({ serverId: row.id, remoteTool: remote })
+    }
+    return out
+  }
+
+  async callExternal(
+    serverId: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<unknown> {
+    const row = this.repo.get(serverId)
+    if (!row) throw new Error(`未知 MCP Server: ${serverId}`)
+    if (!row.enabled || row.paused) throw new Error(`MCP Server ${serverId} 未启用或已暂停`)
+    if (this.health.shouldSkip(serverId, row.paused)) {
+      throw new Error(`MCP Server ${serverId} 熔断冷却中: ${this.health.lastError(serverId)}`)
+    }
+    let conn = this.connections.get(serverId) ?? null
+    if (!conn) {
+      conn = await this.ensureConnected(row)
+      if (!conn) throw new Error(`无法连接 MCP Server ${serverId}`)
+    }
+    try {
+      const result = await conn.callTool(toolName, args, opts)
+      this.health.recordSuccess(serverId)
+      return result
+    } catch (e) {
+      this.health.recordFailure(serverId, e)
+      throw e
+    }
+  }
+
+  async callNamespaced(
+    name: string,
+    args: Record<string, unknown>,
+    opts?: { signal?: AbortSignal; timeoutMs?: number },
+  ): Promise<unknown> {
+    const parsed = parseNamespacedMcpTool(name)
+    if (!parsed) throw new Error(`非命名空间 MCP 工具: ${name}`)
+    return this.callExternal(parsed.serverId, parsed.toolName, args, opts)
+  }
+
+  async testConnection(id: string): Promise<{ ok: boolean; message: string; tools?: string[] }> {
+    const row = this.repo.get(id)
+    if (!row) return { ok: false, message: `未知服务器: ${id}` }
+    const conn = new ExternalMcpConnection(row)
+    try {
+      await conn.connect()
+      const tools = conn.tools.map(t => t.name)
+      this.health.recordSuccess(id)
+      await conn.close()
+      return { ok: true, message: `连接成功，发现 ${tools.length} 个工具`, tools }
+    } catch (e) {
+      this.health.recordFailure(id, e)
+      const msg = e instanceof Error ? e.message : String(e)
+      await conn.close().catch(() => {})
+      return { ok: false, message: msg }
+    }
+  }
+
+  async closeAll(): Promise<void> {
+    await Promise.all([...this.connections.values()].map(c => c.close().catch(() => {})))
+    this.connections.clear()
+  }
+}
+
+let sharedRegistry: ExternalMcpRegistry | null = null
+
+export function getExternalMcpRegistry(): ExternalMcpRegistry {
+  if (!sharedRegistry) sharedRegistry = new ExternalMcpRegistry()
+  return sharedRegistry
+}
+
+export function resetExternalMcpRegistry(): void {
+  void sharedRegistry?.closeAll()
+  sharedRegistry = null
+}
+
+export function annotateMcpResult(
+  data: unknown,
+  source: string,
+  opts?: { degraded?: boolean },
+): unknown {
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
+    return {
+      ...(data as Record<string, unknown>),
+      _mcp: {
+        source,
+        degraded: Boolean(opts?.degraded),
+      },
+    }
+  }
+  return {
+    data,
+    _mcp: { source, degraded: Boolean(opts?.degraded) },
+  }
+}
+
+export { isMcpServerFailoverError }

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -459,6 +459,36 @@ export const TOOL_META: Record<string, ToolMeta> = {
     usageGuide: '按需激活业务工具包，使本轮及后续轮次可调用该包内工具；当前 tools 不足时使用。',
     compliance: 'pack_ids 为字符串数组（如 ["news","instrument_analytics"]）；同会话累积激活；无效 id 会出现在 skipped。',
   },
+  list_mcp_servers: {
+    packId: 'meta',
+    usageGuide: '查看用户已配置的外部 MCP Server 状态（健康、优先级、工具数）；需要外部数据源或排查不可用时使用。',
+    compliance: '只读；无密钥；返回 servers 列表。',
+  },
+  enable_mcp_server: {
+    packId: 'meta',
+    usageGuide: '启用并取消暂停某外部 MCP；启用后本轮工具目录会刷新，绑定工具优先走外部源。',
+    compliance: 'server_id 必填；不可改 command/url/env。',
+  },
+  pause_mcp_server: {
+    packId: 'meta',
+    usageGuide: '暂时停用外部 MCP（配额耗尽或异常时）；配置保留，本地工具仍兜底。',
+    compliance: 'server_id 必填。',
+  },
+  install_mcp_server: {
+    packId: 'meta',
+    usageGuide: '登记新的外部 MCP。必须先 ask_user 确认，再 confirmed=true 安装。',
+    compliance: 'transport=stdio|http；stdio 需 command；http 需 url；密钥走设置页；勿在未确认时重复安装。',
+  },
+  uninstall_mcp_server: {
+    packId: 'meta',
+    usageGuide: '卸载外部 MCP；须 ask_user 后 confirmed=true。',
+    compliance: 'server_id 必填；确认后删除配置并断开。',
+  },
+  reorder_mcp_servers: {
+    packId: 'meta',
+    usageGuide: '调整外部 MCP 故障转移优先级（列表越前越优先；本地始终最后兜底）。',
+    compliance: 'server_ids 为完整顺序列表。',
+  },
 }
 
 /** 为 TOOL_META 条目补全 packId（单一事实源仍是 TOOL_PACK_MEMBERSHIP） */

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -507,6 +507,185 @@ export class ToolRegistry {
           return this.packBridge.activatePacks(packIds)
         },
       },
+      {
+        name: 'list_mcp_servers',
+        category: 'MCP服务器',
+        description: '列出用户配置的外部 MCP Server（启用/暂停/健康/工具数/优先级），无密钥',
+        parameters: S({}),
+        handler: async () => {
+          const { getExternalMcpRegistry } = await import('./mcp/external/registry.js')
+          const reg = getExternalMcpRegistry()
+          await reg.hydrate()
+          return { servers: reg.listPublic() }
+        },
+      },
+      {
+        name: 'enable_mcp_server',
+        category: 'MCP服务器',
+        description: '启用外部 MCP Server 并热加载到本轮工具目录（不改 command/url/env）',
+        parameters: S({
+          server_id: { type: 'string', description: 'MCP Server id' },
+        }, ['server_id']),
+        handler: async (a: Record<string, unknown>) => {
+          const { getExternalMcpRegistry } = await import('./mcp/external/registry.js')
+          const id = String(a.server_id ?? a.serverId ?? '').trim()
+          if (!id) return { error: 'server_id 必填' }
+          const reg = getExternalMcpRegistry()
+          if (!reg.getRecord(id)) return { error: `未知服务器: ${id}` }
+          reg.save(id, { enabled: true, paused: false })
+          await reg.hydrate()
+          return { ok: true, server: reg.listPublic().find(s => s.id === id) }
+        },
+      },
+      {
+        name: 'pause_mcp_server',
+        category: 'MCP服务器',
+        description: '暂停外部 MCP Server（保留配置，不参与路由/目录）',
+        parameters: S({
+          server_id: { type: 'string', description: 'MCP Server id' },
+        }, ['server_id']),
+        handler: async (a: Record<string, unknown>) => {
+          const { getExternalMcpRegistry } = await import('./mcp/external/registry.js')
+          const id = String(a.server_id ?? a.serverId ?? '').trim()
+          if (!id) return { error: 'server_id 必填' }
+          const reg = getExternalMcpRegistry()
+          if (!reg.getRecord(id)) return { error: `未知服务器: ${id}` }
+          reg.save(id, { paused: true })
+          await reg.hydrate()
+          return { ok: true, server: reg.listPublic().find(s => s.id === id) }
+        },
+      },
+      {
+        name: 'install_mcp_server',
+        category: 'MCP服务器',
+        description: '安装（登记）外部 MCP Server。首次调用勿传 confirmed；向用户 ask_user 确认后再以 confirmed=true 重试。禁止仅由 Agent 改已有服务器的 command/url/密钥。',
+        parameters: S({
+          title: { type: 'string', description: '显示名称' },
+          transport: { type: 'string', description: 'stdio | http' },
+          command: { type: 'string', description: 'stdio：可执行文件' },
+          args: { type: 'array', description: 'stdio 参数', items: { type: 'string' } },
+          cwd: { type: 'string', description: 'stdio 工作目录' },
+          url: { type: 'string', description: 'http：MCP endpoint URL' },
+          server_id: { type: 'string', description: '可选自定义 id' },
+          capability_bindings: {
+            type: 'object',
+            description: '本地工具名→外部工具名，如 {"get_instrument_quotes":"get_quotes"}',
+          },
+          confirmed: { type: 'boolean', description: '用户已确认安装；缺省或 false 时仅返回确认摘要' },
+        }, ['title', 'transport']),
+        handler: async (a: Record<string, unknown>) => {
+          const { getExternalMcpRegistry } = await import('./mcp/external/registry.js')
+          const transport = String(a.transport ?? '').trim().toLowerCase()
+          const title = String(a.title ?? '').trim()
+          if (!title) return { error: 'title 必填' }
+          if (transport !== 'stdio' && transport !== 'http') {
+            return { error: 'transport 须为 stdio 或 http' }
+          }
+          const transportConfig = transport === 'stdio'
+            ? {
+                transport: 'stdio' as const,
+                command: String(a.command ?? '').trim(),
+                args: Array.isArray(a.args) ? a.args.map(String) : [],
+                cwd: a.cwd != null ? String(a.cwd) : undefined,
+              }
+            : {
+                transport: 'http' as const,
+                url: String(a.url ?? '').trim(),
+              }
+          if (transport === 'stdio' && !transportConfig.command) {
+            return { error: 'stdio 须提供 command' }
+          }
+          if (transport === 'http' && !('url' in transportConfig && transportConfig.url)) {
+            return { error: 'http 须提供 url' }
+          }
+          const bindingsRaw = a.capability_bindings ?? a.capabilityBindings
+          const capabilityBindings = bindingsRaw && typeof bindingsRaw === 'object' && !Array.isArray(bindingsRaw)
+            ? Object.fromEntries(
+              Object.entries(bindingsRaw as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+            )
+            : {}
+          const draft = {
+            id: a.server_id != null ? String(a.server_id).trim() : undefined,
+            title,
+            transportConfig,
+            capabilityBindings,
+            installSource: 'manual' as const,
+            enabled: true,
+            paused: false,
+          }
+          if (a.confirmed !== true) {
+            return {
+              needs_confirmation: true,
+              summary: transport === 'stdio'
+                ? `安装 MCP「${title}」：${transportConfig.command} ${(transportConfig.args ?? []).join(' ')}`
+                : `安装 MCP「${title}」：${(transportConfig as { url: string }).url}`,
+              hint: '请先用 ask_user 向用户确认安全与来源；用户同意后以相同参数 + confirmed=true 再调用 install_mcp_server',
+              draft,
+            }
+          }
+          try {
+            const reg = getExternalMcpRegistry()
+            const row = reg.create(draft)
+            await reg.hydrate()
+            const test = await reg.testConnection(row.id)
+            return {
+              ok: test.ok,
+              server: reg.listPublic().find(s => s.id === row.id),
+              test,
+            }
+          } catch (e) {
+            return { error: e instanceof Error ? e.message : String(e) }
+          }
+        },
+      },
+      {
+        name: 'uninstall_mcp_server',
+        category: 'MCP服务器',
+        description: '卸载外部 MCP Server。须 confirmed=true；建议先 ask_user 确认。',
+        parameters: S({
+          server_id: { type: 'string', description: 'MCP Server id' },
+          confirmed: { type: 'boolean', description: '用户已确认卸载' },
+        }, ['server_id']),
+        handler: async (a: Record<string, unknown>) => {
+          const { getExternalMcpRegistry } = await import('./mcp/external/registry.js')
+          const id = String(a.server_id ?? a.serverId ?? '').trim()
+          if (!id) return { error: 'server_id 必填' }
+          const reg = getExternalMcpRegistry()
+          const row = reg.getRecord(id)
+          if (!row) return { error: `未知服务器: ${id}` }
+          if (a.confirmed !== true) {
+            return {
+              needs_confirmation: true,
+              summary: `卸载 MCP「${row.title}」(${id})，将断开连接并删除配置`,
+              hint: '请先 ask_user 确认，再以 confirmed=true 调用',
+            }
+          }
+          reg.delete(id)
+          return { ok: true, uninstalled: id }
+        },
+      },
+      {
+        name: 'reorder_mcp_servers',
+        category: 'MCP服务器',
+        description: '按给定 id 列表重排外部 MCP 优先级（越靠前越优先，本地始终最终兜底）',
+        parameters: S({
+          server_ids: {
+            type: 'array',
+            description: '服务器 id 新顺序',
+            items: { type: 'string' },
+          },
+        }, ['server_ids']),
+        handler: async (a: Record<string, unknown>) => {
+          const { getExternalMcpRegistry } = await import('./mcp/external/registry.js')
+          const raw = a.server_ids ?? a.serverIds
+          const ids = Array.isArray(raw) ? raw.map(String) : []
+          if (!ids.length) return { error: 'server_ids 必填' }
+          const reg = getExternalMcpRegistry()
+          reg.reorder(ids)
+          await reg.hydrate()
+          return { ok: true, servers: reg.listPublic() }
+        },
+      },
     ].map(t => ({ ...t, meta: TOOL_META[t.name] }))
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,7 @@ export * from './provider-binding.js'
 export * from './provider-settings.js'
 export * from './provider-priority-order.js'
 export * from './free-provider-throttle.js'
+export * from './mcp-servers.js'
 export * from './onboarding.js'
 export {
   initOutboundNetwork,

--- a/packages/shared/src/mcp-servers.ts
+++ b/packages/shared/src/mcp-servers.ts
@@ -1,0 +1,157 @@
+/**
+ * 用户可配置的外部 MCP Server — 配置契约（无 I/O）。
+ *
+ * 路由约定：已启用且未 pause 的外部源按 sortOrder 优先；
+ * 不可用 / 额度过 / 熔断后换下一源；最后回落进程内本地 ToolRegistry。
+ */
+
+export type McpServerTransport = 'stdio' | 'http'
+
+export type McpServerInstallSource = 'manual' | 'registry'
+
+export type McpServerHealthState = 'unknown' | 'healthy' | 'degraded' | 'open' | 'paused'
+
+/** 本地稳定工具名 → 外部 Server 上的真实 tool 名 */
+export type McpCapabilityBindings = Record<string, string>
+
+export interface McpStdioTransportConfig {
+  transport: 'stdio'
+  command: string
+  args?: string[]
+  cwd?: string
+  /** 非密钥环境变量 */
+  env?: Record<string, string>
+}
+
+export interface McpHttpTransportConfig {
+  transport: 'http'
+  url: string
+  /** 非密钥 Header（如 Accept） */
+  headers?: Record<string, string>
+}
+
+export type McpTransportConfig = McpStdioTransportConfig | McpHttpTransportConfig
+
+/**
+ * 持久化行（含密钥明文，仅存用户库；API 对外须掩码）。
+ */
+export interface McpServerRecord {
+  id: string
+  title: string
+  enabled: boolean
+  /** pause=true 时保留配置但不参与路由 / catalog */
+  paused: boolean
+  /** 越小越优先（外部源之间） */
+  sortOrder: number
+  transportConfig: McpTransportConfig
+  /** secret 环境变量（stdio）或 Authorization Bearer（http）等 */
+  secrets: Record<string, string>
+  capabilityBindings: McpCapabilityBindings
+  installSource: McpServerInstallSource
+  createdAt: string
+  updatedAt: string
+  lastError?: string
+  lastHealthyAt?: string
+}
+
+export interface McpServerPatch {
+  title?: string
+  enabled?: boolean
+  paused?: boolean
+  sortOrder?: number
+  transportConfig?: McpTransportConfig
+  /** 合并写入；传空字符串可清除某 key */
+  secrets?: Record<string, string>
+  capabilityBindings?: McpCapabilityBindings
+}
+
+/** API / Agent 列表用公开视图（无明文密钥） */
+export interface PublicMcpServer {
+  id: string
+  title: string
+  enabled: boolean
+  paused: boolean
+  sortOrder: number
+  transport: McpServerTransport
+  /** stdio command 或 http url（脱敏后） */
+  endpointPreview: string
+  secretsConfigured: Record<string, boolean>
+  capabilityBindings: McpCapabilityBindings
+  installSource: McpServerInstallSource
+  health: McpServerHealthState
+  toolCount: number
+  lastError?: string
+  lastHealthyAt?: string
+  updatedAt: string
+}
+
+export interface McpServerCreateInput {
+  id?: string
+  title: string
+  enabled?: boolean
+  paused?: boolean
+  sortOrder?: number
+  transportConfig: McpTransportConfig
+  secrets?: Record<string, string>
+  capabilityBindings?: McpCapabilityBindings
+  installSource?: McpServerInstallSource
+}
+
+export const MCP_SERVERS_NAMESPACE = 'mcp_servers'
+
+export const MCP_TOOL_NAMESPACE_SEP = '__'
+
+export function namespacedMcpTool(serverId: string, toolName: string): string {
+  return `${serverId}${MCP_TOOL_NAMESPACE_SEP}${toolName}`
+}
+
+export function parseNamespacedMcpTool(
+  name: string,
+): { serverId: string; toolName: string } | null {
+  const i = name.indexOf(MCP_TOOL_NAMESPACE_SEP)
+  if (i <= 0) return null
+  const serverId = name.slice(0, i)
+  const toolName = name.slice(i + MCP_TOOL_NAMESPACE_SEP.length)
+  if (!serverId || !toolName) return null
+  return { serverId, toolName }
+}
+
+export function isValidMcpServerId(id: string): boolean {
+  return /^[a-z][a-z0-9_-]{1,63}$/.test(id)
+}
+
+export function maskSecretPreview(value: string): string {
+  const v = value.trim()
+  if (v.length <= 8) return v ? '••••' : ''
+  return `${v.slice(0, 4)}…${v.slice(-4)}`
+}
+
+export function endpointPreviewFromTransport(cfg: McpTransportConfig): string {
+  if (cfg.transport === 'stdio') {
+    const args = (cfg.args ?? []).join(' ')
+    return args ? `${cfg.command} ${args}` : cfg.command
+  }
+  try {
+    const u = new URL(cfg.url)
+    return `${u.protocol}//${u.host}${u.pathname}`
+  } catch {
+    return cfg.url.slice(0, 80)
+  }
+}
+
+/** 判定外部调用失败是否应 failover / 熔断（业务参数错误不在此列） */
+export function isMcpServerFailoverError(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error ?? '')
+  if (!msg.trim()) return false
+  if (/quota|rate\s*limit|too\s*many|429|credit|额度过|额度用尽|限流|请求过于频繁/i.test(msg)) {
+    return true
+  }
+  if (/\b(401|403|502|503|504)\b/.test(msg) || /ECONN|ETIMEDOUT|ENOTFOUND|fetch failed|timeout|超时|unavailable|不可用/i.test(msg)) {
+    return true
+  }
+  if (typeof error === 'object' && error !== null && 'status' in error) {
+    const status = Number((error as { status: unknown }).status)
+    if (status === 401 || status === 403 || status === 429 || status >= 500) return true
+  }
+  return false
+}

--- a/packages/shared/src/tool-packs.ts
+++ b/packages/shared/src/tool-packs.ts
@@ -43,8 +43,8 @@ export const TOOL_PACK_DEFS: readonly ToolPackDef[] = [
   {
     id: 'meta',
     title: '工具包管理',
-    description: '列出与按需激活其它工具包',
-    whenToUse: '当前工具不足、需深挖专题时',
+    description: '列出与按需激活其它工具包；管理外部 MCP Server（列表/启用/暂停/安装确认）',
+    whenToUse: '当前工具不足、需深挖专题，或管理用户外部 MCP 数据源时',
     alwaysOn: true,
   },
   {
@@ -121,6 +121,12 @@ export const TOOL_PACK_MEMBERSHIP: Readonly<Record<string, ToolPackId>> = {
   // meta
   list_tool_packs: 'meta',
   activate_tool_pack: 'meta',
+  list_mcp_servers: 'meta',
+  enable_mcp_server: 'meta',
+  pause_mcp_server: 'meta',
+  install_mcp_server: 'meta',
+  uninstall_mcp_server: 'meta',
+  reorder_mcp_servers: 'meta',
 
   // instrument_analytics
   get_instrument_chart: 'instrument_analytics',
@@ -237,5 +243,6 @@ export function buildToolPackCatalogPrompt(): string {
   lines.push('- 用户已明确代码时跳过搜索直接分析；跨市场先 search_instruments')
   lines.push('- A 股专用工具（机构评级、筹码等）勿用于非 A 股')
   lines.push('- 标准 API 可用时禁止用自定义 Provider 方法替代')
+  lines.push('- 外部 MCP：已绑定工具由引擎优先外部再本地兜底；独有工具名形如 serverId__tool；安装/卸载须用户确认')
   return lines.join('\n')
 }

--- a/packages/user-store/src/index.ts
+++ b/packages/user-store/src/index.ts
@@ -10,4 +10,5 @@ export {
   FreeProviderThrottleRepository,
   initFreeProviderThrottleSchema,
 } from './free-provider-throttle.js'
+export { McpServersRepository } from './mcp-servers.js'
 export { UserDataStore, getUserDataStore } from './store.js'

--- a/packages/user-store/src/mcp-servers.ts
+++ b/packages/user-store/src/mcp-servers.ts
@@ -1,0 +1,145 @@
+/**
+ * 外部 MCP Server 配置持久化 — documents 命名空间 `mcp_servers`。
+ */
+
+import {
+  MCP_SERVERS_NAMESPACE,
+  endpointPreviewFromTransport,
+  isValidMcpServerId,
+  type McpServerCreateInput,
+  type McpServerPatch,
+  type McpServerRecord,
+  type PublicMcpServer,
+} from '@opptrix/shared'
+import type { UserDataStore } from './store.js'
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function slugifyId(title: string): string {
+  const base = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40)
+  return base || `mcp-${Date.now().toString(36)}`
+}
+
+export class McpServersRepository {
+  constructor(private readonly store: UserDataStore) {}
+
+  listAll(): McpServerRecord[] {
+    return this.store
+      .listDocuments<McpServerRecord>(MCP_SERVERS_NAMESPACE)
+      .slice()
+      .sort((a, b) => a.sortOrder - b.sortOrder || a.id.localeCompare(b.id))
+  }
+
+  get(id: string): McpServerRecord | null {
+    return this.store.getDocument<McpServerRecord>(MCP_SERVERS_NAMESPACE, id)
+  }
+
+  create(input: McpServerCreateInput): McpServerRecord {
+    let id = (input.id ?? slugifyId(input.title)).trim().toLowerCase()
+    if (!isValidMcpServerId(id)) {
+      throw new Error(`无效的 MCP Server id: ${id}（须小写字母开头，仅 a-z0-9_-）`)
+    }
+    if (this.get(id)) {
+      throw new Error(`MCP Server 已存在: ${id}`)
+    }
+    const ts = nowIso()
+    const maxOrder = this.listAll().reduce((m, r) => Math.max(m, r.sortOrder), -1)
+    const row: McpServerRecord = {
+      id,
+      title: input.title.trim() || id,
+      enabled: input.enabled ?? true,
+      paused: input.paused ?? false,
+      sortOrder: input.sortOrder ?? maxOrder + 1,
+      transportConfig: input.transportConfig,
+      secrets: { ...(input.secrets ?? {}) },
+      capabilityBindings: { ...(input.capabilityBindings ?? {}) },
+      installSource: input.installSource ?? 'manual',
+      createdAt: ts,
+      updatedAt: ts,
+    }
+    this.store.setDocument(MCP_SERVERS_NAMESPACE, id, row)
+    return row
+  }
+
+  save(id: string, patch: McpServerPatch): McpServerRecord {
+    const prev = this.get(id)
+    if (!prev) throw new Error(`未知 MCP Server: ${id}`)
+    const secrets = { ...prev.secrets }
+    if (patch.secrets) {
+      for (const [k, v] of Object.entries(patch.secrets)) {
+        if (v === '') delete secrets[k]
+        else secrets[k] = v
+      }
+    }
+    const row: McpServerRecord = {
+      ...prev,
+      title: patch.title?.trim() || prev.title,
+      enabled: patch.enabled ?? prev.enabled,
+      paused: patch.paused ?? prev.paused,
+      sortOrder: patch.sortOrder ?? prev.sortOrder,
+      transportConfig: patch.transportConfig ?? prev.transportConfig,
+      secrets,
+      capabilityBindings: patch.capabilityBindings ?? prev.capabilityBindings,
+      updatedAt: nowIso(),
+    }
+    this.store.setDocument(MCP_SERVERS_NAMESPACE, id, row)
+    return row
+  }
+
+  delete(id: string): boolean {
+    if (!this.get(id)) return false
+    this.store.deleteDocument(MCP_SERVERS_NAMESPACE, id)
+    return true
+  }
+
+  reorder(ids: string[]): McpServerRecord[] {
+    const all = this.listAll()
+    const byId = new Map(all.map(r => [r.id, r]))
+    const ordered = ids.filter(id => byId.has(id))
+    for (const r of all) {
+      if (!ordered.includes(r.id)) ordered.push(r.id)
+    }
+    const out: McpServerRecord[] = []
+    ordered.forEach((id, index) => {
+      const prev = byId.get(id)!
+      const row: McpServerRecord = { ...prev, sortOrder: index, updatedAt: nowIso() }
+      this.store.setDocument(MCP_SERVERS_NAMESPACE, id, row)
+      out.push(row)
+    })
+    return out
+  }
+
+  toPublic(
+    row: McpServerRecord,
+    extras?: { health?: PublicMcpServer['health']; toolCount?: number },
+  ): PublicMcpServer {
+    const secretsConfigured: Record<string, boolean> = {}
+    for (const [k, v] of Object.entries(row.secrets)) {
+      secretsConfigured[k] = Boolean(v?.trim())
+    }
+    return {
+      id: row.id,
+      title: row.title,
+      enabled: row.enabled,
+      paused: row.paused,
+      sortOrder: row.sortOrder,
+      transport: row.transportConfig.transport,
+      endpointPreview: endpointPreviewFromTransport(row.transportConfig),
+      secretsConfigured,
+      capabilityBindings: row.capabilityBindings,
+      installSource: row.installSource,
+      health: extras?.health ?? (row.paused ? 'paused' : 'unknown'),
+      toolCount: extras?.toolCount ?? 0,
+      lastError: row.lastError,
+      lastHealthyAt: row.lastHealthyAt,
+      updatedAt: row.updatedAt,
+    }
+  }
+}

--- a/packages/user-store/src/store.ts
+++ b/packages/user-store/src/store.ts
@@ -15,6 +15,7 @@ import {
   initFreeProviderThrottleSchema,
   FreeProviderThrottleRepository,
 } from './free-provider-throttle.js'
+import { McpServersRepository } from './mcp-servers.js'
 import {
   clearFtsNews,
   clearFtsSessions,
@@ -37,6 +38,7 @@ export class UserDataStore {
   readonly providerSettings: ProviderSettingsRepository
   readonly speedRanking: SpeedRankingRepository
   readonly freeProviderThrottle: FreeProviderThrottleRepository
+  readonly mcpServers: McpServersRepository
 
   private constructor(dbPath: string) {
     fs.mkdirSync(path.dirname(dbPath), { recursive: true })
@@ -48,6 +50,7 @@ export class UserDataStore {
     this.providerSettings = new ProviderSettingsRepository(this.db)
     this.speedRanking = new SpeedRankingRepository(this.db)
     this.freeProviderThrottle = new FreeProviderThrottleRepository(this.db)
+    this.mcpServers = new McpServersRepository(this)
     this.initSchema()
     this.migrateFromLegacyFiles()
     this.providerSettings.migrateFromLegacy(

--- a/tests/external-mcp-failover.test.mjs
+++ b/tests/external-mcp-failover.test.mjs
@@ -1,0 +1,205 @@
+/**
+ * 外部 MCP：路由 failover、熔断、命名空间、install 确认门闩。
+ */
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isMcpServerFailoverError,
+  namespacedMcpTool,
+  parseNamespacedMcpTool,
+  isValidMcpServerId,
+} from '../packages/shared/dist/mcp-servers.js'
+import { ExternalMcpHealth } from '../packages/agent/dist/mcp/external/health.js'
+import {
+  annotateMcpResult,
+  AggregatingToolBroker,
+} from '../packages/agent/dist/mcp/external/index.js'
+
+test('namespaced tool round-trip', () => {
+  const name = namespacedMcpTool('alpha', 'get_quotes')
+  assert.equal(name, 'alpha__get_quotes')
+  assert.deepEqual(parseNamespacedMcpTool(name), { serverId: 'alpha', toolName: 'get_quotes' })
+  assert.equal(parseNamespacedMcpTool('local_tool'), null)
+})
+
+test('isValidMcpServerId', () => {
+  assert.equal(isValidMcpServerId('my-server'), true)
+  assert.equal(isValidMcpServerId('A1'), false)
+  assert.equal(isValidMcpServerId('_bad'), false)
+})
+
+test('isMcpServerFailoverError classifies quota and network', () => {
+  assert.equal(isMcpServerFailoverError(new Error('rate limit 429')), true)
+  assert.equal(isMcpServerFailoverError(new Error('ETIMEDOUT')), true)
+  assert.equal(isMcpServerFailoverError(new Error('invalid argument foo')), false)
+})
+
+test('ExternalMcpHealth opens after consecutive failover failures', () => {
+  const h = new ExternalMcpHealth()
+  assert.equal(h.shouldSkip('s1', false), false)
+  h.recordFailure('s1', new Error('timeout'))
+  h.recordFailure('s1', new Error('timeout'))
+  assert.equal(h.getState('s1', false), 'degraded')
+  h.recordFailure('s1', new Error('timeout'))
+  assert.equal(h.getState('s1', false), 'open')
+  assert.equal(h.shouldSkip('s1', false), true)
+  h.recordSuccess('s1')
+  assert.equal(h.shouldSkip('s1', false), false)
+  assert.equal(h.getState('s1', false), 'healthy')
+})
+
+test('ExternalMcpHealth does not trip on business errors', () => {
+  const h = new ExternalMcpHealth()
+  h.recordFailure('s1', new Error('unknown symbol XYZ'))
+  h.recordFailure('s1', new Error('unknown symbol XYZ'))
+  h.recordFailure('s1', new Error('unknown symbol XYZ'))
+  assert.notEqual(h.getState('s1', false), 'open')
+  assert.equal(h.shouldSkip('s1', false), false)
+})
+
+test('quota error opens circuit immediately', () => {
+  const h = new ExternalMcpHealth()
+  h.recordFailure('s1', new Error('quota exceeded 429'))
+  assert.equal(h.getState('s1', false), 'open')
+  assert.equal(h.shouldSkip('s1', false), true)
+})
+
+test('annotateMcpResult marks source and degraded', () => {
+  const a = annotateMcpResult({ price: 1 }, 'ext-a')
+  assert.deepEqual(a, { price: 1, _mcp: { source: 'ext-a', degraded: false } })
+  const b = annotateMcpResult('raw', 'local', { degraded: true })
+  assert.deepEqual(b, { data: 'raw', _mcp: { source: 'local', degraded: true } })
+})
+
+test('AggregatingToolBroker failover: skip failed external then local', async () => {
+  const calls = []
+  const local = {
+    async openAiTools() {
+      return [{
+        type: 'function',
+        function: { name: 'get_quotes', description: 'local', parameters: { type: 'object' } },
+      }]
+    },
+    async call(name, args) {
+      calls.push(`local:${name}`)
+      return { price: 42, args }
+    },
+    async close() {},
+  }
+
+  const external = {
+    async hydrate() {},
+    listNamespacedOpenAiTools() { return [] },
+    resolveBindingChain(name) {
+      if (name !== 'get_quotes') return []
+      return [
+        { serverId: 'a', remoteTool: 'quotes' },
+        { serverId: 'b', remoteTool: 'quotes' },
+      ]
+    },
+    async callExternal(serverId, toolName) {
+      calls.push(`${serverId}:${toolName}`)
+      if (serverId === 'a') throw new Error('ETIMEDOUT')
+      if (serverId === 'b') throw new Error('503 unavailable')
+      return { ok: true }
+    },
+    async callNamespaced() {
+      throw new Error('unused')
+    },
+  }
+
+  const broker = await AggregatingToolBroker.create(async () => local, external)
+  const result = await broker.call('get_quotes', { code: '600519' })
+  assert.deepEqual(calls, ['a:quotes', 'b:quotes', 'local:get_quotes'])
+  assert.equal(result.price, 42)
+  assert.equal(result._mcp.source, 'local')
+  assert.equal(result._mcp.degraded, true)
+  await broker.close()
+})
+
+test('AggregatingToolBroker business error does not failover', async () => {
+  const calls = []
+  const local = {
+    async openAiTools() { return [] },
+    async call() {
+      calls.push('local')
+      return { from: 'local' }
+    },
+    async close() {},
+  }
+  const external = {
+    async hydrate() {},
+    listNamespacedOpenAiTools() { return [] },
+    resolveBindingChain() {
+      return [{ serverId: 'a', remoteTool: 't' }]
+    },
+    async callExternal(serverId) {
+      calls.push(serverId)
+      throw new Error('invalid argument')
+    },
+    async callNamespaced() { throw new Error('unused') },
+  }
+  const broker = await AggregatingToolBroker.create(async () => local, external)
+  const result = await broker.call('get_quotes', {})
+  assert.deepEqual(calls, ['a'])
+  assert.ok(result.error)
+  assert.equal(result._mcp?.source, 'a')
+  await broker.close()
+})
+
+test('AggregatingToolBroker namespaced tool calls external only', async () => {
+  const local = {
+    async openAiTools() { return [] },
+    async call() { throw new Error('local should not run') },
+    async close() {},
+  }
+  const external = {
+    async hydrate() {},
+    listNamespacedOpenAiTools() {
+      return [{
+        type: 'function',
+        function: {
+          name: 'ext__special',
+          description: 'x',
+          parameters: { type: 'object' },
+        },
+      }]
+    },
+    resolveBindingChain() { return [] },
+    async callExternal() { throw new Error('unused') },
+    async callNamespaced(name, args) {
+      assert.equal(name, 'ext__special')
+      return { args, ok: true }
+    },
+  }
+  const broker = await AggregatingToolBroker.create(async () => local, external)
+  const tools = await broker.openAiTools()
+  assert.equal(tools.some(t => t.function.name === 'ext__special'), true)
+  const result = await broker.call('ext__special', { q: 1 })
+  assert.equal(result.ok, true)
+  assert.equal(result._mcp.source, 'ext')
+  await broker.close()
+})
+
+test('install_mcp_server requires confirmed=true', async () => {
+  const { ToolRegistry } = await import('../packages/agent/dist/tools.js')
+  const { ResearchHub } = await import('../packages/research-hub/dist/hub.js')
+  const registry = new ToolRegistry(new ResearchHub())
+  const tool = registry.list().find(t => t.name === 'install_mcp_server')
+  assert.ok(tool)
+  const draft = await tool.handler({
+    title: 'Test MCP',
+    transport: 'stdio',
+    command: 'echo',
+    args: ['hi'],
+  })
+  assert.equal(draft.needs_confirmation, true)
+  assert.ok(draft.summary)
+
+  const uninstall = registry.list().find(t => t.name === 'uninstall_mcp_server')
+  assert.ok(uninstall)
+  // without existing server still gates on confirmed
+  const u = await uninstall.handler({ server_id: 'nope' })
+  assert.ok(u.error)
+})


### PR DESCRIPTION
## Summary
- Add user-configurable external MCP servers (stdio + Streamable HTTP) with user-store persistence and masked secrets
- Route bound local tool names through external sources by `sortOrder` with circuit breaking, then fall back to local ToolRegistry; expose exclusive tools as `serverId__toolName`
- Settings UI + REST `/api/mcp-servers*`, Agent meta tools (install/uninstall require `ask_user` confirmation), docs and failover tests

## Test plan
- [x] `node --test tests/external-mcp-failover.test.mjs`
- [x] `npm run check:ui`
- [x] `npx tsc -p apps/server/tsconfig.json --noEmit`
- [ ] Settings → MCP 服务器：添加 stdio/HTTP、测试连接、排序、启停、删除
- [ ] Agent：`list_mcp_servers`；`install_mcp_server` 无 `confirmed` 应返回确认摘要


Made with [Cursor](https://cursor.com)