### PR TITLE
perf(chat): cache session context usage across switches

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -946,7 +946,8 @@ app.post<{ Body: { title?: string; expertId?: string } }>('/api/sessions', async
 app.get<{ Params: { id: string } }>('/api/sessions/:id', async (req, reply) => {
   const session = agent.getSession(req.params.id)
   if (!session) return reply.code(404).send({ error: 'session not found' })
-  const contextUsage = await agent.getSessionContextUsage(req.params.id)
+  // 仅读缓存；miss 不阻塞（UI 再异步拉 /context-usage）
+  const contextUsage = agent.getCachedSessionContextUsage(req.params.id)
   return {
     session: {
       id: session.id,

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -436,19 +436,6 @@ export default function ChatApp() {
     return groups
   }, [])
 
-  const loadSession = useCallback(async (id: string) => {
-    pushComposerDraft('')
-    const data = await getSession(id)
-    setActiveId(id)
-    setActiveSessionMeta(data.session)
-    setMessages(data.messages)
-    setContextRef(data.contextRef ?? null)
-    setSessionModelState(data.session.model)
-    setContextUsage(data.contextUsage ?? null)
-    setError('')
-    setChatScrollEpoch(epoch => epoch + 1)
-  }, [pushComposerDraft])
-
   const refreshContextUsage = useCallback(async (sessionId: string) => {
     try {
       const { contextUsage: next } = await getSessionContextUsage(sessionId)
@@ -461,6 +448,23 @@ export default function ChatApp() {
       }
     }
   }, [])
+
+  const loadSession = useCallback(async (id: string) => {
+    pushComposerDraft('')
+    const data = await getSession(id)
+    setActiveId(id)
+    setActiveSessionMeta(data.session)
+    setMessages(data.messages)
+    setContextRef(data.contextRef ?? null)
+    setSessionModelState(data.session.model)
+    setContextUsage(data.contextUsage ?? null)
+    setError('')
+    setChatScrollEpoch(epoch => epoch + 1)
+    // miss 时异步补拉，不阻塞消息切换
+    if (!data.contextUsage) {
+      void refreshContextUsage(id)
+    }
+  }, [pushComposerDraft, refreshContextUsage])
 
   useEffect(() => {
     let cancelled = false
@@ -986,10 +990,11 @@ export default function ChatApp() {
     try {
       await clearSessionContext(activeId)
       setContextRef(null)
+      await refreshContextUsage(activeId)
     } catch (e) {
       setError(e instanceof Error ? e.message : '移除引用失败')
     }
-  }, [activeId])
+  }, [activeId, refreshContextUsage])
 
   const handleQuoteSelection = useCallback(async (selection: MessageSelection) => {
     if (!activeId) return
@@ -1011,10 +1016,11 @@ export default function ChatApp() {
       const data = await setSessionContext(activeId, nextRef)
       setContextRef(data.contextRef ?? nextRef)
       setError('')
+      await refreshContextUsage(activeId)
     } catch (e) {
       setError(e instanceof Error ? e.message : '设置引用失败')
     }
-  }, [activeId, messages])
+  }, [activeId, messages, refreshContextUsage])
 
   const handleFocusStockConsumed = useCallback(() => {
     setFocusStockCode(null)
@@ -1045,10 +1051,11 @@ export default function ChatApp() {
       setContextRef(data.contextRef ?? nextRef)
       pushComposerDraft(payload.prompt)
       setError('')
+      await refreshContextUsage(activeId)
     } catch (e) {
       setError(e instanceof Error ? e.message : '无法开始讨论，请稍后重试')
     }
-  }, [activeId, pushComposerDraft, restoreChatColumn])
+  }, [activeId, pushComposerDraft, refreshContextUsage, restoreChatColumn])
 
   const handleDiscussArticle = useCallback(async (article: FeedArticle) => {
     restoreChatColumn()
@@ -1068,10 +1075,11 @@ export default function ChatApp() {
       setWelcomeEpoch(epoch => epoch + 1)
       closeDrawer()
       navigate('chat')
+      await refreshContextUsage(session.id)
     } catch (e) {
       setError(e instanceof Error ? e.message : '创建对话失败')
     }
-  }, [closeDrawer, navigate, pushComposerDraft, refreshSessions, restoreChatColumn])
+  }, [closeDrawer, navigate, pushComposerDraft, refreshContextUsage, refreshSessions, restoreChatColumn])
 
   const handleEphemeralAsk = useCallback(async (
     message: string,

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -133,6 +133,8 @@ export class AgentEngine {
   private readonly expertPacksSeeded = new Set<string>()
   readonly userPromptBridge = new UserPromptBridge()
   private readonly workspaceService = getWorkspaceService()
+  /** 会话上下文用量估算缓存（内存；切会话命中则不再 rebuildRoundTools） */
+  private readonly contextUsageCache = new Map<string, SessionContextUsage>()
   /** 附件 GET 与 content parts 本地 URL 前缀 */
   private apiBaseUrl = 'http://127.0.0.1:8711/api'
 
@@ -306,6 +308,7 @@ export class AgentEngine {
       activatePacks: (packIds: string[]) => {
         const { activated, skipped } = this.toolPackSessions.activate(sessionId, packIds)
         this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
+        this.invalidateContextUsage(sessionId)
         return {
           ok: true,
           activated,
@@ -324,6 +327,7 @@ export class AgentEngine {
     this.registry.setProviders(providers, defaultModel)
     this.settings.defaultModel = defaultModel
     this.settings.providers = providers
+    this.contextUsageCache.clear()
   }
 
   listAvailableModels(): AvailableModel[] {
@@ -334,9 +338,29 @@ export class AgentEngine {
     return this.registry.listAvailableAsync()
   }
 
-  async getSessionContextUsage(sessionId: string): Promise<SessionContextUsage | null> {
+  /** 仅读缓存；miss 时返回 null，不触发估算（供 getSession 非阻塞） */
+  getCachedSessionContextUsage(sessionId: string): SessionContextUsage | null {
+    return this.contextUsageCache.get(sessionId) ?? null
+  }
+
+  private invalidateContextUsage(sessionId: string) {
+    this.contextUsageCache.delete(sessionId)
+  }
+
+  async getSessionContextUsage(
+    sessionId: string,
+    opts?: { force?: boolean },
+  ): Promise<SessionContextUsage | null> {
+    if (opts?.force !== true) {
+      const cached = this.contextUsageCache.get(sessionId)
+      if (cached) return cached
+    }
+
     const record = this.sessions.get(sessionId)
-    if (!record) return null
+    if (!record) {
+      this.invalidateContextUsage(sessionId)
+      return null
+    }
 
     const modelRef = record.model?.trim()
       || this.settings.defaultModel
@@ -372,13 +396,15 @@ export class AgentEngine {
     // modelView 已含 system + memory + 近端；tools 为 API 侧单独字段，另加固定开销
     const usedTokens = estimateModelViewTokens(modelView) + toolsTokens + 512
 
-    return {
+    const usage: SessionContextUsage = {
       usedTokens,
       limitTokens,
       remainingTokens: Math.max(0, limitTokens - usedTokens),
       modelRef,
       estimated: true,
     }
+    this.contextUsageCache.set(sessionId, usage)
+    return usage
   }
 
   async setSessionModel(sessionId: string, modelRef: string | null): Promise<{
@@ -389,6 +415,7 @@ export class AgentEngine {
     if (!record) return null
     record.model = modelRef?.trim() || undefined
     this.sessions.save(record)
+    this.invalidateContextUsage(sessionId)
 
     const activeModel = record.model
     const llm = this.registry.createLlm(activeModel)
@@ -406,6 +433,7 @@ export class AgentEngine {
       emit: undefined,
       aggressive: false,
     })
+    // UI 会 refreshContextUsage；此处不 force，避免 setModel 路径额外阻塞
     return { session: record, contextHint: budget.hint }
   }
 
@@ -448,6 +476,7 @@ export class AgentEngine {
       record.messages = result.state.messages
       record.sessionMemory = result.state.sessionMemory ?? null
       this.sessions.save(record)
+      this.invalidateContextUsage(record.id)
       for (const r of result.results) {
         if (!r.changed) continue
         opts.emit?.({
@@ -574,7 +603,9 @@ export class AgentEngine {
     if (!sanitized) {
       throw new Error('技能专长无效，请修改后重试')
     }
-    return this.sessions.updateRolePersona(id, sanitized)
+    const updated = this.sessions.updateRolePersona(id, sanitized)
+    this.invalidateContextUsage(id)
+    return updated
   }
 
   sessionMeta(record: SessionRecord) {
@@ -586,6 +617,7 @@ export class AgentEngine {
     this.toolPackSessions.clear(id)
     this.workspaceService.clearSession(id)
     this.sessions.delete(id)
+    this.invalidateContextUsage(id)
   }
 
   renameSession(id: string, title: string) {
@@ -610,11 +642,15 @@ export class AgentEngine {
   }
 
   clearSessionContextRef(sessionId: string) {
-    return this.sessions.clearContextRef(sessionId)
+    const updated = this.sessions.clearContextRef(sessionId)
+    this.invalidateContextUsage(sessionId)
+    return updated
   }
 
   setSessionContextRef(sessionId: string, contextRef: SessionContextRef | null) {
-    return this.sessions.setContextRef(sessionId, contextRef)
+    const updated = this.sessions.setContextRef(sessionId, contextRef)
+    this.invalidateContextUsage(sessionId)
+    return updated
   }
 
   async ephemeralAsk(
@@ -761,6 +797,7 @@ export class AgentEngine {
       record.title = titleSeed.slice(0, 28) + (titleSeed.length > 28 ? '…' : '')
     }
     this.sessions.save(record)
+    this.invalidateContextUsage(sessionId)
 
     const emit = (event: ChatProgressEvent) => {
       progress?.onProgress?.(event)
@@ -778,7 +815,7 @@ export class AgentEngine {
       partialSteps?: ChatToolStep[]
       cancelled?: boolean
     }) => {
-      const contextUsage = await this.getSessionContextUsage(sessionId)
+      const contextUsage = await this.getSessionContextUsage(sessionId, { force: true })
       emit({
         type: 'done',
         reply: payload.reply,
@@ -1115,6 +1152,7 @@ export class AgentEngine {
       record.usageTotals = mergeTokenUsage(record.usageTotals ?? emptyTokenUsage(), usage)
     }
     this.sessions.save(record)
+    this.invalidateContextUsage(record.id)
   }
 }
 

--- a/tests/session-context-usage-cache.test.mjs
+++ b/tests/session-context-usage-cache.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * AgentEngine contextUsage 内存缓存 — hit / miss / invalidate
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  AgentEngine,
+  resetExpertCatalogServiceForTests,
+} from '../packages/agent/dist/index.js'
+import { resetBuiltinExpertCacheForTests } from '../packages/agent/dist/experts/local-json-provider.js'
+import { ResearchHub } from '../packages/research-hub/dist/hub.js'
+import { getUserDataStore } from '../packages/user-store/dist/index.js'
+
+function withTempStore(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-ctx-usage-'))
+  const prev = process.env.OPPTRIX_DATA_DIR
+  process.env.OPPTRIX_DATA_DIR = tmp
+  getUserDataStore().close()
+  resetBuiltinExpertCacheForTests()
+  resetExpertCatalogServiceForTests()
+  return fn().finally(() => {
+    getUserDataStore().close()
+    resetExpertCatalogServiceForTests()
+    resetBuiltinExpertCacheForTests()
+    fs.rmSync(tmp, { recursive: true, force: true })
+    if (prev == null) delete process.env.OPPTRIX_DATA_DIR
+    else process.env.OPPTRIX_DATA_DIR = prev
+  })
+}
+
+function makeEngine() {
+  return new AgentEngine(new ResearchHub(), {
+    defaultScorecard: 'balanced',
+    defaultTopN: 10,
+  })
+}
+
+test('getCachedSessionContextUsage miss returns null without compute', async () => {
+  await withTempStore(async () => {
+    const engine = makeEngine()
+    const session = await engine.createSession({ title: '缓存测试' })
+    assert.equal(engine.getCachedSessionContextUsage(session.id), null)
+  })
+})
+
+test('getSessionContextUsage caches; hit returns same snapshot; invalidate clears', async () => {
+  await withTempStore(async () => {
+    const engine = makeEngine()
+    const session = await engine.createSession({ title: '缓存测试' })
+
+    const first = await engine.getSessionContextUsage(session.id)
+    assert.ok(first)
+    assert.equal(first.estimated, true)
+    assert.ok(typeof first.usedTokens === 'number')
+    assert.ok(typeof first.limitTokens === 'number')
+
+    const cached = engine.getCachedSessionContextUsage(session.id)
+    assert.equal(cached, first)
+
+    const second = await engine.getSessionContextUsage(session.id)
+    assert.equal(second, first)
+
+    engine.clearSessionContextRef(session.id)
+    assert.equal(engine.getCachedSessionContextUsage(session.id), null)
+
+    const third = await engine.getSessionContextUsage(session.id)
+    assert.ok(third)
+    assert.notEqual(third, first)
+
+    const forced = await engine.getSessionContextUsage(session.id, { force: true })
+    assert.ok(forced)
+    assert.notEqual(forced, third)
+    assert.equal(engine.getCachedSessionContextUsage(session.id), forced)
+  })
+})
+
+test('setProviders clears all contextUsage cache', async () => {
+  await withTempStore(async () => {
+    const engine = makeEngine()
+    const session = await engine.createSession({ title: 'providers' })
+    await engine.getSessionContextUsage(session.id)
+    assert.ok(engine.getCachedSessionContextUsage(session.id))
+
+    engine.setProviders([], undefined)
+    assert.equal(engine.getCachedSessionContextUsage(session.id), null)
+  })
+})
+
+test('deleteSession drops that session cache entry', async () => {
+  await withTempStore(async () => {
+    const engine = makeEngine()
+    const a = await engine.createSession({ title: 'a' })
+    const b = await engine.createSession({ title: 'b' })
+    await engine.getSessionContextUsage(a.id)
+    await engine.getSessionContextUsage(b.id)
+    assert.ok(engine.getCachedSessionContextUsage(a.id))
+    assert.ok(engine.getCachedSessionContextUsage(b.id))
+
+    engine.deleteSession(a.id)
+    assert.equal(engine.getCachedSessionContextUsage(a.id), null)
+    assert.ok(engine.getCachedSessionContextUsage(b.id))
+  })
+})


### PR DESCRIPTION
## Summary
- Cache per-session context usage estimates in AgentEngine so switching chats no longer awaits `rebuildRoundTools` / models.dev on every `GET /sessions/:id`.
- Invalidate or force-refresh on new messages, model changes, contextRef / rolePersona / packs / providers; UI async-fills the meter on cache miss.

## Test plan
- [x] `npm run build:packages`
- [x] `npm run check:ui`
- [x] `node --test --test-force-exit tests/session-context-usage-cache.test.mjs`
- [ ] Manually: switch between two sessions — UI should update quickly; context meter fills without blocking messages


Made with [Cursor](https://cursor.com)