### PR TITLE
feat(ui): 会话侧栏可拖拽调宽并联动标题栏布局

### DIFF
--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -38,8 +38,9 @@ import { setNewsFeedSelectedId } from '../pages/news/newsFeedSession'
 import WorkspaceSearchDialog, { type WorkspaceSearchAction } from './WorkspaceSearchDialog'
 import { normalizeWatchlistItem } from '../market/instrument'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
-import { useBreakpoint, useSidebarPreference, useSidebarOverlayMode, useSidebarResizeSync } from '../hooks/useBreakpoint'
+import { useBreakpoint, useSidebarPreference, useSidebarOverlayMode, useSidebarResizeSync, sidebarExpandThreshold } from '../hooks/useBreakpoint'
 import { useWorkspaceSplit } from '../hooks/useWorkspaceSplit'
+import { useSessionSidebarWidth } from '../hooks/useSessionSidebarWidth'
 import { useAppNavigation } from '../hooks/useAppNavigation'
 import DesktopWindowChrome from '../desktop/DesktopWindowChrome'
 import OverlaySidebarEdgeTrigger from '../desktop/OverlaySidebarEdgeTrigger'
@@ -51,7 +52,7 @@ import { desktopChromeToolbarReserve } from '../desktop/layout'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { useDesktopShell } from '../hooks/useDesktopShell'
 import { isElectron } from '../platform/detect'
