### PR TITLE
feat(agent): 会话上下文管理与压缩

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1005,15 +1005,16 @@ app.patch<{ Params: { id: string }; Body: { title?: string; model?: string | nul
       }
     }
     if (model !== undefined) {
-      const updated = agent.setSessionModel(req.params.id, model)
+      const updated = await agent.setSessionModel(req.params.id, model)
       if (!updated) return reply.code(404).send({ error: 'session not found' })
       return {
         session: {
-          id: updated.id,
-          title: updated.title,
-          model: updated.model,
-          updatedAt: updated.updatedAt,
+          id: updated.session.id,
+          title: updated.session.title,
+          model: updated.session.model,
+          updatedAt: updated.session.updatedAt,
         },
+        contextHint: updated.contextHint,
       }
     }
     return reply.code(400).send({ error: 'title or model required' })

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1353,7 +1353,10 @@ export async function renameSession(id: string, title: string) {
 }
 
 export async function setSessionModel(id: string, model: string | null) {
-  return jsonFetch<{ session: Pick<SessionMeta, 'id' | 'title' | 'model' | 'updatedAt'> }>(`/sessions/${id}`, {
+  return jsonFetch<{
+    session: Pick<SessionMeta, 'id' | 'title' | 'model' | 'updatedAt'>
+    contextHint?: string
+  }>(`/sessions/${id}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ model }),

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -296,6 +296,9 @@ export default function ChatApp() {
     streamCacheRef.current.set(targetSessionId, next)
     if (activeIdRef.current === targetSessionId) {
       syncStreamSnapshotToUi(next, streamUiRef.current)
+      if (event.type === 'context_compact' && next.contextHint) {
+        setContextHintBanner(next.contextHint)
+      }
     }
   }, [])
 
@@ -332,6 +335,8 @@ export default function ChatApp() {
   const [chatScrollEpoch, setChatScrollEpoch] = useState(0)
   const [searchOpen, setSearchOpen] = useState(false)
   const [rolePersonaOpen, setRolePersonaOpen] = useState(false)
+  const [contextHintBanner, setContextHintBanner] = useState('')
+
   const [focusStockCode, setFocusStockCode] = useState<string | null>(null)
   const [newsCenterMounted, setNewsCenterMounted] = useState(() => view === 'news')
   const [marketDynamicsMounted, setMarketDynamicsMounted] = useState(() => view === 'market')
@@ -1004,10 +1009,13 @@ export default function ChatApp() {
     setSessionModelState(ref)
     if (!activeId) return
     try {
-      await setSessionModel(activeId, ref)
+      const res = await setSessionModel(activeId, ref)
       setSessions(prev => prev.map(sess =>
         sess.id === activeId ? { ...sess, model: ref } : sess,
       ))
+      if (res.contextHint?.trim()) {
+        setContextHintBanner(res.contextHint.trim())
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : '切换模型失败')
     }
@@ -1025,7 +1033,14 @@ export default function ChatApp() {
 
   useEffect(() => {
     setRolePersonaOpen(false)
+    setContextHintBanner('')
   }, [activeId, view])
+
+  useEffect(() => {
+    if (!contextHintBanner) return
+    const timer = window.setTimeout(() => setContextHintBanner(''), 4200)
+    return () => window.clearTimeout(timer)
+  }, [contextHintBanner])
 
   const openRolePersonaDrawer = useCallback(() => {
     setRolePersonaOpen(true)
@@ -1352,6 +1367,7 @@ export default function ChatApp() {
                   title={activeSession?.title ?? '新对话'}
                   titleSlot={electronChrome ? undefined : chatTitleSlot}
                   overlaySlot={rolePersonaDrawer}
+                  contextHint={contextHintBanner}
                   sessionId={activeId}
                   welcomeEpoch={welcomeEpoch}
                   chatScrollEpoch={chatScrollEpoch}

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -222,6 +222,21 @@ const useStyles = makeStyles({
     padding: '4px 0 8px',
     ...fadeInUp,
   },
+  contextHint: {
+    flexShrink: 0,
+    margin: '0 auto',
+    width: '100%',
+    maxWidth: opptrixTokens.chatThreadMaxWidth,
+    padding: '8px 16px',
+    boxSizing: 'border-box',
+    fontSize: 'var(--opptrix-font-sm)',
+    lineHeight: 1.45,
+    color: opptrixCssVars.textSecondary,
+    backgroundColor: opptrixCssVars.canvasAlt,
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    ...fadeInUp,
+    animationDuration: '280ms',
+  },
 })
 
 const WELCOME_LETTERS = ['O', 'p', 'p', 't', 'r', 'i', 'x'] as const
@@ -235,6 +250,8 @@ interface ChatViewProps {
   headerTrailing?: React.ReactNode
   /** 聊天区顶部浮层（如技能专长抽屉） */
   overlaySlot?: React.ReactNode
+  /** 上下文整理轻提示 */
+  contextHint?: string
   sessionId?: string | null
   welcomeEpoch?: number
   chatScrollEpoch?: number
@@ -275,7 +292,7 @@ interface ChatViewProps {
 }
 
 function ChatView({
-  title = '新对话', titleSlot, headerTrailing, overlaySlot, sessionId = null, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, composerDraft, loading, streamUiRef, error,
+  title = '新对话', titleSlot, headerTrailing, overlaySlot, contextHint, sessionId = null, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, composerDraft, loading, streamUiRef, error,
   availableModels = [],
   sessionModel,
   isMobile = false,
@@ -600,6 +617,12 @@ function ChatView({
           </div>
         </div>
       )}
+
+      {contextHint ? (
+        <div className={s.contextHint} role="status">
+          {contextHint}
+        </div>
+      ) : null}
 
       <div className={s.bodyShell} ref={bodyShellRef}>
         {overlaySlot}

--- a/client-ui/src/chat/sessionStreamRuntime.ts
+++ b/client-ui/src/chat/sessionStreamRuntime.ts
@@ -4,6 +4,8 @@ export type SessionStreamSnapshot = {
   liveTrace: ChatLiveTrace | null
   pendingUserPrompt: ChatUserPromptPayload | null
   userPromptSubmitting: boolean
+  /** 会话内上下文整理轻提示 */
+  contextHint: string | null
 }
 
 export function createEmptyStreamSnapshot(): SessionStreamSnapshot {
@@ -11,6 +13,7 @@ export function createEmptyStreamSnapshot(): SessionStreamSnapshot {
     liveTrace: null,
     pendingUserPrompt: null,
     userPromptSubmitting: false,
+    contextHint: null,
   }
 }
 
@@ -19,6 +22,7 @@ export function createThinkingStreamSnapshot(label = '模型正在思考…'): S
     liveTrace: { steps: [], thinkingLabel: label },
     pendingUserPrompt: null,
     userPromptSubmitting: false,
+    contextHint: null,
   }
 }
 
@@ -34,6 +38,16 @@ export function applyChatProgressEvent(
           steps: snapshot.liveTrace?.steps ?? [],
           thinkingLabel: event.label,
           thinkingSnippet: event.snippet ?? snapshot.liveTrace?.thinkingSnippet,
+        },
+      }
+    case 'context_compact':
+      return {
+        ...snapshot,
+        contextHint: event.message,
+        liveTrace: {
+          steps: snapshot.liveTrace?.steps ?? [],
+          thinkingLabel: '正在整理对话要点…',
+          thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
         },
       }
     case 'user_prompt':

--- a/client-ui/src/types/chat.ts
+++ b/client-ui/src/types/chat.ts
@@ -56,6 +56,8 @@ export interface AvailableModel {
   model: string
   providerId: string
   providerName: string
+  /** 启发式上下文窗口（tokens） */
+  contextTokens?: number
 }
 
 export interface ChatDisplayMessage {

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -45,6 +45,13 @@ export type ChatProgressEvent =
     cancelled?: boolean
   }
   | { type: 'error'; message: string }
+  | {
+    type: 'context_compact'
+    level: 'micro' | 'structured' | 'overflow_retry'
+    message: string
+    usageRatio?: number
+    contextTokens?: number
+  }
 
 export interface ChatLiveTrace {
   thinkingLabel?: string

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -195,6 +195,11 @@ Opptrix/
   - **默认研究员**：`POST /api/sessions` 不传 `expertId` → `expertId` / `expertIcon` 为 `null`，`rolePersona` 初始为默认投研研究员文案（可编辑）。
   - **专家会话**：传 `expertId`（须存在于目录）→ 持久化 `expertId` + `expertIcon` + `rolePersona` 快照；标题默认 `defaultSessionTitle` 或专家 `title`；首聊天轮前 `seedExpertDefaultPacks` 按专家 `defaultPacks` 激活工具包（每会话每专家仅播种一次）；`defaultResearchTier` 仍可从目录按 `expertId` 读取（未冻结）。
   - **专家目录（一期）**：`ExpertCatalogService` 合并内置（`LocalJsonExpertProvider` → `catalog.mock.json`，`source: "builtin"`）与用户自建（user-store `local_experts`，`source: "local"`）；`RemoteExpertProvider` 预留远程目录，REST 路径不变。REST：`GET/POST/PATCH/DELETE /api/experts*`；UI 专家市场见 `client-ui/src/pages/experts/ExpertMarketPage.tsx`。**如何设计自建专家与远程目录 JSON/HTTP 契约**（技能专长写法、消毒规则、静态/HTTP 部署）：[EXPERT-GUIDE.md §7](./EXPERT-GUIDE.md#7-远程专家-datasource)。
+- **会话上下文管理（长对话压缩）**：实现 `packages/agent/src/context/*` + `llm/model-context.ts`。
+  - **双视图**：UI 仍渲染完整 `turns`；喂给模型的是 `sessionMemory`（结构化工作记忆）+ 近端 messages（`assembleModelView`）。
+  - **窗长**：`resolveModelContextTokens(modelId)` 启发式（未知默认 128k）；`AvailableModel.contextTokens` 只读派生。预算预留输出与 system/tools；**soft 75%** → microcompact（压缩较早 tool 结果正文）；**hard 85%** → structuredCompact（独立一轮 LLM 写 `SessionMemory`，目标/约束神圣不可丢）。
+  - **触发**：每轮 `llm.chat` 前检查；上游 `context_length_exceeded` 等 → 强制 aggressive compact 后**重试 1 次**；`setSessionModel` 换模型后按新窗再检查。
+  - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。测试：`tests/session-context-compact.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
 - **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（末项可自由输入），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
 - **行业分析**：`industry_mining` / `industry_mermaid`（属 `industry` pack，需播种或 activate）→ 代表公司用 `search_instruments` + `get_instrument_*`

--- a/docs/API.md
+++ b/docs/API.md
@@ -637,6 +637,28 @@ Content-Type: application/json
 | GET | `/api/sessions/:id/role-persona` | `{ rolePersona, expertId }`；旧会话空值会惰性回填并持久化 |
 | PUT | `/api/sessions/:id/role-persona` | body `{ rolePersona }` → `sanitizeExpertPersona`；成功写回并返回 `{ rolePersona, expertId }` |
 
+**会话上下文压缩（长对话）**
+
+- 每轮聊天按当前模型启发式 `contextTokens` 估算用量；接近上限时 micro / structured 压缩，SSE 推送 `context_compact`。
+- UI transcript（`turns`）不变；模型侧使用 `sessionMemory` + 近端消息。详见 [AGENT-GUIDE §4.2](./AGENT-GUIDE.md#42-agent-与-mcp)。
+- `PATCH /api/sessions/:id` 切换 `model` 时按新窗口再检查；响应可含 `contextHint`（有压缩时）。
+
+**SSE `context_compact` 事件**
+
+```json
+{
+  "type": "context_compact",
+  "level": "structured",
+  "message": "已整理较早对话要点，后续仍按你的目标继续。",
+  "usageRatio": 0.88,
+  "contextTokens": 128000
+}
+```
+
+`level`：`micro` | `structured` | `overflow_retry`。
+
+**`AvailableModel.contextTokens`**：`GET /api/models/available` 等列表项附带启发式上下文窗口（只读派生，无需用户配置）。
+
 **POST `/api/sessions` body**
 
 | 字段 | 类型 | 说明 |

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -100,6 +100,13 @@ export type ChatProgressEvent =
     cancelled?: boolean
   }
   | { type: 'error'; message: string }
+  | {
+    type: 'context_compact'
+    level: 'micro' | 'structured' | 'overflow_retry'
+    message: string
+    usageRatio?: number
+    contextTokens?: number
+  }
 
 /**
  * 聊天进度回调选项 — 配置进度推送回调和中断信号。

--- a/packages/agent/src/context/compact.ts
+++ b/packages/agent/src/context/compact.ts
@@ -1,0 +1,326 @@
+import type { ChatMessage } from '../llm/provider.js'
+import type { LlmProvider } from '../llm/provider.js'
+import { repairToolCallSequences, tailMessagesForLlm } from '../llm/messages.js'
+import {
+  type ContextBudget,
+  resolveContextBudget,
+  resolveModelContextTokens,
+  usageRatio,
+} from '../llm/model-context.js'
+import {
+  formatSessionMemoryForPrompt,
+  parseSessionMemoryFromModelText,
+  STRUCTURED_COMPACT_SYSTEM,
+  type SessionMemory,
+} from './session-memory.js'
+import {
+  estimateMessageTokens,
+  estimateSystemToolsReserve,
+  estimateTextTokens,
+} from './token-estimate.js'
+import type { OpenAiTool } from '../tools.js'
+
+export const CONTEXT_COMPACT_HINT =
+  '已整理较早对话要点，后续仍按你的目标继续。'
+
+export type CompactLevel = 'micro' | 'structured' | 'overflow_retry'
+
+export interface CompactResult {
+  level: CompactLevel
+  message: string
+  usageRatio: number
+  contextTokens: number
+  changed: boolean
+}
+
+export interface SessionCompactState {
+  messages: ChatMessage[]
+  sessionMemory?: SessionMemory | null
+}
+
+const MICRO_TOOL_MAX = 480
+const KEEP_RECENT_DEFAULT = 16
+const KEEP_RECENT_AGGRESSIVE = 8
+
+function summarizeToolContent(content: string, toolName?: string): string {
+  const raw = content.trim()
+  if (raw.length <= MICRO_TOOL_MAX) return raw
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>
+      if (typeof obj.error === 'string') {
+        return JSON.stringify({ error: obj.error.slice(0, 200), _compacted: true })
+      }
+      const keys = Object.keys(obj).slice(0, 8)
+      const slim: Record<string, unknown> = { _compacted: true, tool: toolName ?? null }
+      for (const k of keys) {
+        const v = obj[k]
+        if (v == null || typeof v === 'number' || typeof v === 'boolean') {
+          slim[k] = v
+        } else if (typeof v === 'string') {
+          slim[k] = v.length > 120 ? `${v.slice(0, 120)}…` : v
+        } else if (Array.isArray(v)) {
+          slim[k] = `[array:${v.length}]`
+        } else {
+          slim[k] = '[object]'
+        }
+      }
+      return JSON.stringify(slim)
+    }
+  } catch {
+    /* plain text */
+  }
+  return `${raw.slice(0, MICRO_TOOL_MAX)}…[compacted]`
+}
+
+/** 压缩较早的 tool 消息体；保留近端 keepRecent 条成组消息不动 */
+export function microcompactMessages(
+  messages: ChatMessage[],
+  keepRecent = KEEP_RECENT_DEFAULT,
+): { messages: ChatMessage[]; changed: boolean } {
+  const repaired = repairToolCallSequences(messages)
+  if (repaired.length <= keepRecent) {
+    return { messages: repaired, changed: false }
+  }
+  const cut = repaired.length - keepRecent
+  let changed = false
+  const out = repaired.map((m, i) => {
+    if (i >= cut) return m
+    if (m.role !== 'tool' || !m.content) return m
+    const next = summarizeToolContent(String(m.content), m.name)
+    if (next !== m.content) {
+      changed = true
+      return { ...m, content: next }
+    }
+    return m
+  })
+  return { messages: out, changed }
+}
+
+function historyForSummarizer(messages: ChatMessage[], maxChars = 48_000): string {
+  const lines: string[] = []
+  let used = 0
+  for (const m of messages) {
+    const role = m.role
+    let body = ''
+    if (m.content) body = String(m.content)
+    if (m.tool_calls?.length) {
+      body += `\n[tool_calls:${m.tool_calls.map(t => t.function.name).join(',')}]`
+    }
+    if (role === 'tool') body = `[tool ${m.name ?? ''}]\n${body}`
+    const chunk = `${role}: ${body.slice(0, 2_000)}`
+    if (used + chunk.length > maxChars) break
+    lines.push(chunk)
+    used += chunk.length
+  }
+  return lines.join('\n\n')
+}
+
+export async function structuredCompact(
+  llm: LlmProvider,
+  state: SessionCompactState,
+  opts?: { keepRecent?: number; signal?: AbortSignal },
+): Promise<{ state: SessionCompactState; changed: boolean }> {
+  const keepRecent = opts?.keepRecent ?? KEEP_RECENT_DEFAULT
+  const repaired = repairToolCallSequences(state.messages)
+  if (repaired.length <= keepRecent + 2) {
+    return { state: { ...state, messages: repaired }, changed: false }
+  }
+
+  const cut = repaired.length - keepRecent
+  const older = repaired.slice(0, cut)
+  const transcript = historyForSummarizer(older)
+  if (!transcript.trim()) {
+    return { state: { ...state, messages: repaired }, changed: false }
+  }
+
+  const prevMemory = formatSessionMemoryForPrompt(state.sessionMemory)
+  const userContent = [
+    prevMemory ? `【已有工作记忆】\n${prevMemory}` : '',
+    '【待压缩的较早对话】',
+    transcript,
+  ].filter(Boolean).join('\n\n')
+
+  const turn = await llm.chat(
+    [
+      { role: 'system', content: STRUCTURED_COMPACT_SYSTEM },
+      { role: 'user', content: userContent },
+    ],
+    undefined,
+    opts?.signal,
+  )
+
+  if (turn.finishReason === 'error' || !turn.message.content?.trim()) {
+    const micro = microcompactMessages(repaired, keepRecent)
+    return {
+      state: { messages: micro.messages, sessionMemory: state.sessionMemory },
+      changed: micro.changed,
+    }
+  }
+
+  const memory = parseSessionMemoryFromModelText(
+    turn.message.content,
+    state.sessionMemory,
+    cut,
+  )
+  // 持久化仍保留全量 messages（UI 用 turns）；ModelView 靠 memory + 近端窗
+  const micro = microcompactMessages(repaired, keepRecent)
+  return {
+    state: {
+      messages: micro.messages,
+      sessionMemory: memory,
+    },
+    changed: true,
+  }
+}
+
+export function assembleModelView(opts: {
+  systemPrompt: string
+  sessionMemory?: SessionMemory | null
+  messages: ChatMessage[]
+  contextPrefix?: ChatMessage[]
+  keepRecent?: number
+}): ChatMessage[] {
+  const keepRecent = opts.keepRecent ?? KEEP_RECENT_DEFAULT
+  const out: ChatMessage[] = [{ role: 'system', content: opts.systemPrompt }]
+  const memoryText = formatSessionMemoryForPrompt(opts.sessionMemory)
+  if (memoryText) {
+    out.push({ role: 'system', content: memoryText })
+  }
+  if (opts.contextPrefix?.length) {
+    out.push(...opts.contextPrefix)
+  }
+  out.push(...tailMessagesForLlm(opts.messages, keepRecent))
+  return out
+}
+
+export function estimateModelViewTokens(messages: ChatMessage[]): number {
+  return estimateMessageTokens(messages)
+}
+
+export function buildBudgetForModel(
+  modelId: string,
+  systemPrompt: string,
+  tools?: OpenAiTool[],
+): ContextBudget {
+  const contextTokens = resolveModelContextTokens(modelId)
+  const reserve = estimateSystemToolsReserve(systemPrompt, tools)
+  return resolveContextBudget(contextTokens, reserve)
+}
+
+export async function ensureContextBudget(opts: {
+  modelId: string
+  systemPrompt: string
+  tools?: OpenAiTool[]
+  state: SessionCompactState
+  contextPrefix?: ChatMessage[]
+  llm: LlmProvider | null
+  signal?: AbortSignal
+  aggressive?: boolean
+}): Promise<{ state: SessionCompactState; results: CompactResult[]; modelView: ChatMessage[] }> {
+  const results: CompactResult[] = []
+  let state: SessionCompactState = {
+    messages: repairToolCallSequences(opts.state.messages),
+    sessionMemory: opts.state.sessionMemory ?? null,
+  }
+  const keepRecent = opts.aggressive ? KEEP_RECENT_AGGRESSIVE : KEEP_RECENT_DEFAULT
+  const budget = buildBudgetForModel(opts.modelId, opts.systemPrompt, opts.tools)
+
+  const buildView = () => assembleModelView({
+    systemPrompt: opts.systemPrompt,
+    sessionMemory: state.sessionMemory,
+    messages: state.messages,
+    contextPrefix: opts.contextPrefix,
+    keepRecent,
+  })
+
+  let view = buildView()
+  let used = estimateModelViewTokens(view) - estimateTextTokens(opts.systemPrompt)
+  // history-ish: exclude primary system from usage vs historyBudget
+  used = Math.max(0, estimateModelViewTokens(view) - estimateTextTokens(opts.systemPrompt))
+
+  if (used < budget.softLimit && !opts.aggressive) {
+    return { state, results, modelView: view }
+  }
+
+  // soft / aggressive → micro
+  {
+    const micro = microcompactMessages(state.messages, keepRecent)
+    if (micro.changed) {
+      state = { ...state, messages: micro.messages }
+      view = buildView()
+      used = Math.max(0, estimateModelViewTokens(view) - estimateTextTokens(opts.systemPrompt))
+      results.push({
+        level: opts.aggressive ? 'overflow_retry' : 'micro',
+        message: CONTEXT_COMPACT_HINT,
+        usageRatio: usageRatio(used, budget),
+        contextTokens: budget.contextTokens,
+        changed: true,
+      })
+    }
+  }
+
+  if (used < budget.hardLimit && !opts.aggressive) {
+    return { state, results, modelView: view }
+  }
+
+  if (!opts.llm) {
+    // 无 LLM：进一步缩短近端
+    const micro2 = microcompactMessages(state.messages, KEEP_RECENT_AGGRESSIVE)
+    state = { ...state, messages: micro2.messages }
+    view = assembleModelView({
+      systemPrompt: opts.systemPrompt,
+      sessionMemory: state.sessionMemory,
+      messages: state.messages,
+      contextPrefix: opts.contextPrefix,
+      keepRecent: KEEP_RECENT_AGGRESSIVE,
+    })
+    used = Math.max(0, estimateModelViewTokens(view) - estimateTextTokens(opts.systemPrompt))
+    if (micro2.changed) {
+      results.push({
+        level: 'micro',
+        message: CONTEXT_COMPACT_HINT,
+        usageRatio: usageRatio(used, budget),
+        contextTokens: budget.contextTokens,
+        changed: true,
+      })
+    }
+    return { state, results, modelView: view }
+  }
+
+  const structured = await structuredCompact(opts.llm, state, {
+    keepRecent,
+    signal: opts.signal,
+  })
+  state = structured.state
+  view = buildView()
+  used = Math.max(0, estimateModelViewTokens(view) - estimateTextTokens(opts.systemPrompt))
+  if (structured.changed) {
+    results.push({
+      level: opts.aggressive ? 'overflow_retry' : 'structured',
+      message: CONTEXT_COMPACT_HINT,
+      usageRatio: usageRatio(used, budget),
+      contextTokens: budget.contextTokens,
+      changed: true,
+    })
+  }
+
+  return { state, results, modelView: view }
+}
+
+export function isContextOverflowError(error: string | undefined, content?: string | null): boolean {
+  const text = `${error ?? ''} ${content ?? ''}`.toLowerCase()
+  if (!text.trim()) return false
+  return (
+    text.includes('context_length_exceeded')
+    || text.includes('context length')
+    || text.includes('maximum context')
+    || text.includes('too many tokens')
+    || text.includes('token limit')
+    || text.includes('context window')
+    || text.includes('exceeds the model')
+    || text.includes('prompt is too long')
+    || text.includes('max_tokens') && text.includes('exceed')
+  )
+}

--- a/packages/agent/src/context/session-memory.ts
+++ b/packages/agent/src/context/session-memory.ts
@@ -1,0 +1,121 @@
+/**
+ * 会话工作记忆 — 结构化压缩后的投研上下文。
+ * Display transcript（turns）不变；ModelView 注入本结构。
+ */
+
+export interface SessionMemory {
+  /** 用户原始诉求 / 当前阶段目标（神圣，压缩时禁止省略） */
+  goal: string
+  /** 约束：市场范围、时间、红线等 */
+  constraints: string
+  /** 标的、行业、关键事件 */
+  entities: string
+  /** 已取证结论 */
+  facts: string
+  /** 用户确认过的偏好 */
+  decisions: string
+  /** 未决问题 */
+  openQuestions: string
+  /** 已否证假设 */
+  rejected: string
+  /** 下一轮应继续什么 */
+  workingState: string
+  updatedAt: string
+  /** 生成该摘要时已覆盖的 messages 条数（近似水位） */
+  sourceMessageCount: number
+  compactVersion: number
+}
+
+export function emptySessionMemory(partial?: Partial<SessionMemory>): SessionMemory {
+  return {
+    goal: '',
+    constraints: '',
+    entities: '',
+    facts: '',
+    decisions: '',
+    openQuestions: '',
+    rejected: '',
+    workingState: '',
+    updatedAt: new Date().toISOString(),
+    sourceMessageCount: 0,
+    compactVersion: 1,
+    ...partial,
+  }
+}
+
+export function formatSessionMemoryForPrompt(memory: SessionMemory | null | undefined): string | null {
+  if (!memory) return null
+  const sections: Array<[string, string]> = [
+    ['目标（必须遵守）', memory.goal],
+    ['约束', memory.constraints],
+    ['标的与实体', memory.entities],
+    ['已确认事实', memory.facts],
+    ['已做决定', memory.decisions],
+    ['未决问题', memory.openQuestions],
+    ['已否证', memory.rejected],
+    ['当前进度', memory.workingState],
+  ]
+  const body = sections
+    .filter(([, v]) => v.trim())
+    .map(([k, v]) => `### ${k}\n${v.trim()}`)
+    .join('\n\n')
+  if (!body.trim()) return null
+  return [
+    '【会话工作记忆 — 较早对话已整理；须延续目标与约束，勿遗忘标的与结论】',
+    body,
+  ].join('\n\n')
+}
+
+export function parseSessionMemoryFromModelText(
+  raw: string,
+  prev: SessionMemory | null | undefined,
+  sourceMessageCount: number,
+): SessionMemory {
+  const text = raw.replace(/\r\n/g, '\n').trim()
+  const pick = (label: string): string => {
+    const re = new RegExp(
+      `(?:^|\\n)(?:#+\\s*)?${label}\\s*[:：]?\\s*\\n([\\s\\S]*?)(?=\\n(?:#+\\s*)?(?:目标|约束|标的|实体|事实|决定|未决|否证|进度|Goal|Constraints|Entities|Facts|Decisions|Open|Rejected|Working)\\b|$)`,
+      'i',
+    )
+    const m = text.match(re)
+    return m?.[1]?.trim() ?? ''
+  }
+
+  const goal = pick('目标') || pick('Goal') || prev?.goal || ''
+  const constraints = pick('约束') || pick('Constraints') || prev?.constraints || ''
+  const entities = pick('标的与实体') || pick('标的') || pick('实体') || pick('Entities') || prev?.entities || ''
+  const facts = pick('已确认事实') || pick('事实') || pick('Facts') || prev?.facts || ''
+  const decisions = pick('已做决定') || pick('决定') || pick('Decisions') || prev?.decisions || ''
+  const openQuestions = pick('未决问题') || pick('未决') || pick('Open') || prev?.openQuestions || ''
+  const rejected = pick('已否证') || pick('否证') || pick('Rejected') || prev?.rejected || ''
+  const workingState = pick('当前进度') || pick('进度') || pick('Working') || prev?.workingState || ''
+
+  return emptySessionMemory({
+    goal: goal || prev?.goal || '（未提取到明确目标，请根据最近用户消息推断并延续）',
+    constraints,
+    entities,
+    facts,
+    decisions,
+    openQuestions,
+    rejected,
+    workingState,
+    sourceMessageCount,
+    compactVersion: (prev?.compactVersion ?? 0) + 1,
+  })
+}
+
+export const STRUCTURED_COMPACT_SYSTEM = [
+  '你是会话上下文整理器。将对话历史压缩为结构化工作记忆。',
+  '必须保留：用户目标原文要点、约束、标的代码/名称、已确认数字与结论（带来源简述）、未决问题。',
+  '可丢弃：冗长行情表、重复工具 JSON、已过期探索分支。',
+  '禁止编造事实；不确定处写「不确定」。',
+  '只输出以下 Markdown 分区（中文标题），不要寒暄：',
+  '## 目标',
+  '## 约束',
+  '## 标的与实体',
+  '## 已确认事实',
+  '## 已做决定',
+  '## 未决问题',
+  '## 已否证',
+  '## 当前进度',
+].join('\n')

--- a/packages/agent/src/context/token-estimate.ts
+++ b/packages/agent/src/context/token-estimate.ts
@@ -1,0 +1,52 @@
+import type { ChatMessage } from '../llm/provider.js'
+import type { OpenAiTool } from '../tools.js'
+
+/** 中英混合粗估：CJK 偏多时略紧 */
+export function estimateTextTokens(text: string): number {
+  if (!text) return 0
+  let cjk = 0
+  let other = 0
+  for (const ch of text) {
+    const code = ch.codePointAt(0) ?? 0
+    if (
+      (code >= 0x4e00 && code <= 0x9fff)
+      || (code >= 0x3400 && code <= 0x4dbf)
+      || (code >= 0x3000 && code <= 0x303f)
+    ) {
+      cjk += 1
+    } else {
+      other += 1
+    }
+  }
+  return Math.ceil(cjk * 0.6 + other / 4)
+}
+
+export function estimateMessageTokens(messages: ChatMessage[]): number {
+  let total = 0
+  for (const m of messages) {
+    total += 4
+    if (m.content) total += estimateTextTokens(String(m.content))
+    if (m.name) total += estimateTextTokens(m.name)
+    if (m.tool_calls?.length) {
+      for (const tc of m.tool_calls) {
+        total += estimateTextTokens(tc.function.name)
+        total += estimateTextTokens(tc.function.arguments ?? '')
+        total += 8
+      }
+    }
+  }
+  return total
+}
+
+export function estimateToolsTokens(tools: OpenAiTool[] | undefined): number {
+  if (!tools?.length) return 0
+  try {
+    return estimateTextTokens(JSON.stringify(tools))
+  } catch {
+    return tools.length * 120
+  }
+}
+
+export function estimateSystemToolsReserve(systemPrompt: string, tools?: OpenAiTool[]): number {
+  return estimateTextTokens(systemPrompt) + estimateToolsTokens(tools) + 512
+}

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -2,7 +2,6 @@ import type { ResearchHub } from '@opptrix/research-hub'
 import type { AgentAppContext } from './app-context.js'
 import { getCurrentTime } from './app-context.js'
 import { type ChatMessage } from './llm/provider.js'
-import { tailMessagesForLlm } from './llm/messages.js'
 import { ProviderRegistry, type ProviderProfile, type AvailableModel } from './llm/providers.js'
 import { DiscoverRunner } from './discover.js'
 import { ToolRegistry } from './tools.js'
@@ -51,6 +50,11 @@ import {
   bindWorkspaceToolBridge,
   type WorkspaceToolBridge,
 } from './mcp/workspace-tools.js'
+import {
+  CONTEXT_COMPACT_HINT,
+  ensureContextBudget,
+  isContextOverflowError,
+} from './context/compact.js'
 
 export interface AgentSettings {
   providers?: ProviderProfile[]
@@ -291,12 +295,76 @@ export class AgentEngine {
     return this.registry.listAvailable()
   }
 
-  setSessionModel(sessionId: string, modelRef: string | null) {
+  async setSessionModel(sessionId: string, modelRef: string | null): Promise<{
+    session: SessionRecord
+    contextHint?: string
+  } | null> {
     const record = this.sessions.get(sessionId)
     if (!record) return null
     record.model = modelRef?.trim() || undefined
     this.sessions.save(record)
-    return record
+
+    const activeModel = record.model
+    const llm = this.registry.createLlm(activeModel)
+    const resolved = this.registry.resolve(activeModel)
+    const modelId = resolved?.model ?? activeModel?.replace(/^[^:]+:/, '') ?? 'default'
+    const systemPrompt = this.buildRoundSystemPrompt(sessionId, [])
+    const budget = await this.applyContextBudget(record, {
+      modelId,
+      systemPrompt,
+      tools: undefined,
+      llm,
+      emit: undefined,
+      aggressive: false,
+    })
+    return { session: record, contextHint: budget.hint }
+  }
+
+  /** 按模型窗预算压缩；返回用户可见轻提示文案（无变更则 undefined） */
+  private async applyContextBudget(
+    record: SessionRecord,
+    opts: {
+      modelId: string
+      systemPrompt: string
+      tools?: import('./tools.js').OpenAiTool[]
+      llm: ReturnType<ProviderRegistry['createLlm']>
+      emit?: (event: ChatProgressEvent) => void
+      aggressive?: boolean
+      contextPrefix?: ChatMessage[]
+      signal?: AbortSignal
+    },
+  ): Promise<{ hint?: string; modelView: ChatMessage[] }> {
+    const result = await ensureContextBudget({
+      modelId: opts.modelId,
+      systemPrompt: opts.systemPrompt,
+      tools: opts.tools,
+      state: {
+        messages: record.messages,
+        sessionMemory: record.sessionMemory,
+      },
+      contextPrefix: opts.contextPrefix,
+      llm: opts.llm,
+      signal: opts.signal,
+      aggressive: opts.aggressive,
+    })
+
+    if (result.results.some(r => r.changed)) {
+      record.messages = result.state.messages
+      record.sessionMemory = result.state.sessionMemory ?? null
+      this.sessions.save(record)
+      for (const r of result.results) {
+        if (!r.changed) continue
+        opts.emit?.({
+          type: 'context_compact',
+          level: r.level,
+          message: r.message,
+          usageRatio: r.usageRatio,
+          contextTokens: r.contextTokens,
+        })
+      }
+      return { hint: CONTEXT_COMPACT_HINT, modelView: result.modelView }
+    }
+    return { modelView: result.modelView }
   }
 
   createSession(opts?: CreateSessionOptions) {
@@ -604,11 +672,25 @@ export class AgentEngine {
       // 每轮刷新会话时钟，保证长工具链下「截至」仍准确
       const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
       const contextMessages = contextRefToChatMessages(record.contextRef)
-      const messages: ChatMessage[] = [
-        { role: 'system', content: systemPrompt },
-        ...contextMessages,
-        ...tailMessagesForLlm(record.messages),
-      ]
+      const resolvedModel = this.registry.resolve(activeModel)
+      const modelId = resolvedModel?.model
+        ?? activeModel?.replace(/^[^:]+:/, '')
+        ?? 'default'
+
+      let overflowRetried = false
+      const runLlmRound = async (aggressive: boolean) => {
+        const budgeted = await this.applyContextBudget(record, {
+          modelId,
+          systemPrompt,
+          tools: openAiTools,
+          llm,
+          emit,
+          aggressive,
+          contextPrefix: contextMessages,
+          signal,
+        })
+        return llm.chat(budgeted.modelView, openAiTools, signal)
+      }
 
       emit({
         type: 'thinking',
@@ -621,14 +703,32 @@ export class AgentEngine {
         research_tier: this.lastRoutePlan?.researchTier,
       })
 
-      const turn = await llm.chat(messages, openAiTools, signal)
+      let turn = await runLlmRound(false)
       throwIfAborted(signal)
+
+      if (
+        turn.finishReason === 'error'
+        && !overflowRetried
+        && (turn.contextOverflow || isContextOverflowError(turn.error, turn.message.content))
+      ) {
+        overflowRetried = true
+        emit({
+          type: 'context_compact',
+          level: 'overflow_retry',
+          message: CONTEXT_COMPACT_HINT,
+        })
+        turn = await runLlmRound(true)
+        throwIfAborted(signal)
+      }
 
       if (turn.finishReason === 'error') {
         if (turn.error === 'cancelled' || signal?.aborted) {
           return finalizeCancelled(toolsUsed, toolSteps)
         }
-        const reply = turn.message.content ?? turn.error ?? '请求失败'
+        const overflow = turn.contextOverflow || isContextOverflowError(turn.error, turn.message.content)
+        const reply = overflow
+          ? '对话内容过多，整理后仍无法继续。请新开对话，或换用更大上下文窗口的模型。'
+          : (turn.message.content ?? turn.error ?? '请求失败')
         pushAssistant(reply, toolsUsed, toolSteps)
         emit({
           type: 'error',

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -98,5 +98,28 @@ export {
 } from './experts/prompt-assembler.js'
 export { SessionArchiveFolderStore, DEFAULT_SESSION_ARCHIVE_FOLDERS, type SessionArchiveFolder } from './archive-folders.js'
 export { ProviderRegistry, type ProviderProfile, type AvailableModel } from './llm/providers.js'
+export {
+  resolveModelContextTokens,
+  resolveContextBudget,
+  DEFAULT_CONTEXT_TOKENS,
+  SOFT_USAGE_RATIO,
+  HARD_USAGE_RATIO,
+} from './llm/model-context.js'
+export {
+  type SessionMemory,
+  formatSessionMemoryForPrompt,
+  emptySessionMemory,
+  parseSessionMemoryFromModelText,
+} from './context/session-memory.js'
+export {
+  ensureContextBudget,
+  assembleModelView,
+  microcompactMessages,
+  isContextOverflowError,
+  CONTEXT_COMPACT_HINT,
+  type CompactLevel,
+  type CompactResult,
+} from './context/compact.js'
+export { estimateTextTokens, estimateMessageTokens } from './context/token-estimate.js'
 export { createProvider, isConfigured, fetchOpenAiModelList, type LlmConfig } from './llm/provider.js'
 export { initOutboundNetwork, type OutboundConnectFamily, type OutboundNetworkStatus } from './llm/outbound-network.js'

--- a/packages/agent/src/llm/model-context.ts
+++ b/packages/agent/src/llm/model-context.ts
@@ -1,0 +1,72 @@
+/**
+ * 按模型名启发式解析上下文窗口（tokens）。
+ * 未知模型默认 128k；不要求用户配置。
+ */
+
+export const DEFAULT_CONTEXT_TOKENS = 128_000
+export const OUTPUT_RESERVE_TOKENS = 8_192
+/** soft：触发 microcompact；hard：触发 structured compact */
+export const SOFT_USAGE_RATIO = 0.75
+export const HARD_USAGE_RATIO = 0.85
+
+interface ModelContextRule {
+  match: RegExp
+  tokens: number
+}
+
+/** 按优先级匹配（更具体的规则应靠前） */
+const MODEL_CONTEXT_RULES: ModelContextRule[] = [
+  { match: /claude[-_]?(opus|sonnet).*[14]m|\[1m\]|1m[-_]?context/i, tokens: 1_000_000 },
+  { match: /gemini[-_]?2\.5|gemini[-_]?2\.0|gemini[-_]?1\.5/i, tokens: 1_000_000 },
+  { match: /gpt[-_]?4\.1|o3|o4[-_]?mini/i, tokens: 200_000 },
+  { match: /claude[-_]?(opus|sonnet|haiku).*4|claude[-_]?3[-_.]?[57]/i, tokens: 200_000 },
+  { match: /gpt[-_]?4o|chatgpt[-_]?4o|gpt[-_]?4[-_]?turbo/i, tokens: 128_000 },
+  { match: /deepseek|qwen[-_]?2\.5|qwen2\.5|qwen[-_]?long|qwq/i, tokens: 128_000 },
+  { match: /qwen|moonshot|kimi|glm[-_]?4|doubao/i, tokens: 128_000 },
+  { match: /gpt[-_]?3\.5|gpt[-_]?35/i, tokens: 16_384 },
+  { match: /claude[-_]?instant|claude[-_]?2/i, tokens: 100_000 },
+  { match: /llama[-_]?3|llama3/i, tokens: 128_000 },
+  { match: /mistral|mixtral|command[-_]?r/i, tokens: 128_000 },
+]
+
+export function resolveModelContextTokens(modelId: string): number {
+  const id = modelId.trim()
+  if (!id) return DEFAULT_CONTEXT_TOKENS
+  for (const rule of MODEL_CONTEXT_RULES) {
+    if (rule.match.test(id)) return rule.tokens
+  }
+  return DEFAULT_CONTEXT_TOKENS
+}
+
+export interface ContextBudget {
+  contextTokens: number
+  /** system + tools 预留（调用方传入估算或默认） */
+  systemToolsReserve: number
+  outputReserve: number
+  /** 可用于历史/memory 的预算 */
+  historyBudget: number
+  softLimit: number
+  hardLimit: number
+}
+
+export function resolveContextBudget(
+  contextTokens: number,
+  systemToolsReserve = 6_000,
+): ContextBudget {
+  const outputReserve = OUTPUT_RESERVE_TOKENS
+  const sysReserve = Math.max(0, Math.floor(systemToolsReserve))
+  const historyBudget = Math.max(2_000, contextTokens - outputReserve - sysReserve)
+  return {
+    contextTokens,
+    systemToolsReserve: sysReserve,
+    outputReserve,
+    historyBudget,
+    softLimit: Math.floor(historyBudget * SOFT_USAGE_RATIO),
+    hardLimit: Math.floor(historyBudget * HARD_USAGE_RATIO),
+  }
+}
+
+export function usageRatio(usedTokens: number, budget: ContextBudget): number {
+  if (budget.historyBudget <= 0) return 1
+  return usedTokens / budget.historyBudget
+}

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -29,6 +29,8 @@ export interface LlmTurn {
   message: ChatMessage
   finishReason: 'stop' | 'tool_calls' | 'error'
   error?: string
+  /** 上游响应表明上下文超限 */
+  contextOverflow?: boolean
 }
 
 export interface LlmProvider {
@@ -42,6 +44,28 @@ export function isConfigured(cfg: LlmConfig) {
 
 export function createProvider(cfg: LlmConfig): LlmProvider {
   return new OpenAiCompatibleProvider(cfg)
+}
+
+function isContextLengthHttpError(status: number, body: string): boolean {
+  const text = body.toLowerCase()
+  if (
+    text.includes('context_length_exceeded')
+    || text.includes('context length')
+    || text.includes('maximum context')
+    || text.includes('too many tokens')
+    || text.includes('prompt is too long')
+    || text.includes('token limit')
+    || (text.includes('context window') && text.includes('exceed'))
+  ) {
+    return true
+  }
+  // 部分网关用 400/413 表示超限
+  if ((status === 400 || status === 413) && (
+    text.includes('token') || text.includes('context') || text.includes('length')
+  )) {
+    return /exceed|too (?:long|large|many)|maximum|limit/i.test(text)
+  }
+  return false
 }
 
 export class OpenAiCompatibleProvider implements LlmProvider {
@@ -93,12 +117,20 @@ export class OpenAiCompatibleProvider implements LlmProvider {
 
       if (!resp.ok) {
         const text = (await resp.text()).slice(0, 300)
+        const overflow = isContextLengthHttpError(resp.status, text)
         const msg = resp.status === 401
           ? '⚠️ API Key 无效'
           : resp.status === 429
             ? '⚠️ 请求过于频繁'
-            : `⚠️ HTTP ${resp.status}: ${text}`
-        return { message: { role: 'assistant', content: msg }, finishReason: 'error', error: msg }
+            : overflow
+              ? '对话内容过多，正在整理后重试…'
+              : `⚠️ HTTP ${resp.status}: ${text}`
+        return {
+          message: { role: 'assistant', content: msg },
+          finishReason: 'error',
+          error: overflow ? 'context_length_exceeded' : msg,
+          contextOverflow: overflow,
+        }
       }
 
       const data = await resp.json() as {

--- a/packages/agent/src/llm/providers.ts
+++ b/packages/agent/src/llm/providers.ts
@@ -1,4 +1,5 @@
 import { createProvider, isConfigured, fetchOpenAiModelList, type LlmConfig } from './provider.js'
+import { resolveModelContextTokens } from './model-context.js'
 
 export { fetchOpenAiModelList }
 
@@ -15,6 +16,8 @@ export interface AvailableModel {
   model: string
   providerId: string
   providerName: string
+  /** 启发式上下文窗口（tokens） */
+  contextTokens: number
 }
 
 export function normalizeBaseUrl(url: string): string {
@@ -45,6 +48,7 @@ export class ProviderRegistry {
           model,
           providerId: p.id,
           providerName: p.name,
+          contextTokens: resolveModelContextTokens(model),
         })
       }
     }

--- a/packages/agent/src/sessions.ts
+++ b/packages/agent/src/sessions.ts
@@ -83,6 +83,10 @@ export interface SessionRecord extends SessionMeta {
    * 列表 meta 不返回此字段全文。
    */
   rolePersona?: string | null
+  /**
+   * 结构化会话工作记忆（压缩产物）。列表 meta 不返回；UI transcript 仍用 turns。
+   */
+  sessionMemory?: import('./context/session-memory.js').SessionMemory | null
 }
 
 function previewText(content: string, max = 72): string {
@@ -136,6 +140,7 @@ function normalizeRecord(raw: SessionRecord): SessionRecord {
     expertId: raw.expertId ?? null,
     expertIcon: raw.expertIcon ?? null,
     rolePersona: raw.rolePersona ?? null,
+    sessionMemory: raw.sessionMemory ?? null,
   }
   return migrateTurns(record)
 }

--- a/tests/session-context-compact.test.mjs
+++ b/tests/session-context-compact.test.mjs
@@ -1,0 +1,229 @@
+/**
+ * 会话上下文压缩 — 窗长启发式、micro/structured、overflow 识别
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  resolveModelContextTokens,
+  resolveContextBudget,
+  SOFT_USAGE_RATIO,
+  HARD_USAGE_RATIO,
+  DEFAULT_CONTEXT_TOKENS,
+  estimateTextTokens,
+  microcompactMessages,
+  assembleModelView,
+  isContextOverflowError,
+  emptySessionMemory,
+  formatSessionMemoryForPrompt,
+  parseSessionMemoryFromModelText,
+  ensureContextBudget,
+  CONTEXT_COMPACT_HINT,
+} from '../packages/agent/dist/index.js'
+
+function buildFatToolHistory(rounds, payloadChars) {
+  const messages = [{ role: 'user', content: '分析 600519 并对比同行' }]
+  for (let i = 0; i < rounds; i++) {
+    messages.push({
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: `c${i}`,
+        type: 'function',
+        function: { name: 'get_quote', arguments: '{}' },
+      }],
+    })
+    messages.push({
+      role: 'tool',
+      tool_call_id: `c${i}`,
+      name: 'get_quote',
+      content: JSON.stringify({ price: 1800, blob: 'x'.repeat(payloadChars) }),
+    })
+  }
+  messages.push({ role: 'assistant', content: '先看估值与量价。' })
+  return messages
+}
+
+test('resolveModelContextTokens maps common families', () => {
+  assert.equal(resolveModelContextTokens('gpt-4o'), 128_000)
+  assert.equal(resolveModelContextTokens('claude-sonnet-4'), 200_000)
+  assert.equal(resolveModelContextTokens('gpt-3.5-turbo'), 16_384)
+  assert.equal(resolveModelContextTokens('unknown-xyz'), DEFAULT_CONTEXT_TOKENS)
+})
+
+test('resolveContextBudget soft/hard ratios', () => {
+  const b = resolveContextBudget(100_000, 10_000)
+  assert.ok(b.historyBudget > 0)
+  assert.equal(b.softLimit, Math.floor(b.historyBudget * SOFT_USAGE_RATIO))
+  assert.equal(b.hardLimit, Math.floor(b.historyBudget * HARD_USAGE_RATIO))
+  assert.ok(b.softLimit < b.hardLimit)
+})
+
+test('estimateTextTokens charges CJK tighter than latin chars/4', () => {
+  const latin = estimateTextTokens('x'.repeat(400))
+  const cjk = estimateTextTokens('中文测试'.repeat(100))
+  assert.ok(latin > 0 && cjk > 0)
+  // CJK ≈0.6 tok/char vs latin ≈0.25 → same length costs more for CJK
+  assert.ok(cjk > latin)
+  assert.equal(cjk, Math.ceil(400 * 0.6))
+  assert.equal(latin, Math.ceil(400 / 4))
+})
+
+test('microcompactMessages shortens old tool bodies and keeps recent intact', () => {
+  const messages = []
+  for (let i = 0; i < 10; i++) {
+    messages.push({
+      role: 'assistant',
+      content: null,
+      tool_calls: [{
+        id: `c${i}`,
+        type: 'function',
+        function: { name: 'get_quote', arguments: '{}' },
+      }],
+    })
+    messages.push({
+      role: 'tool',
+      tool_call_id: `c${i}`,
+      name: 'get_quote',
+      content: JSON.stringify({ price: 1, payload: 'x'.repeat(2000) }),
+    })
+  }
+  const { messages: out, changed } = microcompactMessages(messages, 4)
+  assert.equal(changed, true)
+  assert.equal(out.length, messages.length)
+  const oldTool = out[1]
+  assert.equal(oldTool.role, 'tool')
+  assert.ok(String(oldTool.content).length < 2000)
+  assert.match(String(oldTool.content), /_compacted|compacted/)
+  const recentTool = out[out.length - 1]
+  assert.equal(String(recentTool.content).length > 1500, true)
+})
+
+test('assembleModelView injects session memory and keeps system first', () => {
+  const memory = emptySessionMemory({
+    goal: '分析 600519 基本面',
+    entities: '600519 贵州茅台',
+  })
+  const view = assembleModelView({
+    systemPrompt: 'LAYER0',
+    sessionMemory: memory,
+    messages: [
+      { role: 'user', content: '继续' },
+      { role: 'assistant', content: '好的' },
+    ],
+    keepRecent: 24,
+  })
+  assert.equal(view[0].role, 'system')
+  assert.equal(view[0].content, 'LAYER0')
+  assert.equal(view[1].role, 'system')
+  assert.match(String(view[1].content), /600519/)
+  assert.match(String(view[1].content), /工作记忆/)
+})
+
+test('parseSessionMemoryFromModelText preserves goal as sacred', () => {
+  const prev = emptySessionMemory({ goal: '旧目标保留', entities: '旧实体' })
+  const parsed = parseSessionMemoryFromModelText(
+    [
+      '## 目标',
+      '研究宁德时代供需',
+      '## 约束',
+      '只用公开数据',
+      '## 标的与实体',
+      '300750',
+      '## 已确认事实',
+      '',
+      '## 已做决定',
+      '',
+      '## 未决问题',
+      '估值是否偏高',
+      '## 已否证',
+      '',
+      '## 当前进度',
+      '待取财报',
+    ].join('\n'),
+    prev,
+    40,
+  )
+  assert.match(parsed.goal, /宁德时代/)
+  assert.match(parsed.entities, /300750/)
+  assert.match(parsed.openQuestions, /估值/)
+  assert.equal(parsed.compactVersion, 2)
+  const formatted = formatSessionMemoryForPrompt(parsed)
+  assert.ok(formatted)
+  assert.match(formatted, /目标/)
+})
+
+test('isContextOverflowError detects common upstream phrases', () => {
+  assert.equal(isContextOverflowError('context_length_exceeded'), true)
+  assert.equal(isContextOverflowError(undefined, 'Error: maximum context length'), true)
+  assert.equal(isContextOverflowError('rate_limit'), false)
+  assert.ok(CONTEXT_COMPACT_HINT.includes('整理'))
+})
+
+test('ensureContextBudget soft path triggers micro on small window', async () => {
+  const messages = buildFatToolHistory(40, 4000)
+  const { results, state } = await ensureContextBudget({
+    modelId: 'gpt-3.5-turbo',
+    systemPrompt: 'LAYER0',
+    state: { messages, sessionMemory: null },
+    llm: null,
+  })
+  assert.ok(results.some((r) => r.level === 'micro' && r.changed))
+  const oldTool = state.messages.find((m) => m.role === 'tool')
+  assert.ok(oldTool)
+  assert.ok(String(oldTool.content).length < 4000)
+  // tool_calls 成组：assistant(tool_calls) 后仍有对应 tool
+  for (let i = 0; i < state.messages.length; i++) {
+    const m = state.messages[i]
+    if (m.role === 'assistant' && m.tool_calls?.length) {
+      const id = m.tool_calls[0].id
+      const next = state.messages[i + 1]
+      assert.equal(next?.role, 'tool')
+      assert.equal(next?.tool_call_id, id)
+    }
+  }
+})
+
+test('ensureContextBudget hard path writes sessionMemory via mock llm', async () => {
+  const messages = buildFatToolHistory(40, 4000)
+  const mockLlm = {
+    async chat() {
+      return {
+        message: {
+          role: 'assistant',
+          content: [
+            '## 目标',
+            '分析 600519 并对比同行',
+            '## 约束',
+            '只用公开数据',
+            '## 标的与实体',
+            '600519',
+            '## 已确认事实',
+            '股价约 1800',
+            '## 已做决定',
+            '',
+            '## 未决问题',
+            '估值是否偏高',
+            '## 已否证',
+            '',
+            '## 当前进度',
+            '待取财报',
+          ].join('\n'),
+        },
+        finishReason: 'stop',
+      }
+    },
+    async listModels() {
+      return []
+    },
+  }
+  const { results, state } = await ensureContextBudget({
+    modelId: 'gpt-3.5-turbo',
+    systemPrompt: 'LAYER0',
+    state: { messages, sessionMemory: null },
+    llm: mockLlm,
+  })
+  assert.ok(results.some((r) => r.level === 'structured' && r.changed))
+  assert.ok(state.sessionMemory)
+  assert.match(state.sessionMemory.goal, /600519/)
+  assert.match(state.sessionMemory.constraints, /公开/)
+})

--- a/tests/session-stream-runtime.test.mjs
+++ b/tests/session-stream-runtime.test.mjs
@@ -73,4 +73,14 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
     })
     assert.deepEqual(next.pendingUserPrompt, pendingPrompt)
   })
+
+  it('sets contextHint on context_compact', () => {
+    const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'context_compact',
+      level: 'structured',
+      message: '已整理较早对话要点，后续仍按你的目标继续。',
+    })
+    assert.match(next.contextHint ?? '', /整理/)
+    assert.match(next.liveTrace?.thinkingLabel ?? '', /整理/)
+  })
 })


### PR DESCRIPTION
## Summary
- 按模型启发式 `contextTokens` 做会话预算门禁；soft→microcompact、hard→structured SessionMemory
- UI `turns` 不变；模型侧 `assembleModelView`；上游超限 aggressive 重试 1 次；换模型返回 `contextHint`
- SSE `context_compact` 会话内轻提示；文档与测试同步

## Test plan
- [x] `node --test tests/session-context-compact.test.mjs`
- [x] `node --test tests/session-stream-runtime.test.mjs`
- [x] `npm run build:packages`
- [x] `npm run check:ui`
- [ ] 长对话接近窗长时出现轻提示且历史消息仍可见
- [ ] 切换更小上下文模型后出现 `contextHint`（如有压缩）


Made with [Cursor](https://cursor.com)