### PR TITLE
feat(settings): iPhone-style font slider and news URL panel

### DIFF
--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -32,8 +32,9 @@ import {
 } from '../api/client'
 import {
   applyFontScale, readFontScalePreference, writeFontScalePreference,
-  FONT_SCALE_LABELS, FONT_SCALE_OPTIONS, type FontScaleName,
+  type FontScaleName,
 } from '../theme/fontScale'
+import FontScaleSlider from './settings/FontScaleSlider'
 import { opptrixTokens, opptrixCssVars, type ThemePreference } from '../theme/tokens'
 import { useTheme } from '../theme/ThemeContext'
 import { isElectron } from '../platform/detect'
@@ -551,18 +552,10 @@ function SettingsPageView({
                   title="字体大小"
                   desc="调整全局文字尺寸，切换后立即生效"
                   control={(
-                    <div style={{ display: 'flex', gap: '4px' }}>
-                      {FONT_SCALE_OPTIONS.map(name => (
-                        <OpptrixButton
-                          key={name}
-                          variant={fontScale === name ? 'primary' : 'secondary'}
-                          onClick={() => setFontScale(name)}
-                          style={{ minWidth: '48px', fontSize: 'var(--opptrix-font-sm)' }}
-                        >
-                          {FONT_SCALE_LABELS[name]}
-                        </OpptrixButton>
-                      ))}
-                    </div>
+                    <FontScaleSlider
+                      value={fontScale}
+                      onChange={setFontScale}
+                    />
                   )}
                   last
                 />

--- a/client-ui/src/pages/settings/FontScaleSlider.tsx
+++ b/client-ui/src/pages/settings/FontScaleSlider.tsx
@@ -1,0 +1,227 @@
+import { useCallback, useRef, type KeyboardEvent, type PointerEvent as ReactPointerEvent } from 'react'
+import { Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import {
+  FONT_SCALE_LABELS,
+  FONT_SCALE_OPTIONS,
+  type FontScaleName,
+} from '../../theme/fontScale'
+import { focusVisibleRing, motion } from '../../theme/mixins'
+import { opptrixCssVars, opptrixTokens } from '../../theme/tokens'
+
+const STEP_COUNT = FONT_SCALE_OPTIONS.length
+const MAX_INDEX = STEP_COUNT - 1
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: '6px',
+    width: '100%',
+    maxWidth: '280px',
+    minWidth: '168px',
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    width: '100%',
+  },
+  letter: {
+    flexShrink: 0,
+    color: opptrixCssVars.textTertiary,
+    fontWeight: 500,
+    lineHeight: 1,
+    userSelect: 'none',
+    width: '18px',
+    textAlign: 'center',
+  },
+  letterSm: {
+    fontSize: '11px',
+  },
+  letterLg: {
+    fontSize: '20px',
+  },
+  trackWrap: {
+    flex: 1,
+    minWidth: 0,
+    position: 'relative',
+    height: '28px',
+    display: 'flex',
+    alignItems: 'center',
+    touchAction: 'none',
+    cursor: 'pointer',
+    borderRadius: opptrixTokens.radiusSm,
+    ...focusVisibleRing,
+  },
+  track: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: '3px',
+    borderRadius: opptrixTokens.radiusFull,
+    backgroundColor: opptrixCssVars.separatorStrong,
+  },
+  ticks: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: '100%',
+    pointerEvents: 'none',
+  },
+  tick: {
+    position: 'absolute',
+    top: '50%',
+    width: '2px',
+    height: '8px',
+    marginTop: '-4px',
+    marginLeft: '-1px',
+    borderRadius: opptrixTokens.radiusFull,
+    backgroundColor: opptrixCssVars.separatorStrong,
+  },
+  thumb: {
+    position: 'absolute',
+    top: '50%',
+    width: '22px',
+    height: '22px',
+    marginTop: '-11px',
+    marginLeft: '-11px',
+    borderRadius: opptrixTokens.radiusFull,
+    backgroundColor: opptrixCssVars.canvas,
+    border: `1px solid ${opptrixCssVars.separatorStrong}`,
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 1px rgba(0, 0, 0, 0.06)',
+    transitionProperty: 'left, box-shadow',
+    transitionDuration: motion.fast,
+    transitionTimingFunction: motion.ease,
+    pointerEvents: 'none',
+  },
+  label: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.3,
+    textAlign: 'center',
+    minHeight: '16px',
+  },
+})
+
+function clampIndex(index: number): number {
+  if (index < 0) return 0
+  if (index > MAX_INDEX) return MAX_INDEX
+  return index
+}
+
+function indexFromClientX(clientX: number, rect: DOMRect): number {
+  if (rect.width <= 0) return 0
+  const ratio = (clientX - rect.left) / rect.width
+  return clampIndex(Math.round(ratio * MAX_INDEX))
+}
+
+export default function FontScaleSlider({
+  value,
+  onChange,
+}: {
+  value: FontScaleName
+  onChange: (next: FontScaleName) => void
+}) {
+  const s = useStyles()
+  const trackRef = useRef<HTMLDivElement>(null)
+  const dragging = useRef(false)
+  const index = Math.max(0, FONT_SCALE_OPTIONS.indexOf(value))
+  const label = FONT_SCALE_LABELS[value]
+  const thumbPercent = MAX_INDEX === 0 ? 0 : (index / MAX_INDEX) * 100
+
+  const commitIndex = useCallback((nextIndex: number) => {
+    const name = FONT_SCALE_OPTIONS[clampIndex(nextIndex)]
+    if (name && name !== value) onChange(name)
+  }, [onChange, value])
+
+  const applyFromClientX = useCallback((clientX: number) => {
+    const el = trackRef.current
+    if (!el) return
+    commitIndex(indexFromClientX(clientX, el.getBoundingClientRect()))
+  }, [commitIndex])
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    dragging.current = true
+    e.currentTarget.setPointerCapture(e.pointerId)
+    applyFromClientX(e.clientX)
+  }
+
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return
+    applyFromClientX(e.clientX)
+  }
+
+  const onPointerUp = (e: ReactPointerEvent<HTMLDivElement>) => {
+    if (!dragging.current) return
+    dragging.current = false
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+  }
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowDown' || e.key === 'PageDown') {
+      e.preventDefault()
+      commitIndex(index - 1)
+      return
+    }
+    if (e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'PageUp') {
+      e.preventDefault()
+      commitIndex(index + 1)
+      return
+    }
+    if (e.key === 'Home') {
+      e.preventDefault()
+      commitIndex(0)
+      return
+    }
+    if (e.key === 'End') {
+      e.preventDefault()
+      commitIndex(MAX_INDEX)
+    }
+  }
+
+  return (
+    <div className={s.root}>
+      <div className={s.row}>
+        <span className={mergeClasses(s.letter, s.letterSm)} aria-hidden>A</span>
+        <div
+          ref={trackRef}
+          className={mergeClasses(s.trackWrap, 'opptrix-focusable')}
+          role="slider"
+          tabIndex={0}
+          aria-label="字体大小"
+          aria-valuemin={0}
+          aria-valuemax={MAX_INDEX}
+          aria-valuenow={index}
+          aria-valuetext={label}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onKeyDown={onKeyDown}
+        >
+          <div className={s.track} aria-hidden />
+          <div className={s.ticks} aria-hidden>
+            {FONT_SCALE_OPTIONS.map((name, i) => (
+              <span
+                key={name}
+                className={s.tick}
+                style={{ left: `${MAX_INDEX === 0 ? 0 : (i / MAX_INDEX) * 100}%` }}
+              />
+            ))}
+          </div>
+          <div
+            className={s.thumb}
+            style={{ left: `${thumbPercent}%` }}
+            aria-hidden
+          />
+        </div>
+        <span className={mergeClasses(s.letter, s.letterLg)} aria-hidden>A</span>
+      </div>
+      <Text className={s.label} block>{label}</Text>
+    </div>
+  )
+}