-import { DESKTOP_SIDEBAR_EXPAND_THRESHOLD, DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT, DESKTOP_Z_TITLE, SIDEBAR_INLINE_WIDTH } from '../desktop/constants'
+import { DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT, DESKTOP_Z_TITLE, SIDEBAR_DEFAULT_WIDTH, WORKSPACE_CHAT_MIN_WIDTH, WORKSPACE_CHAT_RIGHT_MIN_WIDTH } from '../desktop/constants'
 
 const useStyles = makeStyles({
   root: {
@@ -146,21 +147,15 @@ export default function ChatApp() {
   const { confirm } = useOpptrixDialogAlert()
   const breakpoint = useBreakpoint()
   const isMobile = breakpoint === 'mobile'
-  const {
-    visible: sidebarVisible,
-    drawerOpen,
-    setVisible: setSidebarVisible,
-    toggleVisible,
-    openDrawer,
-    closeDrawer,
-  } = useSidebarPreference(isMobile)
-  const sidebarOverlayMode = useSidebarOverlayMode(!isMobile)
-  const sidebarInlineVisible = sidebarVisible && !sidebarOverlayMode
-  const [settingsSidebarVisible, setSettingsSidebarVisible] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return window.innerWidth >= DESKTOP_SIDEBAR_EXPAND_THRESHOLD
-  })
-  const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSection | undefined>()
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth : 1280,
+  )
+
+  useEffect(() => {
+    const onResize = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   const {
     current: view,
@@ -170,6 +165,53 @@ export default function ChatApp() {
     goBack,
     goForward,
   } = useAppNavigation('chat')
+
+  const splitEnabled = !isMobile && view === 'chat'
+
+  const {
+    workspaceRef,
+    rightPanelOpen: rightPanelVisible,
+    chatVisible,
+    rightPanelWidth,
+    showSplitter,
+    chatWidth,
+    isDragging,
+    canToggleChatColumn,
+    beginDrag,
+    collapseRightPanel,
+    toggleRightPanel: handleToggleRightPanel,
+    toggleChatColumn: handleToggleChatColumn,
+  } = useWorkspaceSplit({ enabled: splitEnabled })
+
+  const workspaceMinWidth = splitEnabled && rightPanelVisible
+    ? WORKSPACE_CHAT_RIGHT_MIN_WIDTH
+    : WORKSPACE_CHAT_MIN_WIDTH
+
+  const {
+    width: sidebarWidth,
+    isDragging: sidebarDragging,
+    beginDrag: beginSidebarDrag,
+  } = useSessionSidebarWidth({
+    enabled: !isMobile,
+    viewportWidth,
+    workspaceMinWidth,
+  })
+
+  const {
+    visible: sidebarVisible,
+    drawerOpen,
+    setVisible: setSidebarVisible,
+    toggleVisible,
+    openDrawer,
+    closeDrawer,
+  } = useSidebarPreference(isMobile, sidebarWidth)
+  const sidebarOverlayMode = useSidebarOverlayMode(!isMobile, sidebarWidth)
+  const sidebarInlineVisible = sidebarVisible && !sidebarOverlayMode
+  const [settingsSidebarVisible, setSettingsSidebarVisible] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.innerWidth >= sidebarExpandThreshold(SIDEBAR_DEFAULT_WIDTH)
+  })
+  const [settingsInitialSection, setSettingsInitialSection] = useState<SettingsSection | undefined>()
 
   const electronChrome = isElectron() && !isMobile
 
@@ -193,22 +235,6 @@ export default function ChatApp() {
   const chromeToolbarReserve = electronChrome && !sidebarInlineVisible
     ? desktopChromeToolbarReserve(macFullscreen)
     : 0
-  const splitEnabled = !isMobile && view === 'chat'
-
-  const {
-    workspaceRef,
-    rightPanelOpen: rightPanelVisible,
-    chatVisible,
-    rightPanelWidth,
-    showSplitter,
-    chatWidth,
-    isDragging,
-    canToggleChatColumn,
-    beginDrag,
-    collapseRightPanel,
-    toggleRightPanel: handleToggleRightPanel,
-    toggleChatColumn: handleToggleChatColumn,
-  } = useWorkspaceSplit({ enabled: splitEnabled })
 
   const collapseSidebars = useCallback(() => {
     setSidebarVisible(false)
@@ -221,7 +247,7 @@ export default function ChatApp() {
     setSettingsSidebarVisible(true)
   }, [setSidebarVisible])
 
-  useSidebarResizeSync(!isMobile, collapseSidebars, expandSidebars)
+  useSidebarResizeSync(!isMobile, sidebarWidth, collapseSidebars, expandSidebars)
 
   const handleToggleSidebar = useCallback(() => {
     if (view === 'settings') {
@@ -1067,6 +1093,8 @@ export default function ChatApp() {
           sidebarInline={isSettings
             ? settingsSidebarVisible && !sidebarOverlayMode
             : sidebarInlineVisible}
+          sidebarWidth={sidebarWidth}
+          sidebarDragging={sidebarDragging}
           showSidebarToggle={!isSettings || sidebarOverlayMode}
           sidebarHoverReveal={sidebarOverlayMode}
           onRevealSidebar={handleEdgeRevealSidebar}
@@ -1079,7 +1107,7 @@ export default function ChatApp() {
           rightPanelOpen={view === 'chat' && !isMobile ? rightPanelVisible : undefined}
           rightPanelWidth={view === 'chat' && !isMobile && rightPanelVisible ? rightPanelWidth : undefined}
           chatColumnWidth={view === 'chat' && !isMobile && chatVisible && showSplitter ? chatWidth : undefined}
-          chatAreaLeft={sidebarInlineVisible ? SIDEBAR_INLINE_WIDTH : 0}
+          chatAreaLeft={sidebarInlineVisible ? sidebarWidth : 0}
           chatColumnVisible={view === 'chat' && !isMobile ? chatVisible : undefined}
           onToggleRightPanel={view === 'chat' && !isMobile ? handleToggleRightPanel : undefined}
           onToggleChatColumn={view === 'chat' && !isMobile && canToggleChatColumn ? handleToggleChatColumn : undefined}
@@ -1088,12 +1116,24 @@ export default function ChatApp() {
       <div className={mergeClasses(s.root, electronChrome && s.rootElectron, electronChrome && 'opptrix-app-shell')}>
         <div className={s.rootLayout}>
         {!isMobile && !isSettings && (
-          <SessionSidebar
-            mode={sidebarOverlayMode ? 'overlay' : 'panel'}
-            visible={sidebarVisible}
-            onClose={handleSidebarClose}
-            {...sidebarProps}
-          />
+          <>
+            <SessionSidebar
+              mode={sidebarOverlayMode ? 'overlay' : 'panel'}
+              width={sidebarWidth}
+              isDragging={sidebarDragging}
+              visible={sidebarVisible}
+              onClose={handleSidebarClose}
+              {...sidebarProps}
+            />
+            {sidebarInlineVisible && (
+              <WorkspaceSplitDivider
+                electronChrome={electronChrome}
+                isDragging={sidebarDragging}
+                onBeginDrag={beginSidebarDrag}
+                ariaLabel="调整侧栏宽度"
+              />
+            )}
+          </>
         )}
 
         {isSettings && (
@@ -1125,6 +1165,7 @@ export default function ChatApp() {
             {isMobile && isNews && (
               <SessionSidebar
                 mode="drawer"
+                width={sidebarWidth}
                 drawerOpen={drawerOpen}
                 onClose={closeDrawer}
                 {...sidebarProps}
@@ -1159,6 +1200,7 @@ export default function ChatApp() {
             {isMobile && isMarket && (
               <SessionSidebar
                 mode="drawer"
+                width={sidebarWidth}
                 drawerOpen={drawerOpen}
                 onClose={closeDrawer}
                 {...sidebarProps}
@@ -1189,6 +1231,7 @@ export default function ChatApp() {
           {isMobile && !isNews && !isMarket && !isSettings && (
             <SessionSidebar
               mode="drawer"
+              width={sidebarWidth}
               drawerOpen={drawerOpen}
               onClose={closeDrawer}
               {...sidebarProps}

--- a/client-ui/src/chat/SessionSidebar.tsx
+++ b/client-ui/src/chat/SessionSidebar.tsx
@@ -43,12 +43,9 @@ const useStyles = makeStyles({
     backgroundColor: 'transparent',
   },
   panelShellVisible: {
-    width: opptrixTokens.sidebarWidth,
     pointerEvents: 'auto',
   },
   sidebarPanel: {
-    width: opptrixTokens.sidebarWidth,
-    minWidth: opptrixTokens.sidebarWidth,
     height: '100%',
     opacity: 0,
     transform: 'translateX(-12px)',
@@ -273,6 +270,8 @@ const useStyles = makeStyles({
 
 interface SessionSidebarProps {
   mode: SidebarMode
+  width: number
+  isDragging?: boolean
   visible?: boolean
   drawerOpen?: boolean
   sessions: SessionMeta[]
@@ -304,7 +303,7 @@ function formatDate(iso: string) {
 }
 
 function SessionSidebar({
-  mode, visible = true, drawerOpen = false,
+  mode, width, isDragging = false, visible = true, drawerOpen = false,
   sessions, activeId, activeRoute = 'chat', busySessionIds = [],
   onSelect, onNew, onDelete, onArchive, onOpenSearch, onOpenSettings, onOpenNewsCenter, onOpenMarketDynamics, onClose,
   listTab: listTabProp,
@@ -520,7 +519,7 @@ function SessionSidebar({
     return (
       <OverlaySidebarShell
         open={visible}
-        width={opptrixTokens.sidebarWidth}
+        width={`${width}px`}
         onClose={onClose}
       >
         <div
@@ -549,8 +548,9 @@ function SessionSidebar({
         sidebarSolidDark && s.sidebarElectronSolid,
         electronChrome && s.sidebarTopElectron,
         sidebarGlass && 'opptrix-glass-sidebar',
-        !isDrawer && 'opptrix-sidebar-edge',
+        isDrawer && 'opptrix-sidebar-edge',
       )}
+      style={!isDrawer ? { width, minWidth: width } : undefined}
     >
       {sidebarBody}
     </aside>
@@ -570,7 +570,13 @@ function SessionSidebar({
   }
 
   return (
-    <div className={mergeClasses(s.panelShell, visible && s.panelShellVisible)}>
+    <div
+      className={mergeClasses(s.panelShell, visible && s.panelShellVisible)}
+      style={{
+        width: visible ? width : 0,
+        transitionProperty: isDragging ? 'none' : 'width',
+      }}
+    >
       {sidebarEl}
     </div>
   )

--- a/client-ui/src/chat/WorkspaceSplitDivider.tsx
+++ b/client-ui/src/chat/WorkspaceSplitDivider.tsx
@@ -8,7 +8,7 @@ import {
   WORKSPACE_SPLITTER_Z_INDEX,
 } from '../desktop/constants'
 
-const FOCUS_FADE_PERCENT = 14
+const FOCUS_FADE_PERCENT = 10
 
 function buildLineBackground(focusRatio: number | null): string {
   const normal = opptrixCssVars.separatorStrong
@@ -63,12 +63,14 @@ interface Props {
   electronChrome?: boolean
   isDragging?: boolean
   onBeginDrag: (clientX: number) => void
+  ariaLabel?: string
 }
 
 export default function WorkspaceSplitDivider({
   electronChrome = false,
   isDragging = false,
   onBeginDrag,
+  ariaLabel = '调整聊天区与右侧面板宽度',
 }: Props) {
   const s = useStyles()
   const dividerRef = useRef<HTMLDivElement>(null)
@@ -111,7 +113,7 @@ export default function WorkspaceSplitDivider({
       className={mergeClasses(s.divider, electronChrome && s.dividerElectron)}
       role="separator"
       aria-orientation="vertical"
-      aria-label="调整聊天区与右侧面板宽度"
+      aria-label={ariaLabel}
     >
       <div
         className={s.line}

--- a/client-ui/src/desktop/DesktopWindowChrome.tsx
+++ b/client-ui/src/desktop/DesktopWindowChrome.tsx
@@ -17,7 +17,7 @@ import {
   DESKTOP_Z_CHROME_TOOLS,
   DESKTOP_NEWS_TITLE_DRAG_CLIP_DARWIN,
   DESKTOP_NEWS_TITLE_DRAG_CLIP_WIN,
-  SIDEBAR_INLINE_WIDTH,
+  SIDEBAR_DEFAULT_WIDTH,
   DESKTOP_TITLE_BAR_ACTIONS_WIDTH,
 } from './constants'
 import {
@@ -124,6 +124,8 @@ interface DesktopWindowChromeProps {
   viewMode?: DesktopViewMode
   sidebarOpen?: boolean
   sidebarInline?: boolean
+  sidebarWidth?: number
+  sidebarDragging?: boolean
   showSidebarToggle?: boolean
   sidebarHoverReveal?: boolean
   canGoBack?: boolean
@@ -156,6 +158,7 @@ function resolveDragRightClip(
   rightPanelOpen: boolean,
   chatColumnVisible: boolean,
   sidebarInline: boolean,
+  sidebarWidth: number,
   rightPanelWidth: number,
 ): DragClipStyle {
   if (isStandalonePanel) {
@@ -167,7 +170,7 @@ function resolveDragRightClip(
   if (isSettings || !rightPanelOpen) return {}
   if (!chatColumnVisible) {
     if (sidebarInline) {
-      return { right: `calc(100% - ${SIDEBAR_INLINE_WIDTH}px)` }
+      return { right: `calc(100% - ${sidebarWidth}px)` }
     }
     return {
       width: 0,
@@ -186,6 +189,8 @@ export default function DesktopWindowChrome({
   viewMode = 'chat',
   sidebarOpen = false,
   sidebarInline = false,
+  sidebarWidth = SIDEBAR_DEFAULT_WIDTH,
+  sidebarDragging = false,
   showSidebarToggle = true,
   sidebarHoverReveal = false,
   canGoBack = false,
@@ -223,7 +228,7 @@ export default function DesktopWindowChrome({
   const isStandalonePanel = isNews || isMarket
   const chromeTop = desktopChromeTopOffset()
   const chromeBand = desktopChromeBandHeight()
-  const titleLeft = desktopTitleLeft(sidebarInline, viewMode, macFullscreen)
+  const titleLeft = desktopTitleLeft(sidebarInline, viewMode, macFullscreen, sidebarWidth)
   const toolbarLeft = desktopToolbarLeft(macFullscreen)
   const titleBarActionsRight = desktopTitleBarActionsRight()
   const showTitleBarActions = !isSettings && !rightPanelOpen && Boolean(onToggleRightPanel || onToggleChatColumn)
@@ -270,12 +275,17 @@ export default function DesktopWindowChrome({
     ? titleLeft + (titleBlockWidth > 0 ? titleBlockWidth : 0)
     : titleLeft
 
+  const chromeTransition = sidebarDragging
+    ? 'none'
+    : `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`
+
   const dragRightClip = resolveDragRightClip(
     isStandalonePanel,
     isSettings,
     rightPanelOpen,
     chatColumnVisible,
     sidebarInline,
+    sidebarWidth,
     rightPanelWidth,
   )
 
@@ -319,12 +329,13 @@ export default function DesktopWindowChrome({
         {showPageTitle && (
           <div
             className={mergeClasses(s.title, titleSlot != null && titleSlot !== false && s.titleInteractive)}
-            style={{
-              top: `${chromeTop}px`,
-              height: `${chromeBand}px`,
-              left: `${titleLeft}px`,
-              maxWidth: `${titleMaxWidth}px`,
-            }}
+          style={{
+            top: `${chromeTop}px`,
+            height: `${chromeBand}px`,
+            left: `${titleLeft}px`,
+            maxWidth: `${titleMaxWidth}px`,
+            transitionDuration: chromeTransition,
+          }}
           >
             {titleSlotWithLayout ? (
               <div ref={titleMeasureRef} className={s.titleSlotWrap}>
@@ -342,6 +353,7 @@ export default function DesktopWindowChrome({
             top: `${chromeTop}px`,
             height: `${chromeBand}px`,
             left: `${toolbarLeft}px`,
+            transitionDuration: chromeTransition,
           }}
         >
           {showSidebarToggle && (onToggleSidebar || onRevealSidebar) && (

--- a/client-ui/src/desktop/constants.ts
+++ b/client-ui/src/desktop/constants.ts
@@ -37,11 +37,24 @@ export const DESKTOP_TOOLBAR_TOOL_COUNT = 4
 /** Settings nav column (Codex-style) */
 export const DESKTOP_SETTINGS_SIDEBAR_WIDTH = 210
 
-/** sidebarWidth (200) × 2.5 — below this, expanded sidebar floats over content */
-export const DESKTOP_SIDEBAR_OVERLAY_THRESHOLD = 500
+/** Default session sidebar width (px) — persisted via `opptrix-sidebar-width` */
+export const SIDEBAR_DEFAULT_WIDTH = 200
+/** Inline sidebar must clear title-bar chrome (traffic lights + toolbar tools) so session title does not overlap icons */
+export const SIDEBAR_MIN_WIDTH =
+  DESKTOP_TRAFFIC_LIGHT_WIDTH +
+  DESKTOP_TOOLBAR_TOOL_COUNT * DESKTOP_TOOL_SIZE +
+  (DESKTOP_TOOLBAR_TOOL_COUNT - 1) * DESKTOP_TOOL_GAP
+export const SIDEBAR_MAX_WIDTH = 360
 
-/** sidebarWidth (200) × 3 — at/above this width, auto-expand inline sidebar when growing */
-export const DESKTOP_SIDEBAR_EXPAND_THRESHOLD = 600
+/** Overlay / expand thresholds are sidebarWidth × these multipliers — see `useBreakpoint` helpers */
+export const SIDEBAR_OVERLAY_MULTIPLIER = 2.5
+export const SIDEBAR_EXPAND_MULTIPLIER = 3
+
+/** @deprecated use `sidebarOverlayThreshold(sidebarWidth)` from useBreakpoint */
+export const DESKTOP_SIDEBAR_OVERLAY_THRESHOLD = SIDEBAR_DEFAULT_WIDTH * SIDEBAR_OVERLAY_MULTIPLIER
+
+/** @deprecated use `sidebarExpandThreshold(sidebarWidth)` from useBreakpoint */
+export const DESKTOP_SIDEBAR_EXPAND_THRESHOLD = SIDEBAR_DEFAULT_WIDTH * SIDEBAR_EXPAND_MULTIPLIER
 
 /** Shared duration for inline panel width + title chrome when sidebar toggles */
 export const DESKTOP_SIDEBAR_LAYOUT_MS = 340
@@ -64,8 +77,8 @@ export const WORKSPACE_SPLITTER_HIT_SLOP = 1
 /** Stacking above chat / right panel so the widened hit layer receives pointer events */
 export const WORKSPACE_SPLITTER_Z_INDEX = 50
 
-/** Inline left sidebar width — keep in sync with opptrixTokens.sidebarWidthPx */
-export const SIDEBAR_INLINE_WIDTH = 200
+/** Default inline sidebar width — runtime width from `useSessionSidebarWidth`; alias for fallbacks */
+export const SIDEBAR_INLINE_WIDTH = SIDEBAR_DEFAULT_WIDTH
 
 /**
  * Minimum workspace width (chat area) to keep chat + splitter + right panel open.

--- a/client-ui/src/desktop/layout.ts
+++ b/client-ui/src/desktop/layout.ts
@@ -1,5 +1,4 @@
 import { electronPlatform } from '../platform/detect'
-import { opptrixTokens } from '../theme/tokens'
 import {
   DESKTOP_CHROME_TOP_OFFSET,
   DESKTOP_CHROME_TOP_OFFSET_WIN,
@@ -14,6 +13,7 @@ import {
   DESKTOP_TRAFFIC_LIGHT_WIDTH_FULLSCREEN,
   DESKTOP_WIN_WINDOW_CONTROLS_RESERVE,
   DESKTOP_Z_TITLE_INTERACTIVE,
+  SIDEBAR_DEFAULT_WIDTH,
 } from './constants'
 
 /** Platform chrome inset — Windows sits higher to share a line with window buttons */
@@ -47,6 +47,7 @@ export function desktopTitleLeft(
   sidebarInline: boolean,
   view: DesktopViewMode = 'chat',
   fullscreen = false,
+  sidebarWidth = SIDEBAR_DEFAULT_WIDTH,
 ): number {
   const afterToolbar = desktopToolbarLeft(fullscreen) + desktopToolbarWidth() + DESKTOP_TITLE_GAP
   if (view === 'settings') {
@@ -56,7 +57,7 @@ export function desktopTitleLeft(
     return afterToolbar
   }
   if (sidebarInline) {
-    return opptrixTokens.sidebarWidthPx + DESKTOP_TITLE_GAP
+    return sidebarWidth + DESKTOP_TITLE_GAP
   }
   return afterToolbar
 }

--- a/client-ui/src/hooks/useBreakpoint.ts
+++ b/client-ui/src/hooks/useBreakpoint.ts
@@ -1,13 +1,21 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { isDesktopApp } from '../platform/detect'
 import {
-  DESKTOP_SIDEBAR_EXPAND_THRESHOLD,
-  DESKTOP_SIDEBAR_OVERLAY_THRESHOLD,
+  SIDEBAR_EXPAND_MULTIPLIER,
+  SIDEBAR_OVERLAY_MULTIPLIER,
 } from '../desktop/constants'
 
 export type Breakpoint = 'mobile' | 'desktop'
 
 const MOBILE_QUERY = '(max-width: 767px)'
+
+export function sidebarOverlayThreshold(sidebarWidth: number): number {
+  return sidebarWidth * SIDEBAR_OVERLAY_MULTIPLIER
+}
+
+export function sidebarExpandThreshold(sidebarWidth: number): number {
+  return sidebarWidth * SIDEBAR_EXPAND_MULTIPLIER
+}
 
 function readBreakpoint(): Breakpoint {
   if (typeof window === 'undefined') return 'desktop'
@@ -38,29 +46,33 @@ export function useIsMobile() {
 
 const SIDEBAR_KEY = 'opptrix-sidebar-visible'
 
-function isOverlayDesktop(): boolean {
+function isOverlayDesktop(sidebarWidth: number): boolean {
   if (typeof window === 'undefined') return false
-  return window.innerWidth < DESKTOP_SIDEBAR_OVERLAY_THRESHOLD
+  return window.innerWidth < sidebarOverlayThreshold(sidebarWidth)
 }
 
-function shouldAutoExpandSidebar(): boolean {
+function shouldAutoExpandSidebar(sidebarWidth: number): boolean {
   if (typeof window === 'undefined') return false
-  return window.innerWidth >= DESKTOP_SIDEBAR_EXPAND_THRESHOLD
+  return window.innerWidth >= sidebarExpandThreshold(sidebarWidth)
 }
 
 /** Collapse on shrink into overlay; expand when growing past 3× sidebar width. */
 export function useSidebarResizeSync(
   enabled: boolean,
+  sidebarWidth: number,
   onCollapse: () => void,
   onExpand: () => void,
 ) {
   const prevWidthRef = useRef(
-    typeof window !== 'undefined' ? window.innerWidth : DESKTOP_SIDEBAR_EXPAND_THRESHOLD,
+    typeof window !== 'undefined' ? window.innerWidth : sidebarExpandThreshold(sidebarWidth),
   )
   const onCollapseRef = useRef(onCollapse)
   const onExpandRef = useRef(onExpand)
   onCollapseRef.current = onCollapse
   onExpandRef.current = onExpand
+
+  const overlayThreshold = sidebarOverlayThreshold(sidebarWidth)
+  const expandThreshold = sidebarExpandThreshold(sidebarWidth)
 
   useEffect(() => {
     if (!enabled) return undefined
@@ -69,10 +81,10 @@ export function useSidebarResizeSync(
       const w = window.innerWidth
       const prev = prevWidthRef.current
 
-      if (w < DESKTOP_SIDEBAR_OVERLAY_THRESHOLD && prev >= DESKTOP_SIDEBAR_OVERLAY_THRESHOLD) {
+      if (w < overlayThreshold && prev >= overlayThreshold) {
         onCollapseRef.current()
       }
-      if (w >= DESKTOP_SIDEBAR_EXPAND_THRESHOLD && prev < DESKTOP_SIDEBAR_EXPAND_THRESHOLD) {
+      if (w >= expandThreshold && prev < expandThreshold) {
         onExpandRef.current()
       }
 
@@ -81,12 +93,12 @@ export function useSidebarResizeSync(
 
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
-  }, [enabled])
+  }, [enabled, overlayThreshold, expandThreshold])
 }
 
 /** True when session sidebar should float over content instead of pushing layout. */
-export function useSidebarOverlayMode(enabled: boolean) {
-  const [overlayMode, setOverlayMode] = useState(() => enabled && isOverlayDesktop())
+export function useSidebarOverlayMode(enabled: boolean, sidebarWidth: number) {
+  const [overlayMode, setOverlayMode] = useState(() => enabled && isOverlayDesktop(sidebarWidth))
 
   useEffect(() => {
     if (!enabled) {
@@ -94,25 +106,25 @@ export function useSidebarOverlayMode(enabled: boolean) {
       return undefined
     }
 
-    const onResize = () => setOverlayMode(isOverlayDesktop())
+    const onResize = () => setOverlayMode(isOverlayDesktop(sidebarWidth))
     onResize()
     window.addEventListener('resize', onResize)
     return () => window.removeEventListener('resize', onResize)
-  }, [enabled])
+  }, [enabled, sidebarWidth])
 
   return overlayMode
 }
 
 /** Desktop: sidebar panel or overlay. Mobile: overlay drawer. */
-export function useSidebarPreference(isMobile: boolean) {
+export function useSidebarPreference(isMobile: boolean, sidebarWidth: number) {
   const [userVisible, setUserVisibleState] = useState(() => {
     if (typeof window === 'undefined') return false
     if (isDesktopApp()) {
-      return shouldAutoExpandSidebar()
+      return shouldAutoExpandSidebar(sidebarWidth)
     }
     // Web 桌面没有 Electron 标题栏里的侧栏展开按钮；宽屏下默认展开，避免用户被隐藏偏好卡住。
     if (!window.matchMedia(MOBILE_QUERY).matches) {
-      return shouldAutoExpandSidebar()
+      return shouldAutoExpandSidebar(sidebarWidth)
     }
     return localStorage.getItem(SIDEBAR_KEY) === 'true' || localStorage.getItem('inno-sidebar-visible') === 'true'
   })

--- a/client-ui/src/hooks/useSessionSidebarWidth.ts
+++ b/client-ui/src/hooks/useSessionSidebarWidth.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  SIDEBAR_DEFAULT_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+} from '../desktop/constants'
+
+const SIDEBAR_WIDTH_KEY = 'opptrix-sidebar-width'
+
+function readStoredWidth(): number {
+  if (typeof window === 'undefined') return SIDEBAR_DEFAULT_WIDTH
+  const raw = localStorage.getItem(SIDEBAR_WIDTH_KEY)
+  if (raw == null) return SIDEBAR_DEFAULT_WIDTH
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed)) return SIDEBAR_DEFAULT_WIDTH
+  return parsed
+}
+
+/** Read persisted sidebar width, clamped to viewport — for overlay threshold without drag hook */
+export function getSessionSidebarWidth(
+  viewportWidth: number,
+  workspaceMinWidth: number,
+): number {
+  return clampSessionSidebarWidth(readStoredWidth(), { viewportWidth, workspaceMinWidth })
+}
+
+export function clampSessionSidebarWidth(
+  width: number,
+  opts: { viewportWidth: number; workspaceMinWidth: number },
+): number {
+  const dynamicMax = opts.viewportWidth - opts.workspaceMinWidth
+  const max = Math.min(SIDEBAR_MAX_WIDTH, dynamicMax)
+  if (max < SIDEBAR_MIN_WIDTH) return SIDEBAR_MIN_WIDTH
+  return Math.max(SIDEBAR_MIN_WIDTH, Math.min(width, max))
+}
+
+interface Options {
+  enabled?: boolean
+  viewportWidth: number
+  workspaceMinWidth: number
+}
+
+export function useSessionSidebarWidth({
+  enabled = true,
+  viewportWidth,
+  workspaceMinWidth,
+}: Options) {
+  const [width, setWidth] = useState(() => {
+    const stored = readStoredWidth()
+    if (typeof window === 'undefined') return stored
+    return clampSessionSidebarWidth(stored, {
+      viewportWidth: window.innerWidth,
+      workspaceMinWidth,
+    })
+  })
+  const [isDragging, setIsDragging] = useState(false)
+  const widthRef = useRef(width)
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
+
+  useEffect(() => {
+    widthRef.current = width
+  }, [width])
+
+  useEffect(() => {
+    if (!enabled || isDragging) return
+    const clamped = clampSessionSidebarWidth(widthRef.current, { viewportWidth, workspaceMinWidth })
+    if (clamped !== widthRef.current) {
+      setWidth(clamped)
+      localStorage.setItem(SIDEBAR_WIDTH_KEY, String(clamped))
+    }
+  }, [enabled, isDragging, viewportWidth, workspaceMinWidth])
+
+  const commitWidth = useCallback((next: number) => {
+    const clamped = clampSessionSidebarWidth(next, { viewportWidth, workspaceMinWidth })
+    setWidth(clamped)
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(clamped))
+  }, [viewportWidth, workspaceMinWidth])
+
+  const beginDrag = useCallback((clientX: number) => {
+    if (!enabled) return
+    dragRef.current = { startX: clientX, startWidth: widthRef.current }
+    setIsDragging(true)
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }, [enabled])
+
+  const endDrag = useCallback(() => {
+    dragRef.current = null
+    setIsDragging(false)
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const onMove = (e: MouseEvent) => {
+      const drag = dragRef.current
+      if (!drag) return
+      const delta = e.clientX - drag.startX
+      const next = clampSessionSidebarWidth(drag.startWidth + delta, {
+        viewportWidth,
+        workspaceMinWidth,
+      })
+      setWidth(next)
+    }
+
+    const onUp = () => {
+      const hadDrag = dragRef.current != null
+      endDrag()
+      if (hadDrag) {
+        commitWidth(widthRef.current)
+      }
+    }
+
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+      endDrag()
+    }
+  }, [commitWidth, enabled, endDrag, viewportWidth, workspaceMinWidth])
+
+  return { width, isDragging, beginDrag }
+}

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -37,9 +37,10 @@ import {
 import { opptrixTokens, opptrixCssVars, type ThemePreference } from '../theme/tokens'
 import { useTheme } from '../theme/ThemeContext'
 import { isElectron } from '../platform/detect'
-import { DESKTOP_TITLEBAR_HEIGHT } from '../desktop/constants'
+import { DESKTOP_TITLEBAR_HEIGHT, WORKSPACE_CHAT_MIN_WIDTH } from '../desktop/constants'
 import { useDebouncedEffect } from '../hooks/useDebouncedEffect'
 import { useSidebarOverlayMode } from '../hooks/useBreakpoint'
+import { getSessionSidebarWidth } from '../hooks/useSessionSidebarWidth'
 
 const SCORECARD_SAVE_MS = 650
 
@@ -319,7 +320,19 @@ function SettingsPageView({
     setFontScaleState(name)
   }, [])
   const s = useStyles()
-  const sidebarOverlayMode = useSidebarOverlayMode(!isMobile)
+  const [viewportWidth, setViewportWidth] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth : 1280,
+  )
+  useEffect(() => {
+    const onResize = () => setViewportWidth(window.innerWidth)
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+  const sessionSidebarWidth = useMemo(
+    () => getSessionSidebarWidth(viewportWidth, WORKSPACE_CHAT_MIN_WIDTH),
+    [viewportWidth],
+  )
+  const sidebarOverlayMode = useSidebarOverlayMode(!isMobile, sessionSidebarWidth)
   const [section, setSection] = useState<SettingsSection>(() => normalizeSettingsSection(initialSection))
   const [search, setSearch] = useState('')
   const [wizardOpen, setWizardOpen] = useState(false)

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -148,4 +148,4 @@ Stacking order (low → high), defined in `client-ui/src/desktop/constants.ts` a
 | Toolbar + window controls | `1300` | `DESKTOP_Z_CHROME_TOOLS` — global fixed chrome |
 | Clickable session title | `1310` | `DESKTOP_Z_TITLE_INTERACTIVE` — title text above drag layer |
 
-Narrow windows (&lt; sidebar width × 2.5): left sidebar becomes a **full-height overlay** (`top: 0; bottom: 0`), light glass, **no fullscreen scrim**. Minimum width: `DESKTOP_CHAT_MIN_WIDTH` (510px), synced with `apps/desktop/electron/main.cjs`.
+Narrow windows (&lt; current session sidebar width × 2.5): left sidebar becomes a **full-height overlay** (`top: 0; bottom: 0`), light glass, **no fullscreen scrim**. At ≥ × 3, growing the window auto-expands the inline sidebar. Sidebar width defaults to 200px, draggable between ~196–360px, persisted in `localStorage` (`opptrix-sidebar-width`). Minimum window width: `DESKTOP_CHAT_MIN_WIDTH` (510px), synced with `apps/desktop/electron/main.cjs`.

--- a/docs/UI-LAYOUT.md
+++ b/docs/UI-LAYOUT.md
@@ -33,8 +33,13 @@
 ┌─────────────┬──────────────────────────────┬──────────────────┐
 │  Session    │  Chat + 工具过程 + 输入区     │  关注/发现/个股   │
 │  Sidebar    │  (flex 1)                    │  RightMarketPanel │
+│  可调宽     │                              │                   │
 └─────────────┴──────────────────────────────┴──────────────────┘
 ```
+
+- **默认宽度** 200px；拖拽范围约 196–360px，持久化至 `localStorage`（`opptrix-sidebar-width`）
+- **内联模式**：侧栏右缘可拖拽调宽（复用 `WorkspaceSplitDivider` 交互）
+- **浮层模式**：窗口宽度 &lt; 当前侧栏宽度 × 2.5 时侧栏浮于内容之上；≥ × 3 时窗口放大可自动展开内联侧栏
 
 代码：`client-ui/src/chat/ChatApp.tsx`、`client-ui/src/market/RightMarketPanel.tsx`。
 


### PR DESCRIPTION
## Summary
- 会话左侧栏可拖拽调宽并写入本地偏好
- 最小宽度覆盖 titlebar 工具按钮区；inline 仅保留一条分割线
- 标题栏 drag/title 位置与浮层阈值随侧栏宽度联动

## Test plan
- [ ] 拖拽侧栏右缘，刷新后宽度保留
- [ ] 拖到最窄时 titlebar 图标不被标题压住
- [ ] 仅一条竖分割线（无双线）
- [ ] 小窗口 overlay / 放大自动展开仍正常


Made with [Cursor](https://cursor.com)