### PR TITLE
feat(settings): 大模型预置提供商与侧栏导航优化

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
+import { getModelsDevCatalog, resolveModelsDevProviderMeta } from '@opptrix/agent'
 import { getUserDataStore } from '@opptrix/user-store'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -39,12 +40,85 @@ const DEFAULTS: AppConfig = {
   default_top_n: Number(process.env.DEFAULT_TOP_N ?? 20),
 }
 
-export const PROVIDER_PRESETS = [
-  { id: 'deepseek', name: 'DeepSeek', base_url: 'https://api.deepseek.com' },
-  { id: 'openai', name: 'OpenAI', base_url: 'https://api.openai.com' },
-  { id: 'moonshot', name: 'Moonshot', base_url: 'https://api.moonshot.cn' },
-  { id: 'custom', name: '自定义', base_url: '' },
-] as const
+export type ProviderPresetRegion = 'cn' | 'global' | 'custom'
+
+export interface ProviderPresetSpec {
+  id: string
+  name: string
+  region: ProviderPresetRegion
+  /** OpenAI 兼容地址；catalog 缺失或非 OpenAI 路径时使用 */
+  fallback_base_url: string
+}
+
+export interface ProviderPreset {
+  id: string
+  name: string
+  base_url: string
+  region: ProviderPresetRegion
+}
+
+/** 有序白名单：中国组 → 海外组 → 自定义；展示名以产品文案为准 */
+export const PROVIDER_PRESET_WHITELIST: readonly ProviderPresetSpec[] = [
+  { id: 'deepseek', name: 'DeepSeek', region: 'cn', fallback_base_url: 'https://api.deepseek.com/v1' },
+  { id: 'minimax-cn', name: 'MiniMax', region: 'cn', fallback_base_url: 'https://api.minimaxi.com/v1' },
+  { id: 'moonshotai-cn', name: 'Kimi', region: 'cn', fallback_base_url: 'https://api.moonshot.cn/v1' },
+  { id: 'xiaomi', name: 'MiMo', region: 'cn', fallback_base_url: 'https://api.xiaomimimo.com/v1' },
+  { id: 'siliconflow-cn', name: 'SiliconFlow (China)', region: 'cn', fallback_base_url: 'https://api.siliconflow.cn/v1' },
+  { id: 'alibaba-cn', name: 'Alibaba (China)', region: 'cn', fallback_base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1' },
+  { id: 'zhipuai', name: 'Zhipu AI', region: 'cn', fallback_base_url: 'https://open.bigmodel.cn/api/paas/v4' },
+  { id: 'moonshotai', name: 'Moonshot AI', region: 'cn', fallback_base_url: 'https://api.moonshot.ai/v1' },
+  { id: 'longcat', name: 'Meituan', region: 'cn', fallback_base_url: 'https://api.longcat.chat/openai' },
+  { id: 'openai', name: 'OpenAI', region: 'global', fallback_base_url: 'https://api.openai.com/v1' },
+  { id: 'openrouter', name: 'OpenRouter', region: 'global', fallback_base_url: 'https://openrouter.ai/api/v1' },
+  {
+    id: 'google',
+    name: 'Google',
+    region: 'global',
+    fallback_base_url: 'https://generativelanguage.googleapis.com/v1beta/openai',
+  },
+  { id: 'meta', name: 'Meta', region: 'global', fallback_base_url: 'https://api.meta.ai/v1' },
+  { id: 'ollama', name: '本地 Ollama', region: 'global', fallback_base_url: 'http://127.0.0.1:11434/v1' },
+  { id: 'custom', name: '自定义', region: 'custom', fallback_base_url: '' },
+]
+
+function isOpenAiCompatibleApi(api: string): boolean {
+  const lower = api.toLowerCase()
+  // models.dev 上 MiniMax 等可能给出 anthropic 路径，本产品仅接 OpenAI 兼容
+  return !lower.includes('/anthropic')
+}
+
+function normalizeBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '')
+}
+
+/** 用 models.dev 缓存填充 api；miss / 非 OpenAI 兼容时用静态 fallback */
+export async function resolveProviderPresets(): Promise<ProviderPreset[]> {
+  const catalog = await getModelsDevCatalog()
+  return PROVIDER_PRESET_WHITELIST.map((spec) => {
+    if (spec.id === 'custom') {
+      return { id: spec.id, name: spec.name, base_url: '', region: spec.region }
+    }
+    const meta = resolveModelsDevProviderMeta(spec.id, catalog)
+    const catalogApi = meta?.api?.trim()
+    const base_url = catalogApi && isOpenAiCompatibleApi(catalogApi)
+      ? normalizeBaseUrl(catalogApi)
+      : normalizeBaseUrl(spec.fallback_base_url)
+    return {
+      id: spec.id,
+      name: spec.name,
+      base_url,
+      region: spec.region,
+    }
+  })
+}
+
+/** @deprecated 同步静态列表；请优先 `resolveProviderPresets()` */
+export const PROVIDER_PRESETS: readonly ProviderPreset[] = PROVIDER_PRESET_WHITELIST.map((spec) => ({
+  id: spec.id,
+  name: spec.name,
+  base_url: spec.fallback_base_url,
+  region: spec.region,
+}))
 
 function migrateLegacy(file: Partial<AppConfig> & { llm?: LegacyLlmConfig }): StoredProvider[] {
   if (file.providers?.length) return file.providers

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,7 +9,7 @@ import { ResearchHub } from '@opptrix/research-hub'
 import { listTemplates, REGISTRY } from '@opptrix/stock-eval'
 import {
   loadConfig, saveConfig, publicConfig, toAgentProviders,
-  PROVIDER_PRESETS, type StoredProvider,
+  resolveProviderPresets, type StoredProvider,
 } from './config.js'
 import { getMarketDataService } from '@opptrix/market-data-store'
 import { registerStaticUi, shouldServeUi, isApiPath, resolveUiDist } from './static-ui.js'
@@ -753,7 +753,7 @@ app.patch<{ Body: { default_scorecard?: string; default_top_n?: number; default_
   },
 )
 
-app.get('/api/providers/presets', async () => ({ presets: PROVIDER_PRESETS }))
+app.get('/api/providers/presets', async () => ({ presets: await resolveProviderPresets() }))
 
 app.post<{ Body: { base_url: string; api_key: string } }>(
   '/api/providers/discover-models',

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1169,6 +1169,7 @@ export interface ProviderPreset {
   id: string
   name: string
   base_url: string
+  region?: 'cn' | 'global' | 'custom'
 }
 
 export interface AppConfig {

--- a/client-ui/src/pages/ProviderWizard.tsx
+++ b/client-ui/src/pages/ProviderWizard.tsx
@@ -1,11 +1,10 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import {
   Text, Checkbox, makeStyles, mergeClasses,
 } from '@fluentui/react-components'
-import { CheckmarkRegular } from '@fluentui/react-icons'
+import { CheckmarkRegular, ChevronRightRegular } from '@fluentui/react-icons'
 import OpptrixField from '../components/opptrix/OpptrixField'
 import OpptrixInput from '../components/opptrix/OpptrixInput'
-import OpptrixSelect, { OpptrixOption } from '../components/opptrix/OpptrixSelect'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import {
   getProviderPresets, discoverModels, createProvider, updateProvider,
@@ -13,18 +12,84 @@ import {
 } from '../api/client'
 import { useSettingsToast } from './settings/SettingsToast'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
+import { focusRing, ghostInteractive } from '../theme/mixins'
+
+/** 返利预置置顶顺序（kimi → xiaomimimo → siliconflow → bigmodel） */
+const PROMO_PRESET_IDS = ['moonshotai-cn', 'xiaomi', 'siliconflow-cn', 'zhipuai'] as const
+
+/** 次要文案：返利权益说明 */
+const PROMO_PRESET_HINTS: Record<(typeof PROMO_PRESET_IDS)[number], string> = {
+  'moonshotai-cn': '新注册用户100%得会员权益',
+  xiaomi: '新注册免费得10元体验金',
+  'siliconflow-cn': '新用户注册得14元体验金',
+  zhipuai: '新注册免费得2000万Tokens',
+}
+
+const PROMO_PRESET_ID_SET = new Set<string>(PROMO_PRESET_IDS)
+
+/** 预置提供商注册/控制台链接；返利四家必须用指定 URL，勿改 */
+const PRESET_SIGNUP_URLS: Record<string, string> = {
+  'moonshotai-cn': 'https://kimi-bot.com/activities/zh-cn/viral-referral/share?scenario=invite&from=share_poster&invitation_code=ST7TJY',
+  xiaomi: 'https://platform.xiaomimimo.com?ref=BFGUJ2',
+  'siliconflow-cn': 'https://cloud.siliconflow.cn/i/USDgicnv',
+  zhipuai: 'https://www.bigmodel.cn/invite?icode=3vdsl7O%2FnRjGs22eJGFJ3VwpqjqOwPB5EXW6OL4DgqY%3D',
+  deepseek: 'https://platform.deepseek.com/',
+  'minimax-cn': 'https://platform.minimaxi.com/',
+  'alibaba-cn': 'https://dashscope.console.aliyun.com/',
+  moonshotai: 'https://platform.moonshot.ai/',
+  longcat: 'https://longcat.chat/',
+  openai: 'https://platform.openai.com/api-keys',
+  openrouter: 'https://openrouter.ai/keys',
+  google: 'https://aistudio.google.com/apikey',
+  meta: 'https://llama.developer.meta.com/',
+  ollama: 'https://ollama.com/',
+}
+
+function normalizePresetBaseUrl(url: string): string {
+  return url.trim().replace(/\/+$/, '')
+}
+
+/** 从已选 id，或按 name/baseUrl 反查预置 id（编辑已有提供商时） */
+function resolvePresetId(
+  presets: ProviderPreset[],
+  selectedPresetId: string | null,
+  name: string,
+  baseUrl: string,
+): string | null {
+  if (selectedPresetId && selectedPresetId !== 'custom') return selectedPresetId
+  const u = normalizePresetBaseUrl(baseUrl)
+  if (u) {
+    const byUrl = presets.find(p => p.id !== 'custom' && normalizePresetBaseUrl(p.base_url) === u)
+    if (byUrl) return byUrl.id
+  }
+  const n = name.trim()
+  if (n) {
+    const byName = presets.find(p => p.id !== 'custom' && p.name === n)
+    if (byName) return byName.id
+  }
+  return null
+}
+
+function resolveSignupUrl(presetId: string | null): string | undefined {
+  if (!presetId) return undefined
+  const url = PRESET_SIGNUP_URLS[presetId]?.trim()
+  return url || undefined
+}
 
 const useStyles = makeStyles({
   root: {
     display: 'flex',
     flexDirection: 'column',
     gap: '18px',
+    flex: 1,
     minHeight: 0,
+    overflow: 'hidden',
   },
   steps: {
     display: 'flex',
     gap: '6px',
     width: '100%',
+    flexShrink: 0,
   },
   stepDot: {
     flex: 1,
@@ -39,9 +104,8 @@ const useStyles = makeStyles({
   },
   scroll: {
     flex: 1,
-    overflowY: 'auto',
     minHeight: 0,
-    maxHeight: 'min(52vh, 420px)',
+    overflowY: 'auto',
     marginRight: '-4px',
     paddingRight: '4px',
   },
@@ -71,6 +135,106 @@ const useStyles = makeStyles({
     display: 'flex',
     flexDirection: 'column',
     gap: '14px',
+  },
+  providerMeta: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'baseline',
+    gap: '6px 12px',
+  },
+  providerMetaName: {
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 600,
+    color: opptrixCssVars.textPrimary,
+    lineHeight: 1.4,
+  },
+  signupLink: {
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 500,
+    color: opptrixCssVars.accent,
+    textDecoration: 'none',
+    lineHeight: 1.4,
+    ':hover': {
+      textDecoration: 'underline',
+    },
+    ':focus-visible': {
+      ...focusRing,
+      borderRadius: opptrixTokens.radiusSm,
+    },
+  },
+  presetList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    border: `1px solid ${opptrixCssVars.border}`,
+    borderRadius: opptrixTokens.radiusMd,
+    padding: '4px',
+    overflow: 'hidden',
+  },
+  presetRow: {
+    ...ghostInteractive,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    width: '100%',
+    padding: '10px 12px',
+    minHeight: '42px',
+    cursor: 'pointer',
+    textAlign: 'left',
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 500,
+    lineHeight: 1.35,
+    position: 'relative',
+    borderRadius: opptrixTokens.radiusSm,
+    border: 'none',
+    backgroundColor: 'transparent',
+    /* 分割线独立于圆角，避免 borderBottom 随 radius 弯折 */
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      left: '12px',
+      right: '12px',
+      bottom: 0,
+      height: '1px',
+      backgroundColor: opptrixCssVars.separator,
+      borderRadius: 0,
+      pointerEvents: 'none',
+    },
+    ':last-child::after': {
+      display: 'none',
+    },
+    /* surfaceHover 在浅色底上近乎不可见；改用 canvasAlt */
+    ':hover': {
+      backgroundColor: opptrixCssVars.canvasAlt,
+    },
+    ':hover::after': {
+      backgroundColor: opptrixCssVars.canvasAlt,
+    },
+    ':focus': {
+      outline: 'none',
+    },
+    ':focus-visible': {
+      ...focusRing,
+      backgroundColor: opptrixCssVars.canvasAlt,
+    },
+    ':focus-visible::after': {
+      backgroundColor: opptrixCssVars.canvasAlt,
+    },
+  },
+  presetRowLabel: {
+    flex: 1,
+    minWidth: 0,
+  },
+  presetRowHint: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 400,
+    color: opptrixCssVars.textTertiary,
+    marginTop: '2px',
+  },
+  presetChevron: {
+    color: opptrixCssVars.textTertiary,
+    flexShrink: 0,
   },
   modelList: {
     display: 'flex',
@@ -161,11 +325,56 @@ export interface ProviderWizardNavState {
 }
 
 const DEFAULT_PRESETS: ProviderPreset[] = [
-  { id: 'deepseek', name: 'DeepSeek', base_url: 'https://api.deepseek.com/v1' },
-  { id: 'openai', name: 'OpenAI', base_url: 'https://api.openai.com/v1' },
-  { id: 'moonshot', name: 'Moonshot', base_url: 'https://api.moonshot.cn/v1' },
-  { id: 'custom', name: '自定义', base_url: '' },
+  { id: 'deepseek', name: 'DeepSeek', base_url: 'https://api.deepseek.com/v1', region: 'cn' },
+  { id: 'minimax-cn', name: 'MiniMax', base_url: 'https://api.minimaxi.com/v1', region: 'cn' },
+  { id: 'moonshotai-cn', name: 'Kimi', base_url: 'https://api.moonshot.cn/v1', region: 'cn' },
+  { id: 'xiaomi', name: 'MiMo', base_url: 'https://api.xiaomimimo.com/v1', region: 'cn' },
+  { id: 'siliconflow-cn', name: 'SiliconFlow (China)', base_url: 'https://api.siliconflow.cn/v1', region: 'cn' },
+  { id: 'alibaba-cn', name: 'Alibaba (China)', base_url: 'https://dashscope.aliyuncs.com/compatible-mode/v1', region: 'cn' },
+  { id: 'zhipuai', name: 'Zhipu AI', base_url: 'https://open.bigmodel.cn/api/paas/v4', region: 'cn' },
+  { id: 'moonshotai', name: 'Moonshot AI', base_url: 'https://api.moonshot.ai/v1', region: 'cn' },
+  { id: 'longcat', name: 'Meituan', base_url: 'https://api.longcat.chat/openai', region: 'cn' },
+  { id: 'openai', name: 'OpenAI', base_url: 'https://api.openai.com/v1', region: 'global' },
+  { id: 'openrouter', name: 'OpenRouter', base_url: 'https://openrouter.ai/api/v1', region: 'global' },
+  { id: 'google', name: 'Google', base_url: 'https://generativelanguage.googleapis.com/v1beta/openai', region: 'global' },
+  { id: 'meta', name: 'Meta', base_url: 'https://api.meta.ai/v1', region: 'global' },
+  { id: 'ollama', name: '本地 Ollama', base_url: 'http://127.0.0.1:11434/v1', region: 'global' },
+  { id: 'custom', name: '自定义', base_url: '', region: 'custom' },
 ]
+
+function presetRegion(p: ProviderPreset): 'cn' | 'global' | 'custom' {
+  if (p.region) return p.region
+  if (p.id === 'custom') return 'custom'
+  if (
+    p.id === 'openai'
+    || p.id === 'openrouter'
+    || p.id === 'google'
+    || p.id === 'meta'
+    || p.id === 'ollama'
+  ) {
+    return 'global'
+  }
+  return 'cn'
+}
+
+/** 合并远端预置：禁止被旧短列表覆盖；白名单顺序/名称/region 为准，非空 base_url 取远端。 */
+function mergeProviderPresets(remote: ProviderPreset[]): ProviderPreset[] {
+  const remoteIsFull =
+    remote.length >= DEFAULT_PRESETS.length
+    && remote.every(p => p.region != null)
+  if (remoteIsFull) return remote
+
+  const byId = new Map(remote.map(p => [p.id, p]))
+  return DEFAULT_PRESETS.map(local => {
+    const fromApi = byId.get(local.id)
+    if (!fromApi) return local
+    const remoteUrl = typeof fromApi.base_url === 'string' ? fromApi.base_url.trim() : ''
+    return {
+      ...local,
+      base_url: remoteUrl || local.base_url,
+    }
+  })
+}
 
 export default function ProviderWizard({
   onCancel,
@@ -182,9 +391,10 @@ export default function ProviderWizard({
   const isEdit = Boolean(provider)
   const [step, setStep] = useState(1)
   const [presets, setPresets] = useState<ProviderPreset[]>(DEFAULT_PRESETS)
-  const [presetId, setPresetId] = useState('deepseek')
-  const [name, setName] = useState('DeepSeek')
-  const [baseUrl, setBaseUrl] = useState('https://api.deepseek.com')
+  const [customFormOpen, setCustomFormOpen] = useState(false)
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null)
+  const [name, setName] = useState('')
+  const [baseUrl, setBaseUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [discovered, setDiscovered] = useState<string[]>([])
   const [selected, setSelected] = useState<Set<string>>(new Set())
@@ -196,7 +406,7 @@ export default function ProviderWizard({
   useEffect(() => {
     getProviderPresets()
       .then(({ presets: list }) => {
-        if (list.length) setPresets(list)
+        if (list.length) setPresets(mergeProviderPresets(list))
       })
       .catch(() => { /* keep defaults */ })
   }, [])
@@ -209,33 +419,56 @@ export default function ProviderWizard({
     setDiscovered(provider.models)
     setApiKey('')
     setStep(1)
+    setCustomFormOpen(false)
+    setSelectedPresetId(null)
     setDiscoverHint('')
   }, [provider])
 
-  useEffect(() => {
-    if (!provider || !presets.length) return
-    const match = presets.find(
-      p => p.id !== 'custom' && p.base_url.replace(/\/$/, '') === provider.base_url.replace(/\/$/, ''),
-    )
-    setPresetId(match?.id ?? 'custom')
-  }, [provider, presets])
+  /** 扁平列表：返利置顶 → 其余中国 → 海外 → 自定义 */
+  const flatPresets = useMemo((): ProviderPreset[] => {
+    const byId = new Map(presets.map(p => [p.id, p]))
+    const promo = PROMO_PRESET_IDS
+      .map(id => byId.get(id))
+      .filter((p): p is ProviderPreset => p != null)
+    const rest = presets.filter(p => !PROMO_PRESET_ID_SET.has(p.id) && presetRegion(p) !== 'custom')
+    const cn = rest.filter(p => presetRegion(p) === 'cn')
+    const global = rest.filter(p => presetRegion(p) === 'global')
+    const custom = presets.find(p => presetRegion(p) === 'custom')
+      ?? { id: 'custom', name: '自定义', base_url: '', region: 'custom' as const }
+    return [...promo, ...cn, ...global, custom]
+  }, [presets])
 
-  const isCustom = presetId === 'custom' || isEdit
+  const showPresetList = !isEdit && !customFormOpen
+  const showCustomForm = !isEdit && customFormOpen
 
-  const handlePresetChange = (id: string) => {
-    setPresetId(id)
-    const preset = presets.find(p => p.id === id)
-    if (preset) {
-      setName(preset.id === 'custom' ? '' : preset.name)
-      setBaseUrl(preset.id === 'custom' ? '' : preset.base_url)
+  const matchedPresetId = useMemo(
+    () => resolvePresetId(presets, selectedPresetId, name, baseUrl),
+    [presets, selectedPresetId, name, baseUrl],
+  )
+  const signupUrl = resolveSignupUrl(matchedPresetId)
+
+  const selectPreset = (preset: ProviderPreset) => {
+    if (preset.id === 'custom') {
+      setName('')
+      setBaseUrl('')
+      setSelectedPresetId(null)
+      setCustomFormOpen(true)
+      return
     }
+    setName(preset.name)
+    setBaseUrl(preset.base_url)
+    setSelectedPresetId(preset.id)
+    // Ollama 兼容接口需带 Authorization，本地常用占位密钥即可
+    setApiKey(preset.id === 'ollama' ? 'ollama' : '')
+    setCustomFormOpen(false)
+    setStep(2)
   }
 
   const runDiscover = async (): Promise<boolean> => {
     const url = baseUrl.trim()
     if (!url || !apiKey.trim()) return false
     setDiscovering(true)
-    setDiscoverHint('正在验证 API Key 并拉取模型…')
+    setDiscoverHint('正在验证密钥并拉取模型…')
     setDiscovered([])
     setSelected(new Set())
     try {
@@ -255,7 +488,7 @@ export default function ProviderWizard({
       return true
     } catch (e) {
       setDiscoverHint('')
-      toast.showError(e instanceof Error ? e.message : 'API Key 验证失败，请检查后重试')
+      toast.showError(e instanceof Error ? e.message : '密钥验证失败，请检查后重试')
       return false
     } finally {
       setDiscovering(false)
@@ -335,6 +568,13 @@ export default function ProviderWizard({
 
   const handleBack = () => {
     if (step === 1) {
+      if (showCustomForm) {
+        setCustomFormOpen(false)
+        setName('')
+        setBaseUrl('')
+        setSelectedPresetId(null)
+        return
+      }
       if (!hideCancel) onCancel()
       return
     }
@@ -350,7 +590,7 @@ export default function ProviderWizard({
       : (isOnboarding ? '完成配置' : (isEdit ? '保存更改' : '完成添加')))
 
   const canAdvance = step === 1
-    ? canNextStep1
+    ? (showPresetList ? false : canNextStep1)
     : step === 2
       ? canNextStep2 && !discovering
       : canSave && !saving
@@ -375,7 +615,7 @@ export default function ProviderWizard({
     if (!hideFooter || !onNavStateChange) return
     onNavStateChange({
       step,
-      canWizardBack: step > 1,
+      canWizardBack: step > 1 || showCustomForm,
       canAdvance,
       advancing: discovering,
       saving,
@@ -387,6 +627,7 @@ export default function ProviderWizard({
     hideFooter,
     onNavStateChange,
     step,
+    showCustomForm,
     canAdvance,
     discovering,
     saving,
@@ -402,6 +643,21 @@ export default function ProviderWizard({
     return () => { onNavStateChange(null) }
   }, [hideFooter, onNavStateChange])
 
+  const renderPresetRow = (preset: ProviderPreset, hint?: string) => (
+    <button
+      key={preset.id}
+      type="button"
+      className={mergeClasses(s.presetRow, 'opptrix-focusable')}
+      onClick={() => selectPreset(preset)}
+    >
+      <span className={s.presetRowLabel}>
+        {preset.name}
+        {hint ? <div className={s.presetRowHint}>{hint}</div> : null}
+      </span>
+      <ChevronRightRegular className={s.presetChevron} fontSize={16} />
+    </button>
+  )
+
   return (
     <div className={s.root}>
       {!compact && (
@@ -415,41 +671,55 @@ export default function ProviderWizard({
       <div className={`${s.scroll} opptrix-scroll`}>
         <div className={s.bodyInner}>
 
-          {step === 1 && (
+          {step === 1 && showPresetList && (
             <>
               <div className={s.stepIntro}>
-                <Text className={s.stepTitle} block>{isEdit ? '编辑提供商' : '选择提供商'}</Text>
-                <Text className={s.stepDesc} block>OpenAI 兼容接口（/v1/chat/completions）</Text>
+                <Text className={s.stepTitle} block>选择提供商</Text>
+                <Text className={s.stepDesc} block>
+                  选一个预置服务，直接填写密钥；也可自定义服务地址。
+                </Text>
+              </div>
+              <div className={s.presetList}>
+                {flatPresets.map(p => {
+                  const promoId = PROMO_PRESET_IDS.find(id => id === p.id)
+                  return renderPresetRow(
+                    p,
+                    p.id === 'custom'
+                      ? '自行填写名称与服务地址'
+                      : (promoId ? PROMO_PRESET_HINTS[promoId] : undefined),
+                  )
+                })}
+              </div>
+            </>
+          )}
+
+          {step === 1 && (isEdit || showCustomForm) && (
+            <>
+              <div className={s.stepIntro}>
+                <Text className={s.stepTitle} block>
+                  {isEdit ? '编辑提供商' : '自定义提供商'}
+                </Text>
+                <Text className={s.stepDesc} block>
+                  {isEdit
+                    ? '可调整显示名称与服务地址'
+                    : '填写显示名称与服务地址，下一步再配置密钥'}
+                </Text>
               </div>
               <div className={s.formGrid}>
-                {!isEdit && (
-                  <OpptrixField label="提供商">
-                    <OpptrixSelect
-                      selectedOptions={[presetId]}
-                      onOptionSelect={(_, d) => handlePresetChange(d.optionValue || presetId)}
-                    >
-                      {presets.map(p => (
-                        <OpptrixOption key={p.id} value={p.id}>{p.name}</OpptrixOption>
-                      ))}
-                    </OpptrixSelect>
-                  </OpptrixField>
-                )}
                 <OpptrixField label="显示名称">
                   <OpptrixInput
                     value={name}
                     onChange={(_, d) => setName(d.value || '')}
-                    placeholder={isCustom ? '例如 My Provider' : '例如 DeepSeek'}
+                    placeholder="例如 我的服务"
                   />
                 </OpptrixField>
-                {isCustom && (
-                  <OpptrixField label="Base URL" hint="请填写完整的 API 地址（含 /v1 等路径）">
-                    <OpptrixInput
-                      value={baseUrl}
-                      onChange={(_, d) => setBaseUrl(d.value || '')}
-                      placeholder="https://api.example.com/v1"
-                    />
-                  </OpptrixField>
-                )}
+                <OpptrixField label="服务地址" hint="请填写完整地址（通常含 /v1 等路径）">
+                  <OpptrixInput
+                    value={baseUrl}
+                    onChange={(_, d) => setBaseUrl(d.value || '')}
+                    placeholder="https://api.example.com/v1"
+                  />
+                </OpptrixField>
               </div>
             </>
           )}
@@ -457,22 +727,37 @@ export default function ProviderWizard({
           {step === 2 && (
             <>
               <div className={s.stepIntro}>
-                <Text className={s.stepTitle} block>配置 API Key</Text>
+                <Text className={s.stepTitle} block>填写密钥</Text>
                 <Text className={s.stepDesc} block>
                   {isEdit
                     ? '留空表示沿用已保存的密钥；填写新密钥将重新验证并拉取模型列表。'
                     : isOnboarding
                       ? '密钥保存在你的电脑上。点「继续」将自动验证并拉取可用模型。'
-                      : '密钥保存在本地服务端。点击「下一步」将自动验证并拉取可用模型。'}
+                      : '密钥保存在本地。点击「下一步」将自动验证并拉取可用模型。'}
                 </Text>
               </div>
               <div className={s.formGrid}>
-                <OpptrixField label={isEdit ? 'API Key（可选）' : 'API Key'}>
+                {name.trim() ? (
+                  <div className={s.providerMeta}>
+                    <Text className={s.providerMetaName}>{name.trim()}</Text>
+                    {signupUrl ? (
+                      <a
+                        className={s.signupLink}
+                        href={signupUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        点此获取密钥
+                      </a>
+                    ) : null}
+                  </div>
+                ) : null}
+                <OpptrixField label={isEdit ? '密钥（可选）' : '密钥'}>
                   <OpptrixInput
                     type="password"
                     value={apiKey}
                     onChange={(_, d) => setApiKey(d.value || '')}
-                    placeholder={isEdit ? '留空不修改' : 'sk-...'}
+                    placeholder={isEdit ? '留空不修改' : '粘贴密钥'}
                   />
                 </OpptrixField>
               </div>
@@ -539,26 +824,30 @@ export default function ProviderWizard({
 
       {!hideFooter && (
       <div className={s.footer}>
-        {!(hideCancel && step === 1) && (
+        {!(hideCancel && step === 1 && !showCustomForm) && (
         <OpptrixButton
           className={s.footerBack}
           variant="secondary"
           onClick={handleBack}
         >
-          {step === 1 ? '取消' : '上一步'}
+          {step === 1
+            ? (showCustomForm ? '返回列表' : '取消')
+            : '上一步'}
         </OpptrixButton>
         )}
         {step < 3 ? (
-          <OpptrixButton
-            variant="primary"
-            onClick={() => void handleNext()}
-            disabled={
-              (step === 1 && !canNextStep1)
-              || (step === 2 && (!canNextStep2 || discovering))
-            }
-          >
-            {step === 2 && discovering ? '验证中…' : '下一步'}
-          </OpptrixButton>
+          showPresetList ? null : (
+            <OpptrixButton
+              variant="primary"
+              onClick={() => void handleNext()}
+              disabled={
+                (step === 1 && !canNextStep1)
+                || (step === 2 && (!canNextStep2 || discovering))
+              }
+            >
+              {step === 2 && discovering ? '验证中…' : '下一步'}
+            </OpptrixButton>
+          )
         ) : (
           <OpptrixButton
             variant="primary"

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -197,12 +197,31 @@ const useStyles = makeStyles({
   dialogSurface: {
     maxWidth: '520px',
     width: 'calc(100vw - 40px)',
+    maxHeight: 'calc(100dvh - 32px)',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  dialogBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
   },
   dialogTitle: {
     fontSize: 'var(--opptrix-font-2xl)',
     fontWeight: 650,
     letterSpacing: '-0.02em',
     color: opptrixCssVars.textPrimary,
+    flexShrink: 0,
+  },
+  dialogContent: {
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
   },
   themePicker: {
     display: 'inline-flex',
@@ -475,7 +494,7 @@ function SettingsPageView({
       const health = await getHealth()
       toast.showSuccess(health.llm_configured
         ? `连接正常 · ${health.available_models ?? 0} 个可用模型`
-        : '后端已连接，但尚未配置 LLM 提供商')
+        : '后端已连接，但尚未配置大模型提供商')
     } catch (e) {
       toast.showError(e instanceof Error ? e.message : '连接失败')
     }
@@ -489,8 +508,8 @@ function SettingsPageView({
       entries.push({
         section: 'models',
         title: p.name,
-        desc: '模型提供商',
-        keywords: [p.base_url, ...p.models],
+        desc: '提供商',
+        keywords: [p.base_url, ...p.models, '大模型'],
       })
     }
     entries.push(...newsSearchEntries)
@@ -576,7 +595,7 @@ function SettingsPageView({
               <SettingsGroup>
                 <SettingsRow
                   title="后端连接"
-                  desc="检查 API 服务与 LLM 提供商配置是否正常"
+                  desc="检查服务连接与大模型配置是否正常"
                   control={(
                     <OpptrixButton variant="secondary" onClick={handleTest}>
                       测试
@@ -597,7 +616,7 @@ function SettingsPageView({
               {providers.length === 0 ? (
                 <SettingsStaticBlock>
                   <Text className={s.aboutMeta} block>
-                    尚未配置任何提供商。添加 OpenAI 兼容接口以启用多模型对话。
+                    还没有配置任何提供商。添加后即可开始多模型对话。
                   </Text>
                 </SettingsStaticBlock>
               ) : (
@@ -629,10 +648,12 @@ function SettingsPageView({
                 ))
               )}
               <SettingsActionRow
-                title="添加模型提供商"
-                desc="配置 Base URL 与 API Key"
+                title="添加提供商"
+                desc="选择预置服务或自定义，填写密钥即可使用"
                 icon={<ChevronRightRegular fontSize={16} color={opptrixCssVars.textTertiary} />}
                 onClick={() => openProviderWizard()}
+                dividerAbove
+                last
               />
             </SettingsGroup>
           </div>
@@ -740,12 +761,16 @@ function SettingsPageView({
       </div>
 
       <Dialog open={wizardOpen} onOpenChange={(_, data) => { if (!data.open) closeProviderWizard() }}>
-        <DialogSurface className={mergeClasses(s.dialogSurface, 'opptrix-dialog-surface')}>
-          <DialogBody>
+        <DialogSurface className={mergeClasses(
+          s.dialogSurface,
+          'opptrix-dialog-surface',
+          'opptrix-provider-wizard-dialog',
+        )}>
+          <DialogBody className={s.dialogBody}>
             <DialogTitle className={s.dialogTitle}>
-              {editingProvider ? '编辑模型提供商' : '添加模型提供商'}
+              {editingProvider ? '编辑提供商' : '添加提供商'}
             </DialogTitle>
-            <DialogContent>
+            <DialogContent className={s.dialogContent}>
               <ProviderWizard
                 key={editingProvider?.id ?? 'new'}
                 provider={editingProvider}

--- a/client-ui/src/pages/settings/SettingsPrimitives.tsx
+++ b/client-ui/src/pages/settings/SettingsPrimitives.tsx
@@ -562,6 +562,7 @@ export function SettingsActionRow({
   onClick,
   icon,
   last = false,
+  dividerAbove = false,
   dividerFullWidth = false,
 }: {
   title: string
@@ -569,11 +570,14 @@ export function SettingsActionRow({
   onClick: () => void
   icon?: ReactNode
   last?: boolean
+  /** 分割线画在行上方（用于组内末行操作入口） */
+  dividerAbove?: boolean
   dividerFullWidth?: boolean
 }) {
   const s = useStyles()
   return (
     <>
+      {dividerAbove && <SettingsDivider fullWidth={dividerFullWidth} />}
       <OpptrixButton
         variant="ghost"
         block

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -33,16 +33,20 @@ export type { SettingsSection } from './settingsTypes'
 export type SettingsSidebarMode = 'panel' | 'overlay'
 
 const NAV: { id: SettingsSection; label: string; icon: typeof SettingsRegular }[] = [
+  // 基础与核心能力
   { id: 'general', label: '常规', icon: SettingsRegular },
-  { id: 'models', label: '模型', icon: BotRegular },
+  { id: 'models', label: '大模型', icon: BotRegular },
   { id: 'data_providers', label: '数据源', icon: ServerRegular },
-  { id: 'mcp_servers', label: 'MCP 服务器', icon: PlugConnectedRegular },
+  // 内容与阅读
   { id: 'news_feed', label: '新闻订阅', icon: NewsRegular },
-  { id: 'sandbox', label: '沙盒环境', icon: ShieldRegular },
-  { id: 'python', label: 'Python 环境', icon: CodeRegular },
   { id: 'translation', label: '翻译', icon: TranslateRegular },
   { id: 'multimodal', label: '多模态', icon: ImageRegular },
-  { id: 'about', label: '关于 Opptrix', icon: InfoRegular },
+  // 扩展与运行环境
+  { id: 'mcp_servers', label: 'MCP 服务', icon: PlugConnectedRegular },
+  { id: 'sandbox', label: '沙盒', icon: ShieldRegular },
+  { id: 'python', label: 'Python', icon: CodeRegular },
+  // 关于
+  { id: 'about', label: '关于', icon: InfoRegular },
 ]
 
 const useStyles = makeStyles({
@@ -381,21 +385,21 @@ export function settingsSectionSubtitle(section: SettingsSection): string {
     case 'general':
       return '评分偏好与连接设置'
     case 'models':
-      return '添加和管理 AI 模型服务'
+      return '添加和管理大模型服务'
     case 'data_providers':
       return '管理行情与资讯数据来源'
-    case 'mcp_servers':
-      return '接入外部智能服务'
     case 'news_feed':
       return '订阅源与更新频率'
-    case 'sandbox':
-      return '管理命令隔离环境的网络访问规则'
-    case 'python':
-      return '查看 Python 状态、配置镜像源与安装选项'
     case 'translation':
       return '离线翻译与远程回退'
     case 'multimodal':
       return '图片、语音与媒体处理'
+    case 'mcp_servers':
+      return '接入外部智能服务'
+    case 'sandbox':
+      return '管理命令隔离环境的网络访问规则'
+    case 'python':
+      return '查看 Python 状态、配置镜像源与安装选项'
     case 'about':
       return '版本信息与法律说明'
     default:

--- a/client-ui/src/pages/settings/settingsSearchIndex.ts
+++ b/client-ui/src/pages/settings/settingsSearchIndex.ts
@@ -22,17 +22,17 @@ function haystack(entry: SettingsSearchEntry): string {
 }
 
 export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
-  // 分类
+  // 分类（与侧栏导航顺序一致）
   { section: 'general', title: '常规', desc: '管理默认评分卡与后端连接状态' },
-  { section: 'models', title: '模型', desc: '配置 LLM 提供商与可用模型' },
+  { section: 'models', title: '大模型', desc: '配置大模型提供商与可用模型', keywords: ['模型', 'LLM', 'AI'] },
   { section: 'data_providers', title: '数据源', desc: '管理行情与资讯数据提供商、拖拽回退顺序', keywords: ['priority', '回退', '拖拽', '排序'] },
-  { section: 'mcp_servers', title: 'MCP 服务器', desc: '外部 MCP 接入与优先级故障转移', keywords: ['mcp', 'stdio', 'http', '外部工具'] },
   { section: 'news_feed', title: '新闻订阅', desc: '管理 RSS 订阅与资讯更新频率' },
-  { section: 'sandbox', title: '沙盒环境', desc: '管理命令隔离环境的网络访问规则' },
-  { section: 'python', title: 'Python 环境', desc: '查看 Python 状态与镜像源配置' },
   { section: 'translation', title: '翻译', desc: '配置新闻阅读的离线翻译与远程大模型回退' },
   { section: 'multimodal', title: '多模态', desc: '配置图片 OCR、语音转写与文章媒体自动提取策略' },
-  { section: 'about', title: '关于 Opptrix', desc: '产品说明、版本更新、法律条款与帮助反馈' },
+  { section: 'mcp_servers', title: 'MCP 服务', desc: '外部 MCP 接入与优先级故障转移', keywords: ['mcp', 'stdio', 'http', '外部工具', 'MCP 服务器'] },
+  { section: 'sandbox', title: '沙盒', desc: '管理命令隔离环境的网络访问规则', keywords: ['沙盒环境'] },
+  { section: 'python', title: 'Python', desc: '查看 Python 状态与镜像源配置', keywords: ['Python 环境', 'pip'] },
+  { section: 'about', title: '关于', desc: '产品说明、版本更新、法律条款与帮助反馈', keywords: ['关于 Opptrix', 'Opptrix'] },
   { section: 'about', title: '应用更新', desc: '检查更新与重启安装', keywords: ['版本', '升级', '热更新'] },
   { section: 'about', title: '检查更新', keywords: ['更新', 'upgrade'] },
   { section: 'about', title: '官方网站', desc: 'Opptrix 官网', keywords: ['官网', 'opptrix.org', '网站'] },
@@ -49,10 +49,10 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   { section: 'general', group: '偏好', title: '评分卡', desc: '因子评估默认使用的评分模板', keywords: ['scorecard', 'G=B+M', '因子'] },
   { section: 'general', group: '连接', title: '后端连接', desc: '检查 API 服务与 LLM 提供商配置', keywords: ['测试', 'health', '连接'] },
 
-  // 模型
-  { section: 'models', title: '模型提供商', desc: '配置 Base URL 与 API Key', keywords: ['LLM', 'OpenAI', 'API', '密钥', '提供商'] },
-  { section: 'models', title: '添加模型提供商', keywords: ['新增', '添加'] },
-  { section: 'models', title: '编辑模型提供商', keywords: ['修改'] },
+  // 大模型
+  { section: 'models', title: '提供商', desc: '配置服务地址与密钥', keywords: ['大模型', 'LLM', 'OpenAI', '密钥', '提供商'] },
+  { section: 'models', title: '添加提供商', keywords: ['新增', '添加', '大模型'] },
+  { section: 'models', title: '编辑提供商', keywords: ['修改', '大模型'] },
 
   // 数据源
   { section: 'data_providers', group: 'A 股', title: 'Tushare Pro', keywords: ['tushare', '行情源', 'token'] },
@@ -104,15 +104,15 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
 
 const SECTION_LABEL: Record<SettingsSection, string> = {
   general: '常规',
-  models: '模型',
+  models: '大模型',
   data_providers: '数据源',
-  mcp_servers: 'MCP 服务器',
   news_feed: '新闻订阅',
-  sandbox: '沙盒环境',
-  python: 'Python 环境',
   translation: '翻译',
   multimodal: '多模态',
-  about: '关于 Opptrix',
+  mcp_servers: 'MCP 服务',
+  sandbox: '沙盒',
+  python: 'Python',
+  about: '关于',
 }
 
 export function settingsSectionLabel(section: SettingsSection): string {

--- a/client-ui/src/pages/settings/settingsTypes.ts
+++ b/client-ui/src/pages/settings/settingsTypes.ts
@@ -14,12 +14,12 @@ const SETTINGS_SECTION_IDS: readonly SettingsSection[] = [
   'general',
   'models',
   'data_providers',
-  'mcp_servers',
   'news_feed',
-  'sandbox',
-  'python',
   'translation',
   'multimodal',
+  'mcp_servers',
+  'sandbox',
+  'python',
   'about',
 ]
 

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -933,6 +933,34 @@ select:focus-visible {
   overflow: visible !important;
 }
 
+/* 添加/编辑提供商向导 — 小窗口内 footer 始终可见，中间列表滚动 */
+.opptrix-provider-wizard-dialog.fui-DialogSurface {
+  max-height: calc(100dvh - 32px) !important;
+  display: flex !important;
+  flex-direction: column !important;
+  overflow: hidden !important;
+}
+
+.opptrix-provider-wizard-dialog .fui-DialogBody {
+  display: flex !important;
+  flex-direction: column !important;
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+}
+
+.opptrix-provider-wizard-dialog .fui-DialogTitle {
+  flex-shrink: 0 !important;
+}
+
+.opptrix-provider-wizard-dialog .fui-DialogContent {
+  flex: 1 1 auto !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+  display: flex !important;
+  flex-direction: column !important;
+}
+
 /* Workspace search — flush body, borderless inline input */
 .opptrix-workspace-search-dialog.fui-DialogBody {
   padding: 0 !important;

--- a/docs/API.md
+++ b/docs/API.md
@@ -107,6 +107,7 @@
 |------|------|------|
 | GET | `/api/config` | 公开配置（不含明文 API Key） |
 | POST | `/api/config` | 保存 LLM / 默认评分卡 |
+| GET | `/api/providers/presets` | 大模型提供商预置列表（有序：中国 → 海外 → 本地 Ollama → 自定义；`base_url` 优先 models.dev 缓存，否则静态 fallback；含 `region`） |
 | GET | `/api/templates` | 评分卡模板列表 |
 | POST | `/api/chat` | `{ "message": "..." }` Agent 对话 |
 | POST | `/api/evaluate` | `{ "code", "scorecard?" }` |

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -119,10 +119,14 @@ export {
   resolveModelContextTokensAsync,
   lookupModelsDevContextLimit,
   getModelsDevCatalog,
+  resolveModelsDevProviderMeta,
   resetModelsDevCacheForTests,
   resolveModelMediaCapabilitiesAsync,
   lookupModelsDevMediaEntry,
   defaultTextOnlyMediaCapabilities,
+  type ModelsDevCatalog,
+  type ModelsDevProviderEntry,
+  type ModelsDevProviderMeta,
 } from './llm/models-dev-context.js'
 export {
   type MediaKind,

--- a/packages/agent/src/llm/models-dev-context.ts
+++ b/packages/agent/src/llm/models-dev-context.ts
@@ -46,12 +46,21 @@ interface ModelsDevModelEntry {
   modalities?: ModelsDevModalities
 }
 
-interface ModelsDevProviderEntry {
+export interface ModelsDevProviderEntry {
   id?: string
+  name?: string
+  /** OpenAI-compatible base URL when present in models.dev catalog */
+  api?: string
   models?: Record<string, ModelsDevModelEntry>
 }
 
-type ModelsDevCatalog = Record<string, ModelsDevProviderEntry>
+export type ModelsDevCatalog = Record<string, ModelsDevProviderEntry>
+
+export interface ModelsDevProviderMeta {
+  id: string
+  name?: string
+  api?: string
+}
 
 let memoryCache: { fetchedAt: number; catalog: ModelsDevCatalog } | null = null
 let inflightFetch: Promise<ModelsDevCatalog | null> | null = null
@@ -80,18 +89,43 @@ function stripCommonPrefix(id: string): string {
   return id
 }
 
+function parseProviderEntry(key: string, value: unknown): ModelsDevProviderEntry | null {
+  if (!isRecord(value) || !isRecord(value.models)) return null
+  const name = typeof value.name === 'string' ? value.name : undefined
+  const api = typeof value.api === 'string' ? value.api : undefined
+  const id = typeof value.id === 'string' ? value.id : key
+  return {
+    id,
+    ...(name ? { name } : {}),
+    ...(api ? { api } : {}),
+    models: value.models as Record<string, ModelsDevModelEntry>,
+  }
+}
+
 function parseProvidersMap(data: unknown): ModelsDevCatalog {
   if (!isRecord(data)) return {}
-  if (isRecord(data.providers)) {
-    return data.providers as ModelsDevCatalog
-  }
+  const root = isRecord(data.providers) ? data.providers : data
   const out: ModelsDevCatalog = {}
-  for (const [key, value] of Object.entries(data)) {
-    if (isRecord(value) && isRecord(value.models)) {
-      out[key] = value as ModelsDevProviderEntry
-    }
+  for (const [key, value] of Object.entries(root)) {
+    const entry = parseProviderEntry(key, value)
+    if (entry) out[key] = entry
   }
   return out
+}
+
+/** Lookup display name + api URL for a models.dev provider id. */
+export function resolveModelsDevProviderMeta(
+  id: string,
+  catalog: ModelsDevCatalog | null | undefined,
+): ModelsDevProviderMeta | null {
+  if (!catalog || !id.trim()) return null
+  const entry = catalog[id]
+  if (!entry) return null
+  return {
+    id,
+    ...(entry.name ? { name: entry.name } : {}),
+    ...(entry.api ? { api: entry.api } : {}),
+  }
 }
 
 function limitFromEntry(entry: ModelsDevModelEntry | undefined): ModelsDevLimit | null {


### PR DESCRIPTION
## Summary
- 设置项改名为「大模型」；添加提供商支持预置列表（models.dev + fallback）、返利置顶、获取密钥外链、本地 Ollama
- 提供商向导 Dialog 小窗口不溢出；列表 hover/focus、分割线与圆角交互打磨
- 设置侧栏按用途重排，并缩短 MCP/沙盒/Python/关于等导航文案

## Test plan
- [ ] 设置 → 大模型 → 添加提供商：列表完整，返利四家置顶，选中后进入填密钥并可见获取链接
- [ ] 选择本地 Ollama：地址为 `127.0.0.1:11434/v1`，密钥预填
- [ ] 缩小窗口：Dialog 底部按钮仍在容器内
- [ ] 侧栏顺序：常规→大模型→数据源→新闻订阅→翻译→多模态→MCP 服务→沙盒→Python→关于


Made with [Cursor](https://cursor.com)