### PR TITLE
feat(chat): 展示本轮用量与上下文占用

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -835,7 +835,7 @@ app.delete<{ Params: { id: string } }>('/api/providers/:id', async (req, reply) 
 })
 
 app.get('/api/models/available', async () => ({
-  models: agent.listAvailableModels(),
+  models: await agent.listAvailableModelsAsync(),
   default_model: cfg.default_model ?? null,
 }))
 
@@ -944,6 +944,7 @@ app.post<{ Body: { title?: string; expertId?: string } }>('/api/sessions', async
 app.get<{ Params: { id: string } }>('/api/sessions/:id', async (req, reply) => {
   const session = agent.getSession(req.params.id)
   if (!session) return reply.code(404).send({ error: 'session not found' })
+  const contextUsage = await agent.getSessionContextUsage(req.params.id)
   return {
     session: {
       id: session.id,
@@ -951,10 +952,18 @@ app.get<{ Params: { id: string } }>('/api/sessions/:id', async (req, reply) => {
       model: session.model,
       createdAt: session.createdAt,
       updatedAt: session.updatedAt,
+      usageTotals: session.usageTotals ?? null,
     },
     messages: agent.getDisplayMessages(req.params.id),
     contextRef: session.contextRef ?? null,
+    contextUsage,
   }
+})
+
+app.get<{ Params: { id: string } }>('/api/sessions/:id/context-usage', async (req, reply) => {
+  const contextUsage = await agent.getSessionContextUsage(req.params.id)
+  if (!contextUsage) return reply.code(404).send({ error: 'session not found' })
+  return { contextUsage }
 })
 
 app.get<{ Params: { id: string } }>('/api/sessions/:id/role-persona', async (req, reply) => {

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -9,7 +9,7 @@ import type {
   ValidateFeedResult,
 } from '../types/schemas'
 import type { ChatProgressEvent } from '../types/chatProgress'
-import type { ChatDisplayMessage, EphemeralAskTurn, SessionContextRef, SessionMeta, AvailableModel } from '../types/chat'
+import type { ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, SessionContextRef, SessionMeta, AvailableModel } from '../types/chat'
 import type { ExportDestination, ExportPackageResult } from '../platform/saveMarketPackage'
 import {
   formatExportResultMessage,
@@ -1341,7 +1341,12 @@ export async function getSession(id: string) {
     session: SessionMeta
     messages: ChatDisplayMessage[]
     contextRef: SessionContextRef | null
+    contextUsage?: ChatContextUsage | null
   }>(`/sessions/${id}`)
+}
+
+export async function getSessionContextUsage(id: string) {
+  return jsonFetch<{ contextUsage: ChatContextUsage }>(`/sessions/${id}/context-usage`)
 }
 
 export async function renameSession(id: string, title: string) {

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -21,7 +21,7 @@ import RightPanel from './RightPanel'
 import type { StockDiscussPayload } from '../market/StockDecisionCard'
 import WorkspaceSplitDivider from './WorkspaceSplitDivider'
 import {
-  listSessions, createSession, getSession, deleteSession, forkSession, clearSessionContext,
+  listSessions, createSession, getSession, getSessionContextUsage, deleteSession, forkSession, clearSessionContext,
   setSessionContext, ephemeralAsk,
   streamSessionChat, cancelSessionChat, getHealth, listAvailableModels, setSessionModel,
   archiveSession,
@@ -29,7 +29,7 @@ import {
   clearSessionArchiveFolder, renameSession,
 } from '../api/client'
 import type {
-  ChatDisplayMessage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
+  ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
   SessionMeta, AvailableModel,
 } from '../types/chat'
 import type { FeedArticle } from '../types/schemas'
@@ -275,6 +275,7 @@ export default function ChatApp() {
   const [error, setError] = useState('')
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
   const [sessionModel, setSessionModelState] = useState<string | undefined>()
+  const [contextUsage, setContextUsage] = useState<ChatContextUsage | null>(null)
   const [llmLabel, setLlmLabel] = useState('连接中…')
   const [backendOk, setBackendOk] = useState(false)
   const streamCacheRef = useRef(new Map<string, SessionStreamSnapshot>())
@@ -298,6 +299,9 @@ export default function ChatApp() {
       syncStreamSnapshotToUi(next, streamUiRef.current)
       if (event.type === 'context_compact' && next.contextHint) {
         setContextHintBanner(next.contextHint)
+      }
+      if (event.type === 'done' && event.context_usage) {
+        setContextUsage(event.context_usage)
       }
     }
   }, [])
@@ -389,9 +393,23 @@ export default function ChatApp() {
     setMessages(data.messages)
     setContextRef(data.contextRef ?? null)
     setSessionModelState(data.session.model)
+    setContextUsage(data.contextUsage ?? null)
     setError('')
     setChatScrollEpoch(epoch => epoch + 1)
   }, [pushComposerDraft])
+
+  const refreshContextUsage = useCallback(async (sessionId: string) => {
+    try {
+      const { contextUsage: next } = await getSessionContextUsage(sessionId)
+      if (activeIdRef.current === sessionId) {
+        setContextUsage(next)
+      }
+    } catch {
+      if (activeIdRef.current === sessionId) {
+        setContextUsage(null)
+      }
+    }
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -811,6 +829,7 @@ export default function ChatApp() {
         setMessages(fresh.messages)
         setContextRef(fresh.contextRef ?? null)
         setSessionModelState(fresh.session.model)
+        setContextUsage(fresh.contextUsage ?? null)
       }
       const list = await refreshSessions()
       if (isStreamStale()) return
@@ -1016,10 +1035,11 @@ export default function ChatApp() {
       if (res.contextHint?.trim()) {
         setContextHintBanner(res.contextHint.trim())
       }
+      await refreshContextUsage(activeId)
     } catch (e) {
       setError(e instanceof Error ? e.message : '切换模型失败')
     }
-  }, [activeId])
+  }, [activeId, refreshContextUsage])
 
   const activeSession = activeSessionMeta ?? sessions.find(x => x.id === activeId) ?? null
   const isSettings = view === 'settings'
@@ -1065,6 +1085,8 @@ export default function ChatApp() {
       sessionId={activeId}
       variant="chrome"
       textClassName="opptrix-desktop-title-text"
+      createdAt={activeSession?.createdAt}
+      sessionUsageTotal={activeSession?.usageTotals?.totalTokens ?? null}
       onRename={handleRenameSession}
       onArchive={handleArchiveActiveSession}
       onDelete={() => { void handleDeleteActiveSession() }}
@@ -1078,6 +1100,8 @@ export default function ChatApp() {
       title={activeSession?.title ?? '新对话'}
       sessionId={activeId}
       variant="header"
+      createdAt={activeSession?.createdAt}
+      sessionUsageTotal={activeSession?.usageTotals?.totalTokens ?? null}
       onRename={handleRenameSession}
       onArchive={handleArchiveActiveSession}
       onDelete={() => { void handleDeleteActiveSession() }}
@@ -1379,6 +1403,7 @@ export default function ChatApp() {
                   error={error}
                   availableModels={availableModels}
                   sessionModel={sessionModel}
+                  contextUsage={contextUsage}
                   isMobile={isMobile}
                   llmLabel={llmLabel}
                   backendOk={backendOk}

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, useState } from 'react'
 import { Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { ArrowUpRegular, PauseFilled } from '@fluentui/react-icons'
 import ModelSelector from './ModelSelector'
+import ContextUsageMeter from './ContextUsageMeter'
 import ComposerContextRefTag from './ComposerContextRefTag'
 import ComposerQuickTasks from './ComposerQuickTasks'
 import ChatWorkspaceGrants from './ChatWorkspaceGrants'
@@ -10,7 +11,7 @@ import ComposerAgentUserPromptPanel from './ComposerAgentUserPromptPanel'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import { useWatchlist } from '../market/useWatchlist'
 import { useStockMention } from './useStockMention'
-import type { AvailableModel, SessionContextRef } from '../types/chat'
+import type { AvailableModel, ChatContextUsage, SessionContextRef } from '../types/chat'
 import type { ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
 import type { WatchlistItem } from '../types/market'
 import {
@@ -266,6 +267,7 @@ interface ChatComposerProps {
   welcomeKey?: number
   availableModels: AvailableModel[]
   sessionModel?: string
+  contextUsage?: ChatContextUsage | null
   onSubmit: (text?: string) => void
   onStop?: () => void
   onModelChange?: (ref: string) => void
@@ -287,6 +289,7 @@ export default function ChatComposer({
   welcomeKey = 0,
   availableModels,
   sessionModel,
+  contextUsage,
   onSubmit,
   onStop,
   onModelChange,
@@ -579,6 +582,7 @@ export default function ChatComposer({
               />
             </div>
             <div className={s.toolbarRight}>
+              <ContextUsageMeter usage={contextUsage} />
               {onModelChange && (
                 <ModelSelector
                   models={availableModels}

--- a/client-ui/src/chat/ChatMessageItem.tsx
+++ b/client-ui/src/chat/ChatMessageItem.tsx
@@ -8,6 +8,7 @@ import {
 import type { ChatDisplayMessage } from '../types/chat'
 import MarkdownMessage from './MarkdownMessage'
 import ChatProcessTrace from './ChatProcessTrace'
+import MessageTokenLabel from './MessageTokenLabel'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { fadeInUp } from '../theme/mixins'
 import { formatFriendlyTime } from '../utils/formatFriendlyTime'
@@ -242,6 +243,12 @@ function ChatMessageItem({ message, index, isMobile = false, onFork }: Props) {
           <div style={{ marginTop: 12 }}>
             <ChatProcessTrace steps={message.toolSteps} />
           </div>
+        )}
+        {!isUser && message.usage && message.usage.totalTokens > 0 && (
+          <MessageTokenLabel
+            totalTokens={message.usage.totalTokens}
+            estimated={message.usageEstimated}
+          />
         )}
         {!message.toolSteps?.length && message.toolsUsed && message.toolsUsed.length > 0 && (
           <div className={s.toolTags}>

--- a/client-ui/src/chat/ChatSessionTitleTools.tsx
+++ b/client-ui/src/chat/ChatSessionTitleTools.tsx
@@ -28,6 +28,8 @@ import { OPPTRIX_GLASS_PANEL_CLASS } from '../theme/mixins'
 import type { SessionArchiveFolder } from '../types/chat'
 import { createSessionArchiveFolder, listSessionArchiveFolders } from '../api/client'
 import { ComposerTooltipMenuItem } from './ComposerTooltipMenu'
+import { formatTokenCount } from './formatTokenCount'
+import { formatFriendlyTime } from '../utils/formatFriendlyTime'
 
 const MENU_WIDTH = 208
 const ARCHIVE_PANEL_WIDTH = 220
@@ -55,6 +57,10 @@ export interface ChatSessionTitleToolsProps {
   onExport: () => void | Promise<void>
   /** 打开本会话技能专长编辑抽屉 */
   onEditRolePersona?: () => void
+  /** 会话创建时间 ISO */
+  createdAt?: string | null
+  /** 会话累计用量 */
+  sessionUsageTotal?: number | null
 }
 
 export default function ChatSessionTitleTools({
@@ -71,6 +77,8 @@ export default function ChatSessionTitleTools({
   onDelete,
   onExport,
   onEditRolePersona,
+  createdAt,
+  sessionUsageTotal,
 }: ChatSessionTitleToolsProps) {
   const anchorRef = useRef<HTMLButtonElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
@@ -419,6 +427,16 @@ export default function ChatSessionTitleTools({
         <ArrowExportRegular fontSize={16} />
         <span>导出会话</span>
       </ComposerTooltipMenuItem>
+      {(createdAt || (sessionUsageTotal != null && sessionUsageTotal > 0)) && (
+        <div className="opptrix-session-tools-menu__meta">
+          {createdAt && (
+            <span>{`创建于 ${formatFriendlyTime(createdAt)}`}</span>
+          )}
+          {sessionUsageTotal != null && sessionUsageTotal > 0 && (
+            <span>{`累计用量 ${formatTokenCount(sessionUsageTotal)}`}</span>
+          )}
+        </div>
+      )}
     </div>,
     document.body,
   ) : null

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -3,7 +3,7 @@ import {
   Text, makeStyles, mergeClasses,
 } from '@fluentui/react-components'
 import type {
-  ChatDisplayMessage, EphemeralAskTurn, MessageSelection, SessionContextRef,
+  ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, MessageSelection, SessionContextRef,
   AvailableModel,
 } from '../types/chat'
 import type { ChatLiveTrace, ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
@@ -263,6 +263,7 @@ interface ChatViewProps {
   error: string
   availableModels?: AvailableModel[]
   sessionModel?: string
+  contextUsage?: ChatContextUsage | null
   isMobile?: boolean
   sidebarVisible?: boolean
   llmLabel?: string
@@ -295,6 +296,7 @@ function ChatView({
   title = '新对话', titleSlot, headerTrailing, overlaySlot, contextHint, sessionId = null, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, composerDraft, loading, streamUiRef, error,
   availableModels = [],
   sessionModel,
+  contextUsage,
   isMobile = false,
   llmLabel = '',
   backendOk = false,
@@ -730,6 +732,7 @@ function ChatView({
               welcomeKey={welcomeEpoch}
               availableModels={availableModels}
               sessionModel={sessionModel}
+              contextUsage={contextUsage}
               onSubmit={handleSubmit}
               onStop={onStop}
               onModelChange={onModelChange}

--- a/client-ui/src/chat/ContextUsageMeter.tsx
+++ b/client-ui/src/chat/ContextUsageMeter.tsx
@@ -1,0 +1,36 @@
+import { Text, makeStyles } from '@fluentui/react-components'
+import { opptrixCssVars } from '../theme/tokens'
+import { formatContextUsageLabel } from './formatTokenCount'
+import type { ChatContextUsage } from '../types/chat'
+
+const useStyles = makeStyles({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    maxWidth: '140px',
+    minWidth: 0,
+    flexShrink: 1,
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    lineHeight: '34px',
+  },
+})
+
+interface ContextUsageMeterProps {
+  usage: ChatContextUsage | null | undefined
+}
+
+export default function ContextUsageMeter({ usage }: ContextUsageMeterProps) {
+  const s = useStyles()
+  if (!usage) return null
+  const ratio = usage.limitTokens > 0 ? usage.usedTokens / usage.limitTokens : 0
+  const title = `${formatContextUsageLabel(usage.usedTokens, usage.limitTokens, usage.estimated)}${ratio >= 0.85 ? ' · 上下文接近上限' : ''}`
+  return (
+    <Text className={s.root} title={title} aria-label={title}>
+      {formatContextUsageLabel(usage.usedTokens, usage.limitTokens, usage.estimated)}
+    </Text>
+  )
+}

--- a/client-ui/src/chat/MessageTokenLabel.tsx
+++ b/client-ui/src/chat/MessageTokenLabel.tsx
@@ -1,0 +1,27 @@
+import { Text, makeStyles } from '@fluentui/react-components'
+import { opptrixCssVars } from '../theme/tokens'
+import { formatTurnUsageLabel } from './formatTokenCount'
+
+const useStyles = makeStyles({
+  root: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.4,
+    marginTop: '6px',
+  },
+})
+
+interface MessageTokenLabelProps {
+  totalTokens: number
+  estimated?: boolean
+}
+
+export default function MessageTokenLabel({ totalTokens, estimated }: MessageTokenLabelProps) {
+  const s = useStyles()
+  if (totalTokens <= 0) return null
+  return (
+    <Text className={s.root} block>
+      {formatTurnUsageLabel(totalTokens, estimated)}
+    </Text>
+  )
+}

--- a/client-ui/src/chat/formatTokenCount.ts
+++ b/client-ui/src/chat/formatTokenCount.ts
@@ -1,0 +1,24 @@
+/** 自适应数量单位：<1000 整数；≥1k → 1.2k；≥1M → 1.1M */
+export function formatTokenCount(n: number): string {
+  const value = Math.max(0, Math.round(n))
+  if (value < 1000) return String(value)
+  if (value >= 1_000_000) {
+    const m = value / 1_000_000
+    const rounded = Math.round(m * 10) / 10
+    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}M`
+  }
+  const k = value / 1000
+  const rounded = Math.round(k * 10) / 10
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}k`
+}
+
+export function formatTurnUsageLabel(totalTokens: number, estimated?: boolean): string {
+  const count = formatTokenCount(totalTokens)
+  return estimated ? `本轮约 ${count}` : `本轮 ${count}`
+}
+
+export function formatContextUsageLabel(used: number, limit: number, estimated = true): string {
+  const usedLabel = formatTokenCount(used)
+  const limitLabel = formatTokenCount(limit)
+  return estimated ? `已用约 ${usedLabel} / ${limitLabel}` : `已用 ${usedLabel} / ${limitLabel}`
+}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -1732,6 +1732,18 @@ html.opptrix-electron .opptrix-session-title-inline-btn {
   animation: opptrix-composer-tooltip-in 160ms cubic-bezier(0, 0, 0.2, 1) both;
 }
 
+.opptrix-session-tools-menu__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 4px;
+  padding: 8px 10px 6px;
+  border-top: 1px solid var(--opptrix-separator, rgba(0, 0, 0, 0.08));
+  font-size: var(--opptrix-font-sm, 11px);
+  color: var(--opptrix-text-tertiary, #8E8E93);
+  line-height: 1.4;
+}
+
 .opptrix-session-tools-menu .opptrix-composer-tooltip-menu__item {
   justify-content: flex-start;
   gap: 8px;

--- a/client-ui/src/types/chat.ts
+++ b/client-ui/src/types/chat.ts
@@ -31,6 +31,20 @@ export interface ExpertCatalog {
   nextCursor?: string
 }
 
+export interface TokenUsage {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+}
+
+export interface ChatContextUsage {
+  usedTokens: number
+  limitTokens: number
+  remainingTokens: number
+  modelRef: string
+  estimated: boolean
+}
+
 export interface SessionMeta {
   id: string
   title: string
@@ -42,6 +56,7 @@ export interface SessionMeta {
   archiveFolderId?: string | null
   expertId?: string | null
   expertIcon?: ExpertIcon | null
+  usageTotals?: TokenUsage | null
 }
 
 export interface SessionArchiveFolder {
@@ -66,6 +81,8 @@ export interface ChatDisplayMessage {
   toolsUsed?: string[]
   toolSteps?: ChatToolStep[]
   at: string
+  usage?: TokenUsage
+  usageEstimated?: boolean
 }
 
 export interface SessionForkContextRef {

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -1,3 +1,5 @@
+import type { TokenUsage } from './chat'
+
 export type ChatToolStepStatus = 'running' | 'done' | 'error'
 
 export interface ChatUserPromptPayload {
@@ -29,6 +31,18 @@ export interface ChatToolStep {
   finishedAt?: string
 }
 
+export interface ChatTurnUsageSnapshot extends TokenUsage {
+  estimated?: boolean
+}
+
+export interface ChatContextUsageSnapshot {
+  usedTokens: number
+  limitTokens: number
+  remainingTokens: number
+  modelRef: string
+  estimated: boolean
+}
+
 export type ChatProgressEvent =
   | { type: 'thinking'; round: number; label: string; snippet?: string }
   | { type: 'tool_start'; step: ChatToolStep }
@@ -43,6 +57,8 @@ export type ChatProgressEvent =
     title?: string
     tool_steps: ChatToolStep[]
     cancelled?: boolean
+    turn_usage?: ChatTurnUsageSnapshot
+    context_usage?: ChatContextUsageSnapshot
   }
   | { type: 'error'; message: string }
   | {

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -197,9 +197,9 @@ Opptrix/
   - **专家目录**：`ExpertCatalogService` 优先 `StaticHttpExpertProvider`（默认 `https://update.opptrix.org/experts/` 的 `catalog.json` / `{id}.json`），失败降级包内 `LocalJsonExpertProvider`（`catalog.mock.json`）；再合并用户自建（user-store `local_experts`）。REST：`GET/POST/PATCH/DELETE /api/experts*`；UI 见 `client-ui/src/pages/experts/ExpertMarketPage.tsx`。部署与契约：[EXPERT-GUIDE.md §7](./EXPERT-GUIDE.md#7-远程专家-datasource)、[`experts/README.md`](../experts/README.md)。
 - **会话上下文管理（长对话压缩）**：实现 `packages/agent/src/context/*` + `llm/model-context.ts`。
   - **双视图**：UI 仍渲染完整 `turns`；喂给模型的是 `sessionMemory`（结构化工作记忆）+ 近端 messages（`assembleModelView`）。
-  - **窗长**：`resolveModelContextTokens(modelId)` 启发式（未知默认 128k）；`AvailableModel.contextTokens` 只读派生。预算预留输出与 system/tools；**soft 75%** → microcompact（压缩较早 tool 结果正文）；**hard 85%** → structuredCompact（独立一轮 LLM 写 `SessionMemory`，目标/约束神圣不可丢）。
+  - **窗长**：`resolveModelContextTokensAsync` 优先 models.dev（精确/大小写/去品牌前缀/规范化/子串/跨 provider），失败降级 `resolveModelContextTokens` 启发式（未知默认 128k）；`AvailableModel.contextTokens` 只读派生。预算预留输出与 system/tools；**soft 75%** → microcompact（压缩较早 tool 结果正文）；**hard 85%** → structuredCompact（独立一轮 LLM 写 `SessionMemory`，目标/约束神圣不可丢）。
   - **触发**：每轮 `llm.chat` 前检查；上游 `context_length_exceeded` 等 → 强制 aggressive compact 后**重试 1 次**；`setSessionModel` 换模型后按新窗再检查。
-  - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。测试：`tests/session-context-compact.test.mjs`。
+  - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。`done` 可含 `turn_usage`（本轮 LLM 累计用量，含 tool 循环与 structured 压缩）与 `context_usage`（Composer 已用/窗长估算）。测试：`tests/session-context-compact.test.mjs`、`tests/chat-token-usage.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
 - **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（末项可自由输入），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
 - **行业分析**：`industry_mining` / `industry_mermaid`（属 `industry` pack，需播种或 activate）→ 代表公司用 `search_instruments` + `get_instrument_*`

--- a/docs/API.md
+++ b/docs/API.md
@@ -639,7 +639,7 @@ Content-Type: application/json
 
 **会话上下文压缩（长对话）**
 
-- 每轮聊天按当前模型启发式 `contextTokens` 估算用量；接近上限时 micro / structured 压缩，SSE 推送 `context_compact`。
+- 每轮聊天按当前模型窗长（优先 [models.dev](https://models.dev) 模糊匹配，失败降级启发式，默认 128k）估算用量；接近上限时 micro / structured 压缩，SSE 推送 `context_compact`。
 - UI transcript（`turns`）不变；模型侧使用 `sessionMemory` + 近端消息。详见 [AGENT-GUIDE §4.2](./AGENT-GUIDE.md#42-agent-与-mcp)。
 - `PATCH /api/sessions/:id` 切换 `model` 时按新窗口再检查；响应可含 `contextHint`（有压缩时）。
 
@@ -657,7 +657,7 @@ Content-Type: application/json
 
 `level`：`micro` | `structured` | `overflow_retry`。
 
-**`AvailableModel.contextTokens`**：`GET /api/models/available` 等列表项附带启发式上下文窗口（只读派生，无需用户配置）。
+**`AvailableModel.contextTokens`**：`GET /api/models/available` 等列表项附带上下文窗口（优先 models.dev 异步查询 + 模糊匹配，失败降级启发式；只读派生，无需用户配置）。
 
 **POST `/api/sessions` body**
 
@@ -698,6 +698,21 @@ Content-Type: application/json
 | `archiveFolderId` | string \| null | 归档文件夹 |
 | `expertId` | string \| null | 绑定专家 id；`null` 为默认投研研究员会话 |
 | `expertIcon` | `{ kind: "emoji" \| "icon"; value: string } \| null` | 侧栏图标；无专家时为 `null` |
+| `usageTotals` | `{ promptTokens; completionTokens; totalTokens } \| null` | 可选；会话累计 LLM 用量 |
+
+**`GET /api/sessions/:id` 附加字段**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `messages[].usage` | `{ promptTokens; completionTokens; totalTokens }` | 可选；该轮 assistant 回复累计用量（含 tool 循环与压缩） |
+| `messages[].usageEstimated` | boolean | 可选；无上游 usage 时为 `true`（客户端展示「约」） |
+| `contextUsage` | `{ usedTokens; limitTokens; remainingTokens; modelRef; estimated }` | Composer 上下文占用估算（`assembleModelView` + 窗长） |
+
+**`GET /api/sessions/:id/context-usage`**
+
+返回 `{ contextUsage }`；404 时会话不存在。切模型后客户端应 refetch。
+
+**聊天 SSE `done` 事件** 可附带 `turn_usage`（本轮 assistant 用量）与 `context_usage`（同上结构），便于流式结束后刷新 UI。
 
 **示例 — 默认研究员会话**
 

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -6,6 +6,7 @@
  */
 
 import { parseNamespacedMcpTool } from '@opptrix/shared'
+import type { TokenUsage } from './llm/token-usage.js'
 
 /**
  * 工具调用步骤状态 — 标识单次工具调用的当前阶段。
@@ -14,6 +15,18 @@ import { parseNamespacedMcpTool } from '@opptrix/shared'
  * - error:   执行出错
  */
 export type ChatToolStepStatus = 'running' | 'done' | 'error'
+
+export interface ChatContextUsageSnapshot {
+  usedTokens: number
+  limitTokens: number
+  remainingTokens: number
+  modelRef: string
+  estimated: boolean
+}
+
+export interface ChatTurnUsageSnapshot extends TokenUsage {
+  estimated?: boolean
+}
 
 /**
  * 工具调用步骤 — 单次工具调用的完整生命周期信息。
@@ -100,6 +113,10 @@ export type ChatProgressEvent =
     tool_steps: ChatToolStep[]
     /** 是否被用户取消 */
     cancelled?: boolean
+    /** 本轮 assistant 累计用量 */
+    turn_usage?: ChatTurnUsageSnapshot
+    /** Composer 上下文占用快照 */
+    context_usage?: ChatContextUsageSnapshot
   }
   | { type: 'error'; message: string }
   | {

--- a/packages/agent/src/context/compact.ts
+++ b/packages/agent/src/context/compact.ts
@@ -4,9 +4,9 @@ import { repairToolCallSequences, tailMessagesForLlm } from '../llm/messages.js'
 import {
   type ContextBudget,
   resolveContextBudget,
-  resolveModelContextTokens,
   usageRatio,
 } from '../llm/model-context.js'
+import { resolveModelContextTokensAsync } from '../llm/models-dev-context.js'
 import {
   formatSessionMemoryForPrompt,
   parseSessionMemoryFromModelText,
@@ -19,6 +19,8 @@ import {
   estimateTextTokens,
 } from './token-estimate.js'
 import type { OpenAiTool } from '../tools.js'
+import { resolveTurnUsage } from '../llm/usage-estimate.js'
+import type { TokenUsage } from '../llm/token-usage.js'
 
 export const CONTEXT_COMPACT_HINT =
   '已整理较早对话要点，后续仍按你的目标继续。'
@@ -39,7 +41,7 @@ export interface SessionCompactState {
 }
 
 const MICRO_TOOL_MAX = 480
-const KEEP_RECENT_DEFAULT = 16
+export const KEEP_RECENT_DEFAULT = 16
 const KEEP_RECENT_AGGRESSIVE = 8
 
 function summarizeToolContent(content: string, toolName?: string): string {
@@ -121,7 +123,7 @@ export async function structuredCompact(
   llm: LlmProvider,
   state: SessionCompactState,
   opts?: { keepRecent?: number; signal?: AbortSignal },
-): Promise<{ state: SessionCompactState; changed: boolean }> {
+): Promise<{ state: SessionCompactState; changed: boolean; usage?: TokenUsage; usageEstimated?: boolean }> {
   const keepRecent = opts?.keepRecent ?? KEEP_RECENT_DEFAULT
   const repaired = repairToolCallSequences(state.messages)
   if (repaired.length <= keepRecent + 2) {
@@ -150,6 +152,11 @@ export async function structuredCompact(
     undefined,
     opts?.signal,
   )
+  const compactPrompt = [
+    { role: 'system' as const, content: STRUCTURED_COMPACT_SYSTEM },
+    { role: 'user' as const, content: userContent },
+  ]
+  const compactUsage = resolveTurnUsage(turn, compactPrompt)
 
   if (turn.finishReason === 'error' || !turn.message.content?.trim()) {
     const micro = microcompactMessages(repaired, keepRecent)
@@ -172,6 +179,8 @@ export async function structuredCompact(
       sessionMemory: memory,
     },
     changed: true,
+    usage: compactUsage.usage,
+    usageEstimated: compactUsage.estimated,
   }
 }
 
@@ -199,18 +208,20 @@ export function estimateModelViewTokens(messages: ChatMessage[]): number {
   return estimateMessageTokens(messages)
 }
 
-export function buildBudgetForModel(
+export async function buildBudgetForModel(
   modelId: string,
   systemPrompt: string,
   tools?: OpenAiTool[],
-): ContextBudget {
-  const contextTokens = resolveModelContextTokens(modelId)
+  providerId?: string,
+): Promise<ContextBudget> {
+  const contextTokens = await resolveModelContextTokensAsync(modelId, providerId)
   const reserve = estimateSystemToolsReserve(systemPrompt, tools)
   return resolveContextBudget(contextTokens, reserve)
 }
 
 export async function ensureContextBudget(opts: {
   modelId: string
+  providerId?: string
   systemPrompt: string
   tools?: OpenAiTool[]
   state: SessionCompactState
@@ -218,14 +229,25 @@ export async function ensureContextBudget(opts: {
   llm: LlmProvider | null
   signal?: AbortSignal
   aggressive?: boolean
-}): Promise<{ state: SessionCompactState; results: CompactResult[]; modelView: ChatMessage[] }> {
+}): Promise<{
+  state: SessionCompactState
+  results: CompactResult[]
+  modelView: ChatMessage[]
+  compactUsage?: TokenUsage
+  compactUsageEstimated?: boolean
+}> {
   const results: CompactResult[] = []
   let state: SessionCompactState = {
     messages: repairToolCallSequences(opts.state.messages),
     sessionMemory: opts.state.sessionMemory ?? null,
   }
   const keepRecent = opts.aggressive ? KEEP_RECENT_AGGRESSIVE : KEEP_RECENT_DEFAULT
-  const budget = buildBudgetForModel(opts.modelId, opts.systemPrompt, opts.tools)
+  const budget = await buildBudgetForModel(
+    opts.modelId,
+    opts.systemPrompt,
+    opts.tools,
+    opts.providerId,
+  )
 
   const buildView = () => assembleModelView({
     systemPrompt: opts.systemPrompt,
@@ -306,7 +328,13 @@ export async function ensureContextBudget(opts: {
     })
   }
 
-  return { state, results, modelView: view }
+  return {
+    state,
+    results,
+    modelView: view,
+    compactUsage: structured.usage,
+    compactUsageEstimated: structured.usageEstimated,
+  }
 }
 
 export function isContextOverflowError(error: string | undefined, content?: string | null): boolean {

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -53,8 +53,27 @@ import {
 import {
   CONTEXT_COMPACT_HINT,
   ensureContextBudget,
+  assembleModelView,
+  estimateModelViewTokens,
   isContextOverflowError,
+  KEEP_RECENT_DEFAULT,
 } from './context/compact.js'
+import { resolveModelContextTokensAsync } from './llm/models-dev-context.js'
+import { estimateToolsTokens } from './context/token-estimate.js'
+import {
+  accumulateChatUsage,
+  createEmptyChatUsage,
+  resolveTurnUsage,
+} from './llm/usage-estimate.js'
+import { mergeTokenUsage, emptyTokenUsage, type TokenUsage } from './llm/token-usage.js'
+
+export interface SessionContextUsage {
+  usedTokens: number
+  limitTokens: number
+  remainingTokens: number
+  modelRef: string
+  estimated: true
+}
 
 export interface AgentSettings {
   providers?: ProviderProfile[]
@@ -77,6 +96,12 @@ export interface ChatResult {
 // Safety: if 50 rounds reached without convergence, force stop.
 const MAX_SAFETY_ROUNDS = 50
 const TRUNCATE = 12_000
+
+function providerIdFromModelRef(modelRef?: string): string | undefined {
+  if (!modelRef) return undefined
+  const colonIdx = modelRef.indexOf(':')
+  return colonIdx > 0 ? modelRef.slice(0, colonIdx) : undefined
+}
 
 export class ChatCancelledError extends Error {
   constructor() {
@@ -295,6 +320,57 @@ export class AgentEngine {
     return this.registry.listAvailable()
   }
 
+  async listAvailableModelsAsync(): Promise<AvailableModel[]> {
+    return this.registry.listAvailableAsync()
+  }
+
+  async getSessionContextUsage(sessionId: string): Promise<SessionContextUsage | null> {
+    const record = this.sessions.get(sessionId)
+    if (!record) return null
+
+    const modelRef = record.model?.trim()
+      || this.settings.defaultModel
+      || this.registry.listAvailable()[0]?.ref
+      || ''
+    const colonIdx = modelRef.indexOf(':')
+    const providerId = colonIdx > 0 ? modelRef.slice(0, colonIdx) : undefined
+    const resolved = this.registry.resolve(modelRef)
+    const modelId = resolved?.model ?? modelRef.replace(/^[^:]+:/, '') ?? 'default'
+    const limitTokens = await resolveModelContextTokensAsync(modelId, providerId)
+
+    const activeNames = toolNamesForPacks(this.resolveRoundPackIds(sessionId))
+    const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
+    const contextMessages = contextRefToChatMessages(record.contextRef)
+    const modelView = assembleModelView({
+      systemPrompt,
+      sessionMemory: record.sessionMemory,
+      messages: record.messages,
+      contextPrefix: contextMessages,
+      keepRecent: KEEP_RECENT_DEFAULT,
+    })
+    let toolsTokens = activeNames.length * 120
+    try {
+      const { broker, openAiTools } = await this.rebuildRoundTools(activeNames)
+      try {
+        toolsTokens = estimateToolsTokens(openAiTools)
+      } finally {
+        await broker.close().catch(() => {})
+      }
+    } catch {
+      /* 无完整 schema 时沿用 activeNames 粗估 */
+    }
+    // modelView 已含 system + memory + 近端；tools 为 API 侧单独字段，另加固定开销
+    const usedTokens = estimateModelViewTokens(modelView) + toolsTokens + 512
+
+    return {
+      usedTokens,
+      limitTokens,
+      remainingTokens: Math.max(0, limitTokens - usedTokens),
+      modelRef,
+      estimated: true,
+    }
+  }
+
   async setSessionModel(sessionId: string, modelRef: string | null): Promise<{
     session: SessionRecord
     contextHint?: string
@@ -308,9 +384,12 @@ export class AgentEngine {
     const llm = this.registry.createLlm(activeModel)
     const resolved = this.registry.resolve(activeModel)
     const modelId = resolved?.model ?? activeModel?.replace(/^[^:]+:/, '') ?? 'default'
-    const systemPrompt = this.buildRoundSystemPrompt(sessionId, [])
+    const providerId = providerIdFromModelRef(activeModel)
+    const activeNames = toolNamesForPacks(this.resolveRoundPackIds(sessionId))
+    const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
     const budget = await this.applyContextBudget(record, {
       modelId,
+      providerId,
       systemPrompt,
       tools: undefined,
       llm,
@@ -325,6 +404,7 @@ export class AgentEngine {
     record: SessionRecord,
     opts: {
       modelId: string
+      providerId?: string
       systemPrompt: string
       tools?: import('./tools.js').OpenAiTool[]
       llm: ReturnType<ProviderRegistry['createLlm']>
@@ -333,9 +413,15 @@ export class AgentEngine {
       contextPrefix?: ChatMessage[]
       signal?: AbortSignal
     },
-  ): Promise<{ hint?: string; modelView: ChatMessage[] }> {
+  ): Promise<{
+    hint?: string
+    modelView: ChatMessage[]
+    compactUsage?: TokenUsage
+    compactUsageEstimated?: boolean
+  }> {
     const result = await ensureContextBudget({
       modelId: opts.modelId,
+      providerId: opts.providerId,
       systemPrompt: opts.systemPrompt,
       tools: opts.tools,
       state: {
@@ -362,9 +448,18 @@ export class AgentEngine {
           contextTokens: r.contextTokens,
         })
       }
-      return { hint: CONTEXT_COMPACT_HINT, modelView: result.modelView }
+      return {
+        hint: CONTEXT_COMPACT_HINT,
+        modelView: result.modelView,
+        compactUsage: result.compactUsage,
+        compactUsageEstimated: result.compactUsageEstimated,
+      }
     }
-    return { modelView: result.modelView }
+    return {
+      modelView: result.modelView,
+      compactUsage: result.compactUsage,
+      compactUsageEstimated: result.compactUsageEstimated,
+    }
   }
 
   async createSession(opts?: CreateSessionOptions) {
@@ -611,6 +706,43 @@ export class AgentEngine {
 
     const signal = progress?.signal
 
+    const toolsUsed: string[] = []
+    const toolSteps: ChatToolStep[] = []
+    let chatUsage = createEmptyChatUsage()
+
+    const emitDone = async (payload: {
+      reply: string
+      partialTools?: string[]
+      partialSteps?: ChatToolStep[]
+      cancelled?: boolean
+    }) => {
+      const contextUsage = await this.getSessionContextUsage(sessionId)
+      emit({
+        type: 'done',
+        reply: payload.reply,
+        tools_used: payload.partialTools ?? toolsUsed,
+        session_id: sessionId,
+        title: record!.title,
+        tool_steps: payload.partialSteps ?? toolSteps,
+        cancelled: payload.cancelled,
+        turn_usage: chatUsage.usage.totalTokens > 0 ? {
+          ...chatUsage.usage,
+          estimated: chatUsage.estimated || undefined,
+        } : undefined,
+        context_usage: contextUsage ?? undefined,
+      })
+    }
+
+    const pushAssistant = (
+      reply: string,
+      used: string[],
+      steps: ChatToolStep[],
+      usage?: TokenUsage,
+      usageEstimated?: boolean,
+    ) => {
+      this.pushAssistant(record!, reply, used, steps, usage, usageEstimated)
+    }
+
     const finalizeCancelled = (partialTools: string[], partialSteps: ChatToolStep[]): ChatResult => {
       this.userPromptBridge.cancelSession(sessionId)
       record!.messages = record!.messages.slice(0, messagesBeforeAssistant)
@@ -618,26 +750,17 @@ export class AgentEngine {
         record!.turns = record!.turns.slice(0, turnsBeforeAssistant + 1)
       }
       const reply = '（已停止）'
-      pushAssistant(reply, partialTools, partialSteps)
-      emit({ type: 'error', message: '已取消' })
-      emit({
-        type: 'done',
+      pushAssistant(
         reply,
-        tools_used: partialTools,
-        session_id: sessionId,
-        title: record!.title,
-        tool_steps: partialSteps,
-        cancelled: true,
-      })
+        partialTools,
+        partialSteps,
+        chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined,
+        chatUsage.estimated,
+      )
+      emit({ type: 'error', message: '已取消' })
+      void emitDone({ reply, partialTools, partialSteps, cancelled: true })
       return { reply, toolsUsed: partialTools, sessionId, title: record!.title }
     }
-
-    const pushAssistant = (reply: string, used: string[], steps: ChatToolStep[]) => {
-      this.pushAssistant(record!, reply, used, steps)
-    }
-
-    const toolsUsed: string[] = []
-    const toolSteps: ChatToolStep[] = []
 
     try {
     if (!llm) {
@@ -676,11 +799,13 @@ export class AgentEngine {
       const modelId = resolvedModel?.model
         ?? activeModel?.replace(/^[^:]+:/, '')
         ?? 'default'
+      const providerId = providerIdFromModelRef(activeModel)
 
       let overflowRetried = false
       const runLlmRound = async (aggressive: boolean) => {
         const budgeted = await this.applyContextBudget(record, {
           modelId,
+          providerId,
           systemPrompt,
           tools: openAiTools,
           llm,
@@ -689,7 +814,15 @@ export class AgentEngine {
           contextPrefix: contextMessages,
           signal,
         })
-        return llm.chat(budgeted.modelView, openAiTools, signal)
+        if (budgeted.compactUsage) {
+          chatUsage = accumulateChatUsage(chatUsage, {
+            usage: budgeted.compactUsage,
+            estimated: budgeted.compactUsageEstimated ?? true,
+          })
+        }
+        const turn = await llm.chat(budgeted.modelView, openAiTools, signal)
+        chatUsage = accumulateChatUsage(chatUsage, resolveTurnUsage(turn, budgeted.modelView))
+        return turn
       }
 
       emit({
@@ -729,19 +862,12 @@ export class AgentEngine {
         const reply = overflow
           ? '对话内容过多，整理后仍无法继续。请新开对话，或换用更大上下文窗口的模型。'
           : (turn.message.content ?? turn.error ?? '请求失败')
-        pushAssistant(reply, toolsUsed, toolSteps)
+        pushAssistant(reply, toolsUsed, toolSteps, chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined, chatUsage.estimated)
         emit({
           type: 'error',
           message: reply,
         })
-        emit({
-          type: 'done',
-          reply,
-          tools_used: toolsUsed,
-          session_id: sessionId,
-          title: record.title,
-          tool_steps: toolSteps,
-        })
+        void emitDone({ reply })
         return { reply, toolsUsed, sessionId, title: record.title }
       }
 
@@ -858,28 +984,26 @@ export class AgentEngine {
 
       const reply = turn.message.content?.trim() || '（无回复内容）'
       emit({ type: 'reply', content: reply })
-      pushAssistant(reply, toolsUsed, toolSteps)
-      emit({
-        type: 'done',
+      pushAssistant(
         reply,
-        tools_used: toolsUsed,
-        session_id: sessionId,
-        title: record.title,
-        tool_steps: toolSteps,
-      })
+        toolsUsed,
+        toolSteps,
+        chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined,
+        chatUsage.estimated,
+      )
+      void emitDone({ reply })
       return { reply, toolsUsed, sessionId, title: record.title }
     }
 
     const reply = '⚠️ 分析轮次过多，请简化问题或明确分析方向后重试。'
-    pushAssistant(reply, toolsUsed, toolSteps)
-    emit({
-      type: 'done',
+    pushAssistant(
       reply,
-      tools_used: toolsUsed,
-      session_id: sessionId,
-      title: record.title,
-      tool_steps: toolSteps,
-    })
+      toolsUsed,
+      toolSteps,
+      chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined,
+      chatUsage.estimated,
+    )
+    void emitDone({ reply })
     return { reply, toolsUsed, sessionId, title: record.title }
     } finally {
       await broker.close().catch(() => {})
@@ -903,6 +1027,8 @@ export class AgentEngine {
     reply: string,
     toolsUsed: string[],
     toolSteps: ChatToolStep[] = [],
+    usage?: TokenUsage,
+    usageEstimated?: boolean,
   ) {
     if (this.sessions.shouldMaterializeContext(record)) {
       this.sessions.materializeContextRef(record)
@@ -915,7 +1041,12 @@ export class AgentEngine {
       toolsUsed: toolsUsed.length ? toolsUsed : undefined,
       toolSteps: toolSteps.length ? toolSteps : undefined,
       at: new Date().toISOString(),
+      usage,
+      usageEstimated,
     })
+    if (usage) {
+      record.usageTotals = mergeTokenUsage(record.usageTotals ?? emptyTokenUsage(), usage)
+    }
     this.sessions.save(record)
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,4 +1,4 @@
-export { AgentEngine, ChatCancelledError, type AgentSettings, type ChatResult } from './engine.js'
+export { AgentEngine, ChatCancelledError, type AgentSettings, type ChatResult, type SessionContextUsage } from './engine.js'
 export {
   type ChatProgressEvent,
   type ChatProgressOptions,
@@ -116,6 +116,28 @@ export {
   HARD_USAGE_RATIO,
 } from './llm/model-context.js'
 export {
+  resolveModelContextTokensAsync,
+  lookupModelsDevContextLimit,
+  getModelsDevCatalog,
+  resetModelsDevCacheForTests,
+} from './llm/models-dev-context.js'
+export {
+  formatTokenCount,
+  formatTurnUsageLabel,
+} from './llm/format-token-count.js'
+export {
+  type TokenUsage,
+  type TokenUsageDisplay,
+  emptyTokenUsage,
+  mergeTokenUsage,
+  parseOpenAiUsage,
+} from './llm/token-usage.js'
+
+export {
+  type ChatContextUsageSnapshot,
+  type ChatTurnUsageSnapshot,
+} from './chat-progress.js'
+export {
   type SessionMemory,
   formatSessionMemoryForPrompt,
   emptySessionMemory,
@@ -123,6 +145,7 @@ export {
 } from './context/session-memory.js'
 export {
   ensureContextBudget,
+  buildBudgetForModel,
   assembleModelView,
   microcompactMessages,
   isContextOverflowError,

--- a/packages/agent/src/llm/format-token-count.ts
+++ b/packages/agent/src/llm/format-token-count.ts
@@ -1,0 +1,21 @@
+/**
+ * 自适应数量单位：<1000 整数；≥1k → 1.2k；≥1M → 1.1M
+ */
+export function formatTokenCount(n: number): string {
+  const value = Math.max(0, Math.round(n))
+  if (value < 1000) return String(value)
+  if (value >= 1_000_000) {
+    const m = value / 1_000_000
+    const rounded = Math.round(m * 10) / 10
+    return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}M`
+  }
+  const k = value / 1000
+  const rounded = Math.round(k * 10) / 10
+  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded.toFixed(1)}k`
+}
+
+/** 助手消息本轮用量文案，如「本轮约 1.2k」 */
+export function formatTurnUsageLabel(usage: { totalTokens: number; estimated?: boolean }): string {
+  const count = formatTokenCount(usage.totalTokens)
+  return usage.estimated ? `本轮约 ${count}` : `本轮 ${count}`
+}

--- a/packages/agent/src/llm/models-dev-context.ts
+++ b/packages/agent/src/llm/models-dev-context.ts
@@ -1,0 +1,262 @@
+import { resolveModelContextTokens } from './model-context.js'
+
+const MODELS_DEV_URL = 'https://models.dev/api.json'
+const CACHE_TTL_MS = 60 * 60 * 1000
+const FETCH_TIMEOUT_MS = 12_000
+const MIN_SUBSTRING_LEN = 5
+
+const STRIP_PREFIXES = [
+  'openai/',
+  'anthropic/',
+  'google/',
+  'gemini/',
+  'deepseek/',
+  'deepseek-ai/',
+  'qwen/',
+  'moonshot/',
+  'moonshotai/',
+  'mistral/',
+  'mistralai/',
+  'meta-llama/',
+  'meta/',
+  'zhipuai/',
+  'zai-org/',
+  'perplexity/',
+  'xai/',
+  'cohere/',
+  'nvidia/',
+  'microsoft/',
+]
+
+export interface ModelsDevLimit {
+  context: number
+  output?: number
+}
+
+interface ModelsDevModelEntry {
+  limit?: { context?: number; output?: number }
+}
+
+interface ModelsDevProviderEntry {
+  id?: string
+  models?: Record<string, ModelsDevModelEntry>
+}
+
+type ModelsDevCatalog = Record<string, ModelsDevProviderEntry>
+
+let memoryCache: { fetchedAt: number; catalog: ModelsDevCatalog } | null = null
+let inflightFetch: Promise<ModelsDevCatalog | null> | null = null
+
+export function resetModelsDevCacheForTests() {
+  memoryCache = null
+  inflightFetch = null
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null
+}
+
+function normalizeModelKey(id: string): string {
+  return id.trim().toLowerCase()
+    .replace(/_/g, '-')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+function stripCommonPrefix(id: string): string {
+  const lower = id.toLowerCase()
+  for (const prefix of STRIP_PREFIXES) {
+    if (lower.startsWith(prefix)) return id.slice(prefix.length)
+  }
+  return id
+}
+
+function parseProvidersMap(data: unknown): ModelsDevCatalog {
+  if (!isRecord(data)) return {}
+  if (isRecord(data.providers)) {
+    return data.providers as ModelsDevCatalog
+  }
+  const out: ModelsDevCatalog = {}
+  for (const [key, value] of Object.entries(data)) {
+    if (isRecord(value) && isRecord(value.models)) {
+      out[key] = value as ModelsDevProviderEntry
+    }
+  }
+  return out
+}
+
+function limitFromEntry(entry: ModelsDevModelEntry | undefined): ModelsDevLimit | null {
+  const ctx = entry?.limit?.context
+  if (typeof ctx === 'number' && ctx > 0) {
+    const output = entry?.limit?.output
+    return {
+      context: ctx,
+      ...(typeof output === 'number' && output > 0 ? { output } : {}),
+    }
+  }
+  return null
+}
+
+function splitModelRef(modelId: string): { provider?: string; model: string } {
+  const trimmed = modelId.trim()
+  const colon = trimmed.indexOf(':')
+  if (colon > 0) {
+    return {
+      provider: trimmed.slice(0, colon).trim(),
+      model: trimmed.slice(colon + 1).trim(),
+    }
+  }
+  return { model: trimmed }
+}
+
+function collectModelKeys(
+  catalog: ModelsDevCatalog,
+  providerId?: string,
+): Array<{ provider: string; modelKey: string }> {
+  const out: Array<{ provider: string; modelKey: string }> = []
+  const providers = providerId
+    ? [[providerId, catalog[providerId]] as const]
+    : Object.entries(catalog)
+  for (const [provider, entry] of providers) {
+    if (!entry?.models) continue
+    for (const modelKey of Object.keys(entry.models)) {
+      out.push({ provider, modelKey })
+    }
+  }
+  return out
+}
+
+function matchInProvider(
+  catalog: ModelsDevCatalog,
+  providerId: string,
+  query: string,
+): ModelsDevLimit | null {
+  const provider = catalog[providerId]
+  if (!provider?.models) return null
+  const models = provider.models
+  const candidates = [
+    query,
+    query.toLowerCase(),
+    stripCommonPrefix(query),
+    normalizeModelKey(query),
+    normalizeModelKey(stripCommonPrefix(query)),
+  ]
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    if (models[candidate]) {
+      const hit = limitFromEntry(models[candidate])
+      if (hit) return hit
+    }
+    const lower = candidate.toLowerCase()
+    for (const [key, entry] of Object.entries(models)) {
+      if (key.toLowerCase() === lower) {
+        const hit = limitFromEntry(entry)
+        if (hit) return hit
+      }
+    }
+  }
+  return null
+}
+
+function substringMatch(
+  catalog: ModelsDevCatalog,
+  query: string,
+  providerId?: string,
+): ModelsDevLimit | null {
+  const normalizedQuery = normalizeModelKey(stripCommonPrefix(query))
+  if (normalizedQuery.length < MIN_SUBSTRING_LEN) return null
+
+  for (const { provider, modelKey } of collectModelKeys(catalog, providerId)) {
+    const normalizedKey = normalizeModelKey(stripCommonPrefix(modelKey))
+    if (normalizedKey.length < MIN_SUBSTRING_LEN) continue
+    const contains = normalizedKey.includes(normalizedQuery) || normalizedQuery.includes(normalizedKey)
+    if (!contains) continue
+    const hit = limitFromEntry(catalog[provider]?.models?.[modelKey])
+    if (hit) return hit
+  }
+  return null
+}
+
+export function lookupModelsDevContextLimit(
+  catalog: ModelsDevCatalog,
+  modelId: string,
+  providerId?: string,
+): ModelsDevLimit | null {
+  const { provider: refProvider, model } = splitModelRef(modelId)
+  const effectiveProvider = providerId?.trim() || refProvider
+  const query = model || modelId
+
+  if (effectiveProvider) {
+    const direct = matchInProvider(catalog, effectiveProvider, query)
+    if (direct) return direct
+  }
+
+  if (effectiveProvider) {
+    const fuzzy = substringMatch(catalog, query, effectiveProvider)
+    if (fuzzy) return fuzzy
+  }
+
+  for (const provider of Object.keys(catalog)) {
+    if (provider === effectiveProvider) continue
+    const hit = matchInProvider(catalog, provider, query)
+    if (hit) return hit
+  }
+
+  return substringMatch(catalog, query)
+}
+
+async function fetchModelsDevCatalog(): Promise<ModelsDevCatalog | null> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const resp = await fetch(MODELS_DEV_URL, { signal: controller.signal })
+    if (!resp.ok) return null
+    const data: unknown = await resp.json()
+    return parseProvidersMap(data)
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export async function getModelsDevCatalog(forceRefresh = false): Promise<ModelsDevCatalog | null> {
+  const now = Date.now()
+  if (!forceRefresh && memoryCache && now - memoryCache.fetchedAt < CACHE_TTL_MS) {
+    return memoryCache.catalog
+  }
+  if (!inflightFetch) {
+    inflightFetch = fetchModelsDevCatalog().finally(() => {
+      inflightFetch = null
+    })
+  }
+  const catalog = await inflightFetch
+  if (catalog) {
+    memoryCache = { fetchedAt: now, catalog }
+    return catalog
+  }
+  return memoryCache?.catalog ?? null
+}
+
+export async function resolveModelContextTokensAsync(
+  modelId: string,
+  providerId?: string,
+): Promise<number> {
+  const catalog = await getModelsDevCatalog()
+  if (catalog) {
+    const limit = lookupModelsDevContextLimit(catalog, modelId, providerId)
+    if (limit) return limit.context
+  }
+  const { model } = splitModelRef(modelId)
+  return resolveModelContextTokens(model || modelId)
+}
+
+export async function resolveModelsDevOutputReserve(
+  modelId: string,
+  providerId?: string,
+): Promise<number | undefined> {
+  const catalog = await getModelsDevCatalog()
+  if (!catalog) return undefined
+  const limit = lookupModelsDevContextLimit(catalog, modelId, providerId)
+  return limit?.output
+}

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -1,5 +1,6 @@
 import type { OpenAiTool } from '../tools.js'
 import { formatOutboundFetchError, outboundFetch } from './outbound-fetch.js'
+import { parseOpenAiUsage, type TokenUsage } from './token-usage.js'
 
 export interface LlmConfig {
   provider: string
@@ -31,6 +32,7 @@ export interface LlmTurn {
   error?: string
   /** 上游响应表明上下文超限 */
   contextOverflow?: boolean
+  usage?: TokenUsage
 }
 
 export interface LlmProvider {
@@ -134,6 +136,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       }
 
       const data = await resp.json() as {
+        usage?: unknown
         choices?: {
           finish_reason?: string
           message?: {
@@ -144,6 +147,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       }
       const choice = data.choices?.[0]
       const raw = choice?.message
+      const usage = parseOpenAiUsage(data.usage)
       if (!raw) {
         return {
           message: { role: 'assistant', content: '⚠️ API 返回格式异常' },
@@ -156,12 +160,14 @@ export class OpenAiCompatibleProvider implements LlmProvider {
         return {
           message: { role: 'assistant', content: raw.content ?? null, tool_calls: raw.tool_calls },
           finishReason: 'tool_calls',
+          usage,
         }
       }
 
       return {
         message: { role: 'assistant', content: raw.content ?? '' },
         finishReason: 'stop',
+        usage,
       }
     } catch (e) {
       if (signal?.aborted) {

--- a/packages/agent/src/llm/providers.ts
+++ b/packages/agent/src/llm/providers.ts
@@ -1,5 +1,6 @@
 import { createProvider, isConfigured, fetchOpenAiModelList, type LlmConfig } from './provider.js'
 import { resolveModelContextTokens } from './model-context.js'
+import { resolveModelContextTokensAsync } from './models-dev-context.js'
 
 export { fetchOpenAiModelList }
 
@@ -49,6 +50,24 @@ export class ProviderRegistry {
           providerId: p.id,
           providerName: p.name,
           contextTokens: resolveModelContextTokens(model),
+        })
+      }
+    }
+    return out
+  }
+
+  async listAvailableAsync(): Promise<AvailableModel[]> {
+    const out: AvailableModel[] = []
+    for (const p of this.providers) {
+      if (!p.apiKey || !p.baseUrl) continue
+      for (const model of p.models) {
+        const contextTokens = await resolveModelContextTokensAsync(model, p.id)
+        out.push({
+          ref: `${p.id}:${model}`,
+          model,
+          providerId: p.id,
+          providerName: p.name,
+          contextTokens,
         })
       }
     }

--- a/packages/agent/src/llm/token-usage.ts
+++ b/packages/agent/src/llm/token-usage.ts
@@ -1,0 +1,36 @@
+/** LLM token 用量（与 OpenAI usage 字段对齐） */
+export interface TokenUsage {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+}
+
+export interface TokenUsageDisplay extends TokenUsage {
+  /** 无上游 usage 时为 true，UI 展示「约」 */
+  estimated?: boolean
+}
+
+export function emptyTokenUsage(): TokenUsage {
+  return { promptTokens: 0, completionTokens: 0, totalTokens: 0 }
+}
+
+export function mergeTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
+  return {
+    promptTokens: a.promptTokens + b.promptTokens,
+    completionTokens: a.completionTokens + b.completionTokens,
+    totalTokens: a.totalTokens + b.totalTokens,
+  }
+}
+
+export function parseOpenAiUsage(raw: unknown): TokenUsage | undefined {
+  if (!raw || typeof raw !== 'object') return undefined
+  const u = raw as Record<string, unknown>
+  const prompt = typeof u.prompt_tokens === 'number' ? u.prompt_tokens : undefined
+  const completion = typeof u.completion_tokens === 'number' ? u.completion_tokens : undefined
+  const total = typeof u.total_tokens === 'number' ? u.total_tokens : undefined
+  if (prompt === undefined && completion === undefined && total === undefined) return undefined
+  const promptTokens = Math.max(0, prompt ?? 0)
+  const completionTokens = Math.max(0, completion ?? 0)
+  const totalTokens = Math.max(0, total ?? promptTokens + completionTokens)
+  return { promptTokens, completionTokens, totalTokens }
+}

--- a/packages/agent/src/llm/usage-estimate.ts
+++ b/packages/agent/src/llm/usage-estimate.ts
@@ -1,0 +1,50 @@
+import type { ChatMessage, LlmTurn } from './provider.js'
+import { estimateMessageTokens, estimateTextTokens } from '../context/token-estimate.js'
+import { emptyTokenUsage, mergeTokenUsage, type TokenUsage } from './token-usage.js'
+
+export function estimateUsageFromMessages(messages: ChatMessage[]): TokenUsage {
+  const promptTokens = estimateMessageTokens(messages)
+  return {
+    promptTokens,
+    completionTokens: 0,
+    totalTokens: promptTokens,
+  }
+}
+
+export function estimateUsageFromTurn(
+  turn: LlmTurn,
+  promptMessages: ChatMessage[],
+): TokenUsage {
+  const promptTokens = estimateMessageTokens(promptMessages)
+  const content = turn.message.content ?? ''
+  const completionTokens = typeof content === 'string' ? estimateTextTokens(content) : 0
+  return {
+    promptTokens,
+    completionTokens,
+    totalTokens: promptTokens + completionTokens,
+  }
+}
+
+export function resolveTurnUsage(
+  turn: LlmTurn,
+  promptMessages: ChatMessage[],
+): { usage: TokenUsage; estimated: boolean } {
+  if (turn.usage) {
+    return { usage: turn.usage, estimated: false }
+  }
+  return { usage: estimateUsageFromTurn(turn, promptMessages), estimated: true }
+}
+
+export function accumulateChatUsage(
+  current: { usage: TokenUsage; estimated: boolean },
+  next: { usage: TokenUsage; estimated: boolean },
+): { usage: TokenUsage; estimated: boolean } {
+  return {
+    usage: mergeTokenUsage(current.usage, next.usage),
+    estimated: current.estimated || next.estimated,
+  }
+}
+
+export function createEmptyChatUsage(): { usage: TokenUsage; estimated: boolean } {
+  return { usage: emptyTokenUsage(), estimated: false }
+}

--- a/packages/agent/src/sessions.ts
+++ b/packages/agent/src/sessions.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { getUserDataStore } from '@opptrix/user-store'
 import type { ChatMessage } from './llm/provider.js'
 import type { ChatToolStep } from './chat-progress.js'
+import type { TokenUsage } from './llm/token-usage.js'
 import { SessionArchiveFolderStore } from './archive-folders.js'
 
 import type { ExpertIcon } from '@opptrix/shared'
@@ -21,6 +22,8 @@ export interface SessionMeta {
   archiveFolderId?: string | null
   expertId?: string | null
   expertIcon?: ExpertIcon | null
+  /** 会话累计用量（列表 meta 可含） */
+  usageTotals?: TokenUsage
 }
 
 export interface CreateSessionOptions {
@@ -37,6 +40,8 @@ export interface DisplayMessage {
   toolsUsed?: string[]
   toolSteps?: ChatToolStep[]
   at: string
+  usage?: TokenUsage
+  usageEstimated?: boolean
 }
 
 export interface SessionForkContextRef {
@@ -76,7 +81,15 @@ export type SessionContextRef = SessionForkContextRef | SessionSelectionContextR
 export interface SessionRecord extends SessionMeta {
   messages: ChatMessage[]
   /** UI-visible turns (user/assistant only) */
-  turns: { role: 'user' | 'assistant'; content: string; toolsUsed?: string[]; toolSteps?: ChatToolStep[]; at: string }[]
+  turns: {
+    role: 'user' | 'assistant'
+    content: string
+    toolsUsed?: string[]
+    toolSteps?: ChatToolStep[]
+    at: string
+    usage?: TokenUsage
+    usageEstimated?: boolean
+  }[]
   contextRef?: SessionContextRef | null
   /**
    * 会话级 Layer1 技能专长快照。创建时从专家/默认研究员复制；之后与目录解耦。
@@ -156,6 +169,7 @@ function toMeta(raw: SessionRecord): SessionMeta {
     archiveFolderId: raw.archiveFolderId ?? null,
     expertId: raw.expertId ?? null,
     expertIcon: raw.expertIcon ?? null,
+    usageTotals: raw.usageTotals,
   }
 }
 
@@ -335,6 +349,8 @@ export class SessionStore {
         toolsUsed: t.toolsUsed,
         toolSteps: t.toolSteps,
         at: t.at,
+        usage: t.usage,
+        usageEstimated: t.usageEstimated,
       }))
     }
     const out: DisplayMessage[] = []

--- a/tests/chat-token-usage.test.mjs
+++ b/tests/chat-token-usage.test.mjs
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  lookupModelsDevContextLimit,
+  resetModelsDevCacheForTests,
+} from '../packages/agent/dist/llm/models-dev-context.js'
+import { formatTokenCount, formatTurnUsageLabel } from '../packages/agent/dist/llm/format-token-count.js'
+import { parseOpenAiUsage, mergeTokenUsage } from '../packages/agent/dist/llm/token-usage.js'
+
+const SAMPLE_CATALOG = {
+  openai: {
+    models: {
+      'gpt-4o': { limit: { context: 128000, output: 16384 } },
+      'gpt-4.1': { limit: { context: 1047576, output: 32768 } },
+    },
+  },
+  deepseek: {
+    models: {
+      'deepseek-chat': { limit: { context: 1000000, output: 8192 } },
+    },
+  },
+  anyapi: {
+    models: {
+      'anthropic/claude-sonnet-4-6': { limit: { context: 1000000, output: 64000 } },
+      'deepseek/deepseek-chat': { limit: { context: 1000000, output: 384000 } },
+    },
+  },
+}
+
+describe('lookupModelsDevContextLimit', () => {
+  it('exact match within provider', () => {
+    const hit = lookupModelsDevContextLimit(SAMPLE_CATALOG, 'gpt-4o', 'openai')
+    assert.equal(hit?.context, 128000)
+  })
+
+  it('case-insensitive match', () => {
+    const hit = lookupModelsDevContextLimit(SAMPLE_CATALOG, 'GPT-4O', 'openai')
+    assert.equal(hit?.context, 128000)
+  })
+
+  it('providerId:model ref form', () => {
+    const hit = lookupModelsDevContextLimit(SAMPLE_CATALOG, 'openai:gpt-4.1')
+    assert.equal(hit?.context, 1047576)
+  })
+
+  it('strip vendor prefix and cross-provider scan', () => {
+    const hit = lookupModelsDevContextLimit(SAMPLE_CATALOG, 'deepseek-chat', 'custom-gateway')
+    assert.equal(hit?.context, 1000000)
+  })
+
+  it('substring match with prefixed model id', () => {
+    const hit = lookupModelsDevContextLimit(SAMPLE_CATALOG, 'claude-sonnet-4-6')
+    assert.equal(hit?.context, 1000000)
+  })
+
+  it('returns null when no match', () => {
+    const hit = lookupModelsDevContextLimit(SAMPLE_CATALOG, 'unknown-model-xyz')
+    assert.equal(hit, null)
+  })
+})
+
+describe('formatTokenCount', () => {
+  it('formats under 1k as integer', () => {
+    assert.equal(formatTokenCount(42), '42')
+    assert.equal(formatTokenCount(999), '999')
+  })
+
+  it('formats thousands with one decimal', () => {
+    assert.equal(formatTokenCount(1200), '1.2k')
+    assert.equal(formatTokenCount(42000), '42k')
+  })
+
+  it('formats millions', () => {
+    assert.equal(formatTokenCount(1_100_000), '1.1M')
+  })
+
+  it('turn usage label respects estimated flag', () => {
+    assert.equal(formatTurnUsageLabel({ totalTokens: 1200, estimated: true }), '本轮约 1.2k')
+    assert.equal(formatTurnUsageLabel({ totalTokens: 1200, estimated: false }), '本轮 1.2k')
+  })
+})
+
+describe('parseOpenAiUsage', () => {
+  it('parses OpenAI usage object', () => {
+    const usage = parseOpenAiUsage({
+      prompt_tokens: 100,
+      completion_tokens: 50,
+      total_tokens: 150,
+    })
+    assert.deepEqual(usage, {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+    })
+  })
+
+  it('merges usage totals', () => {
+    const a = { promptTokens: 10, completionTokens: 5, totalTokens: 15 }
+    const b = { promptTokens: 20, completionTokens: 8, totalTokens: 28 }
+    assert.deepEqual(mergeTokenUsage(a, b), {
+      promptTokens: 30,
+      completionTokens: 13,
+      totalTokens: 43,
+    })
+  })
+})
+
+describe('models.dev cache reset', () => {
+  it('resetModelsDevCacheForTests is callable', () => {
+    resetModelsDevCacheForTests()
+    assert.ok(true)
+  })
+})

--- a/tests/session-context-compact.test.mjs
+++ b/tests/session-context-compact.test.mjs
@@ -18,6 +18,7 @@ import {
   parseSessionMemoryFromModelText,
   ensureContextBudget,
   CONTEXT_COMPACT_HINT,
+  buildBudgetForModel,
 } from '../packages/agent/dist/index.js'
 
 function buildFatToolHistory(rounds, payloadChars) {
@@ -157,6 +158,13 @@ test('isContextOverflowError detects common upstream phrases', () => {
   assert.equal(isContextOverflowError(undefined, 'Error: maximum context length'), true)
   assert.equal(isContextOverflowError('rate_limit'), false)
   assert.ok(CONTEXT_COMPACT_HINT.includes('整理'))
+})
+
+test('buildBudgetForModel resolves context window asynchronously', async () => {
+  const budget = await buildBudgetForModel('unknown-model-xyz-for-test', 'LAYER0')
+  assert.ok(budget.contextTokens > 0)
+  assert.ok(budget.historyBudget > 0)
+  assert.ok(budget.softLimit < budget.hardLimit)
 })
 
 test('ensureContextBudget soft path triggers micro on small window', async () => {


### PR DESCRIPTION
## Summary
- 解析上游 LLM usage 并累计会话消耗；无 usage 时估算并显示「约」
- 窗长优先 models.dev（模糊匹配），失败降级启发式；compact 预算同步
- 消息底 / Composer 模型选择器左侧 / 标题菜单展示自适应单位用量

## Test plan
- [x] `npm run build -w @opptrix/agent` / `apps/server`
- [x] `node --test tests/chat-token-usage.test.mjs tests/session-context-compact.test.mjs`
- [x] `npm run check:ui`
- [ ] 手动：发消息看「本轮」；切模型看「已用」；标题菜单看累计用量


Made with [Cursor](https://cursor.com)