--- a/client-ui/src/pages/settings/NewsFeedSettingsSection.tsx
+++ b/client-ui/src/pages/settings/NewsFeedSettingsSection.tsx
@@ -15,6 +15,7 @@ import {
   ArrowSyncRegular,
   ChevronDownRegular,
   ChevronRightRegular,
+  CopyRegular,
   DeleteRegular,
   DocumentArrowDownRegular,
   DocumentArrowUpRegular,
@@ -98,15 +99,22 @@ const useStyles = makeStyles({
   },
   listRow: {
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: '10px',
-    padding: '5px 12px',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: '4px',
+    padding: '8px 12px',
     minHeight: '34px',
     borderBottom: `1px solid ${opptrixCssVars.separator}`,
     ':last-child': {
       borderBottom: 'none',
     },
+  },
+  listRowPrimary: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '10px',
+    minWidth: 0,
   },
   listRowMain: {
     flex: 1,
@@ -134,6 +142,14 @@ const useStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     gap: '6px',
+  },
+  listRowSecondary: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: '4px',
+    minWidth: 0,
+    paddingRight: '2px',
   },
   groupSelect: {
     minWidth: '88px',
@@ -228,11 +244,6 @@ const useStyles = makeStyles({
     color: opptrixCssVars.textSecondary,
     whiteSpace: 'nowrap',
   },
-  subMeta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2px',
-  },
   subError: {
     fontSize: 'var(--opptrix-font-sm)',
     color: opptrixCssVars.error,
@@ -241,8 +252,10 @@ const useStyles = makeStyles({
   urlToggle: {
     display: 'inline-flex',
     alignItems: 'center',
-    gap: '3px',
-    padding: 0,
+    gap: '4px',
+    alignSelf: 'flex-start',
+    maxWidth: '100%',
+    padding: '1px 0',
     border: 'none',
     background: 'none',
     fontSize: 'var(--opptrix-font-sm)',
@@ -250,7 +263,7 @@ const useStyles = makeStyles({
     cursor: 'pointer',
     textAlign: 'left',
     lineHeight: 1.45,
-    maxWidth: '100%',
+    borderRadius: opptrixTokens.radiusSm,
     ':hover': {
       color: opptrixCssVars.textSecondary,
     },
@@ -259,11 +272,49 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    minWidth: 0,
+  },
+  urlPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '8px 10px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.canvasAlt,
+  },
+  urlPanelHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '8px',
+    minWidth: 0,
+  },
+  urlPanelLabel: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.3,
+  },
+  urlPanelActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '2px',
+    flexShrink: 0,
+  },
+  urlPanelAction: {
+    minHeight: '24px',
+    height: '24px',
+    paddingLeft: '8px',
+    paddingRight: '8px',
+    fontSize: 'var(--opptrix-font-sm)',
   },
   urlFull: {
     fontSize: 'var(--opptrix-font-sm)',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
     color: opptrixCssVars.textSecondary,
-    lineHeight: 1.4,
+    lineHeight: 1.45,
     wordBreak: 'break-all',
     userSelect: 'text',
   },
@@ -503,6 +554,15 @@ export default function NewsFeedSettingsSection() {
 
   const toggleSubUrl = (id: string) => {
     setExpandedSubIds(prev => ({ ...prev, [id]: !prev[id] }))
+  }
+
+  const copySubscriptionUrl = async (url: string) => {
+    try {
+      await navigator.clipboard.writeText(url)
+      toast.showSuccess('已复制订阅地址')
+    } catch {
+      toast.showError('无法复制，请手动选择地址')
+    }
   }
 
   const checkDuplicateUrl = (url: string): FeedSubscription | undefined => {
@@ -764,62 +824,92 @@ export default function NewsFeedSettingsSection() {
           </div>
         ) : (
           <div className={mergeClasses(s.listScroll, 'opptrix-scroll', 'opptrix-scroll-hover')}>
-            {subs.map(sub => (
-              <div key={sub.id} className={s.listRow}>
-                <div className={s.listRowMain}>
-                  <Text className={s.listRowTitle} block title={sub.title}>{sub.title}</Text>
-                  <div className={s.subMeta}>
+            {subs.map(sub => {
+              const expanded = !!expandedSubIds[sub.id]
+              return (
+                <div key={sub.id} className={s.listRow}>
+                  <div className={s.listRowPrimary}>
+                    <div className={s.listRowMain}>
+                      <Text className={s.listRowTitle} block title={sub.title}>{sub.title}</Text>
+                    </div>
+                    <div className={s.listRowControls}>
+                      <OpptrixSelect
+                        className={s.groupSelect}
+                        size="small"
+                        selectedOptions={[sub.group_id ?? '']}
+                        onOptionSelect={(_, d) => {
+                          void handleMoveGroup(sub.id, d.optionValue ?? '')
+                        }}
+                      >
+                        <OpptrixOption value="">未分组</OpptrixOption>
+                        {groups.map(g => (
+                          <OpptrixOption key={g.id} value={g.id}>{g.title}</OpptrixOption>
+                        ))}
+                      </OpptrixSelect>
+                      <Switch
+                        checked={sub.enabled}
+                        onChange={(_, d) => { void toggleEnabled(sub, d.checked) }}
+                      />
+                      <OpptrixButton
+                        variant="icon"
+                        icon={<DeleteRegular />}
+                        aria-label="删除"
+                        onClick={() => { void handleDelete(sub.id) }}
+                      />
+                    </div>
+                  </div>
+                  <div className={s.listRowSecondary}>
                     {sub.last_error && (
-                      <Text className={s.subError} block>拉取失败：{sub.last_error}</Text>
+                      <Text className={s.subError} block>暂时无法更新：{sub.last_error}</Text>
                     )}
-                    <OpptrixButton
-                      variant="ghost"
-                      size="small"
-                      className={s.urlToggle}
-                      aria-expanded={!!expandedSubIds[sub.id]}
-                      onClick={() => toggleSubUrl(sub.id)}
-                    >
-                      {expandedSubIds[sub.id]
-                        ? <ChevronDownRegular fontSize={11} />
-                        : <ChevronRightRegular fontSize={11} />}
-                      <span className={s.urlToggleLabel}>
-                        {expandedSubIds[sub.id] ? '收起订阅地址' : formatSubscriptionUrlShort(sub.url)}
-                      </span>
-                    </OpptrixButton>
-                    {expandedSubIds[sub.id] && (
-                      <Text className={s.urlFull} block>
-                        {sub.url}
-                      </Text>
+                    {!expanded ? (
+                      <button
+                        type="button"
+                        className={mergeClasses(s.urlToggle, 'opptrix-focusable')}
+                        aria-expanded={false}
+                        aria-label="查看订阅地址"
+                        onClick={() => toggleSubUrl(sub.id)}
+                      >
+                        <ChevronRightRegular fontSize={11} />
+                        <span className={s.urlToggleLabel}>
+                          {formatSubscriptionUrlShort(sub.url)}
+                        </span>
+                      </button>
+                    ) : (
+                      <div className={s.urlPanel}>
+                        <div className={s.urlPanelHeader}>
+                          <Text className={s.urlPanelLabel} block>订阅地址</Text>
+                          <div className={s.urlPanelActions}>
+                            <OpptrixButton
+                              variant="ghost"
+                              size="small"
+                              className={s.urlPanelAction}
+                              icon={<CopyRegular fontSize={12} />}
+                              onClick={() => { void copySubscriptionUrl(sub.url) }}
+                            >
+                              复制
+                            </OpptrixButton>
+                            <OpptrixButton
+                              variant="ghost"
+                              size="small"
+                              className={s.urlPanelAction}
+                              icon={<ChevronDownRegular fontSize={12} />}
+                              aria-expanded
+                              onClick={() => toggleSubUrl(sub.id)}
+                            >
+                              收起
+                            </OpptrixButton>
+                          </div>
+                        </div>
+                        <Text className={s.urlFull} block>
+                          {sub.url}
+                        </Text>
+                      </div>
                     )}
                   </div>
                 </div>
-                <div className={s.listRowControls}>
-                  <OpptrixSelect
-                    className={s.groupSelect}
-                    size="small"
-                    selectedOptions={[sub.group_id ?? '']}
-                    onOptionSelect={(_, d) => {
-                      void handleMoveGroup(sub.id, d.optionValue ?? '')
-                    }}
-                  >
-                    <OpptrixOption value="">未分组</OpptrixOption>
-                    {groups.map(g => (
-                      <OpptrixOption key={g.id} value={g.id}>{g.title}</OpptrixOption>
-                    ))}
-                  </OpptrixSelect>
-                  <Switch
-                    checked={sub.enabled}
-                    onChange={(_, d) => { void toggleEnabled(sub, d.checked) }}
-                  />
-                  <OpptrixButton
-                    variant="icon"
-                    icon={<DeleteRegular />}
-                    aria-label="删除"
-                    onClick={() => { void handleDelete(sub.id) }}
-                  />
-                </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
         </div>
@@ -857,23 +947,25 @@ export default function NewsFeedSettingsSection() {
                 const count = subs.filter(sub => sub.group_id === g.id).length
                 return (
                   <div key={g.id} className={s.listRow}>
-                    <div className={s.listRowMain}>
-                      <Text className={s.listRowTitle} block title={g.title}>{g.title}</Text>
-                      <Text className={s.listRowMeta} block>{count} 个订阅源</Text>
-                    </div>
-                    <div className={s.listRowControls}>
-                      <OpptrixButton
-                        variant="icon"
-                        icon={<EditRegular />}
-                        aria-label={`重命名 ${g.title}`}
-                        onClick={() => openGroupDialog(g)}
-                      />
-                      <OpptrixButton
-                        variant="icon"
-                        icon={<DeleteRegular />}
-                        aria-label={`删除 ${g.title}`}
-                        onClick={() => { void handleDeleteGroup(g.id) }}
-                      />
+                    <div className={s.listRowPrimary}>
+                      <div className={s.listRowMain}>
+                        <Text className={s.listRowTitle} block title={g.title}>{g.title}</Text>
+                        <Text className={s.listRowMeta} block>{count} 个订阅源</Text>
+                      </div>
+                      <div className={s.listRowControls}>
+                        <OpptrixButton
+                          variant="icon"
+                          icon={<EditRegular />}
+                          aria-label={`重命名 ${g.title}`}
+                          onClick={() => openGroupDialog(g)}
+                        />
+                        <OpptrixButton
+                          variant="icon"
+                          icon={<DeleteRegular />}
+                          aria-label={`删除 ${g.title}`}
+                          onClick={() => { void handleDeleteGroup(g.id) }}
+                        />
+                      </div>
                     </div>
                   </div>
                 )


### PR DESCRIPTION
## Summary
- 常规设置字体大小改为 iPhone 式横向步进滑条（小 A — 轨道 — 大 A），四档立即生效
- 新闻订阅源「查看地址」改为主行 + 次行结构，展开为独立面板（复制 / 收起），避免右侧控件错位

## Test plan
- [ ] 设置 → 常规：拖动 / 点轨道 / 方向键切换字体档位，界面字号即时变化
- [ ] 设置 → 新闻订阅：展开/收起订阅地址，主行分组/开关/删除保持对齐
- [ ] 展开面板可复制地址，toast 提示正常
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)