### PR TITLE
fix(chat): 消息用量与时间复制同一行展示

### DIFF
--- a/client-ui/src/chat/ChatMessageItem.tsx
+++ b/client-ui/src/chat/ChatMessageItem.tsx
@@ -210,6 +210,12 @@ function ChatMessageItem({ message, index, sessionId, isMobile = false, onFork }
       ) : (
         <>
           {timeNode}
+          {!isUser && message.usage && message.usage.totalTokens > 0 && (
+            <MessageTokenLabel
+              totalTokens={message.usage.totalTokens}
+              estimated={message.usageEstimated}
+            />
+          )}
           {forkButton}
           {copyButton}
         </>
@@ -253,12 +259,6 @@ function ChatMessageItem({ message, index, sessionId, isMobile = false, onFork }
           <div style={{ marginTop: 12 }}>
             <ChatProcessTrace steps={message.toolSteps} />
           </div>
-        )}
-        {!isUser && message.usage && message.usage.totalTokens > 0 && (
-          <MessageTokenLabel
-            totalTokens={message.usage.totalTokens}
-            estimated={message.usageEstimated}
-          />
         )}
         {!message.toolSteps?.length && message.toolsUsed && message.toolsUsed.length > 0 && (
           <div className={s.toolTags}>

--- a/client-ui/src/chat/MessageTokenLabel.tsx
+++ b/client-ui/src/chat/MessageTokenLabel.tsx
@@ -6,8 +6,8 @@ const useStyles = makeStyles({
   root: {
     fontSize: 'var(--opptrix-font-sm)',
     color: opptrixCssVars.textTertiary,
-    lineHeight: 1.4,
-    marginTop: '6px',
+    lineHeight: 1,
+    display: 'inline',
   },
 })
 
@@ -20,7 +20,7 @@ export default function MessageTokenLabel({ totalTokens, estimated }: MessageTok
   const s = useStyles()
   if (totalTokens <= 0) return null
   return (
-    <Text className={s.root} block>
+    <Text className={s.root}>
       {formatTurnUsageLabel(totalTokens, estimated)}
     </Text>
   )


### PR DESCRIPTION
## Summary
- 助手消息底部将「本轮用量」并入时间/操作同一行，放在时间之后
- `MessageTokenLabel` 改为 inline，去掉独立 block 行距

## Test plan
- [x] `npm run check:ui`
- [ ] 有 usage 的助手消息：时间 → 本轮用量 → 分叉/复制 同一行
- [ ] 无 usage 时 footer 正常
- [ ] 用户消息 footer 不变


Made with [Cursor](https://cursor.com)