### PR TITLE
feat(chat): 按模型能力支持多媒体附件与预览

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -35,6 +35,7 @@ import { registerSandboxSettingsRoutes } from './sandbox-settings-routes.js'
 import { registerPythonSettingsRoutes } from './python-settings-routes.js'
 import { registerEnrichmentRoutes } from './enrichment-routes.js'
 import { registerSearchRoutes } from './search-routes.js'
+import { registerSessionAttachmentRoutes } from './session-attachment-routes.js'
 import { registerMcpServerRoutes } from './mcp-server-routes.js'
 import {
   startNewsFeedScheduler,
@@ -86,6 +87,7 @@ agent = new AgentEngine(hub, {
   defaultTopN: cfg.default_top_n,
   appContext: serverAppContext,
 })
+agent.setApiBaseUrl(`http://${HOST}:${PORT}/api`)
 
 setSessionPersistHooks({
   onPersist: syncSessionSearchIndex,
@@ -1204,10 +1206,13 @@ app.post<{
   },
 )
 
-app.post<{ Params: { id: string }; Body: { message: string; model?: string } }>(
+app.post<{ Params: { id: string }; Body: { message: string; model?: string; attachments?: string[] } }>(
   '/api/sessions/:id/chat/stream',
   async (req, reply) => {
-    if (!req.body?.message?.trim()) return reply.code(400).send({ error: 'message required' })
+    const hasAttachments = Array.isArray(req.body?.attachments) && req.body.attachments.length > 0
+    if (!req.body?.message?.trim() && !hasAttachments) {
+      return reply.code(400).send({ error: 'message required' })
+    }
 
     reply.hijack()
     reply.raw.writeHead(200, {
@@ -1232,9 +1237,10 @@ app.post<{ Params: { id: string }; Body: { message: string; model?: string } }>(
     try {
       await agent.chat(
         req.params.id,
-        req.body.message,
+        req.body.message ?? '',
         req.body.model,
         { onProgress: write, signal: ac.signal },
+        req.body.attachments,
       )
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e)
@@ -1255,14 +1261,19 @@ app.post<{ Params: { id: string }; Body: { message: string; model?: string } }>(
   },
 )
 
-app.post<{ Params: { id: string }; Body: { message: string; model?: string } }>(
+app.post<{ Params: { id: string }; Body: { message: string; model?: string; attachments?: string[] } }>(
   '/api/sessions/:id/chat',
   async (req, reply) => {
-    if (!req.body?.message?.trim()) return reply.code(400).send({ error: 'message required' })
+    const hasAttachments = Array.isArray(req.body?.attachments) && req.body.attachments.length > 0
+    if (!req.body?.message?.trim() && !hasAttachments) {
+      return reply.code(400).send({ error: 'message required' })
+    }
     const result = await agent.chat(
       req.params.id,
-      req.body.message,
+      req.body.message ?? '',
       req.body.model,
+      undefined,
+      req.body.attachments,
     )
     return {
       reply: result.reply,
@@ -1440,6 +1451,7 @@ async function bootstrap() {
   await registerEnrichmentRoutes(app)
   await registerMcpServerRoutes(app)
   registerSearchRoutes(app, hub, agent)
+  registerSessionAttachmentRoutes(app, agent)
   startNewsFeedScheduler()
   startEnrichmentScheduler(90_000, resolveProjectRoot())
   void maybeBootstrapTranslationModel(getNewsSettings().translation).catch(() => {})

--- a/apps/server/src/session-attachment-routes.ts
+++ b/apps/server/src/session-attachment-routes.ts
@@ -1,0 +1,131 @@
+import type { FastifyInstance } from 'fastify'
+import fs from 'node:fs'
+import path from 'node:path'
+import type { AgentEngine } from '@opptrix/agent'
+import {
+  mimeToMediaKind,
+  resolveModelMediaCapabilitiesAsync,
+  saveAttachment,
+  deleteAttachment,
+  readAttachmentMeta,
+  resolveAttachmentFilePath,
+  validateAttachmentAgainstCapabilities,
+  isAttachmentReferenced,
+  parseNonNegativeIntHeader,
+  resolveUploadMime,
+} from '@opptrix/agent'
+
+function sanitizeFilename(name: string): string {
+  const base = path.basename(name.trim() || 'file')
+  return base.replace(/[^\w.\-()\u4e00-\u9fff]/g, '_').slice(0, 180) || 'file'
+}
+
+async function resolveSessionMediaCaps(agent: AgentEngine, sessionId: string) {
+  const session = agent.getSession(sessionId)
+  if (!session) return null
+  const modelRef = session.model?.trim() || ''
+  const colon = modelRef.indexOf(':')
+  const providerId = colon > 0 ? modelRef.slice(0, colon) : undefined
+  const modelId = colon > 0 ? modelRef.slice(colon + 1) : modelRef
+  if (!modelId) {
+    return resolveModelMediaCapabilitiesAsync('default', providerId)
+  }
+  return resolveModelMediaCapabilitiesAsync(modelId, providerId)
+}
+
+export function registerSessionAttachmentRoutes(app: FastifyInstance, agent: AgentEngine) {
+  app.addContentTypeParser(
+    'application/octet-stream',
+    { parseAs: 'buffer' },
+    (_req, body, done) => { done(null, body) },
+  )
+
+  app.post<{ Params: { id: string } }>(
+    '/api/sessions/:id/attachments',
+    async (req, reply) => {
+      const session = agent.getSession(req.params.id)
+      if (!session) return reply.code(404).send({ error: 'session not found' })
+
+      const contentType = typeof req.headers['content-type'] === 'string'
+        ? req.headers['content-type']
+        : undefined
+      const attachmentMime = typeof req.headers['x-attachment-mime'] === 'string'
+        ? req.headers['x-attachment-mime']
+        : undefined
+      const rawName = req.headers['x-attachment-name']
+      const name = sanitizeFilename(typeof rawName === 'string' ? decodeURIComponent(rawName) : 'file')
+
+      const mime = resolveUploadMime(contentType, attachmentMime, name)
+      const kind = mimeToMediaKind(mime, name)
+      if (!kind) return reply.code(400).send({ error: '不支持此文件类型' })
+
+      const body = req.body
+      if (!Buffer.isBuffer(body) || body.length === 0) {
+        return reply.code(400).send({ error: '请上传有效文件' })
+      }
+
+      const caps = await resolveSessionMediaCaps(agent, req.params.id)
+      if (!caps) return reply.code(404).send({ error: 'session not found' })
+
+      const pinnedCount = parseNonNegativeIntHeader(req.headers['x-pinned-count'])
+      const pinnedTotal = parseNonNegativeIntHeader(req.headers['x-pinned-total-bytes'])
+      const validation = validateAttachmentAgainstCapabilities(
+        kind,
+        body.length,
+        caps,
+        pinnedCount,
+        pinnedTotal,
+      )
+      if (!validation.ok) return reply.code(400).send({ error: validation.error })
+
+      try {
+        const meta = saveAttachment({
+          sessionId: req.params.id,
+          name,
+          mime,
+          data: body,
+        })
+        return { attachment: meta }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : '上传失败'
+        return reply.code(400).send({ error: message })
+      }
+    },
+  )
+
+  app.get<{ Params: { id: string; attachmentId: string } }>(
+    '/api/sessions/:id/attachments/:attachmentId',
+    async (req, reply) => {
+      const session = agent.getSession(req.params.id)
+      if (!session) return reply.code(404).send({ error: 'session not found' })
+
+      const meta = readAttachmentMeta(req.params.id, req.params.attachmentId)
+      if (!meta) return reply.code(404).send({ error: 'attachment not found' })
+
+      const filePath = resolveAttachmentFilePath(req.params.id, req.params.attachmentId)
+      if (!filePath) return reply.code(404).send({ error: 'attachment not found' })
+
+      reply.header('Content-Type', meta.mime)
+      reply.header('Content-Disposition', `inline; filename="${encodeURIComponent(meta.name)}"`)
+      return reply.send(fs.createReadStream(filePath))
+    },
+  )
+
+  app.delete<{ Params: { id: string; attachmentId: string } }>(
+    '/api/sessions/:id/attachments/:attachmentId',
+    async (req, reply) => {
+      const session = agent.getSession(req.params.id)
+      if (!session) return reply.code(404).send({ error: 'session not found' })
+
+      const meta = readAttachmentMeta(req.params.id, req.params.attachmentId)
+      if (!meta) return reply.code(404).send({ error: 'attachment not found' })
+
+      if (isAttachmentReferenced(req.params.attachmentId, session.turns)) {
+        return reply.code(409).send({ error: '该附件已在对话中使用，无法删除' })
+      }
+
+      const ok = deleteAttachment(req.params.id, req.params.attachmentId)
+      return { ok }
+    },
+  )
+}

--- a/apps/server/src/translation-remote.ts
+++ b/apps/server/src/translation-remote.ts
@@ -1,4 +1,4 @@
-import { createProvider } from '@opptrix/agent'
+import { createProvider, chatMessageContentToText } from '@opptrix/agent'
 import type { NewsTranslationSettings } from '@opptrix/news-feed'
 import { loadConfig } from './config.js'
 import {
@@ -71,10 +71,10 @@ async function translateRemoteSegment(
 
   const turn = await llm.chat([{ role: 'user', content: prompt }])
   if (turn.finishReason === 'error') {
-    throw new Error(turn.error ?? turn.message.content ?? '远程翻译请求失败')
+    throw new Error(turn.error ?? (chatMessageContentToText(turn.message.content) || '远程翻译请求失败'))
   }
 
-  const raw = String(turn.message.content ?? '').trim()
+  const raw = chatMessageContentToText(turn.message.content).trim()
   if (kind === 'html') {
     return cleanHtmlTranslationOutput(raw, sourceText) || raw
   }

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -9,7 +9,8 @@ import type {
   ValidateFeedResult,
 } from '../types/schemas'
 import type { ChatProgressEvent } from '../types/chatProgress'
-import type { ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, SessionContextRef, SessionMeta, AvailableModel } from '../types/chat'
+import type { ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, SessionContextRef, SessionMeta, AvailableModel, ChatAttachmentMeta } from '../types/chat'
+import { resolveFileMime } from '../chat/mediaCapabilities'
 import type { ExportDestination, ExportPackageResult } from '../platform/saveMarketPackage'
 import {
   formatExportResultMessage,
@@ -1589,12 +1590,48 @@ export async function submitUserPromptResponse(
   }, CHAT_REQUEST_TIMEOUT)
 }
 
+export async function uploadSessionAttachment(
+  sessionId: string,
+  file: File,
+  pinnedCount = 0,
+  pinnedTotalBytes = 0,
+): Promise<ChatAttachmentMeta> {
+  const resp = await fetchWithTimeout(`${API_BASE}/sessions/${sessionId}/attachments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'X-Attachment-Mime': resolveFileMime(file),
+      'X-Attachment-Name': encodeURIComponent(file.name),
+      'X-Pinned-Count': String(pinnedCount),
+      'X-Pinned-Total-Bytes': String(pinnedTotalBytes),
+    },
+    body: file,
+  }, 120_000)
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({})) as { error?: string }
+    throw new Error(err.error || `上传失败 (${resp.status})`)
+  }
+  const data = await resp.json() as { attachment: ChatAttachmentMeta }
+  return data.attachment
+}
+
+export function sessionAttachmentUrl(sessionId: string, attachmentId: string): string {
+  return `${API_BASE}/sessions/${sessionId}/attachments/${attachmentId}`
+}
+
+export async function deleteSessionAttachment(sessionId: string, attachmentId: string) {
+  return jsonFetch<{ ok: boolean }>(`/sessions/${sessionId}/attachments/${attachmentId}`, {
+    method: 'DELETE',
+  })
+}
+
 export async function streamSessionChat(
   sessionId: string,
   message: string,
   onEvent: (event: ChatProgressEvent) => void,
   model?: string,
   signal?: AbortSignal,
+  attachments?: string[],
 ): Promise<void> {
   const resp = await fetchWithTimeout(`${API_BASE}/sessions/${sessionId}/chat/stream`, {
     method: 'POST',
@@ -1605,6 +1642,7 @@ export async function streamSessionChat(
     body: JSON.stringify({
       message,
       ...(model ? { model } : {}),
+      ...(attachments?.length ? { attachments } : {}),
     }),
     signal,
   }, CHAT_REQUEST_TIMEOUT)

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -30,7 +30,7 @@ import {
 } from '../api/client'
 import type {
   ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
-  SessionMeta, AvailableModel,
+  SessionMeta, AvailableModel, ChatAttachmentMeta,
 } from '../types/chat'
 import type { FeedArticle } from '../types/schemas'
 import { previewSelectionText } from '../utils/formatContextRefPreview'
@@ -774,11 +774,12 @@ export default function ChatApp() {
   loadingRef.current = loading
   sessionModelRef.current = sessionModel
 
-  const submitImplRef = useRef<(text?: string) => Promise<void>>(async () => {})
+  const submitImplRef = useRef<(text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => Promise<void>>(async () => {})
 
-  submitImplRef.current = async (text?: string) => {
+  submitImplRef.current = async (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => {
     const msg = (text ?? '').trim()
-    if (!msg) return
+    const ids = attachmentIds?.filter(Boolean) ?? []
+    if (!msg && !ids.length) return
 
     let sessionId = activeIdRef.current
     if (!sessionId) {
@@ -808,8 +809,9 @@ export default function ChatApp() {
 
     const optimistic: ChatDisplayMessage = {
       role: 'user',
-      content: msg,
+      content: msg || '（附件）',
       at: new Date().toISOString(),
+      ...(attachmentMetas?.length ? { attachments: attachmentMetas } : {}),
     }
     if (activeIdRef.current === sessionId) {
       setMessages(prev => [...prev, optimistic])
@@ -842,7 +844,7 @@ export default function ChatApp() {
         if (event.type === 'done') {
           resolvedSessionId = event.session_id || resolvedSessionId
         }
-      }, sessionModelRef.current, abortController.signal)
+      }, sessionModelRef.current, abortController.signal, ids.length ? ids : undefined)
 
       if (isStreamStale()) return
 
@@ -889,9 +891,18 @@ export default function ChatApp() {
     }
   }
 
-  const handleSubmit = useCallback((text?: string) => {
-    void submitImplRef.current(text)
+  const handleSubmit = useCallback((text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => {
+    void submitImplRef.current(text, attachmentIds, attachmentMetas)
   }, [])
+
+  const ensureSession = useCallback(async (): Promise<string> => {
+    if (activeIdRef.current) return activeIdRef.current
+    const { session } = await createSession()
+    setActiveId(session.id)
+    setActiveSessionMeta(session)
+    await refreshSessions()
+    return session.id
+  }, [refreshSessions])
 
   const handleStreamError = useCallback((message: string) => {
     setError(message)
@@ -1408,6 +1419,7 @@ export default function ChatApp() {
                   llmLabel={llmLabel}
                   backendOk={backendOk}
                   onSubmit={handleSubmit}
+                  ensureSession={ensureSession}
                   onStop={handleStop}
                   onForkMessage={handleForkFromMessage}
                   onQuoteSelection={activeId ? handleQuoteSelection : undefined}

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -1,6 +1,6 @@
-import { useRef, useEffect, useCallback, useState } from 'react'
+import { useRef, useEffect, useCallback, useState, useMemo } from 'react'
 import { Text, makeStyles, mergeClasses } from '@fluentui/react-components'
-import { ArrowUpRegular, PauseFilled } from '@fluentui/react-icons'
+import { ArrowUpRegular, AttachRegular, PauseFilled } from '@fluentui/react-icons'
 import ModelSelector from './ModelSelector'
 import ContextUsageMeter from './ContextUsageMeter'
 import ComposerContextRefTag from './ComposerContextRefTag'
@@ -11,7 +11,7 @@ import ComposerAgentUserPromptPanel from './ComposerAgentUserPromptPanel'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import { useWatchlist } from '../market/useWatchlist'
 import { useStockMention } from './useStockMention'
-import type { AvailableModel, ChatContextUsage, SessionContextRef } from '../types/chat'
+import type { AvailableModel, ChatAttachmentMeta, ChatContextUsage, SessionContextRef } from '../types/chat'
 import type { ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
 import type { WatchlistItem } from '../types/market'
 import {
@@ -37,6 +37,9 @@ import {
 } from './composerEditor'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { motion, primaryInteractive, interactiveTransition, fadeInUp } from '../theme/mixins'
+import ComposerAttachmentStrip from './ComposerAttachmentStrip'
+import { useComposerAttachments } from './useComposerAttachments'
+import { resolveActiveModelMedia, modelAllowsAttachments, buildAcceptForMedia } from './mediaCapabilities'
 import { listRowKey } from '../utils/listRowKey'
 
 const LINE_HEIGHT = 1.5
@@ -268,10 +271,11 @@ interface ChatComposerProps {
   availableModels: AvailableModel[]
   sessionModel?: string
   contextUsage?: ChatContextUsage | null
-  onSubmit: (text?: string) => void
+  onSubmit: (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => void
   onStop?: () => void
   onModelChange?: (ref: string) => void
   onClearContextRef?: () => void
+  ensureSession?: () => Promise<string>
   userPrompt?: ChatUserPromptPayload | null
   userPromptSubmitting?: boolean
   onUserPromptSubmit?: (answer: UserPromptAnswerPayload) => void
@@ -294,6 +298,7 @@ export default function ChatComposer({
   onStop,
   onModelChange,
   onClearContextRef,
+  ensureSession,
   userPrompt = null,
   userPromptSubmitting = false,
   onUserPromptSubmit,
@@ -307,6 +312,31 @@ export default function ChatComposer({
   const caretRangeRef = useRef<Range | null>(null)
   // 有无可发送内容（文字或 chip）；驱动发送按钮与 placeholder。
   const [hasContent, setHasContent] = useState(false)
+  const {
+    pinned,
+    uploading,
+    toast: attachmentToast,
+    fileInputRef,
+    addFiles,
+    removePinned,
+    reconcileWithModel,
+    clearPinned,
+    openFilePicker,
+    attachmentIds,
+  } = useComposerAttachments(sessionId, ensureSession)
+
+  const activeMedia = useMemo(
+    () => resolveActiveModelMedia(availableModels, sessionModel),
+    [availableModels, sessionModel],
+  )
+
+  const acceptTypes = useMemo(() => buildAcceptForMedia(activeMedia), [activeMedia])
+  const attachmentsAllowed = modelAllowsAttachments(activeMedia)
+
+  useEffect(() => {
+    reconcileWithModel(activeMedia)
+  }, [activeMedia, reconcileWithModel])
+
   const { items: watchlistItems } = useWatchlist()
 
   const {
@@ -405,19 +435,23 @@ export default function ChatComposer({
 
   const handleSubmitMessage = useCallback((text?: string) => {
     const explicit = text?.trim()
+    const metas = pinned.length ? pinned : undefined
+    const ids = attachmentIds.length ? attachmentIds : undefined
     if (explicit) {
-      onSubmit(explicit)
+      onSubmit(explicit, ids, metas)
       clearEditorContent()
+      clearPinned()
       return
     }
     const root = editorRef.current
     const composed = root ? getSendText(root).trim() : ''
-    if (!composed || loading) return
-    onSubmit(composed)
+    if ((!composed && !attachmentIds.length) || loading) return
+    onSubmit(composed || undefined, ids, metas)
     clearEditorContent()
-  }, [clearEditorContent, loading, onSubmit])
+    clearPinned()
+  }, [attachmentIds, clearEditorContent, clearPinned, loading, onSubmit, pinned])
 
-  const canSend = hasContent && !loading && !userPrompt
+  const canSend = (hasContent || attachmentIds.length > 0) && !loading && !userPrompt && !uploading
   const composerLocked = loading || Boolean(userPrompt)
 
   const handleInput = useCallback(() => {
@@ -436,13 +470,37 @@ export default function ChatComposer({
   }, [refreshContentState, syncMention])
 
   const handlePaste = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
-    // 只接受纯文本，避免粘贴富文本/HTML 破坏编辑器结构。
+    const items = e.clipboardData.items
+    const imageFiles: File[] = []
+    for (const item of items) {
+      if (item.type.startsWith('image/')) {
+        const f = item.getAsFile()
+        if (f) imageFiles.push(f)
+      }
+    }
+    if (imageFiles.length) {
+      e.preventDefault()
+      void addFiles(imageFiles, activeMedia)
+      return
+    }
     e.preventDefault()
     const text = e.clipboardData.getData('text/plain')
     if (text) document.execCommand('insertText', false, text)
     refreshContentState()
     syncMention()
-  }, [refreshContentState, syncMention])
+  }, [activeMedia, addFiles, refreshContentState, syncMention])
+
+  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    if (composerLocked || uploading) return
+    if (e.dataTransfer.files?.length) {
+      void addFiles(e.dataTransfer.files, activeMedia)
+    }
+  }, [activeMedia, addFiles, composerLocked, uploading])
+
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+  }, [])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (composingRef.current) return
@@ -523,6 +581,9 @@ export default function ChatComposer({
       )}
 
       {error && <div className={s.error} role="alert">{error}</div>}
+      {attachmentToast && !error && (
+        <div className={s.error} role="status">{attachmentToast}</div>
+      )}
 
       <div className={s.panelWrap}>
         <div className={s.panelGround} aria-hidden />
@@ -533,7 +594,22 @@ export default function ChatComposer({
             onSubmit={onUserPromptSubmit}
           />
         )}
-        <div className={mergeClasses(s.panel, 'opptrix-composer-shell')}>
+        <div
+          className={mergeClasses(s.panel, 'opptrix-composer-shell')}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            hidden
+            multiple
+            accept={acceptTypes || undefined}
+            onChange={(e) => {
+              if (e.target.files?.length) void addFiles(e.target.files, activeMedia)
+              e.target.value = ''
+            }}
+          />
           <div className={s.inputRow}>
             {contextRef && (
               <ComposerContextRefTag
@@ -541,6 +617,11 @@ export default function ChatComposer({
                 onClear={onClearContextRef}
               />
             )}
+            <ComposerAttachmentStrip
+              items={pinned}
+              sessionId={sessionId}
+              onRemove={removePinned}
+            />
             <div className={s.editorRow}>
               <span ref={mentionAnchorRef} className={s.mentionAnchor} aria-hidden />
               <div
@@ -571,6 +652,14 @@ export default function ChatComposer({
           </div>
           <div className={s.toolbar}>
             <div className={s.toolbarLeft}>
+              <OpptrixButton
+                variant="ghost"
+                size="small"
+                icon={<AttachRegular fontSize={16} />}
+                disabled={composerLocked || uploading || !attachmentsAllowed}
+                aria-label="添加附件"
+                onClick={openFilePicker}
+              />
               <ComposerQuickTasks
                 disabled={composerLocked}
                 onApply={handleApplyQuickTask}

--- a/client-ui/src/chat/ChatMessageItem.tsx
+++ b/client-ui/src/chat/ChatMessageItem.tsx
@@ -5,10 +5,12 @@ import {
   CheckmarkCircleFilled,
   ClipboardPasteRegular,
 } from '@fluentui/react-icons'
-import type { ChatDisplayMessage } from '../types/chat'
 import MarkdownMessage from './MarkdownMessage'
 import ChatProcessTrace from './ChatProcessTrace'
 import MessageTokenLabel from './MessageTokenLabel'
+import { MessageAttachmentStrip } from './ComposerAttachmentStrip'
+import MediaPreviewBox from './MediaPreviewBox'
+import type { ChatAttachmentMeta, ChatDisplayMessage } from '../types/chat'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { fadeInUp } from '../theme/mixins'
 import { formatFriendlyTime } from '../utils/formatFriendlyTime'
@@ -140,13 +142,15 @@ const useStyles = makeStyles({
 interface Props {
   message: ChatDisplayMessage
   index: number
+  sessionId?: string | null
   isMobile?: boolean
   onFork?: () => void
 }
 
-function ChatMessageItem({ message, index, isMobile = false, onFork }: Props) {
+function ChatMessageItem({ message, index, sessionId, isMobile = false, onFork }: Props) {
   const s = useStyles()
   const [copied, setCopied] = useState(false)
+  const [previewAttachment, setPreviewAttachment] = useState<ChatAttachmentMeta | null>(null)
   const isUser = message.role === 'user'
   const timeLabel = formatFriendlyTime(message.at)
 
@@ -236,6 +240,12 @@ function ChatMessageItem({ message, index, isMobile = false, onFork }: Props) {
             : s.assistantBubble,
         )}
       >
+        {message.attachments && message.attachments.length > 0 && (
+          <MessageAttachmentStrip
+            items={message.attachments}
+            onOpen={setPreviewAttachment}
+          />
+        )}
         {isUser
           ? message.content
           : <MarkdownMessage content={message.content} />}
@@ -260,6 +270,14 @@ function ChatMessageItem({ message, index, isMobile = false, onFork }: Props) {
         {!isUser && metaFooter}
       </div>
       {isUser && metaFooter}
+      {sessionId && (
+        <MediaPreviewBox
+          open={Boolean(previewAttachment)}
+          sessionId={sessionId}
+          attachment={previewAttachment}
+          onClose={() => setPreviewAttachment(null)}
+        />
+      )}
     </div>
   )
 }

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -4,7 +4,7 @@ import {
 } from '@fluentui/react-components'
 import type {
   ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, MessageSelection, SessionContextRef,
-  AvailableModel,
+  AvailableModel, ChatAttachmentMeta,
 } from '../types/chat'
 import type { ChatLiveTrace, ChatUserPromptPayload, UserPromptAnswerPayload } from '../types/chatProgress'
 import { submitUserPromptResponse } from '../api/client'
@@ -268,9 +268,10 @@ interface ChatViewProps {
   sidebarVisible?: boolean
   llmLabel?: string
   backendOk?: boolean
-  onSubmit: (text?: string) => void
+  onSubmit: (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => void
   onStop?: () => void
   onForkMessage?: (messageIndex: number) => void
+  ensureSession?: () => Promise<string>
   onQuoteSelection?: (selection: MessageSelection) => void
   onEphemeralAsk?: (
     message: string,
@@ -301,6 +302,7 @@ function ChatView({
   llmLabel = '',
   backendOk = false,
   onSubmit, onStop, onForkMessage, onQuoteSelection, onEphemeralAsk, onClearContextRef, onModelChange,
+  ensureSession,
   onOpenSidebar, onNewChat, onOpenSettings,
   rightPanelOpen = false,
   onToggleRightPanel,
@@ -562,9 +564,9 @@ function ChatView({
     })
   }, [chatScrollEpoch, sessionId, loading, liveTrace, messages.length, scrollToMessageStart])
 
-  const handleSubmit = (text?: string) => {
+  const handleSubmit = (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => {
     stickToBottomRef.current = true
-    onSubmit(text)
+    onSubmit(text, attachmentIds, attachmentMetas)
   }
 
   const threadColumnClass = mergeClasses(s.threadColumn, isMobile && s.threadColumnMobile)
@@ -685,6 +687,7 @@ function ChatView({
                   key={listRowKey(i, m.at, m.role)}
                   message={m}
                   index={i}
+                  sessionId={sessionId}
                   isMobile={isMobile}
                   onFork={onForkMessage ? () => onForkMessage(i) : undefined}
                 />
@@ -737,6 +740,7 @@ function ChatView({
               onStop={onStop}
               onModelChange={onModelChange}
               onClearContextRef={onClearContextRef}
+              ensureSession={ensureSession}
               userPrompt={pendingUserPrompt}
               userPromptSubmitting={userPromptSubmitting}
               onUserPromptSubmit={pendingUserPrompt ? handleUserPromptSubmit : undefined}

--- a/client-ui/src/chat/ComposerAttachmentStrip.tsx
+++ b/client-ui/src/chat/ComposerAttachmentStrip.tsx
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useState, useRef } from 'react'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import {
+  DocumentPdfRegular,
+  MusicNote2Regular,
+  VideoRegular,
+  ImageRegular,
+  DismissRegular,
+} from '@fluentui/react-icons'
+import type { ChatAttachmentMeta, MediaKind } from '../types/chat'
+import { formatBytesShort } from './mediaCapabilities'
+import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+
+const useStyles = makeStyles({
+  strip: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '8px',
+    padding: '0 2px 4px',
+  },
+  chip: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '8px',
+    maxWidth: '220px',
+    padding: '6px 8px 6px 6px',
+    borderRadius: opptrixTokens.radiusMd,
+    border: `1px solid ${opptrixCssVars.border}`,
+    backgroundColor: opptrixCssVars.canvasAlt,
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textSecondary,
+  },
+  thumb: {
+    width: '36px',
+    height: '36px',
+    borderRadius: opptrixTokens.radiusSm,
+    objectFit: 'cover',
+    flexShrink: 0,
+    backgroundColor: opptrixCssVars.canvas,
+  },
+  iconBox: {
+    width: '36px',
+    height: '36px',
+    borderRadius: opptrixTokens.radiusSm,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    backgroundColor: opptrixCssVars.canvas,
+    color: opptrixCssVars.textTertiary,
+  },
+  meta: {
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  name: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-base)',
+  },
+  size: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+  },
+  remove: {
+    border: 'none',
+    background: 'transparent',
+    padding: 0,
+    marginLeft: '2px',
+    color: opptrixCssVars.textTertiary,
+    cursor: 'pointer',
+    display: 'inline-flex',
+    ':hover': { color: opptrixCssVars.textSecondary },
+  },
+})
+
+function kindIcon(kind: MediaKind) {
+  switch (kind) {
+    case 'pdf': return <DocumentPdfRegular fontSize={18} />
+    case 'video': return <VideoRegular fontSize={18} />
+    case 'audio': return <MusicNote2Regular fontSize={18} />
+    default: return <ImageRegular fontSize={18} />
+  }
+}
+
+interface Props {
+  items: ChatAttachmentMeta[]
+  sessionId?: string | null
+  onRemove?: (id: string) => void
+  getUrl?: (attachmentId: string) => string
+  className?: string
+}
+
+export default function ComposerAttachmentStrip({
+  items,
+  sessionId,
+  onRemove,
+  getUrl,
+  className,
+}: Props) {
+  const s = useStyles()
+  const [thumbUrls, setThumbUrls] = useState<Record<string, string>>({})
+  const urlsRef = useRef<string[]>([])
+
+  const resolveUrl = useCallback((id: string) => {
+    if (getUrl) return getUrl(id)
+    if (!sessionId) return ''
+    return `/api/sessions/${sessionId}/attachments/${id}`
+  }, [getUrl, sessionId])
+
+  useEffect(() => {
+    const created: string[] = []
+    const next: Record<string, string> = {}
+    for (const item of items) {
+      if (item.kind !== 'image') continue
+      const url = resolveUrl(item.id)
+      if (!url) continue
+      next[item.id] = url
+    }
+    setThumbUrls(next)
+    urlsRef.current = created
+    return () => {
+      for (const u of urlsRef.current) URL.revokeObjectURL(u)
+    }
+  }, [items, resolveUrl])
+
+  if (!items.length) return null
+
+  return (
+    <div className={mergeClasses(s.strip, className)}>
+      {items.map(item => (
+        <div key={item.id} className={s.chip}>
+          {item.kind === 'image' && thumbUrls[item.id] ? (
+            <img src={thumbUrls[item.id]} alt="" className={s.thumb} />
+          ) : (
+            <span className={s.iconBox}>{kindIcon(item.kind)}</span>
+          )}
+          <span className={s.meta}>
+            <span className={s.name} title={item.name}>{item.name}</span>
+            <span className={s.size}>{formatBytesShort(item.size)}</span>
+          </span>
+          {onRemove ? (
+            <button
+              type="button"
+              className={s.remove}
+              aria-label={`移除 ${item.name}`}
+              onClick={() => onRemove(item.id)}
+            >
+              <DismissRegular fontSize={14} />
+            </button>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export function MessageAttachmentStrip({
+  items,
+  onOpen,
+}: {
+  items: ChatAttachmentMeta[]
+  onOpen: (item: ChatAttachmentMeta) => void
+}) {
+  const s = useStyles()
+  if (!items.length) return null
+  return (
+    <div className={s.strip}>
+      {items.map(item => (
+        <button
+          key={item.id}
+          type="button"
+          className={s.chip}
+          onClick={() => onOpen(item)}
+          aria-label={`查看 ${item.name}`}
+        >
+          <span className={s.iconBox}>{kindIcon(item.kind)}</span>
+          <span className={s.meta}>
+            <span className={s.name}>{item.name}</span>
+            <span className={s.size}>{formatBytesShort(item.size)}</span>
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/client-ui/src/chat/MediaPreviewBox.tsx
+++ b/client-ui/src/chat/MediaPreviewBox.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useRef } from 'react'
+import { makeStyles } from '@fluentui/react-components'
+import { DismissRegular } from '@fluentui/react-icons'
+import type { ChatAttachmentMeta } from '../types/chat'
+import { sessionAttachmentUrl } from '../api/client'
+import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+
+const useStyles = makeStyles({
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 1200,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '24px',
+    backgroundColor: 'rgba(0, 0, 0, 0.72)',
+  },
+  panel: {
+    position: 'relative',
+    maxWidth: 'min(960px, 96vw)',
+    maxHeight: '92vh',
+    width: '100%',
+    borderRadius: opptrixTokens.radiusLg,
+    backgroundColor: opptrixCssVars.canvas,
+    boxShadow: opptrixCssVars.composerFloatShadowFocus,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+    padding: '12px 16px',
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-base)',
+  },
+  close: {
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+    color: opptrixCssVars.textSecondary,
+    display: 'inline-flex',
+    padding: '4px',
+  },
+  body: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '16px',
+    overflow: 'auto',
+  },
+  image: {
+    maxWidth: '100%',
+    maxHeight: '78vh',
+    objectFit: 'contain',
+  },
+  pdf: {
+    width: '100%',
+    height: '78vh',
+    border: 'none',
+  },
+  media: {
+    width: '100%',
+    maxHeight: '78vh',
+  },
+})
+
+interface Props {
+  open: boolean
+  sessionId: string
+  attachment: ChatAttachmentMeta | null
+  onClose: () => void
+}
+
+export default function MediaPreviewBox({ open, sessionId, attachment, onClose }: Props) {
+  const s = useStyles()
+  const backdropRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open || !attachment) return null
+
+  const url = sessionAttachmentUrl(sessionId, attachment.id)
+
+  return (
+    <div
+      ref={backdropRef}
+      className={s.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`预览 ${attachment.name}`}
+      onClick={(e) => {
+        if (e.target === backdropRef.current) onClose()
+      }}
+    >
+      <div className={s.panel}>
+        <div className={s.header}>
+          <span>{attachment.name}</span>
+          <button type="button" className={s.close} onClick={onClose} aria-label="关闭预览">
+            <DismissRegular fontSize={18} />
+          </button>
+        </div>
+        <div className={s.body}>
+          {attachment.kind === 'image' ? (
+            <img src={url} alt={attachment.name} className={s.image} />
+          ) : attachment.kind === 'pdf' ? (
+            <iframe src={url} title={attachment.name} className={s.pdf} />
+          ) : attachment.kind === 'video' ? (
+            <video src={url} controls className={s.media} />
+          ) : attachment.kind === 'audio' ? (
+            <audio src={url} controls className={s.media} />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client-ui/src/chat/ModelSelector.tsx
+++ b/client-ui/src/chat/ModelSelector.tsx
@@ -4,6 +4,7 @@ import { ChevronDownRegular, CheckmarkRegular } from '@fluentui/react-icons'
 import type { AvailableModel } from '../types/chat'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { focusVisibleRing, ghostInteractive, motion } from '../theme/mixins'
+import { modelMediaHint } from './mediaCapabilities'
 import ComposerTooltipMenu, {
   COMPOSER_MENU_WIDTH,
   ComposerTooltipMenuItem,
@@ -133,6 +134,7 @@ export default function ModelSelector({
   const active = models.find(m => m.ref === activeRef)
   const groups = useMemo(() => groupModelsByProvider(models), [models])
   const displayModel = active?.model ?? '选择模型'
+  const mediaHint = modelMediaHint(active?.media ?? null)
 
   if (!models.length) {
     return (
@@ -166,7 +168,7 @@ export default function ModelSelector({
           'opptrix-focusable',
         )}
         disabled={disabled}
-        aria-label={`当前模型：${displayModel}`}
+        aria-label={`当前模型：${displayModel}${mediaHint ? `，${mediaHint}` : ''}`}
         aria-expanded={open}
         onClick={() => setOpen(v => !v)}
       >
@@ -198,6 +200,16 @@ export default function ModelSelector({
                 }}
               >
                 <span className={s.modelName}>{model.model}</span>
+                {modelMediaHint(model.media ?? null) ? (
+                  <span style={{
+                    marginLeft: 6,
+                    fontSize: 'var(--opptrix-font-sm)',
+                    color: 'var(--opptrix-text-tertiary)',
+                  }}
+                  >
+                    {modelMediaHint(model.media ?? null)}
+                  </span>
+                ) : null}
                 {activeRef === model.ref ? (
                   <CheckmarkRegular fontSize={16} />
                 ) : null}

--- a/client-ui/src/chat/mediaCapabilities.ts
+++ b/client-ui/src/chat/mediaCapabilities.ts
@@ -1,0 +1,151 @@
+import type { MediaKind, ChatAttachmentMeta, ModelMediaCapabilities } from '../types/chat'
+
+const KIND_LABEL: Record<Exclude<MediaKind, 'text'>, string> = {
+  image: '图片',
+  pdf: 'PDF',
+  video: '视频',
+  audio: '音频',
+}
+
+const EXT_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+  '.pdf': 'application/pdf',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.mkv': 'video/x-matroska',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.m4a': 'audio/mp4',
+  '.ogg': 'audio/ogg',
+  '.aac': 'audio/aac',
+}
+
+export function inferMimeFromFilename(filename: string): string | null {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0) return null
+  return EXT_MIME[filename.slice(dot).toLowerCase()] ?? null
+}
+
+export function resolveFileMime(file: Pick<File, 'type' | 'name'>): string {
+  const normalized = file.type.toLowerCase().split(';')[0]?.trim() ?? ''
+  if (normalized && normalized !== 'application/octet-stream') return normalized
+  return inferMimeFromFilename(file.name) ?? (normalized || 'application/octet-stream')
+}
+
+export function resolveActiveModelMedia(
+  models: Array<{ ref: string; media?: ModelMediaCapabilities; attachment?: boolean; inputModalities?: MediaKind[]; attachmentLimits?: ModelMediaCapabilities['limits'] }>,
+  modelRef?: string,
+): ModelMediaCapabilities | null {
+  const ref = modelRef?.trim()
+  const hit = ref ? models.find(m => m.ref === ref) : models[0]
+  if (!hit) return null
+  if (hit.media) return hit.media
+  if (hit.inputModalities || hit.attachmentLimits) {
+    return {
+      attachment: hit.attachment ?? false,
+      input: hit.inputModalities ?? ['text'],
+      output: ['text'],
+      limits: hit.attachmentLimits ?? { maxBytesByKind: {}, maxCount: 0, maxTotalBytes: 0 },
+    }
+  }
+  return null
+}
+
+export function modelAllowsAttachments(media: ModelMediaCapabilities | null): boolean {
+  if (!media) return false
+  return media.input.some(k => k !== 'text')
+}
+
+export function buildAcceptForMedia(media: ModelMediaCapabilities | null): string {
+  if (!modelAllowsAttachments(media) || !media) return ''
+  const parts: string[] = []
+  if (media.input.includes('image')) parts.push('image/*')
+  if (media.input.includes('pdf')) parts.push('application/pdf')
+  if (media.input.includes('video')) parts.push('video/*')
+  if (media.input.includes('audio')) parts.push('audio/*')
+  return parts.join(',')
+}
+
+export function modelMediaHint(media: ModelMediaCapabilities | null): string | null {
+  if (!media) return null
+  const kinds = media.input.filter(k => k !== 'text')
+  if (!kinds.length) return null
+  if (kinds.length === 1 && kinds[0] === 'image') return '支持图片'
+  return `支持${kinds.map(k => KIND_LABEL[k as Exclude<MediaKind, 'text'>] ?? k).join('、')}`
+}
+
+export function isKindSupported(media: ModelMediaCapabilities | null, kind: MediaKind): boolean {
+  if (kind === 'text') return true
+  if (!media) return false
+  return media.input.includes(kind)
+}
+
+export function formatBytesShort(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(bytes < 10_240 ? 1 : 0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function mimeToKind(mime: string, filename?: string): MediaKind | null {
+  const m = resolveFileMime({ type: mime, name: filename ?? '' }).toLowerCase().split(';')[0]?.trim() ?? ''
+  if (!m || m === 'application/octet-stream') return null
+  if (m.startsWith('image/')) return 'image'
+  if (m === 'application/pdf') return 'pdf'
+  if (m.startsWith('video/')) return 'video'
+  if (m.startsWith('audio/')) return 'audio'
+  return null
+}
+
+export function validateFileForModel(
+  file: File,
+  media: ModelMediaCapabilities | null,
+  pinnedCount: number,
+  pinnedTotal: number,
+): string | null {
+  const kind = mimeToKind(resolveFileMime(file), file.name)
+  if (!kind) return '不支持此文件类型'
+  if (!isKindSupported(media, kind)) {
+    return '当前模型不支持此类文件，可换模型或去掉附件'
+  }
+  const maxBytes = media?.limits.maxBytesByKind[kind]
+  if (maxBytes && file.size > maxBytes) {
+    return `文件过大（上限 ${formatBytesShort(maxBytes)}）`
+  }
+  if (media && pinnedCount >= media.limits.maxCount) {
+    return `附件数量已达上限（${media.limits.maxCount} 个）`
+  }
+  if (media && pinnedTotal + file.size > media.limits.maxTotalBytes) {
+    return `附件总大小超出限制（上限 ${formatBytesShort(media.limits.maxTotalBytes)}）`
+  }
+  return null
+}
+
+/** 按模型能力拆分 pin：media 未加载时不移除任何项 */
+export function partitionPinsForModel(
+  pinned: ChatAttachmentMeta[],
+  media: ModelMediaCapabilities | null,
+): { kept: ChatAttachmentMeta[]; removedIds: string[] } {
+  if (media == null) return { kept: pinned, removedIds: [] }
+  const kept: ChatAttachmentMeta[] = []
+  const removedIds: string[] = []
+  let total = 0
+  for (const item of pinned) {
+    const fake = new File([], item.name, { type: item.mime })
+    Object.defineProperty(fake, 'size', { value: item.size })
+    const err = validateFileForModel(fake, media, kept.length, total)
+    if (err) {
+      removedIds.push(item.id)
+      continue
+    }
+    kept.push(item)
+    total += item.size
+  }
+  return { kept, removedIds }
+}

--- a/client-ui/src/chat/useComposerAttachments.ts
+++ b/client-ui/src/chat/useComposerAttachments.ts
@@ -1,0 +1,131 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { ChatAttachmentMeta, ModelMediaCapabilities } from '../types/chat'
+import { uploadSessionAttachment, deleteSessionAttachment } from '../api/client'
+import { validateFileForModel, partitionPinsForModel } from './mediaCapabilities'
+
+export function useComposerAttachments(
+  sessionId: string | null | undefined,
+  ensureSession?: () => Promise<string>,
+) {
+  const [pinned, setPinned] = useState<ChatAttachmentMeta[]>([])
+  const [uploading, setUploading] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const effectiveSessionIdRef = useRef<string | null>(sessionId ?? null)
+  const prevSessionIdRef = useRef(sessionId)
+
+  useEffect(() => {
+    const prev = prevSessionIdRef.current ?? null
+    const next = sessionId ?? null
+    if (prev != null && next != null && prev !== next) {
+      setPinned([])
+    } else if (prev != null && next == null) {
+      setPinned([])
+    }
+    prevSessionIdRef.current = sessionId
+    if (sessionId) effectiveSessionIdRef.current = sessionId
+  }, [sessionId])
+
+  const clearToastLater = useCallback((msg: string) => {
+    setToast(msg)
+    window.setTimeout(() => setToast(null), 3200)
+  }, [])
+
+  const resolveSessionId = useCallback(async (): Promise<string | null> => {
+    if (effectiveSessionIdRef.current) return effectiveSessionIdRef.current
+    if (sessionId) {
+      effectiveSessionIdRef.current = sessionId
+      return sessionId
+    }
+    if (!ensureSession) return null
+    try {
+      const id = await ensureSession()
+      effectiveSessionIdRef.current = id
+      return id
+    } catch {
+      return null
+    }
+  }, [ensureSession, sessionId])
+
+  const addFiles = useCallback(async (
+    files: FileList | File[],
+    media: ModelMediaCapabilities | null,
+  ) => {
+    const sid = await resolveSessionId()
+    if (!sid) {
+      clearToastLater('暂时无法添加附件，请稍后再试')
+      return
+    }
+
+    const list = Array.from(files)
+    if (!list.length) return
+    setUploading(true)
+    try {
+      let next = [...pinned]
+      let total = next.reduce((sum, p) => sum + p.size, 0)
+      for (const file of list) {
+        const err = validateFileForModel(file, media, next.length, total)
+        if (err) {
+          clearToastLater(err)
+          continue
+        }
+        const meta = await uploadSessionAttachment(sid, file, next.length, total)
+        next = [...next, meta]
+        total += meta.size
+      }
+      setPinned(next)
+    } catch (e) {
+      clearToastLater(e instanceof Error ? e.message : '上传失败，请稍后重试')
+    } finally {
+      setUploading(false)
+    }
+  }, [pinned, clearToastLater, resolveSessionId])
+
+  const removePinned = useCallback(async (id: string) => {
+    setPinned(prev => prev.filter(p => p.id !== id))
+    const sid = effectiveSessionIdRef.current ?? sessionId
+    if (sid) {
+      try {
+        await deleteSessionAttachment(sid, id)
+      } catch {
+        /* 已引用附件可能无法删除 */
+      }
+    }
+  }, [sessionId])
+
+  const reconcileWithModel = useCallback((
+    media: ModelMediaCapabilities | null,
+  ) => {
+    if (!pinned.length) return
+    const { kept, removedIds } = partitionPinsForModel(pinned, media)
+    if (removedIds.length) {
+      setPinned(kept)
+      clearToastLater('部分附件与当前模型不兼容，已自动移除')
+      const sid = effectiveSessionIdRef.current ?? sessionId
+      if (sid) {
+        for (const id of removedIds) {
+          void deleteSessionAttachment(sid, id).catch(() => {})
+        }
+      }
+    }
+  }, [pinned, clearToastLater, sessionId])
+
+  const clearPinned = useCallback(() => setPinned([]), [])
+
+  const openFilePicker = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [])
+
+  return {
+    pinned,
+    uploading,
+    toast,
+    fileInputRef,
+    addFiles,
+    removePinned,
+    reconcileWithModel,
+    clearPinned,
+    openFilePicker,
+    attachmentIds: pinned.map(p => p.id),
+  }
+}

--- a/client-ui/src/types/chat.ts
+++ b/client-ui/src/types/chat.ts
@@ -66,6 +66,33 @@ export interface SessionArchiveFolder {
   isDefault: boolean
 }
 
+export interface AttachmentLimits {
+  maxBytesByKind: Partial<Record<MediaKind, number>>
+  maxCount: number
+  maxTotalBytes: number
+}
+
+export type MediaKind = 'text' | 'image' | 'pdf' | 'video' | 'audio'
+
+export interface ChatAttachmentMeta {
+  id: string
+  kind: MediaKind
+  mime: string
+  name: string
+  size: number
+  createdAt: string
+  width?: number
+  height?: number
+  duration?: number
+}
+
+export interface ModelMediaCapabilities {
+  attachment: boolean
+  input: MediaKind[]
+  output: MediaKind[]
+  limits: AttachmentLimits
+}
+
 export interface AvailableModel {
   ref: string
   model: string
@@ -73,6 +100,11 @@ export interface AvailableModel {
   providerName: string
   /** 启发式上下文窗口（tokens） */
   contextTokens?: number
+  attachment?: boolean
+  inputModalities?: MediaKind[]
+  outputModalities?: MediaKind[]
+  attachmentLimits?: AttachmentLimits
+  media?: ModelMediaCapabilities
 }
 
 export interface ChatDisplayMessage {
@@ -83,6 +115,7 @@ export interface ChatDisplayMessage {
   at: string
   usage?: TokenUsage
   usageEstimated?: boolean
+  attachments?: ChatAttachmentMeta[]
 }
 
 export interface SessionForkContextRef {

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -198,6 +198,7 @@ Opptrix/
 - **会话上下文管理（长对话压缩）**：实现 `packages/agent/src/context/*` + `llm/model-context.ts`。
   - **双视图**：UI 仍渲染完整 `turns`；喂给模型的是 `sessionMemory`（结构化工作记忆）+ 近端 messages（`assembleModelView`）。
   - **窗长**：`resolveModelContextTokensAsync` 优先 models.dev（精确/大小写/去品牌前缀/规范化/子串/跨 provider），失败降级 `resolveModelContextTokens` 启发式（未知默认 128k）；`AvailableModel.contextTokens` 只读派生。预算预留输出与 system/tools；**soft 75%** → microcompact（压缩较早 tool 结果正文）；**hard 85%** → structuredCompact（独立一轮 LLM 写 `SessionMemory`，目标/约束神圣不可丢）。
+  - **多媒体**：`resolveModelMediaCapabilitiesAsync` 从 models.dev 读取 `modalities` / `attachment`；`resolveAttachmentLimits` 按模型族分档限额。用户附件经 `POST .../attachments` 落盘，聊天以 OpenAI 兼容 content parts 发送；模型原生输出（`image_url` / base64 file 等）解析落盘并挂到 assistant `turns[].attachments`。
   - **触发**：每轮 `llm.chat` 前检查；上游 `context_length_exceeded` 等 → 强制 aggressive compact 后**重试 1 次**；`setSessionModel` 换模型后按新窗再检查。
   - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。`done` 可含 `turn_usage`（本轮 LLM 累计用量，含 tool 循环与 structured 压缩）与 `context_usage`（Composer 已用/窗长估算）。测试：`tests/session-context-compact.test.mjs`、`tests/chat-token-usage.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`

--- a/docs/API.md
+++ b/docs/API.md
@@ -636,6 +636,11 @@ Content-Type: application/json
 | GET | `/api/sessions/:id` | 会话详情 + 消息列表（当前 `session` 子对象不含 `expertId`；专家绑定以列表或创建响应为准） |
 | GET | `/api/sessions/:id/role-persona` | `{ rolePersona, expertId }`；旧会话空值会惰性回填并持久化 |
 | PUT | `/api/sessions/:id/role-persona` | body `{ rolePersona }` → `sanitizeExpertPersona`；成功写回并返回 `{ rolePersona, expertId }` |
+| POST | `/api/sessions/:id/attachments` | 上传附件（raw body + `Content-Type` + `X-Attachment-Name`）；校验当前会话模型 `media` 能力与限额；响应 `{ attachment: ChatAttachmentMeta }` |
+| GET | `/api/sessions/:id/attachments/:attachmentId` | 流式返回附件二进制（`Content-Type` 来自元数据；路径规范化防穿越） |
+| DELETE | `/api/sessions/:id/attachments/:attachmentId` | 删除未入 turns 引用的附件；已引用 → 409 |
+| POST | `/api/sessions/:id/chat/stream` | SSE 聊天；body `{ message, model?, attachments?: string[] }`（`attachments` 为已上传附件 id 列表） |
+| POST | `/api/sessions/:id/chat` | 同步聊天；body 同上 |
 
 **会话上下文压缩（长对话）**
 
@@ -656,6 +661,25 @@ Content-Type: application/json
 ```
 
 `level`：`micro` | `structured` | `overflow_retry`。
+
+**`AvailableModel`（`GET /api/models/available`）**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `contextTokens` | number | 上下文窗口（models.dev + 启发式） |
+| `attachment` | boolean | 是否支持附件上传 |
+| `inputModalities` / `outputModalities` | `MediaKind[]` | 输入/输出模态（含 `text` / `image` / `pdf` / `video` / `audio`） |
+| `attachmentLimits` | `{ maxBytesByKind; maxCount; maxTotalBytes }` | 按模型族动态分档的上传限额 |
+| `media` | 同上嵌套对象 | 与上述字段等价的组合视图 |
+
+**`ChatAttachmentMeta`**
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | string | 附件 id（落盘 `~/.opptrix/chat-attachments/{sessionId}/{id}/`） |
+| `kind` | `image` \| `pdf` \| `video` \| `audio` | 媒体种类 |
+| `mime` / `name` / `size` / `createdAt` | — | MIME、原始文件名、字节数、ISO 时间 |
+| `width` / `height` / `duration` | number | 可选元数据 |
 
 **`AvailableModel.contextTokens`**：`GET /api/models/available` 等列表项附带上下文窗口（优先 models.dev 异步查询 + 模糊匹配，失败降级启发式；只读派生，无需用户配置）。
 
@@ -705,6 +729,7 @@ Content-Type: application/json
 | 字段 | 类型 | 说明 |
 |------|------|------|
 | `messages[].usage` | `{ promptTokens; completionTokens; totalTokens }` | 可选；该轮 assistant 回复累计用量（含 tool 循环与压缩） |
+| `messages[].attachments` | `ChatAttachmentMeta[]` | 可选；用户 pin 或模型原生输出的媒体元数据 |
 | `messages[].usageEstimated` | boolean | 可选；无上游 usage 时为 `true`（客户端展示「约」） |
 | `contextUsage` | `{ usedTokens; limitTokens; remainingTokens; modelRef; estimated }` | Composer 上下文占用估算（`assembleModelView` + 窗长） |
 

--- a/packages/agent/src/attachment-limits.ts
+++ b/packages/agent/src/attachment-limits.ts
@@ -1,0 +1,91 @@
+import type { AttachmentLimits, MediaKind } from './media-types.js'
+
+const MB = 1024 * 1024
+
+const DEFAULT_BY_KIND: Partial<Record<MediaKind, number>> = {
+  image: 10 * MB,
+  pdf: 20 * MB,
+  video: 50 * MB,
+  audio: 25 * MB,
+}
+
+const DEFAULT_MAX_COUNT = 5
+const DEFAULT_MAX_TOTAL = 80 * MB
+
+interface LimitTier {
+  test: (modelId: string) => boolean
+  maxBytesByKind: Partial<Record<MediaKind, number>>
+  maxCount: number
+  maxTotalBytes: number
+}
+
+const LIMIT_TIERS: LimitTier[] = [
+  {
+    test: id => /\bgpt-4o\b|\bgpt-4\.1\b|\bgpt-5/i.test(id) || /\bo[34](?:-mini)?\b/i.test(id),
+    maxBytesByKind: { image: 20 * MB, pdf: 32 * MB, video: 100 * MB, audio: 50 * MB },
+    maxCount: 10,
+    maxTotalBytes: 150 * MB,
+  },
+  {
+    test: id => /claude|anthropic/i.test(id),
+    maxBytesByKind: { image: 5 * MB, pdf: 32 * MB, video: 50 * MB, audio: 25 * MB },
+    maxCount: 5,
+    maxTotalBytes: 60 * MB,
+  },
+  {
+    test: id => /gemini/i.test(id),
+    maxBytesByKind: { image: 20 * MB, pdf: 50 * MB, video: 200 * MB, audio: 50 * MB },
+    maxCount: 10,
+    maxTotalBytes: 250 * MB,
+  },
+  {
+    test: id => /glm-v|glm-4\.5v|glm-4\.6v|glm-5v/i.test(id),
+    maxBytesByKind: { image: 10 * MB, pdf: 20 * MB, video: 100 * MB, audio: 25 * MB },
+    maxCount: 6,
+    maxTotalBytes: 120 * MB,
+  },
+  {
+    test: id => /qwen-vl|qwen3\.6|qwen3\.5|qwen-v|deepseek-vl/i.test(id),
+    maxBytesByKind: { image: 10 * MB, pdf: 20 * MB, video: 80 * MB, audio: 25 * MB },
+    maxCount: 6,
+    maxTotalBytes: 100 * MB,
+  },
+]
+
+function pickTier(modelId: string): LimitTier | null {
+  const id = modelId.toLowerCase()
+  for (const tier of LIMIT_TIERS) {
+    if (tier.test(id)) return tier
+  }
+  return null
+}
+
+function filterLimitsForModalities(
+  base: Partial<Record<MediaKind, number>>,
+  inputModalities: MediaKind[],
+): Partial<Record<MediaKind, number>> {
+  const out: Partial<Record<MediaKind, number>> = {}
+  for (const kind of inputModalities) {
+    if (kind === 'text') continue
+    const cap = base[kind] ?? DEFAULT_BY_KIND[kind]
+    if (cap) out[kind] = cap
+  }
+  return out
+}
+
+/** 按模型族与 modalities.input 动态分档附件限额 */
+export function resolveAttachmentLimits(
+  modelId: string,
+  inputModalities: MediaKind[],
+): AttachmentLimits {
+  const tier = pickTier(modelId)
+  const maxBytesByKind = filterLimitsForModalities(
+    tier?.maxBytesByKind ?? DEFAULT_BY_KIND,
+    inputModalities,
+  )
+  return {
+    maxBytesByKind,
+    maxCount: tier?.maxCount ?? DEFAULT_MAX_COUNT,
+    maxTotalBytes: tier?.maxTotalBytes ?? DEFAULT_MAX_TOTAL,
+  }
+}

--- a/packages/agent/src/chat-attachments.ts
+++ b/packages/agent/src/chat-attachments.ts
@@ -1,0 +1,203 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { resolveUserDataRoot } from '@opptrix/shared'
+import type { AttachmentLimits, ChatAttachmentMeta, MediaKind, ModelMediaCapabilities } from './media-types.js'
+import {
+  formatBytesShort,
+  mediaKindLabel,
+  mimeToMediaKind,
+  resolveMediaMime,
+} from './media-types.js'
+
+const META_FILENAME = 'meta.json'
+
+export interface SaveAttachmentInput {
+  sessionId: string
+  name: string
+  mime: string
+  data: Buffer
+  width?: number
+  height?: number
+  duration?: number
+}
+
+export type AttachmentValidationResult =
+  | { ok: true }
+  | { ok: false; error: string }
+
+export function parseNonNegativeIntHeader(value: unknown): number {
+  const raw = Array.isArray(value) ? value[0] : value
+  const n = Number.parseInt(String(raw ?? ''), 10)
+  return Number.isFinite(n) && n >= 0 ? n : 0
+}
+
+/** 上传 MIME：优先 X-Attachment-Mime，Content-Type 为 octet-stream 时不当作真实类型 */
+export function resolveUploadMime(
+  contentType?: string,
+  attachmentMime?: string,
+  filename?: string,
+): string {
+  const explicit = typeof attachmentMime === 'string' ? attachmentMime.split(';')[0].trim() : ''
+  const ct = typeof contentType === 'string' ? contentType.split(';')[0].trim() : ''
+  return resolveMediaMime(explicit || ct || '', filename)
+}
+
+function attachmentsRoot(): string {
+  return path.join(resolveUserDataRoot(), 'chat-attachments')
+}
+
+function sessionDir(sessionId: string): string {
+  return path.join(attachmentsRoot(), sanitizeId(sessionId))
+}
+
+function attachmentDir(sessionId: string, attachmentId: string): string {
+  return path.join(sessionDir(sessionId), sanitizeId(attachmentId))
+}
+
+function sanitizeId(id: string): string {
+  const trimmed = id.trim()
+  if (!trimmed || trimmed.includes('..') || trimmed.includes('/') || trimmed.includes('\\')) {
+    throw new Error('无效的附件标识')
+  }
+  return trimmed
+}
+
+function metaPath(sessionId: string, attachmentId: string): string {
+  return path.join(attachmentDir(sessionId, attachmentId), META_FILENAME)
+}
+
+function dataPath(sessionId: string, attachmentId: string, name: string): string {
+  const ext = path.extname(name) || ''
+  return path.join(attachmentDir(sessionId, attachmentId), `data${ext}`)
+}
+
+function resolveSafeDataPath(sessionId: string, attachmentId: string, meta: ChatAttachmentMeta): string {
+  const dir = attachmentDir(sessionId, attachmentId)
+  const expected = path.resolve(dataPath(sessionId, attachmentId, meta.name))
+  if (!expected.startsWith(path.resolve(dir) + path.sep) && expected !== path.resolve(dir)) {
+    throw new Error('附件路径无效')
+  }
+  return expected
+}
+
+export function readAttachmentMeta(sessionId: string, attachmentId: string): ChatAttachmentMeta | null {
+  try {
+    const raw = fs.readFileSync(metaPath(sessionId, attachmentId), 'utf8')
+    const parsed = JSON.parse(raw) as ChatAttachmentMeta
+    if (typeof parsed.id !== 'string' || typeof parsed.mime !== 'string') return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export function resolveAttachmentFilePath(sessionId: string, attachmentId: string): string | null {
+  const meta = readAttachmentMeta(sessionId, attachmentId)
+  if (!meta) return null
+  const filePath = resolveSafeDataPath(sessionId, attachmentId, meta)
+  return fs.existsSync(filePath) ? filePath : null
+}
+
+export function validateAttachmentAgainstCapabilities(
+  kind: MediaKind,
+  size: number,
+  caps: ModelMediaCapabilities,
+  existingCount: number,
+  existingTotalBytes: number,
+): AttachmentValidationResult {
+  if (kind === 'text') {
+    return { ok: false, error: '不支持此文件类型' }
+  }
+  if (!caps.attachment && !caps.input.includes(kind)) {
+    return {
+      ok: false,
+      error: '当前模型不支持此类文件，可换模型或去掉附件',
+    }
+  }
+  if (!caps.input.includes(kind)) {
+    return {
+      ok: false,
+      error: `当前模型不支持${mediaKindLabel(kind)}，可换模型或去掉附件`,
+    }
+  }
+  const maxBytes = caps.limits.maxBytesByKind[kind]
+  if (maxBytes && size > maxBytes) {
+    return {
+      ok: false,
+      error: `${mediaKindLabel(kind)}过大（上限 ${formatBytesShort(maxBytes)}）`,
+    }
+  }
+  if (existingCount >= caps.limits.maxCount) {
+    return { ok: false, error: `附件数量已达上限（${caps.limits.maxCount} 个）` }
+  }
+  if (existingTotalBytes + size > caps.limits.maxTotalBytes) {
+    return {
+      ok: false,
+      error: `附件总大小超出限制（上限 ${formatBytesShort(caps.limits.maxTotalBytes)}）`,
+    }
+  }
+  return { ok: true }
+}
+
+export function saveAttachment(input: SaveAttachmentInput): ChatAttachmentMeta {
+  const resolvedMime = resolveMediaMime(input.mime, input.name)
+  const kind = mimeToMediaKind(resolvedMime, input.name)
+  if (!kind) throw new Error('不支持此文件类型')
+
+  const attachmentId = randomUUID()
+  const dir = attachmentDir(input.sessionId, attachmentId)
+  fs.mkdirSync(dir, { recursive: true })
+
+  const meta: ChatAttachmentMeta = {
+    id: attachmentId,
+    kind,
+    mime: resolvedMime,
+    name: input.name,
+    size: input.data.length,
+    createdAt: new Date().toISOString(),
+    ...(input.width ? { width: input.width } : {}),
+    ...(input.height ? { height: input.height } : {}),
+    ...(input.duration ? { duration: input.duration } : {}),
+  }
+
+  const filePath = dataPath(input.sessionId, attachmentId, input.name)
+  fs.writeFileSync(filePath, input.data)
+  fs.writeFileSync(metaPath(input.sessionId, attachmentId), JSON.stringify(meta, null, 0))
+  return meta
+}
+
+export function readAttachmentBuffer(sessionId: string, attachmentId: string): Buffer | null {
+  const meta = readAttachmentMeta(sessionId, attachmentId)
+  if (!meta) return null
+  const filePath = resolveSafeDataPath(sessionId, attachmentId, meta)
+  try {
+    return fs.readFileSync(filePath)
+  } catch {
+    return null
+  }
+}
+
+export function deleteAttachment(sessionId: string, attachmentId: string): boolean {
+  const dir = attachmentDir(sessionId, attachmentId)
+  if (!fs.existsSync(dir)) return false
+  fs.rmSync(dir, { recursive: true, force: true })
+  return true
+}
+
+export function isAttachmentReferenced(
+  attachmentId: string,
+  turns: Array<{ attachments?: ChatAttachmentMeta[] }> | undefined,
+): boolean {
+  if (!turns?.length) return false
+  return turns.some(t => t.attachments?.some(a => a.id === attachmentId))
+}
+
+export function summarizePinnedLimits(limits: AttachmentLimits): string {
+  const parts: string[] = []
+  for (const kind of ['image', 'pdf', 'video', 'audio'] as MediaKind[]) {
+    const max = limits.maxBytesByKind[kind]
+    if (max) parts.push(`${mediaKindLabel(kind)} ${formatBytesShort(max)}`)
+  }
+  return parts.join(' · ')
+}

--- a/packages/agent/src/content-parts.ts
+++ b/packages/agent/src/content-parts.ts
@@ -1,0 +1,192 @@
+import type { ChatAttachmentMeta, MediaKind } from './media-types.js'
+import { mimeToMediaKind } from './media-types.js'
+import { readAttachmentBuffer, saveAttachment } from './chat-attachments.js'
+import type { ContentPart, ChatMessage } from './llm/provider.js'
+
+const DATA_URL_INLINE_MAX = 8 * 1024 * 1024
+
+export interface ParsedAssistantContent {
+  text: string
+  attachments: ChatAttachmentMeta[]
+}
+
+function parseDataUrl(url: string): { mime: string; data: Buffer } | null {
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(url)
+  if (!match) return null
+  try {
+    return { mime: match[1], data: Buffer.from(match[2], 'base64') }
+  } catch {
+    return null
+  }
+}
+
+function guessNameFromMime(mime: string): string {
+  const ext = mime.split('/')[1]?.split('+')[0] ?? 'bin'
+  return `model-output-${Date.now()}.${ext}`
+}
+
+export function attachmentToContentPart(
+  sessionId: string,
+  meta: ChatAttachmentMeta,
+  apiBaseUrl: string,
+): ContentPart {
+  const buf = readAttachmentBuffer(sessionId, meta.id)
+  if (!buf) {
+    return { type: 'text', text: `[附件 ${meta.name} 不可用]` }
+  }
+
+  if (meta.kind === 'image') {
+    const b64 = buf.toString('base64')
+    const url = `data:${meta.mime};base64,${b64}`
+    return { type: 'image_url', image_url: { url, detail: 'auto' } }
+  }
+
+  if (meta.kind === 'pdf') {
+    return {
+      type: 'file',
+      file: { filename: meta.name, file_data: buf.toString('base64') },
+    }
+  }
+
+  if (meta.kind === 'video' || meta.kind === 'audio') {
+    if (buf.length <= DATA_URL_INLINE_MAX) {
+      const b64 = buf.toString('base64')
+      if (meta.kind === 'audio') {
+        const fmt = meta.mime.split('/')[1]?.split(';')[0] ?? 'wav'
+        return { type: 'input_audio', input_audio: { data: b64, format: fmt } }
+      }
+      const url = `data:${meta.mime};base64,${b64}`
+      return { type: 'image_url', image_url: { url } }
+    }
+    const url = `${apiBaseUrl.replace(/\/$/, '')}/sessions/${sessionId}/attachments/${meta.id}`
+    return { type: 'file', file: { filename: meta.name, file_data: url } }
+  }
+
+  return { type: 'text', text: `[不支持的附件类型: ${meta.name}]` }
+}
+
+export function buildUserContentParts(
+  text: string,
+  sessionId: string,
+  attachments: ChatAttachmentMeta[],
+  apiBaseUrl: string,
+): ContentPart[] {
+  const parts: ContentPart[] = []
+  if (text.trim()) parts.push({ type: 'text', text: text.trim() })
+  for (const meta of attachments) {
+    parts.push(attachmentToContentPart(sessionId, meta, apiBaseUrl))
+  }
+  return parts.length ? parts : [{ type: 'text', text: '' }]
+}
+
+export function chatMessageContentToText(content: ChatMessage['content']): string {
+  if (content == null) return ''
+  if (typeof content === 'string') return content
+  return content
+    .filter((p): p is Extract<ContentPart, { type: 'text' }> => p.type === 'text')
+    .map(p => p.text)
+    .join('\n')
+    .trim()
+}
+
+export function persistOutputMediaParts(
+  sessionId: string,
+  parts: ContentPart[],
+): { text: string; attachments: ChatAttachmentMeta[] } {
+  const textParts: string[] = []
+  const attachments: ChatAttachmentMeta[] = []
+
+  for (const part of parts) {
+    if (part.type === 'text') {
+      if (part.text.trim()) textParts.push(part.text)
+      continue
+    }
+    if (part.type === 'image_url') {
+      const url = part.image_url.url
+      const parsed = parseDataUrl(url)
+      if (parsed && mimeToMediaKind(parsed.mime) === 'image') {
+        attachments.push(saveAttachment({
+          sessionId,
+          name: guessNameFromMime(parsed.mime),
+          mime: parsed.mime,
+          data: parsed.data,
+        }))
+        continue
+      }
+      if (url.startsWith('http://') || url.startsWith('https://')) {
+        textParts.push(`![模型输出](${url})`)
+      }
+      continue
+    }
+    if (part.type === 'file') {
+      const parsed = parseDataUrl(part.file.file_data)
+      if (parsed) {
+        const kind = mimeToMediaKind(parsed.mime)
+        if (kind) {
+          attachments.push(saveAttachment({
+            sessionId,
+            name: part.file.filename || guessNameFromMime(parsed.mime),
+            mime: parsed.mime,
+            data: parsed.data,
+          }))
+          continue
+        }
+      }
+    }
+    if (part.type === 'input_audio') {
+      const mime = `audio/${part.input_audio.format}`
+      attachments.push(saveAttachment({
+        sessionId,
+        name: guessNameFromMime(mime),
+        mime,
+        data: Buffer.from(part.input_audio.data, 'base64'),
+      }))
+    }
+  }
+
+  return { text: textParts.join('\n').trim(), attachments }
+}
+
+export function parseAssistantResponseContent(
+  sessionId: string,
+  raw: unknown,
+): ParsedAssistantContent {
+  if (raw == null) return { text: '', attachments: [] }
+  if (typeof raw === 'string') return { text: raw.trim(), attachments: [] }
+  if (!Array.isArray(raw)) return { text: String(raw), attachments: [] }
+
+  const parts: ContentPart[] = []
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue
+    const rec = item as Record<string, unknown>
+    const type = rec.type
+    if (type === 'text' && typeof rec.text === 'string') {
+      parts.push({ type: 'text', text: rec.text })
+    } else if (type === 'image_url' && rec.image_url && typeof rec.image_url === 'object') {
+      const iu = rec.image_url as Record<string, unknown>
+      if (typeof iu.url === 'string') {
+        parts.push({
+          type: 'image_url',
+          image_url: {
+            url: iu.url,
+            ...(typeof iu.detail === 'string'
+              ? { detail: iu.detail as 'auto' | 'low' | 'high' }
+              : {}),
+          },
+        })
+      }
+    } else if (type === 'file' && rec.file && typeof rec.file === 'object') {
+      const f = rec.file as Record<string, unknown>
+      if (typeof f.filename === 'string' && typeof f.file_data === 'string') {
+        parts.push({ type: 'file', file: { filename: f.filename, file_data: f.file_data } })
+      }
+    } else if (type === 'input_audio' && rec.input_audio && typeof rec.input_audio === 'object') {
+      const ia = rec.input_audio as Record<string, unknown>
+      if (typeof ia.data === 'string' && typeof ia.format === 'string') {
+        parts.push({ type: 'input_audio', input_audio: { data: ia.data, format: ia.format } })
+      }
+    }
+  }
+
+  return persistOutputMediaParts(sessionId, parts)
+}

--- a/packages/agent/src/context/compact.ts
+++ b/packages/agent/src/context/compact.ts
@@ -1,5 +1,5 @@
-import type { ChatMessage } from '../llm/provider.js'
-import type { LlmProvider } from '../llm/provider.js'
+import { chatMessageContentToText } from '../content-parts.js'
+import type { ChatMessage, LlmProvider } from '../llm/provider.js'
 import { repairToolCallSequences, tailMessagesForLlm } from '../llm/messages.js'
 import {
   type ContextBudget,
@@ -158,7 +158,7 @@ export async function structuredCompact(
   ]
   const compactUsage = resolveTurnUsage(turn, compactPrompt)
 
-  if (turn.finishReason === 'error' || !turn.message.content?.trim()) {
+  if (turn.finishReason === 'error' || !chatMessageContentToText(turn.message.content).trim()) {
     const micro = microcompactMessages(repaired, keepRecent)
     return {
       state: { messages: micro.messages, sessionMemory: state.sessionMemory },
@@ -167,7 +167,7 @@ export async function structuredCompact(
   }
 
   const memory = parseSessionMemoryFromModelText(
-    turn.message.content,
+    chatMessageContentToText(turn.message.content),
     state.sessionMemory,
     cut,
   )

--- a/packages/agent/src/context/token-estimate.ts
+++ b/packages/agent/src/context/token-estimate.ts
@@ -1,5 +1,9 @@
 import type { ChatMessage } from '../llm/provider.js'
 import type { OpenAiTool } from '../tools.js'
+import { chatMessageContentToText } from '../content-parts.js'
+
+const IMAGE_PART_TOKEN_ESTIMATE = 512
+const FILE_PART_TOKEN_ESTIMATE = 800
 
 /** 中英混合粗估：CJK 偏多时略紧 */
 export function estimateTextTokens(text: string): number {
@@ -25,7 +29,18 @@ export function estimateMessageTokens(messages: ChatMessage[]): number {
   let total = 0
   for (const m of messages) {
     total += 4
-    if (m.content) total += estimateTextTokens(String(m.content))
+    if (m.content != null) {
+      if (typeof m.content === 'string') {
+        total += estimateTextTokens(m.content)
+      } else {
+        for (const part of m.content) {
+          if (part.type === 'text') total += estimateTextTokens(part.text)
+          else if (part.type === 'image_url') total += IMAGE_PART_TOKEN_ESTIMATE
+          else if (part.type === 'file') total += FILE_PART_TOKEN_ESTIMATE
+          else if (part.type === 'input_audio') total += FILE_PART_TOKEN_ESTIMATE
+        }
+      }
+    }
     if (m.name) total += estimateTextTokens(m.name)
     if (m.tool_calls?.length) {
       for (const tc of m.tool_calls) {

--- a/packages/agent/src/discover.ts
+++ b/packages/agent/src/discover.ts
@@ -14,6 +14,7 @@ import type { ToolRegistry } from './tools.js'
 import { McpToolBroker } from './mcp/broker.js'
 import type { ProviderRegistry } from './llm/providers.js'
 import type { ChatMessage } from './llm/provider.js'
+import { chatMessageContentToText } from './content-parts.js'
 import {
   getDiscoverStrategy,
   buildStrategyExecutionPrompt,
@@ -758,7 +759,7 @@ export class DiscoverRunner {
       { role: 'user', content: prompt },
     ]
     const turn = await llm.chat(messages)
-    const content = turn.message.content ?? ''
+    const content = chatMessageContentToText(turn.message.content)
     const json = extractJsonObject(content)
     if (!json) throw new Error('策略解析失败')
     return normalizePlan(json, prompt, profile)
@@ -893,13 +894,13 @@ export class DiscoverRunner {
 
         const turn = await llm.chat(messages, openAiTools.length ? openAiTools : undefined)
         if (turn.finishReason === 'error') {
-          throw new Error(turn.error ?? turn.message.content ?? 'Agent 请求失败')
+          throw new Error(turn.error ?? (chatMessageContentToText(turn.message.content) || 'Agent 请求失败'))
         }
 
         if (turn.finishReason === 'tool_calls' && turn.message.tool_calls?.length) {
           messages.push({
             role: 'assistant',
-            content: turn.message.content ?? null,
+            content: chatMessageContentToText(turn.message.content) || null,
             tool_calls: turn.message.tool_calls,
           })
           for (const tc of turn.message.tool_calls) {
@@ -928,7 +929,7 @@ export class DiscoverRunner {
           continue
         }
 
-        const content = turn.message.content?.trim() ?? ''
+        const content = chatMessageContentToText(turn.message.content).trim()
         const json = extractJsonObject(content)
         if (json && Array.isArray(json.items)) {
           const allowed = new Set(candidates.map(c => c.code))

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -58,7 +58,7 @@ import {
   isContextOverflowError,
   KEEP_RECENT_DEFAULT,
 } from './context/compact.js'
-import { resolveModelContextTokensAsync } from './llm/models-dev-context.js'
+import { resolveModelContextTokensAsync, resolveModelMediaCapabilitiesAsync } from './llm/models-dev-context.js'
 import { estimateToolsTokens } from './context/token-estimate.js'
 import {
   accumulateChatUsage,
@@ -66,6 +66,9 @@ import {
   resolveTurnUsage,
 } from './llm/usage-estimate.js'
 import { mergeTokenUsage, emptyTokenUsage, type TokenUsage } from './llm/token-usage.js'
+import { readAttachmentMeta, validateAttachmentAgainstCapabilities } from './chat-attachments.js'
+import type { ChatAttachmentMeta } from './media-types.js'
+import { buildUserContentParts, chatMessageContentToText } from './content-parts.js'
 
 export interface SessionContextUsage {
   usedTokens: number
@@ -130,6 +133,13 @@ export class AgentEngine {
   private readonly expertPacksSeeded = new Set<string>()
   readonly userPromptBridge = new UserPromptBridge()
   private readonly workspaceService = getWorkspaceService()
+  /** 附件 GET 与 content parts 本地 URL 前缀 */
+  private apiBaseUrl = 'http://127.0.0.1:8711/api'
+
+  setApiBaseUrl(url: string) {
+    const trimmed = url.trim().replace(/\/$/, '')
+    if (trimmed) this.apiBaseUrl = trimmed
+  }
 
   constructor(
     private hub: ResearchHub,
@@ -660,9 +670,9 @@ export class AgentEngine {
 
     const turn = await llm.chat(messages)
     if (turn.finishReason === 'error') {
-      return { reply: turn.message.content ?? turn.error ?? '请求失败' }
+      return { reply: chatMessageContentToText(turn.message.content) || turn.error || '请求失败' }
     }
-    return { reply: turn.message.content?.trim() || '（无回复内容）' }
+    return { reply: chatMessageContentToText(turn.message.content).trim() || '（无回复内容）' }
   }
 
   resolveUserPrompt(sessionId: string, promptId: string, answer: UserPromptAnswer) {
@@ -674,6 +684,7 @@ export class AgentEngine {
     message: string,
     modelRef?: string,
     progress?: ChatProgressOptions,
+    attachmentIds?: string[],
   ): Promise<ChatResult> {
     const text = message.trim()
     let record = this.sessions.get(sessionId)
@@ -682,21 +693,72 @@ export class AgentEngine {
       sessionId = record.id
     }
 
-    if (!text) return { reply: '请输入问题。', toolsUsed: [], sessionId }
+    const attachmentMetas: ChatAttachmentMeta[] = []
+    for (const id of attachmentIds ?? []) {
+      const trimmed = id.trim()
+      if (!trimmed) continue
+      const meta = readAttachmentMeta(sessionId, trimmed)
+      if (meta) attachmentMetas.push(meta)
+    }
+
+    if (!text && !attachmentMetas.length) {
+      return { reply: '请输入问题。', toolsUsed: [], sessionId }
+    }
 
     const activeModel = modelRef?.trim() || record.model
+
+    if (attachmentMetas.length) {
+      const resolvedModel = this.registry.resolve(activeModel)
+      const modelId = resolvedModel?.model
+        ?? activeModel?.replace(/^[^:]+:/, '')
+        ?? 'default'
+      const providerId = providerIdFromModelRef(activeModel)
+      const caps = await resolveModelMediaCapabilitiesAsync(modelId, providerId)
+      let count = 0
+      let total = 0
+      for (const meta of attachmentMetas) {
+        const validation = validateAttachmentAgainstCapabilities(
+          meta.kind,
+          meta.size,
+          caps,
+          count,
+          total,
+        )
+        if (!validation.ok) {
+          return {
+            reply: validation.error,
+            toolsUsed: [],
+            sessionId,
+            title: record.title,
+          }
+        }
+        count += 1
+        total += meta.size
+      }
+    }
+
     const llm = this.registry.createLlm(activeModel)
     if (modelRef?.trim()) {
       record.model = modelRef.trim()
     }
 
-    record.messages.push({ role: 'user', content: text })
+    const userContent = attachmentMetas.length
+      ? buildUserContentParts(text, sessionId, attachmentMetas, this.apiBaseUrl)
+      : text
+
+    record.messages.push({ role: 'user', content: userContent })
     if (!record.turns) record.turns = []
     const turnsBeforeAssistant = record.turns.length
-    record.turns.push({ role: 'user', content: text, at: new Date().toISOString() })
+    record.turns.push({
+      role: 'user',
+      content: text || '（附件）',
+      attachments: attachmentMetas.length ? attachmentMetas : undefined,
+      at: new Date().toISOString(),
+    })
     const messagesBeforeAssistant = record.messages.length
     if (record.title === '新对话' || record.messages.filter(m => m.role === 'user').length === 1) {
-      record.title = text.slice(0, 28) + (text.length > 28 ? '…' : '')
+      const titleSeed = text || attachmentMetas[0]?.name || '新对话'
+      record.title = titleSeed.slice(0, 28) + (titleSeed.length > 28 ? '…' : '')
     }
     this.sessions.save(record)
 
@@ -739,8 +801,9 @@ export class AgentEngine {
       steps: ChatToolStep[],
       usage?: TokenUsage,
       usageEstimated?: boolean,
+      attachments?: ChatAttachmentMeta[],
     ) => {
-      this.pushAssistant(record!, reply, used, steps, usage, usageEstimated)
+      this.pushAssistant(record!, reply, used, steps, usage, usageEstimated, attachments)
     }
 
     const finalizeCancelled = (partialTools: string[], partialSteps: ChatToolStep[]): ChatResult => {
@@ -820,7 +883,7 @@ export class AgentEngine {
             estimated: budgeted.compactUsageEstimated ?? true,
           })
         }
-        const turn = await llm.chat(budgeted.modelView, openAiTools, signal)
+        const turn = await llm.chat(budgeted.modelView, openAiTools, signal, { sessionId })
         chatUsage = accumulateChatUsage(chatUsage, resolveTurnUsage(turn, budgeted.modelView))
         return turn
       }
@@ -842,7 +905,7 @@ export class AgentEngine {
       if (
         turn.finishReason === 'error'
         && !overflowRetried
-        && (turn.contextOverflow || isContextOverflowError(turn.error, turn.message.content))
+        && (turn.contextOverflow || isContextOverflowError(turn.error, chatMessageContentToText(turn.message.content)))
       ) {
         overflowRetried = true
         emit({
@@ -858,10 +921,10 @@ export class AgentEngine {
         if (turn.error === 'cancelled' || signal?.aborted) {
           return finalizeCancelled(toolsUsed, toolSteps)
         }
-        const overflow = turn.contextOverflow || isContextOverflowError(turn.error, turn.message.content)
+        const overflow = turn.contextOverflow || isContextOverflowError(turn.error, chatMessageContentToText(turn.message.content))
         const reply = overflow
           ? '对话内容过多，整理后仍无法继续。请新开对话，或换用更大上下文窗口的模型。'
-          : (turn.message.content ?? turn.error ?? '请求失败')
+          : (chatMessageContentToText(turn.message.content) || turn.error || '请求失败')
         pushAssistant(reply, toolsUsed, toolSteps, chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined, chatUsage.estimated)
         emit({
           type: 'error',
@@ -872,7 +935,7 @@ export class AgentEngine {
       }
 
       if (turn.finishReason === 'tool_calls' && turn.message.tool_calls?.length) {
-        const thinkingSnippet = turn.message.content?.trim()
+        const thinkingSnippet = chatMessageContentToText(turn.message.content).trim()
         if (thinkingSnippet) {
           emit({
             type: 'thinking',
@@ -886,7 +949,7 @@ export class AgentEngine {
 
         record.messages.push({
           role: 'assistant',
-          content: turn.message.content ?? null,
+          content: chatMessageContentToText(turn.message.content) || null,
           tool_calls: turn.message.tool_calls,
         })
         this.sessions.save(record)
@@ -982,7 +1045,8 @@ export class AgentEngine {
         continue
       }
 
-      const reply = turn.message.content?.trim() || '（无回复内容）'
+      const reply = chatMessageContentToText(turn.message.content).trim() || '（无回复内容）'
+      const outputAttachments = turn.outputAttachments
       emit({ type: 'reply', content: reply })
       pushAssistant(
         reply,
@@ -990,6 +1054,7 @@ export class AgentEngine {
         toolSteps,
         chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined,
         chatUsage.estimated,
+        outputAttachments,
       )
       void emitDone({ reply })
       return { reply, toolsUsed, sessionId, title: record.title }
@@ -1029,6 +1094,7 @@ export class AgentEngine {
     toolSteps: ChatToolStep[] = [],
     usage?: TokenUsage,
     usageEstimated?: boolean,
+    attachments?: ChatAttachmentMeta[],
   ) {
     if (this.sessions.shouldMaterializeContext(record)) {
       this.sessions.materializeContextRef(record)
@@ -1043,6 +1109,7 @@ export class AgentEngine {
       at: new Date().toISOString(),
       usage,
       usageEstimated,
+      attachments: attachments?.length ? attachments : undefined,
     })
     if (usage) {
       record.usageTotals = mergeTokenUsage(record.usageTotals ?? emptyTokenUsage(), usage)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -120,7 +120,41 @@ export {
   lookupModelsDevContextLimit,
   getModelsDevCatalog,
   resetModelsDevCacheForTests,
+  resolveModelMediaCapabilitiesAsync,
+  lookupModelsDevMediaEntry,
+  defaultTextOnlyMediaCapabilities,
 } from './llm/models-dev-context.js'
+export {
+  type MediaKind,
+  type ChatAttachmentMeta,
+  type AttachmentLimits,
+  type ModelMediaCapabilities,
+  mimeToMediaKind,
+  inferMimeFromFilename,
+  resolveMediaMime,
+  formatBytesShort,
+  mediaKindLabel,
+} from './media-types.js'
+export { resolveAttachmentLimits } from './attachment-limits.js'
+export {
+  saveAttachment,
+  readAttachmentMeta,
+  readAttachmentBuffer,
+  deleteAttachment,
+  resolveAttachmentFilePath,
+  validateAttachmentAgainstCapabilities,
+  isAttachmentReferenced,
+  summarizePinnedLimits,
+  parseNonNegativeIntHeader,
+  resolveUploadMime,
+} from './chat-attachments.js'
+export {
+  buildUserContentParts,
+  attachmentToContentPart,
+  chatMessageContentToText,
+  parseAssistantResponseContent,
+} from './content-parts.js'
+export type { ContentPart, TextContentPart, ImageUrlContentPart, FileContentPart, InputAudioContentPart } from './llm/provider.js'
 export {
   formatTokenCount,
   formatTurnUsageLabel,

--- a/packages/agent/src/llm/models-dev-context.ts
+++ b/packages/agent/src/llm/models-dev-context.ts
@@ -1,3 +1,5 @@
+import { resolveAttachmentLimits } from '../attachment-limits.js'
+import type { MediaKind, ModelMediaCapabilities } from '../media-types.js'
 import { resolveModelContextTokens } from './model-context.js'
 
 const MODELS_DEV_URL = 'https://models.dev/api.json'
@@ -33,8 +35,15 @@ export interface ModelsDevLimit {
   output?: number
 }
 
+interface ModelsDevModalities {
+  input?: string[]
+  output?: string[]
+}
+
 interface ModelsDevModelEntry {
   limit?: { context?: number; output?: number }
+  attachment?: boolean
+  modalities?: ModelsDevModalities
 }
 
 interface ModelsDevProviderEntry {
@@ -249,6 +258,133 @@ export async function resolveModelContextTokensAsync(
   }
   const { model } = splitModelRef(modelId)
   return resolveModelContextTokens(model || modelId)
+}
+
+function normalizeMediaKind(raw: string): MediaKind | null {
+  const v = raw.trim().toLowerCase()
+  if (v === 'text' || v === 'image' || v === 'pdf' || v === 'video' || v === 'audio') {
+    return v
+  }
+  return null
+}
+
+function mediaFromEntry(entry: ModelsDevModelEntry | undefined): {
+  attachment: boolean
+  input: MediaKind[]
+  output: MediaKind[]
+} {
+  const inputRaw = entry?.modalities?.input ?? ['text']
+  const outputRaw = entry?.modalities?.output ?? ['text']
+  const input = inputRaw
+    .map(normalizeMediaKind)
+    .filter((k): k is MediaKind => k !== null)
+  const output = outputRaw
+    .map(normalizeMediaKind)
+    .filter((k): k is MediaKind => k !== null)
+  const attachment = entry?.attachment === true
+    || input.some(k => k !== 'text')
+  return {
+    attachment,
+    input: input.length ? input : ['text'],
+    output: output.length ? output : ['text'],
+  }
+}
+
+function matchModelEntry(
+  catalog: ModelsDevCatalog,
+  modelId: string,
+  providerId?: string,
+): ModelsDevModelEntry | null {
+  const { provider: refProvider, model } = splitModelRef(modelId)
+  const effectiveProvider = providerId?.trim() || refProvider
+  const query = model || modelId
+
+  if (effectiveProvider) {
+    const provider = catalog[effectiveProvider]
+    if (provider?.models) {
+      const candidates = [
+        query,
+        query.toLowerCase(),
+        stripCommonPrefix(query),
+        normalizeModelKey(query),
+        normalizeModelKey(stripCommonPrefix(query)),
+      ]
+      for (const candidate of candidates) {
+        if (!candidate) continue
+        if (provider.models[candidate]) return provider.models[candidate]
+        const lower = candidate.toLowerCase()
+        for (const [key, entry] of Object.entries(provider.models)) {
+          if (key.toLowerCase() === lower) return entry
+        }
+      }
+    }
+  }
+
+  for (const { provider, modelKey } of collectModelKeys(catalog, providerId)) {
+    const normalizedQuery = normalizeModelKey(stripCommonPrefix(query))
+    const normalizedKey = normalizeModelKey(stripCommonPrefix(modelKey))
+    if (normalizedQuery.length >= MIN_SUBSTRING_LEN && (
+      normalizedKey.includes(normalizedQuery) || normalizedQuery.includes(normalizedKey)
+    )) {
+      return catalog[provider]?.models?.[modelKey] ?? null
+    }
+  }
+
+  for (const provider of Object.keys(catalog)) {
+    if (provider === effectiveProvider) continue
+    const hit = matchInProvider(catalog, provider, query)
+    if (hit) {
+      const providerEntry = catalog[provider]
+      if (!providerEntry?.models) continue
+      for (const [key, entry] of Object.entries(providerEntry.models)) {
+        const limit = limitFromEntry(entry)
+        if (limit && limit.context === hit.context) return entry
+        if (key.toLowerCase().includes(query.toLowerCase())) return entry
+      }
+    }
+  }
+
+  return null
+}
+
+export function lookupModelsDevMediaEntry(
+  catalog: ModelsDevCatalog,
+  modelId: string,
+  providerId?: string,
+): ReturnType<typeof mediaFromEntry> | null {
+  const entry = matchModelEntry(catalog, modelId, providerId)
+  if (!entry) return null
+  return mediaFromEntry(entry)
+}
+
+export async function resolveModelMediaCapabilitiesAsync(
+  modelId: string,
+  providerId?: string,
+): Promise<ModelMediaCapabilities> {
+  const catalog = await getModelsDevCatalog()
+  const fromCatalog = catalog
+    ? lookupModelsDevMediaEntry(catalog, modelId, providerId)
+    : null
+
+  const input = fromCatalog?.input ?? ['text']
+  const output = fromCatalog?.output ?? ['text']
+  const attachment = fromCatalog?.attachment ?? input.some(k => k !== 'text')
+
+  return {
+    attachment,
+    input,
+    output,
+    limits: resolveAttachmentLimits(modelId, input),
+  }
+}
+
+export function defaultTextOnlyMediaCapabilities(): ModelMediaCapabilities {
+  return {
+    attachment: false,
+    input: ['text'],
+    output: ['text'],
+    limits: resolveAttachmentLimits('default', ['text']),
+  }
 }
 
 export async function resolveModelsDevOutputReserve(

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -1,6 +1,7 @@
 import type { OpenAiTool } from '../tools.js'
 import { formatOutboundFetchError, outboundFetch } from './outbound-fetch.js'
 import { parseOpenAiUsage, type TokenUsage } from './token-usage.js'
+import { parseAssistantResponseContent } from '../content-parts.js'
 
 export interface LlmConfig {
   provider: string
@@ -18,9 +19,35 @@ export interface ToolCall {
   function: { name: string; arguments: string }
 }
 
+export interface TextContentPart {
+  type: 'text'
+  text: string
+}
+
+export interface ImageUrlContentPart {
+  type: 'image_url'
+  image_url: { url: string; detail?: 'auto' | 'low' | 'high' }
+}
+
+export interface FileContentPart {
+  type: 'file'
+  file: { filename: string; file_data: string }
+}
+
+export interface InputAudioContentPart {
+  type: 'input_audio'
+  input_audio: { data: string; format: string }
+}
+
+export type ContentPart =
+  | TextContentPart
+  | ImageUrlContentPart
+  | FileContentPart
+  | InputAudioContentPart
+
 export interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool'
-  content?: string | null
+  content?: string | null | ContentPart[]
   tool_calls?: ToolCall[]
   tool_call_id?: string
   name?: string
@@ -33,10 +60,17 @@ export interface LlmTurn {
   /** 上游响应表明上下文超限 */
   contextOverflow?: boolean
   usage?: TokenUsage
+  /** 从模型原生 content parts 解析出的输出媒体 */
+  outputAttachments?: import('./../media-types.js').ChatAttachmentMeta[]
 }
 
 export interface LlmProvider {
-  chat(messages: ChatMessage[], tools?: OpenAiTool[], signal?: AbortSignal): Promise<LlmTurn>
+  chat(
+    messages: ChatMessage[],
+    tools?: OpenAiTool[],
+    signal?: AbortSignal,
+    opts?: { sessionId?: string },
+  ): Promise<LlmTurn>
   listModels(): Promise<string[]>
 }
 
@@ -70,10 +104,34 @@ function isContextLengthHttpError(status: number, body: string): boolean {
   return false
 }
 
+function serializeMessageContent(content: ChatMessage['content']): string | ContentPart[] | null {
+  if (content == null) return null
+  if (typeof content === 'string') return content
+  return content
+}
+
+function serializeMessage(m: ChatMessage): Record<string, unknown> {
+  const content = serializeMessageContent(m.content)
+  return {
+    role: m.role,
+    ...(m.role === 'assistant' && m.tool_calls
+      ? { content: content ?? null }
+      : { content: content ?? '' }),
+    ...(m.tool_calls ? { tool_calls: m.tool_calls } : {}),
+    ...(m.tool_call_id ? { tool_call_id: m.tool_call_id } : {}),
+    ...(m.name ? { name: m.name } : {}),
+  }
+}
+
 export class OpenAiCompatibleProvider implements LlmProvider {
   constructor(private cfg: LlmConfig) {}
 
-  async chat(messages: ChatMessage[], tools?: OpenAiTool[], signal?: AbortSignal): Promise<LlmTurn> {
+  async chat(
+    messages: ChatMessage[],
+    tools?: OpenAiTool[],
+    signal?: AbortSignal,
+    opts?: { sessionId?: string },
+  ): Promise<LlmTurn> {
     if (!isConfigured(this.cfg)) {
       return {
         message: { role: 'assistant', content: '[LLM 未配置] 请在设置或环境变量中填入 API Key' },
@@ -85,15 +143,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
     try {
       const body: Record<string, unknown> = {
         model: this.cfg.model,
-        messages: messages.map(m => ({
-          role: m.role,
-          ...(m.role === 'assistant' && m.tool_calls
-            ? { content: m.content ?? null }
-            : { content: m.content ?? '' }),
-          ...(m.tool_calls ? { tool_calls: m.tool_calls } : {}),
-          ...(m.tool_call_id ? { tool_call_id: m.tool_call_id } : {}),
-          ...(m.name ? { name: m.name } : {}),
-        })),
+        messages: messages.map(serializeMessage),
         temperature: this.cfg.temperature ?? 0.3,
         max_tokens: this.cfg.maxTokens ?? 4096,
       }
@@ -140,7 +190,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
         choices?: {
           finish_reason?: string
           message?: {
-            content?: string | null
+            content?: string | null | unknown[]
             tool_calls?: ToolCall[]
           }
         }[]
@@ -158,14 +208,40 @@ export class OpenAiCompatibleProvider implements LlmProvider {
 
       if (raw.tool_calls?.length) {
         return {
-          message: { role: 'assistant', content: raw.content ?? null, tool_calls: raw.tool_calls },
+          message: {
+            role: 'assistant',
+            content: typeof raw.content === 'string' ? raw.content : null,
+            tool_calls: raw.tool_calls,
+          },
           finishReason: 'tool_calls',
           usage,
         }
       }
 
+      const sessionId = opts?.sessionId
+      if (sessionId && Array.isArray(raw.content)) {
+        const parsed = parseAssistantResponseContent(sessionId, raw.content)
+        return {
+          message: { role: 'assistant', content: parsed.text || '（无回复内容）' },
+          finishReason: 'stop',
+          usage,
+          outputAttachments: parsed.attachments.length ? parsed.attachments : undefined,
+        }
+      }
+
+      const textContent = typeof raw.content === 'string'
+        ? raw.content
+        : Array.isArray(raw.content)
+          ? raw.content
+            .filter((p): p is { type: 'text'; text: string } =>
+              typeof p === 'object' && p !== null && (p as { type?: string }).type === 'text'
+              && typeof (p as { text?: unknown }).text === 'string')
+            .map(p => p.text)
+            .join('\n')
+          : ''
+
       return {
-        message: { role: 'assistant', content: raw.content ?? '' },
+        message: { role: 'assistant', content: textContent ?? '' },
         finishReason: 'stop',
         usage,
       }

--- a/packages/agent/src/llm/providers.ts
+++ b/packages/agent/src/llm/providers.ts
@@ -1,6 +1,11 @@
 import { createProvider, isConfigured, fetchOpenAiModelList, type LlmConfig } from './provider.js'
 import { resolveModelContextTokens } from './model-context.js'
-import { resolveModelContextTokensAsync } from './models-dev-context.js'
+import {
+  resolveModelContextTokensAsync,
+  resolveModelMediaCapabilitiesAsync,
+  defaultTextOnlyMediaCapabilities,
+} from './models-dev-context.js'
+import type { ModelMediaCapabilities } from '../media-types.js'
 
 export { fetchOpenAiModelList }
 
@@ -19,6 +24,13 @@ export interface AvailableModel {
   providerName: string
   /** 启发式上下文窗口（tokens） */
   contextTokens: number
+  /** 是否支持附件上传 */
+  attachment?: boolean
+  inputModalities?: import('../media-types.js').MediaKind[]
+  outputModalities?: import('../media-types.js').MediaKind[]
+  attachmentLimits?: import('../media-types.js').AttachmentLimits
+  /** 嵌套媒体能力（与上述字段等价，便于 API 消费） */
+  media?: ModelMediaCapabilities
 }
 
 export function normalizeBaseUrl(url: string): string {
@@ -44,12 +56,18 @@ export class ProviderRegistry {
     for (const p of this.providers) {
       if (!p.apiKey || !p.baseUrl) continue
       for (const model of p.models) {
+        const media = defaultTextOnlyMediaCapabilities()
         out.push({
           ref: `${p.id}:${model}`,
           model,
           providerId: p.id,
           providerName: p.name,
           contextTokens: resolveModelContextTokens(model),
+          attachment: media.attachment,
+          inputModalities: media.input,
+          outputModalities: media.output,
+          attachmentLimits: media.limits,
+          media,
         })
       }
     }
@@ -61,13 +79,21 @@ export class ProviderRegistry {
     for (const p of this.providers) {
       if (!p.apiKey || !p.baseUrl) continue
       for (const model of p.models) {
-        const contextTokens = await resolveModelContextTokensAsync(model, p.id)
+        const [contextTokens, media] = await Promise.all([
+          resolveModelContextTokensAsync(model, p.id),
+          resolveModelMediaCapabilitiesAsync(model, p.id),
+        ])
         out.push({
           ref: `${p.id}:${model}`,
           model,
           providerId: p.id,
           providerName: p.name,
           contextTokens,
+          attachment: media.attachment,
+          inputModalities: media.input,
+          outputModalities: media.output,
+          attachmentLimits: media.limits,
+          media,
         })
       }
     }

--- a/packages/agent/src/llm/usage-estimate.ts
+++ b/packages/agent/src/llm/usage-estimate.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, LlmTurn } from './provider.js'
 import { estimateMessageTokens, estimateTextTokens } from '../context/token-estimate.js'
+import { chatMessageContentToText } from '../content-parts.js'
 import { emptyTokenUsage, mergeTokenUsage, type TokenUsage } from './token-usage.js'
 
 export function estimateUsageFromMessages(messages: ChatMessage[]): TokenUsage {
@@ -16,8 +17,8 @@ export function estimateUsageFromTurn(
   promptMessages: ChatMessage[],
 ): TokenUsage {
   const promptTokens = estimateMessageTokens(promptMessages)
-  const content = turn.message.content ?? ''
-  const completionTokens = typeof content === 'string' ? estimateTextTokens(content) : 0
+  const content = chatMessageContentToText(turn.message.content)
+  const completionTokens = content ? estimateTextTokens(content) : 0
   return {
     promptTokens,
     completionTokens,

--- a/packages/agent/src/media-types.ts
+++ b/packages/agent/src/media-types.ts
@@ -1,0 +1,97 @@
+/** 媒体种类；text 不占附件配额 */
+export type MediaKind = 'text' | 'image' | 'pdf' | 'video' | 'audio'
+
+export interface ChatAttachmentMeta {
+  id: string
+  kind: MediaKind
+  mime: string
+  name: string
+  size: number
+  createdAt: string
+  width?: number
+  height?: number
+  duration?: number
+}
+
+export interface AttachmentLimits {
+  maxBytesByKind: Partial<Record<MediaKind, number>>
+  maxCount: number
+  maxTotalBytes: number
+}
+
+export interface ModelMediaCapabilities {
+  attachment: boolean
+  input: MediaKind[]
+  output: MediaKind[]
+  limits: AttachmentLimits
+}
+
+const IMAGE_PREFIX = 'image/'
+const VIDEO_PREFIX = 'video/'
+const AUDIO_PREFIX = 'audio/'
+
+const EXT_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+  '.pdf': 'application/pdf',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.mov': 'video/quicktime',
+  '.mkv': 'video/x-matroska',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.m4a': 'audio/mp4',
+  '.ogg': 'audio/ogg',
+  '.aac': 'audio/aac',
+}
+
+export function inferMimeFromFilename(filename: string): string | null {
+  const dot = filename.lastIndexOf('.')
+  if (dot < 0) return null
+  return EXT_MIME[filename.slice(dot).toLowerCase()] ?? null
+}
+
+function kindFromNormalizedMime(normalized: string): MediaKind | null {
+  if (!normalized) return null
+  if (normalized.startsWith(IMAGE_PREFIX)) return 'image'
+  if (normalized === 'application/pdf') return 'pdf'
+  if (normalized.startsWith(VIDEO_PREFIX)) return 'video'
+  if (normalized.startsWith(AUDIO_PREFIX)) return 'audio'
+  return null
+}
+
+/** 解析有效 MIME：空 type / octet-stream 时按扩展名推断 */
+export function resolveMediaMime(mime: string, filename?: string): string {
+  const normalized = mime.toLowerCase().split(';')[0]?.trim() ?? ''
+  if (normalized && normalized !== 'application/octet-stream') return normalized
+  if (filename) {
+    const inferred = inferMimeFromFilename(filename)
+    if (inferred) return inferred
+  }
+  return normalized || 'application/octet-stream'
+}
+
+export function mimeToMediaKind(mime: string, filename?: string): MediaKind | null {
+  return kindFromNormalizedMime(resolveMediaMime(mime, filename))
+}
+
+export function formatBytesShort(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(bytes < 10_240 ? 1 : 0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+export function mediaKindLabel(kind: MediaKind): string {
+  switch (kind) {
+    case 'image': return '图片'
+    case 'pdf': return 'PDF'
+    case 'video': return '视频'
+    case 'audio': return '音频'
+    default: return '文件'
+  }
+}

--- a/packages/agent/src/sessions.ts
+++ b/packages/agent/src/sessions.ts
@@ -1,13 +1,15 @@
 import { randomUUID } from 'node:crypto'
 import { getUserDataStore } from '@opptrix/user-store'
 import type { ChatMessage } from './llm/provider.js'
+import { chatMessageContentToText } from './content-parts.js'
 import type { ChatToolStep } from './chat-progress.js'
 import type { TokenUsage } from './llm/token-usage.js'
 import { SessionArchiveFolderStore } from './archive-folders.js'
 
+import type { ChatAttachmentMeta } from './media-types.js'
 import type { ExpertIcon } from '@opptrix/shared'
 
-export type { ChatToolStep }
+export type { ChatToolStep, ChatAttachmentMeta }
 
 const NAMESPACE = 'session'
 
@@ -42,6 +44,7 @@ export interface DisplayMessage {
   at: string
   usage?: TokenUsage
   usageEstimated?: boolean
+  attachments?: ChatAttachmentMeta[]
 }
 
 export interface SessionForkContextRef {
@@ -89,6 +92,7 @@ export interface SessionRecord extends SessionMeta {
     at: string
     usage?: TokenUsage
     usageEstimated?: boolean
+    attachments?: ChatAttachmentMeta[]
   }[]
   contextRef?: SessionContextRef | null
   /**
@@ -130,10 +134,10 @@ function migrateTurns(record: SessionRecord): SessionRecord {
 
   const turns: SessionRecord['turns'] = []
   for (const m of record.messages) {
-    if ((m.role === 'user' || m.role === 'assistant') && m.content) {
+    if ((m.role === 'user' || m.role === 'assistant') && m.content != null) {
       turns.push({
         role: m.role,
-        content: String(m.content),
+        content: chatMessageContentToText(m.content),
         at: record.updatedAt,
       })
     }
@@ -351,12 +355,17 @@ export class SessionStore {
         at: t.at,
         usage: t.usage,
         usageEstimated: t.usageEstimated,
+        attachments: t.attachments,
       }))
     }
     const out: DisplayMessage[] = []
     for (const m of record.messages) {
-      if ((m.role === 'user' || m.role === 'assistant') && m.content) {
-        out.push({ role: m.role, content: m.content, at: record.updatedAt })
+      if ((m.role === 'user' || m.role === 'assistant') && m.content != null) {
+        out.push({
+          role: m.role,
+          content: chatMessageContentToText(m.content),
+          at: record.updatedAt,
+        })
       }
     }
     return out

--- a/tests/chat-multimodal.test.mjs
+++ b/tests/chat-multimodal.test.mjs
@@ -1,0 +1,158 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  lookupModelsDevMediaEntry,
+  resetModelsDevCacheForTests,
+} from '../packages/agent/dist/llm/models-dev-context.js'
+import { resolveAttachmentLimits } from '../packages/agent/dist/attachment-limits.js'
+import { parseAssistantResponseContent } from '../packages/agent/dist/content-parts.js'
+import path from 'node:path'
+import fs from 'node:fs'
+import os from 'node:os'
+
+describe('resolveAttachmentLimits', () => {
+  it('applies OpenAI tier for gpt-4o', () => {
+    const limits = resolveAttachmentLimits('gpt-4o', ['text', 'image', 'pdf'])
+    assert.equal(limits.maxBytesByKind.image, 20 * 1024 * 1024)
+    assert.equal(limits.maxBytesByKind.pdf, 32 * 1024 * 1024)
+    assert.ok(limits.maxCount >= 5)
+  })
+
+  it('applies conservative defaults for unknown models', () => {
+    const limits = resolveAttachmentLimits('unknown-model-xyz', ['text', 'image'])
+    assert.equal(limits.maxBytesByKind.image, 10 * 1024 * 1024)
+    assert.equal(limits.maxBytesByKind.pdf, undefined)
+  })
+
+  it('applies Claude tier stricter image cap', () => {
+    const limits = resolveAttachmentLimits('claude-sonnet-4-6', ['text', 'image', 'pdf'])
+    assert.equal(limits.maxBytesByKind.image, 5 * 1024 * 1024)
+  })
+})
+
+describe('lookupModelsDevMediaEntry', () => {
+  it('reads modalities from catalog fixture', () => {
+    const catalog = {
+      openai: {
+        models: {
+          'gpt-4.1': {
+            attachment: true,
+            modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+          },
+        },
+      },
+    }
+    const hit = lookupModelsDevMediaEntry(catalog, 'gpt-4.1', 'openai')
+    assert.ok(hit)
+    assert.equal(hit.attachment, true)
+    assert.deepEqual(hit.input, ['text', 'image', 'pdf'])
+  })
+})
+
+describe('parseAssistantResponseContent', () => {
+  it('extracts text and ignores unknown parts', () => {
+    const parsed = parseAssistantResponseContent('sess-1', [
+      { type: 'text', text: '你好' },
+      { type: 'unknown', data: 'x' },
+    ])
+    assert.equal(parsed.text, '你好')
+    assert.equal(parsed.attachments.length, 0)
+  })
+})
+
+describe('chat attachment path traversal', () => {
+  it('rejects invalid attachment ids', async () => {
+    process.env.OPPTRIX_DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-att-'))
+    const { readAttachmentMeta } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(readAttachmentMeta('sess', '../etc/passwd'), null)
+    fs.rmSync(process.env.OPPTRIX_DATA_DIR, { recursive: true, force: true })
+    delete process.env.OPPTRIX_DATA_DIR
+  })
+})
+
+describe('resolveUploadMime', () => {
+  it('prefers X-Attachment-Mime over octet-stream Content-Type', async () => {
+    const { resolveUploadMime } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(
+      resolveUploadMime('application/octet-stream', 'image/png'),
+      'image/png',
+    )
+  })
+
+  it('falls back to Content-Type when not octet-stream', async () => {
+    const { resolveUploadMime } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(resolveUploadMime('image/jpeg', undefined), 'image/jpeg')
+  })
+
+  it('defaults to octet-stream when no explicit mime', async () => {
+    const { resolveUploadMime } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(resolveUploadMime('application/octet-stream', undefined), 'application/octet-stream')
+  })
+})
+
+describe('parseNonNegativeIntHeader', () => {
+  it('parses valid non-negative integers', async () => {
+    const { parseNonNegativeIntHeader } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(parseNonNegativeIntHeader('3'), 3)
+    assert.equal(parseNonNegativeIntHeader(['5']), 5)
+  })
+
+  it('returns 0 for invalid or negative values', async () => {
+    const { parseNonNegativeIntHeader } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(parseNonNegativeIntHeader(undefined), 0)
+    assert.equal(parseNonNegativeIntHeader('-1'), 0)
+    assert.equal(parseNonNegativeIntHeader('abc'), 0)
+  })
+})
+
+describe('mime extension fallback', () => {
+  it('infers kind from filename when mime empty', async () => {
+    const { mimeToMediaKind, inferMimeFromFilename } = await import('../packages/agent/dist/media-types.js')
+    assert.equal(inferMimeFromFilename('photo.png'), 'image/png')
+    assert.equal(mimeToMediaKind('', 'photo.png'), 'image')
+    assert.equal(mimeToMediaKind('application/octet-stream', 'doc.pdf'), 'pdf')
+  })
+
+  it('resolveUploadMime uses filename fallback', async () => {
+    const { resolveUploadMime } = await import('../packages/agent/dist/chat-attachments.js')
+    assert.equal(
+      resolveUploadMime('application/octet-stream', 'application/octet-stream', 'clip.mp4'),
+      'video/mp4',
+    )
+  })
+})
+
+describe('modelAllowsAttachments', () => {
+  it('true when input has non-text modalities', async () => {
+    const { modelAllowsAttachments } = await import('../client-ui/src/chat/mediaCapabilities.ts')
+    assert.equal(modelAllowsAttachments({ attachment: false, input: ['text', 'image'], output: ['text'], limits: { maxBytesByKind: {}, maxCount: 5, maxTotalBytes: 1e6 } }), true)
+    assert.equal(modelAllowsAttachments({ attachment: true, input: ['text'], output: ['text'], limits: { maxBytesByKind: {}, maxCount: 0, maxTotalBytes: 0 } }), false)
+    assert.equal(modelAllowsAttachments(null), false)
+  })
+})
+
+describe('partitionPinsForModel', () => {
+  it('keeps all pins when media is null', async () => {
+    const { partitionPinsForModel } = await import('../client-ui/src/chat/mediaCapabilities.ts')
+    const pinned = [{ id: 'a1', kind: 'image', name: 'x.png', mime: 'image/png', size: 100, createdAt: '2026-01-01T00:00:00.000Z' }]
+    const { kept, removedIds } = partitionPinsForModel(pinned, null)
+    assert.deepEqual(kept, pinned)
+    assert.deepEqual(removedIds, [])
+  })
+
+  it('removes incompatible pins for text-only model', async () => {
+    const { partitionPinsForModel } = await import('../client-ui/src/chat/mediaCapabilities.ts')
+    const media = {
+      attachment: false,
+      input: ['text'],
+      output: ['text'],
+      limits: { maxBytesByKind: {}, maxCount: 0, maxTotalBytes: 0 },
+    }
+    const pinned = [{ id: 'a1', kind: 'image', name: 'x.png', mime: 'image/png', size: 100, createdAt: '2026-01-01T00:00:00.000Z' }]
+    const { kept, removedIds } = partitionPinsForModel(pinned, media)
+    assert.equal(kept.length, 0)
+    assert.deepEqual(removedIds, ['a1'])
+  })
+})
+
+resetModelsDevCacheForTests()


### PR DESCRIPTION
## Summary
- 按 models.dev modalities/attachment 与模型族动态限额，支持图片、PDF、视频、音频
- 附件落盘 + 上传/下载/删除 API；聊天以 OpenAI content parts 发送，并解析模型原生多媒体输出
- Composer 拖拽/粘贴 pin、消息预览播放器；换模型自动剔除不兼容附件

## Test plan
- [x] `npm run build -w @opptrix/agent` / `@opptrix/server`
- [x] `node --test --test-force-exit tests/chat-multimodal.test.mjs`
- [x] `npm run check:ui`
- [ ] 手动：拖入图片发送；换纯文本模型看 pin 清除；预览框打开图/视频


Made with [Cursor](https://cursor.com)