### PR TITLE
feat(desktop): 窗口失焦时聊天完成与确认提示发系统通知

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -803,6 +803,11 @@ function registerWindowIpc() {
   ipcMain.handle('window-is-fullscreen', (event) => {
     return BrowserWindow.fromWebContents(event.sender)?.isFullScreen() ?? false
   })
+  ipcMain.handle('window-is-focused', (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    if (!win || win.isDestroyed()) return false
+    return win.isFocused()
+  })
 
   ipcMain.handle('pick-export-directory', async (event) => {
     const win = BrowserWindow.fromWebContents(event.sender)
@@ -910,7 +915,14 @@ function registerWindowIpc() {
   registerUpdaterIpc(ipcMain, { prepareForUpdateInstall })
   registerProtocolIpc(ipcMain)
   registerNotificationIpc(ipcMain, {
-    onNotificationClick: () => focusMainWindow(),
+    onNotificationClick: (payload) => {
+      const sessionId = typeof payload?.sessionId === 'string' ? payload.sessionId.trim() : ''
+      if (sessionId) {
+        deliverProtocolUrl(`opptrix://chat?session=${encodeURIComponent(sessionId)}`)
+        return
+      }
+      focusMainWindow()
+    },
   })
 }
 

--- a/apps/desktop/electron/notifications.cjs
+++ b/apps/desktop/electron/notifications.cjs
@@ -3,6 +3,81 @@ const { Notification, app } = require('electron')
 /** @type {'default' | 'granted' | 'denied'} */
 let cachedPermission = 'default'
 
+const TITLE_MAX = 120
+const BODY_MAX = 200
+const TAG_MAX = 128
+const SESSION_ID_MAX = 64
+const TAG_RE = /^[A-Za-z0-9:_-]+$/
+const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/
+const KIND_SET = new Set(['chat_done', 'chat_ask'])
+
+/**
+ * 校验并裁剪 renderer 传入的通知载荷；非法字段忽略或整包拒绝。
+ * @param {unknown} raw
+ * @returns {{
+ *   title: string
+ *   body?: string
+ *   silent?: boolean
+ *   tag?: string
+ *   sessionId?: string
+ *   kind?: 'chat_done' | 'chat_ask'
+ * } | null}
+ */
+function sanitizeNotificationPayload(raw) {
+  if (!raw || typeof raw !== 'object') return null
+
+  const title = String(/** @type {{ title?: unknown }} */ (raw).title ?? '').trim()
+  if (!title || title.length > TITLE_MAX) return null
+
+  /** @type {{
+   *   title: string
+   *   body?: string
+   *   silent?: boolean
+   *   tag?: string
+   *   sessionId?: string
+   *   kind?: 'chat_done' | 'chat_ask'
+   * }} */
+  const out = { title }
+
+  const bodyRaw = /** @type {{ body?: unknown }} */ (raw).body
+  if (bodyRaw != null) {
+    const body = String(bodyRaw).trim()
+    if (body) {
+      out.body = body.length > BODY_MAX ? body.slice(0, BODY_MAX) : body
+    }
+  }
+
+  if (/** @type {{ silent?: unknown }} */ (raw).silent != null) {
+    out.silent = Boolean(/** @type {{ silent?: unknown }} */ (raw).silent)
+  }
+
+  const tagRaw = /** @type {{ tag?: unknown }} */ (raw).tag
+  if (tagRaw != null) {
+    const tag = String(tagRaw).trim()
+    if (tag && tag.length <= TAG_MAX && TAG_RE.test(tag)) {
+      out.tag = tag
+    }
+  }
+
+  const sessionRaw = /** @type {{ sessionId?: unknown }} */ (raw).sessionId
+  if (sessionRaw != null) {
+    const sessionId = String(sessionRaw).trim()
+    if (sessionId && sessionId.length <= SESSION_ID_MAX && SESSION_ID_RE.test(sessionId)) {
+      out.sessionId = sessionId
+    }
+  }
+
+  const kindRaw = /** @type {{ kind?: unknown }} */ (raw).kind
+  if (kindRaw != null) {
+    const kind = String(kindRaw).trim()
+    if (KIND_SET.has(kind)) {
+      out.kind = /** @type {'chat_done' | 'chat_ask'} */ (kind)
+    }
+  }
+
+  return out
+}
+
 function isNotificationSupported() {
   return Notification.isSupported()
 }
@@ -62,15 +137,17 @@ function registerNotificationIpc(ipcMain, { onNotificationClick } = {}) {
   ipcMain.handle('notification-request-permission', async () => requestNotificationPermission())
 
   ipcMain.handle('notification-show', async (_event, payload) => {
+    const sanitized = sanitizeNotificationPayload(payload)
+    if (!sanitized) return false
     const onClick =
       typeof onNotificationClick === 'function'
-        ? () => onNotificationClick(payload)
+        ? () => onNotificationClick(sanitized)
         : undefined
     return showLocalNotification({
-      title: payload?.title,
-      body: payload?.body,
-      silent: payload?.silent,
-      tag: payload?.tag,
+      title: sanitized.title,
+      body: sanitized.body,
+      silent: sanitized.silent,
+      tag: sanitized.tag,
       onClick,
     })
   })
@@ -88,5 +165,6 @@ module.exports = {
   isNotificationSupported,
   registerNotificationIpc,
   requestNotificationPermission,
+  sanitizeNotificationPayload,
   showLocalNotification,
 }

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   windowMaximize: () => ipcRenderer.send('window-maximize'),
   windowClose: () => ipcRenderer.send('window-close'),
   getIsFullscreen: () => ipcRenderer.invoke('window-is-fullscreen'),
+  windowIsFocused: () => ipcRenderer.invoke('window-is-focused'),
   pickExportDirectory: () => ipcRenderer.invoke('pick-export-directory'),
   writeBinaryFile: (payload) => ipcRenderer.invoke('write-binary-file', payload),
   pickSaveFile: (payload) => ipcRenderer.invoke('pick-save-file', payload),

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -54,6 +54,12 @@ import { desktopChromeToolbarReserve } from '../desktop/layout'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { useDesktopShell } from '../hooks/useDesktopShell'
 import { isElectron } from '../platform/detect'
+import {
+  buildChatAskNotification,
+  buildChatDoneNotification,
+  maybeShowChatLocalNotification,
+  resolveWindowFocused,
+} from '../platform/chatNotifications'
 import { DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_TITLEBAR_HEIGHT, DESKTOP_Z_TITLE, SIDEBAR_DEFAULT_WIDTH, WORKSPACE_CHAT_MIN_WIDTH, WORKSPACE_CHAT_RIGHT_MIN_WIDTH } from '../desktop/constants'
 
 const useStyles = makeStyles({
@@ -284,6 +290,9 @@ export default function ChatApp() {
   const stoppingSessionsRef = useRef(new Set<string>())
   const streamingSessionIdsRef = useRef(new Set<string>())
   const activeIdRef = useRef<string | null>(null)
+  const viewRef = useRef(view)
+  const sessionsRef = useRef(sessions)
+  const activeSessionMetaRef = useRef(activeSessionMeta)
   const loading = activeId ? streamingSessionIds.includes(activeId) : false
   const markSessionStreaming = useCallback((sessionId: string, streaming: boolean) => {
     if (streaming) streamingSessionIdsRef.current.add(sessionId)
@@ -303,6 +312,48 @@ export default function ChatApp() {
       if (event.type === 'done' && event.context_usage) {
         setContextUsage(event.context_usage)
       }
+    }
+
+    if (event.type === 'done' && !event.cancelled) {
+      const sessionTitle = event.title
+        ?? (activeSessionMetaRef.current?.id === targetSessionId
+          ? activeSessionMetaRef.current.title
+          : undefined)
+        ?? sessionsRef.current.find(s => s.id === targetSessionId)?.title
+      void (async () => {
+        const documentVisible = typeof document !== 'undefined'
+          && document.visibilityState === 'visible'
+        const windowFocused = await resolveWindowFocused()
+        await maybeShowChatLocalNotification(
+          targetSessionId,
+          {
+            activeSessionId: activeIdRef.current,
+            view: viewRef.current,
+            documentVisible,
+            windowFocused,
+          },
+          buildChatDoneNotification(targetSessionId, sessionTitle),
+        )
+      })()
+    }
+
+    if (event.type === 'user_prompt') {
+      const promptSummary = event.prompt.title || event.prompt.prompt
+      void (async () => {
+        const documentVisible = typeof document !== 'undefined'
+          && document.visibilityState === 'visible'
+        const windowFocused = await resolveWindowFocused()
+        await maybeShowChatLocalNotification(
+          targetSessionId,
+          {
+            activeSessionId: activeIdRef.current,
+            view: viewRef.current,
+            documentVisible,
+            windowFocused,
+          },
+          buildChatAskNotification(targetSessionId, promptSummary),
+        )
+      })()
     }
   }, [])
 
@@ -771,6 +822,9 @@ export default function ChatApp() {
   const loadingRef = useRef(loading)
   const sessionModelRef = useRef(sessionModel)
   activeIdRef.current = activeId
+  viewRef.current = view
+  sessionsRef.current = sessions
+  activeSessionMetaRef.current = activeSessionMeta
   loadingRef.current = loading
   sessionModelRef.current = sessionModel
 

--- a/client-ui/src/platform/chatNotifications.ts
+++ b/client-ui/src/platform/chatNotifications.ts
@@ -1,0 +1,104 @@
+import type { LocalNotificationPayload } from './detect'
+
+export type ChatNotificationAttention = {
+  activeSessionId: string | null
+  view: string
+  documentVisible: boolean
+  windowFocused: boolean
+}
+
+const BODY_MAX = 120
+
+function isElectronRuntime(): boolean {
+  if (typeof window === 'undefined') return false
+  return window.electronAPI?.isElectron === true
+}
+
+/** 用户正在盯着该会话的聊天页（前台可跳过通知） */
+export function isAttendingChat(
+  targetSessionId: string,
+  state: ChatNotificationAttention,
+): boolean {
+  return (
+    state.activeSessionId === targetSessionId
+    && state.view === 'chat'
+    && state.documentVisible
+    && state.windowFocused
+  )
+}
+
+/** 失焦 / 非 chat 页 / 其他会话 → 应发通知 */
+export function shouldNotify(
+  targetSessionId: string,
+  state: ChatNotificationAttention,
+): boolean {
+  return !isAttendingChat(targetSessionId, state)
+}
+
+export function truncateNotificationText(text: string, maxLen = BODY_MAX): string {
+  const normalized = text.replace(/\s+/g, ' ').trim()
+  if (!normalized) return ''
+  if (normalized.length <= maxLen) return normalized
+  if (maxLen <= 1) return '…'
+  return `${normalized.slice(0, maxLen - 1)}…`
+}
+
+export function buildChatDoneNotification(
+  sessionId: string,
+  sessionTitle?: string,
+): LocalNotificationPayload {
+  const body = truncateNotificationText(sessionTitle ?? '') || undefined
+  return {
+    title: '对话已生成完成',
+    body,
+    tag: `chat:done:${sessionId}`,
+    sessionId,
+    kind: 'chat_done',
+  }
+}
+
+export function buildChatAskNotification(
+  sessionId: string,
+  promptSummary?: string,
+): LocalNotificationPayload {
+  const body = truncateNotificationText(promptSummary ?? '') || undefined
+  return {
+    title: '需要你的确认',
+    body,
+    tag: `chat:ask:${sessionId}`,
+    sessionId,
+    kind: 'chat_ask',
+  }
+}
+
+export async function resolveWindowFocused(): Promise<boolean> {
+  const api = typeof window !== 'undefined' ? window.electronAPI : undefined
+  if (api?.windowIsFocused) {
+    try {
+      return await api.windowIsFocused()
+    } catch {
+      return false
+    }
+  }
+  if (typeof document !== 'undefined') {
+    return document.hasFocus()
+  }
+  return false
+}
+
+/**
+ * Electron 下按注意力状态决定是否展示本地通知；Web / 失败静默 no-op。
+ */
+export async function maybeShowChatLocalNotification(
+  targetSessionId: string,
+  attention: ChatNotificationAttention,
+  payload: LocalNotificationPayload,
+): Promise<void> {
+  if (!isElectronRuntime()) return
+  if (!shouldNotify(targetSessionId, attention)) return
+  try {
+    await window.electronAPI?.showLocalNotification?.(payload)
+  } catch {
+    /* fire-and-forget */
+  }
+}

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -38,6 +38,7 @@ declare global {
       onTranslationProgress?: (callback: (progress: TranslationProgress) => void) => () => void
       onFullscreenChange?: (callback: (fullscreen: boolean) => void) => () => void
       onProtocolOpen?: (callback: (payload: OpptrixProtocolPayload) => void) => () => void
+      windowIsFocused?: () => Promise<boolean>
       notificationIsSupported?: () => Promise<boolean>
       notificationGetPermission?: () => Promise<NotificationPermissionState>
       notificationRequestPermission?: () => Promise<NotificationPermissionState>
@@ -170,11 +171,15 @@ export type AppUpdateStatus = {
 
 export type NotificationPermissionState = 'default' | 'granted' | 'denied'
 
+export type LocalNotificationKind = 'chat_done' | 'chat_ask'
+
 export type LocalNotificationPayload = {
   title: string
   body?: string
   silent?: boolean
   tag?: string
+  sessionId?: string
+  kind?: LocalNotificationKind
 }
 
 export type OpptrixProtocolPayload = {

--- a/docs/ARCHITECTURE-COMPREHENSIVE.md
+++ b/docs/ARCHITECTURE-COMPREHENSIVE.md
@@ -974,6 +974,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   translationTranslateArticle: (payload) => ipcRenderer.invoke('translation-translate-article', payload),
   // 通知
   showLocalNotification: (payload) => ipcRenderer.invoke('notification-show', payload),
+  notificationIsSupported: () => ipcRenderer.invoke('notification-is-supported'),
+  notificationGetPermission: () => ipcRenderer.invoke('notification-get-permission'),
+  notificationRequestPermission: () => ipcRenderer.invoke('notification-request-permission'),
+  // 窗口焦点（聊天通知注意力判断）
+  windowIsFocused: () => ipcRenderer.invoke('window-is-focused'),
 })
 ```
 
@@ -1002,7 +1007,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
 - 使用 Electron 原生 `Notification` API
 - 支持权限请求与缓存
 - Windows 设置 `appUserModelId` 以正确显示通知
-- 支持点击通知聚焦主窗口
+- 支持点击通知聚焦主窗口；聊天通知带 `sessionId` 时深链 `opptrix://chat?session=`
+
+**聊天本地通知**（触发条件、失焦定义、IPC、payload）：见 [DESKTOP.md · 本地聊天通知](./DESKTOP.md#本地聊天通知)。
 
 ---
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -92,6 +92,75 @@ The release app loads `http://127.0.0.1:8711` (UI + API same origin).
 
 In Electron, the client forces **desktop layout** (sidebar visible, no mobile drawer) via `client-ui/src/platform/detect.ts`.
 
+## 本地聊天通知
+
+Electron 桌面端在用户**未盯着该会话聊天页**时，用系统本地通知提示对话完成或需要确认。逻辑在 renderer（`client-ui/src/platform/chatNotifications.ts` + `ChatApp`），展示与点击由主进程（`apps/desktop/electron/notifications.cjs`）完成。Web 端 no-op。
+
+### 触发点
+
+| 流事件 | 通知 `kind` | `tag` 格式 | 标题（UI 文案） | body |
+|--------|-------------|------------|-----------------|------|
+| `done`（且非 `cancelled`） | `chat_done` | `chat:done:{sessionId}` | 对话已生成完成 | 会话标题（截断至 120 字） |
+| `user_prompt` | `chat_ask` | `chat:ask:{sessionId}` | 需要你的确认 | `prompt.title` 或 `prompt.prompt`（截断至 120 字） |
+
+触发位置：`ChatApp` 的 `pushStreamEvent`。仅 Electron（`electronAPI.isElectron`）且通过注意力判断后才调用 `showLocalNotification`。
+
+### 失焦定义（何时发通知）
+
+「正在盯着该会话」需**同时**满足（`isAttendingChat`）：
+
+1. `activeSessionId ===` 目标 `sessionId`
+2. 当前 `view === 'chat'`
+3. `document.visibilityState === 'visible'`
+4. 主窗口 focused（优先 `electronAPI.windowIsFocused()` → IPC `window-is-focused` → `BrowserWindow.isFocused()`；无 API 时回退 `document.hasFocus()`）
+
+任一不满足 → `shouldNotify` 为 true → 发通知。因此：切到其他会话 / 非聊天页 / 文档隐藏 / 窗口失焦都会通知。
+
+### 点击深链
+
+通知带有效 `sessionId` 时，主进程 `onNotificationClick` 调用：
+
+```text
+opptrix://chat?session={encodeURIComponent(sessionId)}
+```
+
+经既有 `deliverProtocolUrl` → renderer `onProtocolOpen` → `useDesktopShell` 解析 `route=chat` + `params.session` → `openChat(sessionId)`。无 `sessionId` 时仅 `focusMainWindow()`。
+
+### IPC 与 preload
+
+| IPC channel | preload API | 说明 |
+|-------------|-------------|------|
+| `notification-is-supported` | `notificationIsSupported()` | `Notification.isSupported()` |
+| `notification-get-permission` | `notificationGetPermission()` | 缓存权限状态 |
+| `notification-request-permission` | `notificationRequestPermission()` | 壳启动时 `useDesktopShell` 会请求一次 |
+| `notification-show` | `showLocalNotification(payload)` | 校验后展示；点击走 `onNotificationClick` |
+| `window-is-focused` | `windowIsFocused()` | 主窗口是否 focused（注意力判断） |
+
+协议事件仍为 `opptrix-protocol`（`onProtocolOpen`），与通知点击深链共用。
+
+### Payload（`LocalNotificationPayload`）
+
+| 字段 | 类型 | 校验（主进程 `sanitizeNotificationPayload`） |
+|------|------|-----------------------------------------------|
+| `title` | string | 必填；trim 后非空且 ≤ 120 |
+| `body` | string? | 可选；trim 后 ≤ 200 |
+| `silent` | boolean? | 可选 |
+| `tag` | string? | 可选；`^[A-Za-z0-9:_-]+$`，≤ 128 |
+| `sessionId` | string? | 可选；`^[A-Za-z0-9_-]+$`，≤ 64；非法则丢弃（点击仅聚焦窗口） |
+| `kind` | `'chat_done' \| 'chat_ask'`? | 未知 kind 忽略 |
+
+非法 `title` → 整包拒绝（返回 `false`）。未知字段忽略。
+
+### 平台注意
+
+| 平台 | 注意 |
+|------|------|
+| **Windows** | `configureNotificationIdentity(appId)` → `app.setAppUserModelId`（`package.json` `build.appId`），否则通知可能不归到本应用 |
+| **macOS** | 需系统「通知」权限；启动时请求；用户在系统设置中拒绝则无法展示 |
+| **Linux** | 依赖桌面环境对 Electron `Notification` 的支持（`Notification.isSupported()`）；部分环境可能静默失败 |
+
+单元测试：`tests/chat-notifications.test.mjs`（注意力、builder、sanitize）。
+
 ## 命令隔离（Agent Shell）
 
 智能助手在**本对话工作区**与已授权目录内运行 Python / Node 命令时，使用系统级隔离环境（`shell_run` / `shell_install`）。每段对话有独立的默认读写目录（`agent-workspace/sessions/<会话ID>/`），不会默认与其他对话共享文件。首次运行命令前会请你确认；访问外网或安装依赖时会另行确认。

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -30,7 +30,10 @@ for (const file of testFiles) {
   const label = path.basename(file)
   const t0 = Date.now()
   const nodeArgs = ['--test', '--test-force-exit', file]
-  if (label === 'session-stream-runtime.test.mjs') {
+  if (
+    label === 'session-stream-runtime.test.mjs'
+    || label === 'chat-notifications.test.mjs'
+  ) {
     nodeArgs.unshift('--experimental-strip-types')
   }
   const result = spawnSync(

--- a/tests/chat-notifications.test.mjs
+++ b/tests/chat-notifications.test.mjs
@@ -1,0 +1,110 @@
+import { createRequire } from 'node:module'
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildChatAskNotification,
+  buildChatDoneNotification,
+  isAttendingChat,
+  shouldNotify,
+  truncateNotificationText,
+} from '../client-ui/src/platform/chatNotifications.ts'
+
+const require = createRequire(import.meta.url)
+const { sanitizeNotificationPayload } = require('../apps/desktop/electron/notifications.cjs')
+
+describe('chat notification attention', () => {
+  const attending = {
+    activeSessionId: 'sess-1',
+    view: 'chat',
+    documentVisible: true,
+    windowFocused: true,
+  }
+
+  it('isAttendingChat only when watching that chat session', () => {
+    assert.equal(isAttendingChat('sess-1', attending), true)
+    assert.equal(isAttendingChat('sess-2', attending), false)
+    assert.equal(isAttendingChat('sess-1', { ...attending, view: 'news' }), false)
+    assert.equal(isAttendingChat('sess-1', { ...attending, documentVisible: false }), false)
+    assert.equal(isAttendingChat('sess-1', { ...attending, windowFocused: false }), false)
+  })
+
+  it('shouldNotify is inverse of attending', () => {
+    assert.equal(shouldNotify('sess-1', attending), false)
+    assert.equal(shouldNotify('sess-1', { ...attending, view: 'settings' }), true)
+    assert.equal(shouldNotify('sess-2', attending), true)
+  })
+})
+
+describe('chat notification builders', () => {
+  it('buildChatDoneNotification uses copy and tag', () => {
+    const payload = buildChatDoneNotification('abc_12', '贵州茅台投研')
+    assert.equal(payload.title, '对话已生成完成')
+    assert.equal(payload.body, '贵州茅台投研')
+    assert.equal(payload.tag, 'chat:done:abc_12')
+    assert.equal(payload.sessionId, 'abc_12')
+    assert.equal(payload.kind, 'chat_done')
+  })
+
+  it('buildChatAskNotification truncates long body', () => {
+    const long = '问'.repeat(200)
+    const payload = buildChatAskNotification('s1', long)
+    assert.equal(payload.title, '需要你的确认')
+    assert.ok(payload.body)
+    assert.ok((payload.body?.length ?? 0) <= 120)
+    assert.equal(payload.tag, 'chat:ask:s1')
+    assert.equal(payload.kind, 'chat_ask')
+  })
+
+  it('truncateNotificationText collapses whitespace', () => {
+    assert.equal(truncateNotificationText('  a   b  '), 'a b')
+    assert.equal(truncateNotificationText(''), '')
+  })
+})
+
+describe('sanitizeNotificationPayload', () => {
+  it('accepts valid chat payload', () => {
+    const out = sanitizeNotificationPayload({
+      title: '对话已生成完成',
+      body: '摘要',
+      tag: 'chat:done:sess1',
+      sessionId: 'sess1',
+      kind: 'chat_done',
+      extraIgnored: true,
+    })
+    assert.deepEqual(out, {
+      title: '对话已生成完成',
+      body: '摘要',
+      tag: 'chat:done:sess1',
+      sessionId: 'sess1',
+      kind: 'chat_done',
+    })
+  })
+
+  it('rejects empty or overlong title', () => {
+    assert.equal(sanitizeNotificationPayload({ title: '  ' }), null)
+    assert.equal(sanitizeNotificationPayload({ title: 'x'.repeat(121) }), null)
+  })
+
+  it('drops invalid tag and sessionId', () => {
+    const out = sanitizeNotificationPayload({
+      title: '需要你的确认',
+      tag: 'bad tag!',
+      sessionId: '../evil',
+      kind: 'chat_ask',
+    })
+    assert.equal(out?.title, '需要你的确认')
+    assert.equal(out?.tag, undefined)
+    assert.equal(out?.sessionId, undefined)
+    assert.equal(out?.kind, 'chat_ask')
+  })
+
+  it('truncates body and ignores unknown kind', () => {
+    const out = sanitizeNotificationPayload({
+      title: 't',
+      body: 'b'.repeat(250),
+      kind: 'other',
+    })
+    assert.equal(out?.body?.length, 200)
+    assert.equal(out?.kind, undefined)
+  })
+})


### PR DESCRIPTION
## Summary
- 窗口失焦、切到非对话页或后台会话时，对话生成完成与需确认提示发送系统通知（仅 Electron）
- 点击通知经 `opptrix://chat?session=` 打开对应会话
- 补充 payload 校验、`window-is-focused` IPC、纯函数测试与 DESKTOP 文档

## Test plan
- [x] `npm run check:ui`
- [x] `tests/chat-notifications.test.mjs`（9 passed）
- [ ] Electron 手测：失焦/最小化/切行情页时完成与 ask 弹通知
- [ ] 点击通知进入正确会话；更新类通知点击仍只聚焦窗口
- [ ] Web 端无系统通知且无报错


Made with [Cursor](https://cursor.com)