### PR TITLE
fix(desktop): notify chat completion earlier with real OS permission

### DIFF
--- a/apps/desktop/electron/notifications.cjs
+++ b/apps/desktop/electron/notifications.cjs
@@ -1,4 +1,4 @@
-const { Notification, app } = require('electron')
+const { Notification, app, systemPreferences, shell } = require('electron')
 
 /** @type {'default' | 'granted' | 'denied'} */
 let cachedPermission = 'default'
@@ -10,6 +10,53 @@ const SESSION_ID_MAX = 64
 const TAG_RE = /^[A-Za-z0-9:_-]+$/
 const SESSION_ID_RE = /^[A-Za-z0-9_-]+$/
 const KIND_SET = new Set(['chat_done', 'chat_ask'])
+
+/**
+ * 将 macOS UNAuthorizationStatus 映射为 NotificationPermission 三态。
+ * @param {unknown} status
+ * @returns {'default' | 'granted' | 'denied'}
+ */
+function mapDarwinAuthorizationStatus(status) {
+  const raw = String(status ?? '').trim().toLowerCase()
+  if (
+    raw === 'authorized'
+    || raw === 'provisional'
+    || raw === 'temporary'
+    || raw === 'ephemeral'
+  ) {
+    return 'granted'
+  }
+  if (raw === 'denied' || raw === 'restricted') {
+    return 'denied'
+  }
+  // not-determined / unknown / empty
+  return 'default'
+}
+
+/**
+ * 读取系统真实通知权限（能读则读；读不到时不得假 granted）。
+ * @returns {'default' | 'granted' | 'denied'}
+ */
+function readSystemNotificationPermission() {
+  if (!isNotificationSupported()) return 'denied'
+
+  if (process.platform === 'darwin') {
+    const getSettings = systemPreferences?.getNotificationSettings
+    if (typeof getSettings === 'function') {
+      try {
+        const settings = getSettings.call(systemPreferences)
+        return mapDarwinAuthorizationStatus(settings?.authorizationStatus)
+      } catch (err) {
+        console.warn('[notifications] getNotificationSettings failed:', err)
+      }
+    }
+    // Electron 若无 API：保持缓存，但绝不无条件写成 granted
+    return cachedPermission === 'granted' ? 'default' : cachedPermission
+  }
+
+  // Windows / Linux：能力由 AppUserModelId + 桌面环境决定；支持即视为可发
+  return 'granted'
+}
 
 /**
  * 校验并裁剪 renderer 传入的通知载荷；非法字段忽略或整包拒绝。
@@ -83,16 +130,22 @@ function isNotificationSupported() {
 }
 
 function getNotificationPermission() {
+  cachedPermission = readSystemNotificationPermission()
   return cachedPermission
 }
 
+/**
+ * 请求/刷新通知权限。不得无条件写 granted。
+ * macOS 无法编程式弹出授权框，只能读系统状态；用户需在系统设置中开启。
+ * @returns {Promise<'default' | 'granted' | 'denied'>}
+ */
 async function requestNotificationPermission() {
   if (!isNotificationSupported()) {
     cachedPermission = 'denied'
     return cachedPermission
   }
 
-  cachedPermission = 'granted'
+  cachedPermission = readSystemNotificationPermission()
   return cachedPermission
 }
 
@@ -104,29 +157,105 @@ async function requestNotificationPermission() {
  *   tag?: string
  *   onClick?: () => void
  * }} options
+ * @returns {boolean}
  */
 function showLocalNotification(options) {
-  if (!isNotificationSupported()) return false
+  if (!isNotificationSupported()) {
+    cachedPermission = 'denied'
+    return false
+  }
 
   const title = String(options?.title ?? '').trim()
   if (!title) return false
 
-  const notification = new Notification({
-    title,
-    body: String(options?.body ?? '').trim() || undefined,
-    silent: Boolean(options?.silent),
-    tag: options?.tag ? String(options.tag) : undefined,
-  })
-
-  if (typeof options?.onClick === 'function') {
-    notification.on('click', () => {
-      options.onClick()
-    })
+  // 刷新权限；明确拒绝时不调用 show（避免静默失败）
+  cachedPermission = readSystemNotificationPermission()
+  if (cachedPermission === 'denied') {
+    console.warn('[notifications] skip show: permission denied')
+    return false
   }
 
-  notification.show()
-  cachedPermission = 'granted'
-  return true
+  let delivered = false
+  try {
+    const notification = new Notification({
+      title,
+      body: String(options?.body ?? '').trim() || undefined,
+      silent: Boolean(options?.silent),
+      tag: options?.tag ? String(options.tag) : undefined,
+    })
+
+    if (typeof options?.onClick === 'function') {
+      notification.on('click', () => {
+        options.onClick()
+      })
+    }
+
+    notification.on('show', () => {
+      delivered = true
+      if (cachedPermission !== 'denied') {
+        cachedPermission = 'granted'
+      }
+    })
+
+    notification.on('failed', (_event, error) => {
+      console.warn('[notifications] Notification.failed:', error)
+      if (process.platform === 'darwin') {
+        // 展示失败时回读系统状态，避免继续假 granted
+        cachedPermission = readSystemNotificationPermission()
+        if (cachedPermission === 'granted') {
+          cachedPermission = 'denied'
+        }
+      }
+    })
+
+    notification.show()
+  } catch (err) {
+    console.warn('[notifications] show threw:', err)
+    if (process.platform === 'darwin') {
+      cachedPermission = readSystemNotificationPermission()
+      if (cachedPermission !== 'denied') {
+        // 抛错且无明确系统 denied 时，至少不要假 granted
+        if (cachedPermission === 'granted') cachedPermission = 'default'
+      }
+    }
+    return false
+  }
+
+  // Windows / Linux：show 同步路径通常即成功；macOS 以 show 事件为准，此处不强制写 granted
+  if (process.platform !== 'darwin' && cachedPermission !== 'denied') {
+    cachedPermission = 'granted'
+    delivered = true
+  }
+
+  // macOS：若权限仍为 default（未决定），show 可能弹出系统授权框；返回 true 表示已尝试投递
+  if (process.platform === 'darwin') {
+    return cachedPermission !== 'denied'
+  }
+
+  return delivered
+}
+
+/**
+ * 打开系统「通知」设置页，便于用户手动开启。
+ * @returns {Promise<boolean>}
+ */
+async function openSystemNotificationSettings() {
+  try {
+    if (process.platform === 'darwin') {
+      // macOS Ventura+ Notifications pane；旧版回退到通知偏好
+      await shell.openExternal(
+        'x-apple.systempreferences:com.apple.Notifications-Settings.extension',
+      )
+      return true
+    }
+    if (process.platform === 'win32') {
+      await shell.openExternal('ms-settings:notifications')
+      return true
+    }
+  } catch (err) {
+    console.warn('[notifications] openSystemNotificationSettings failed:', err)
+  }
+  return false
 }
 
 function registerNotificationIpc(ipcMain, { onNotificationClick } = {}) {
@@ -135,6 +264,8 @@ function registerNotificationIpc(ipcMain, { onNotificationClick } = {}) {
   ipcMain.handle('notification-get-permission', async () => getNotificationPermission())
 
   ipcMain.handle('notification-request-permission', async () => requestNotificationPermission())
+
+  ipcMain.handle('notification-open-settings', async () => openSystemNotificationSettings())
 
   ipcMain.handle('notification-show', async (_event, payload) => {
     const sanitized = sanitizeNotificationPayload(payload)
@@ -163,6 +294,8 @@ module.exports = {
   configureNotificationIdentity,
   getNotificationPermission,
   isNotificationSupported,
+  mapDarwinAuthorizationStatus,
+  openSystemNotificationSettings,
   registerNotificationIpc,
   requestNotificationPermission,
   sanitizeNotificationPayload,

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -52,6 +52,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   notificationIsSupported: () => ipcRenderer.invoke('notification-is-supported'),
   notificationGetPermission: () => ipcRenderer.invoke('notification-get-permission'),
   notificationRequestPermission: () => ipcRenderer.invoke('notification-request-permission'),
+  notificationOpenSettings: () => ipcRenderer.invoke('notification-open-settings'),
   showLocalNotification: (payload) => ipcRenderer.invoke('notification-show', payload),
   signalShellReady: () => ipcRenderer.send('shell-ready'),
   shellInstallWindowsSandbox: () => ipcRenderer.invoke('shell-install-windows-sandbox'),

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -57,6 +57,7 @@ import { isElectron } from '../platform/detect'
 import {
   buildChatAskNotification,
   buildChatDoneNotification,
+  isAwayFromForeground,
   maybeShowChatLocalNotification,
   resolveWindowFocused,
 } from '../platform/chatNotifications'
@@ -289,6 +290,12 @@ export default function ChatApp() {
   const sessionStreamGenRef = useRef(new Map<string, number>())
   const stoppingSessionsRef = useRef(new Set<string>())
   const streamingSessionIdsRef = useRef(new Set<string>())
+  /** 本轮生成期间曾失焦/不可见（sessionId → true） */
+  const streamAwayDuringGenRef = useRef(new Map<string, boolean>())
+  /** 同轮完成通知去重键：`${sessionId}:${streamGen}` */
+  const doneNotifiedGensRef = useRef(new Set<string>())
+  /** 系统通知被拒时仅温和提示一次 */
+  const notificationDeniedHintedRef = useRef(false)
   const activeIdRef = useRef<string | null>(null)
   const viewRef = useRef(view)
   const sessionsRef = useRef(sessions)
@@ -299,6 +306,78 @@ export default function ChatApp() {
     else streamingSessionIdsRef.current.delete(sessionId)
     setStreamingSessionIds(Array.from(streamingSessionIdsRef.current))
   }, [])
+
+  const resolveSessionTitle = useCallback((targetSessionId: string, eventTitle?: string) => {
+    return eventTitle
+      ?? (activeSessionMetaRef.current?.id === targetSessionId
+        ? activeSessionMetaRef.current.title
+        : undefined)
+      ?? sessionsRef.current.find(s => s.id === targetSessionId)?.title
+  }, [])
+
+  const handleNotificationResult = useCallback((result: 'skipped' | 'shown' | 'denied' | 'failed') => {
+    if (result !== 'denied' || notificationDeniedHintedRef.current) return
+    notificationDeniedHintedRef.current = true
+    setError('桌面通知未开启。可在系统设置中允许 Opptrix 发送通知，以免错过对话完成提醒。')
+  }, [])
+
+  const maybeNotifyChatDone = useCallback((targetSessionId: string, sessionTitle?: string) => {
+    const streamGen = sessionStreamGenRef.current.get(targetSessionId) ?? 0
+    const dedupeKey = `${targetSessionId}:${streamGen}`
+    if (doneNotifiedGensRef.current.has(dedupeKey)) return
+    doneNotifiedGensRef.current.add(dedupeKey)
+
+    void (async () => {
+      const documentVisible = typeof document !== 'undefined'
+        && document.visibilityState === 'visible'
+      const windowFocused = await resolveWindowFocused()
+      const result = await maybeShowChatLocalNotification(
+        targetSessionId,
+        {
+          activeSessionId: activeIdRef.current,
+          view: viewRef.current,
+          documentVisible,
+          windowFocused,
+          awayDuringGeneration: streamAwayDuringGenRef.current.get(targetSessionId) === true,
+        },
+        buildChatDoneNotification(targetSessionId, sessionTitle),
+      )
+      handleNotificationResult(result)
+    })()
+  }, [handleNotificationResult])
+
+  const markStreamingSessionsAwayIfNeeded = useCallback(async () => {
+    if (streamingSessionIdsRef.current.size === 0) return
+    const documentVisible = typeof document !== 'undefined'
+      && document.visibilityState === 'visible'
+    const windowFocused = await resolveWindowFocused()
+    if (!isAwayFromForeground({ documentVisible, windowFocused })) return
+    for (const sessionId of streamingSessionIdsRef.current) {
+      streamAwayDuringGenRef.current.set(sessionId, true)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!isElectron()) return
+
+    const onVisibilityOrFocusChange = () => {
+      void markStreamingSessionsAwayIfNeeded()
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityOrFocusChange)
+    window.addEventListener('blur', onVisibilityOrFocusChange)
+    window.addEventListener('focus', onVisibilityOrFocusChange)
+    const timer = window.setInterval(() => {
+      void markStreamingSessionsAwayIfNeeded()
+    }, 2000)
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityOrFocusChange)
+      window.removeEventListener('blur', onVisibilityOrFocusChange)
+      window.removeEventListener('focus', onVisibilityOrFocusChange)
+      window.clearInterval(timer)
+    }
+  }, [markStreamingSessionsAwayIfNeeded])
 
   const pushStreamEvent = useCallback((targetSessionId: string, event: ChatProgressEvent) => {
     const prev = streamCacheRef.current.get(targetSessionId) ?? createThinkingStreamSnapshot()
@@ -314,27 +393,17 @@ export default function ChatApp() {
       }
     }
 
+    // 内容已落定：优先在 reply 触发完成通知，避免等待慢 done（token/工具重建）
+    if (event.type === 'reply') {
+      maybeNotifyChatDone(targetSessionId, resolveSessionTitle(targetSessionId))
+    }
+
+    // done 作为兜底（无 reply 的路径）；同轮已通知则去重跳过
     if (event.type === 'done' && !event.cancelled) {
-      const sessionTitle = event.title
-        ?? (activeSessionMetaRef.current?.id === targetSessionId
-          ? activeSessionMetaRef.current.title
-          : undefined)
-        ?? sessionsRef.current.find(s => s.id === targetSessionId)?.title
-      void (async () => {
-        const documentVisible = typeof document !== 'undefined'
-          && document.visibilityState === 'visible'
-        const windowFocused = await resolveWindowFocused()
-        await maybeShowChatLocalNotification(
-          targetSessionId,
-          {
-            activeSessionId: activeIdRef.current,
-            view: viewRef.current,
-            documentVisible,
-            windowFocused,
-          },
-          buildChatDoneNotification(targetSessionId, sessionTitle),
-        )
-      })()
+      maybeNotifyChatDone(
+        targetSessionId,
+        resolveSessionTitle(targetSessionId, event.title),
+      )
     }
 
     if (event.type === 'user_prompt') {
@@ -343,7 +412,7 @@ export default function ChatApp() {
         const documentVisible = typeof document !== 'undefined'
           && document.visibilityState === 'visible'
         const windowFocused = await resolveWindowFocused()
-        await maybeShowChatLocalNotification(
+        const result = await maybeShowChatLocalNotification(
           targetSessionId,
           {
             activeSessionId: activeIdRef.current,
@@ -353,9 +422,10 @@ export default function ChatApp() {
           },
           buildChatAskNotification(targetSessionId, promptSummary),
         )
+        handleNotificationResult(result)
       })()
     }
-  }, [])
+  }, [handleNotificationResult, maybeNotifyChatDone, resolveSessionTitle])
 
   const resolveStreamSnapshot = useCallback((id: string | null) => {
     if (!id || !streamingSessionIdsRef.current.has(id)) return null
@@ -856,9 +926,15 @@ export default function ChatApp() {
 
     const streamGen = (sessionStreamGenRef.current.get(sessionId) ?? 0) + 1
     sessionStreamGenRef.current.set(sessionId, streamGen)
+    streamAwayDuringGenRef.current.set(sessionId, false)
+    for (const key of [...doneNotifiedGensRef.current]) {
+      if (key.startsWith(`${sessionId}:`)) doneNotifiedGensRef.current.delete(key)
+    }
     const initialSnapshot = createThinkingStreamSnapshot()
     streamCacheRef.current.set(sessionId, initialSnapshot)
     markSessionStreaming(sessionId, true)
+    // 若发送时已不在前台，立即记为曾离开
+    void markStreamingSessionsAwayIfNeeded()
     stoppingSessionsRef.current.delete(sessionId)
     if (activeIdRef.current === sessionId) {
       syncStreamSnapshotToUi(initialSnapshot, streamUiRef.current)

--- a/client-ui/src/pages/settings/AboutSettingsSection.tsx
+++ b/client-ui/src/pages/settings/AboutSettingsSection.tsx
@@ -7,7 +7,7 @@ import {
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import { getHealth } from '../../api/client'
 import { useAppUpdate } from '../../hooks/useAppUpdate'
-import { isElectron } from '../../platform/detect'
+import { isElectron, type NotificationPermissionState } from '../../platform/detect'
 import { openExternalUrl } from '../../platform/openUrl'
 import { opptrixCssVars } from '../../theme/tokens'
 import {
@@ -134,6 +134,11 @@ const useStyles = makeStyles({
       height: '14px',
     },
   },
+  notifyActions: {
+    display: 'flex',
+    gap: '8px',
+    flexShrink: 0,
+  },
 })
 
 type AboutSettingsSectionProps = {
@@ -145,12 +150,16 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
   const { status: updateStatus, checkNow, installUpdate } = useAppUpdate()
   const [versionLabel, setVersionLabel] = useState<string | null>(null)
   const [checkedOnce, setCheckedOnce] = useState(false)
+  const [notifyPermission, setNotifyPermission] = useState<NotificationPermissionState | null>(null)
 
   useEffect(() => {
     if (isElectron()) {
       void window.electronAPI?.clientVersion?.().then(version => {
         setVersionLabel(version ? `v${version}` : null)
       })
+      void window.electronAPI?.notificationGetPermission?.()
+        .then(perm => setNotifyPermission(perm))
+        .catch(() => setNotifyPermission(null))
       return
     }
     void getHealth()
@@ -163,6 +172,16 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
     void checkNow()
   }, [checkNow])
 
+  const handleOpenNotificationSettings = useCallback(() => {
+    void window.electronAPI?.notificationOpenSettings?.()
+  }, [])
+
+  const handleRefreshNotificationPermission = useCallback(() => {
+    void window.electronAPI?.notificationRequestPermission?.()
+      .then(perm => setNotifyPermission(perm))
+      .catch(() => {})
+  }, [])
+
   const versionDesc = versionLabel ?? '读取版本中…'
   const showUpdateBlock = isElectron()
   const checkBusy = isAppUpdateCheckBusy(updateStatus)
@@ -172,6 +191,19 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
     () => formatAboutCopyrightLine(typeof navigator !== 'undefined' ? navigator.language : undefined),
     [],
   )
+
+  const notifyPermissionDesc = (() => {
+    switch (notifyPermission) {
+      case 'granted':
+        return '已开启。对话完成或需要你确认时，会在你离开窗口时提醒你。'
+      case 'denied':
+        return '系统未允许通知。请在系统设置中开启，以免错过对话完成提醒。'
+      case 'default':
+        return '尚未确认。完成对话后若未收到提醒，请到系统设置中允许 Opptrix 发送通知。'
+      default:
+        return '正在读取通知状态…'
+    }
+  })()
 
   return (
     <div className={mergeClasses(s.root, contentFlush && s.rootFlush)}>
@@ -254,6 +286,32 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
           )}
         </SettingsGroup>
       </div>
+
+      {showUpdateBlock && (
+        <div className={s.sectionBlock}>
+          <Text className={s.sectionLabel} block>桌面通知</Text>
+          <SettingsGroup>
+            <SettingsRow
+              title="系统通知"
+              desc={notifyPermissionDesc}
+              control={(
+                <div className={s.notifyActions}>
+                  {notifyPermission === 'denied' || notifyPermission === 'default' ? (
+                    <OpptrixButton variant="secondary" onClick={handleOpenNotificationSettings}>
+                      打开系统设置
+                    </OpptrixButton>
+                  ) : (
+                    <OpptrixButton variant="secondary" onClick={handleRefreshNotificationPermission}>
+                      刷新状态
+                    </OpptrixButton>
+                  )}
+                </div>
+              )}
+              last
+            />
+          </SettingsGroup>
+        </div>
+      )}
 
       <div className={s.sectionBlock}>
         <Text className={s.sectionLabel} block>法律与官网</Text>

--- a/client-ui/src/platform/chatNotifications.ts
+++ b/client-ui/src/platform/chatNotifications.ts
@@ -5,7 +5,18 @@ export type ChatNotificationAttention = {
   view: string
   documentVisible: boolean
   windowFocused: boolean
+  /**
+   * 本轮流式生成期间曾不可见或主窗口失焦。
+   * 为 true 时即使当前又回到前台，完成通知仍应发出。
+   */
+  awayDuringGeneration?: boolean
 }
+
+export type ChatLocalNotificationResult =
+  | 'skipped'
+  | 'shown'
+  | 'denied'
+  | 'failed'
 
 const BODY_MAX = 120
 
@@ -27,11 +38,20 @@ export function isAttendingChat(
   )
 }
 
-/** 失焦 / 非 chat 页 / 其他会话 → 应发通知 */
+/** 文档隐藏或主窗口失焦 → 视为离开（用于生成期间标记） */
+export function isAwayFromForeground(state: {
+  documentVisible: boolean
+  windowFocused: boolean
+}): boolean {
+  return !state.documentVisible || !state.windowFocused
+}
+
+/** 失焦 / 非 chat 页 / 其他会话 / 生成期间曾离开 → 应发通知 */
 export function shouldNotify(
   targetSessionId: string,
   state: ChatNotificationAttention,
 ): boolean {
+  if (state.awayDuringGeneration) return true
   return !isAttendingChat(targetSessionId, state)
 }
 
@@ -88,17 +108,22 @@ export async function resolveWindowFocused(): Promise<boolean> {
 
 /**
  * Electron 下按注意力状态决定是否展示本地通知；Web / 失败静默 no-op。
+ * 返回结果便于权限被拒时做一次温和引导。
  */
 export async function maybeShowChatLocalNotification(
   targetSessionId: string,
   attention: ChatNotificationAttention,
   payload: LocalNotificationPayload,
-): Promise<void> {
-  if (!isElectronRuntime()) return
-  if (!shouldNotify(targetSessionId, attention)) return
+): Promise<ChatLocalNotificationResult> {
+  if (!isElectronRuntime()) return 'skipped'
+  if (!shouldNotify(targetSessionId, attention)) return 'skipped'
   try {
-    await window.electronAPI?.showLocalNotification?.(payload)
+    const shown = await window.electronAPI?.showLocalNotification?.(payload)
+    if (shown) return 'shown'
+    const permission = await window.electronAPI?.notificationGetPermission?.()
+    if (permission === 'denied') return 'denied'
+    return 'failed'
   } catch {
-    /* fire-and-forget */
+    return 'failed'
   }
 }

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -42,6 +42,7 @@ declare global {
       notificationIsSupported?: () => Promise<boolean>
       notificationGetPermission?: () => Promise<NotificationPermissionState>
       notificationRequestPermission?: () => Promise<NotificationPermissionState>
+      notificationOpenSettings?: () => Promise<boolean>
       showLocalNotification?: (payload: LocalNotificationPayload) => Promise<boolean>
       signalShellReady?: () => void
       setThemeSource?: (source: 'system' | 'light' | 'dark') => void

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -100,10 +100,13 @@ Electron 桌面端在用户**未盯着该会话聊天页**时，用系统本地�
 
 | 流事件 | 通知 `kind` | `tag` 格式 | 标题（UI 文案） | body |
 |--------|-------------|------------|-----------------|------|
-| `done`（且非 `cancelled`） | `chat_done` | `chat:done:{sessionId}` | 对话已生成完成 | 会话标题（截断至 120 字） |
+| `reply`（内容已落定；优先） | `chat_done` | `chat:done:{sessionId}` | 对话已生成完成 | 会话标题（截断至 120 字） |
+| `done`（且非 `cancelled`；兜底） | 同上 | 同上 | 同上 | 优先用 `event.title`，否则会话标题 |
 | `user_prompt` | `chat_ask` | `chat:ask:{sessionId}` | 需要你的确认 | `prompt.title` 或 `prompt.prompt`（截断至 120 字） |
 
-触发位置：`ChatApp` 的 `pushStreamEvent`。仅 Electron（`electronAPI.isElectron`）且通过注意力判断后才调用 `showLocalNotification`。
+触发位置：`ChatApp` 的 `pushStreamEvent`。完成通知**优先在 `reply`** 发出，避免等待服务端慢 `done`（重建工具 / 估 token）造成「用户已切回前台 → 误判 attending → 漏通知」。同一轮（`sessionId` + `streamGen`）只通知一次；`done` 若已通知则去重跳过。`user_prompt` 仍为即时事件。
+
+仅 Electron（`electronAPI.isElectron`）且通过注意力判断后才调用 `showLocalNotification`。
 
 ### 失焦定义（何时发通知）
 
@@ -115,6 +118,8 @@ Electron 桌面端在用户**未盯着该会话聊天页**时，用系统本地�
 4. 主窗口 focused（优先 `electronAPI.windowIsFocused()` → IPC `window-is-focused` → `BrowserWindow.isFocused()`；无 API 时回退 `document.hasFocus()`）
 
 任一不满足 → `shouldNotify` 为 true → 发通知。因此：切到其他会话 / 非聊天页 / 文档隐藏 / 窗口失焦都会通知。
+
+**生成期间曾离开**：流式开始时清零；在 `visibilitychange` / `blur`/`focus` 与短周期轮询中，若文档不可见或主窗口失焦，则标记 `awayDuringGeneration`。完成后即使当前又回到前台，只要本轮曾离开，仍会尝试发完成通知。
 
 ### 点击深链
 
@@ -131,12 +136,23 @@ opptrix://chat?session={encodeURIComponent(sessionId)}
 | IPC channel | preload API | 说明 |
 |-------------|-------------|------|
 | `notification-is-supported` | `notificationIsSupported()` | `Notification.isSupported()` |
-| `notification-get-permission` | `notificationGetPermission()` | 缓存权限状态 |
-| `notification-request-permission` | `notificationRequestPermission()` | 壳启动时 `useDesktopShell` 会请求一次 |
-| `notification-show` | `showLocalNotification(payload)` | 校验后展示；点击走 `onNotificationClick` |
+| `notification-get-permission` | `notificationGetPermission()` | 读取系统真实权限（见下），非假 granted |
+| `notification-request-permission` | `notificationRequestPermission()` | 刷新系统权限状态；壳启动时 `useDesktopShell` 会请求一次 |
+| `notification-open-settings` | `notificationOpenSettings()` | 打开系统「通知」设置页（macOS / Windows） |
+| `notification-show` | `showLocalNotification(payload)` | 校验后展示；点击走 `onNotificationClick`；权限为 denied 时返回 `false` |
 | `window-is-focused` | `windowIsFocused()` | 主窗口是否 focused（注意力判断） |
 
 协议事件仍为 `opptrix-protocol`（`onProtocolOpen`），与通知点击深链共用。
+
+### 权限模型
+
+| 平台 | 行为 |
+|------|------|
+| **macOS** | 优先 `systemPreferences.getNotificationSettings?.()` 的 `authorizationStatus` 映射为 `granted` / `denied` / `default`。无该 API 时**不得**无条件写 `granted`。`Notification.show` 的 `failed` 事件会记日志并回读权限。系统拒绝后无法编程式弹授权框，需用户在系统设置中开启；设置 → 关于提供引导，「打开系统设置」走 `notification-open-settings`。 |
+| **Windows** | `configureNotificationIdentity(appId)` → `app.setAppUserModelId`；能力可用时视为 `granted` |
+| **Linux** | 依赖桌面环境；`Notification.isSupported()` 为真时视为可发 |
+
+Renderer：若展示返回失败且权限为 `denied`，聊天页温和提示一次（引导去系统设置）；设置「关于」也展示当前通知状态与操作入口。
 
 ### Payload（`LocalNotificationPayload`）
 
@@ -156,10 +172,10 @@ opptrix://chat?session={encodeURIComponent(sessionId)}
 | 平台 | 注意 |
 |------|------|
 | **Windows** | `configureNotificationIdentity(appId)` → `app.setAppUserModelId`（`package.json` `build.appId`），否则通知可能不归到本应用 |
-| **macOS** | 需系统「通知」权限；启动时请求；用户在系统设置中拒绝则无法展示 |
+| **macOS** | 需系统「通知」权限；启动时刷新权限状态；用户在系统设置中拒绝则无法展示，应用内会引导去开启 |
 | **Linux** | 依赖桌面环境对 Electron `Notification` 的支持（`Notification.isSupported()`）；部分环境可能静默失败 |
 
-单元测试：`tests/chat-notifications.test.mjs`（注意力、builder、sanitize）。
+单元测试：`tests/chat-notifications.test.mjs`（注意力、离开标记、builder、sanitize、macOS 权限映射）。
 
 ## 命令隔离（Agent Shell）
 

--- a/tests/chat-notifications.test.mjs
+++ b/tests/chat-notifications.test.mjs
@@ -5,12 +5,16 @@ import {
   buildChatAskNotification,
   buildChatDoneNotification,
   isAttendingChat,
+  isAwayFromForeground,
   shouldNotify,
   truncateNotificationText,
 } from '../client-ui/src/platform/chatNotifications.ts'
 
 const require = createRequire(import.meta.url)
-const { sanitizeNotificationPayload } = require('../apps/desktop/electron/notifications.cjs')
+const {
+  mapDarwinAuthorizationStatus,
+  sanitizeNotificationPayload,
+} = require('../apps/desktop/electron/notifications.cjs')
 
 describe('chat notification attention', () => {
   const attending = {
@@ -32,6 +36,23 @@ describe('chat notification attention', () => {
     assert.equal(shouldNotify('sess-1', attending), false)
     assert.equal(shouldNotify('sess-1', { ...attending, view: 'settings' }), true)
     assert.equal(shouldNotify('sess-2', attending), true)
+  })
+
+  it('awayDuringGeneration forces notify even when currently attending', () => {
+    assert.equal(
+      shouldNotify('sess-1', { ...attending, awayDuringGeneration: true }),
+      true,
+    )
+    assert.equal(
+      shouldNotify('sess-1', { ...attending, awayDuringGeneration: false }),
+      false,
+    )
+  })
+
+  it('isAwayFromForeground when hidden or blurred', () => {
+    assert.equal(isAwayFromForeground({ documentVisible: true, windowFocused: true }), false)
+    assert.equal(isAwayFromForeground({ documentVisible: false, windowFocused: true }), true)
+    assert.equal(isAwayFromForeground({ documentVisible: true, windowFocused: false }), true)
   })
 })
 
@@ -106,5 +127,25 @@ describe('sanitizeNotificationPayload', () => {
     })
     assert.equal(out?.body?.length, 200)
     assert.equal(out?.kind, undefined)
+  })
+})
+
+describe('mapDarwinAuthorizationStatus', () => {
+  it('maps authorized family to granted', () => {
+    assert.equal(mapDarwinAuthorizationStatus('authorized'), 'granted')
+    assert.equal(mapDarwinAuthorizationStatus('provisional'), 'granted')
+    assert.equal(mapDarwinAuthorizationStatus('temporary'), 'granted')
+    assert.equal(mapDarwinAuthorizationStatus('ephemeral'), 'granted')
+  })
+
+  it('maps denied family to denied', () => {
+    assert.equal(mapDarwinAuthorizationStatus('denied'), 'denied')
+    assert.equal(mapDarwinAuthorizationStatus('restricted'), 'denied')
+  })
+
+  it('maps undetermined to default (never fake granted)', () => {
+    assert.equal(mapDarwinAuthorizationStatus('not-determined'), 'default')
+    assert.equal(mapDarwinAuthorizationStatus(''), 'default')
+    assert.equal(mapDarwinAuthorizationStatus(undefined), 'default')
   })
 })


### PR DESCRIPTION
## Summary
- 对话完成通知改为在 `reply` 优先触发（不再等慢 `done`），同轮去重
- 生成期间曾失焦/不可见时，回前台完成仍会尝试通知
- 桌面通知权限改为读取系统真实状态；拒绝时在关于页与聊天提示中引导开启

## Test plan
- [ ] 发问后切到其他应用，完成时收到系统通知
- [ ] 生成中途离开再回来，仍收到完成通知（不因回前台被吞）
- [ ] 系统关闭 Opptrix 通知权限时，设置 → 关于可见状态并可打开系统设置
- [ ] `node --test --test-force-exit tests/chat-notifications.test.mjs` 与 `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)