### PR TITLE
fix(desktop): 独立页标题栏对齐侧栏收起与聊天 chrome

### DIFF
--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -1391,6 +1391,7 @@ export default function ChatApp() {
               onSidebarClose={() => setSettingsSidebarVisible(false)}
               onBack={handleExitSettings}
               initialSection={settingsInitialSection}
+              chromeToolbarReserve={electronChrome ? desktopChromeToolbarReserve(macFullscreen) : 0}
               onSaved={async () => {
                 await refreshHealth()
               }}
@@ -1426,6 +1427,7 @@ export default function ChatApp() {
             >
               <NewsCenterPage
                 electronChrome={electronChrome}
+                chromeToolbarReserve={chromeToolbarReserve}
                 onOpenSettings={openNewsSettings}
                 onDiscussArticle={handleDiscussArticle}
               />
@@ -1459,7 +1461,10 @@ export default function ChatApp() {
                 electronChrome && s.chatColumnElectron,
               )}
             >
-              <MarketDynamicsPage electronChrome={electronChrome} />
+              <MarketDynamicsPage
+                electronChrome={electronChrome}
+                chromeToolbarReserve={chromeToolbarReserve}
+              />
             </div>
           </div>
         )}
@@ -1492,6 +1497,7 @@ export default function ChatApp() {
             >
               <ExpertMarketPage
                 electronChrome={electronChrome}
+                chromeToolbarReserve={chromeToolbarReserve}
                 onSelectExpert={handleSelectExpert}
               />
             </div>

--- a/client-ui/src/desktop/StandaloneElectronTitleBar.tsx
+++ b/client-ui/src/desktop/StandaloneElectronTitleBar.tsx
@@ -1,0 +1,120 @@
+import type { ReactNode } from 'react'
+import { Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { opptrixCssVars } from '../theme/tokens'
+import {
+  DESKTOP_SIDEBAR_LAYOUT_EASE,
+  DESKTOP_SIDEBAR_LAYOUT_MS,
+  DESKTOP_TITLE_GAP,
+  DESKTOP_TITLEBAR_HEIGHT,
+  DESKTOP_Z_PANEL_TITLE,
+} from './constants'
+import {
+  desktopChromeTopOffset,
+  desktopTitleBarActionsRight,
+} from './layout'
+
+const useStyles = makeStyles({
+  root: {
+    flexShrink: 0,
+    height: `${DESKTOP_TITLEBAR_HEIGHT}px`,
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    borderBottom: `1px solid ${opptrixCssVars.separatorStrong}`,
+    backgroundColor: opptrixCssVars.canvas,
+    position: 'relative',
+    zIndex: DESKTOP_Z_PANEL_TITLE,
+    transitionProperty: 'padding-left, padding-right',
+    transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
+    transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
+  },
+  title: {
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 500,
+    letterSpacing: '-0.01em',
+    color: opptrixCssVars.textPrimary,
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+  },
+  spacer: {
+    flex: 1,
+    minWidth: 0,
+    alignSelf: 'stretch',
+  },
+  meta: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    flexShrink: 0,
+  },
+})
+
+export type StandaloneElectronTitleBarProps = {
+  title: string
+  /**
+   * Left safe inset when the session sidebar is fully collapsed.
+   * Pass `desktopChromeToolbarReserve(fullscreen)` (or ChatApp’s `chromeToolbarReserve`);
+   * `0` keeps the compact inline inset (`DESKTOP_TITLE_GAP`).
+   */
+  chromeToolbarReserve?: number
+  meta?: ReactNode
+  actions?: ReactNode
+  className?: string
+  /** Drag-fill class for page-specific drag clips (e.g. `opptrix-news-title-drag`) */
+  dragRegionClassName?: string
+}
+
+/**
+ * Electron standalone-page title band — left inset aligns with chat
+ * `desktopTitleLeft(false)` / `desktopChromeToolbarReserve` when the sidebar is collapsed;
+ * right inset uses `desktopTitleBarActionsRight()` (macOS 12 / Win window-controls reserve).
+ * Vertical: same `desktopChromeTopOffset` nudge as `DesktopWindowChrome` title/toolbar.
+ */
+export default function StandaloneElectronTitleBar({
+  title,
+  chromeToolbarReserve = 0,
+  meta,
+  actions,
+  className,
+  dragRegionClassName,
+}: StandaloneElectronTitleBarProps) {
+  const s = useStyles()
+  const paddingLeft = chromeToolbarReserve > 0 ? chromeToolbarReserve : DESKTOP_TITLE_GAP
+  const paddingRight = desktopTitleBarActionsRight()
+  // Match chat chrome title/toolbar: content centers in the band below chromeTop.
+  const chromeTop = desktopChromeTopOffset()
+
+  return (
+    <div
+      className={mergeClasses(s.root, className)}
+      style={{
+        paddingTop: `${chromeTop}px`,
+        paddingLeft: `${paddingLeft}px`,
+        paddingRight: `${paddingRight}px`,
+      }}
+    >
+      <Text className={mergeClasses(s.title, 'opptrix-panel-title-no-drag')} block>
+        {title}
+      </Text>
+      <div
+        className={mergeClasses(s.spacer, dragRegionClassName)}
+        aria-hidden
+      />
+      {meta != null && meta !== false ? (
+        <Text className={mergeClasses(s.meta, 'opptrix-panel-title-no-drag')}>{meta}</Text>
+      ) : null}
+      {actions != null ? (
+        <div className={mergeClasses(s.actions, 'opptrix-panel-title-no-drag')}>
+          {actions}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -38,7 +38,8 @@ import FontScaleSlider from './settings/FontScaleSlider'
 import { opptrixTokens, opptrixCssVars, type ThemePreference } from '../theme/tokens'
 import { useTheme } from '../theme/ThemeContext'
 import { isElectron } from '../platform/detect'
-import { DESKTOP_TITLEBAR_HEIGHT, WORKSPACE_CHAT_MIN_WIDTH } from '../desktop/constants'
+import { WORKSPACE_CHAT_MIN_WIDTH } from '../desktop/constants'
+import StandaloneElectronTitleBar from '../desktop/StandaloneElectronTitleBar'
 import { useDebouncedEffect } from '../hooks/useDebouncedEffect'
 import { useSidebarOverlayMode } from '../hooks/useBreakpoint'
 import { getSessionSidebarWidth } from '../hooks/useSessionSidebarWidth'
@@ -57,9 +58,23 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     backgroundColor: 'transparent',
   },
+  pageElectron: {
+    flexDirection: 'column',
+  },
   pageMobile: {
     flexDirection: 'column',
     backgroundColor: opptrixCssVars.canvas,
+  },
+  pageBody: {
+    display: 'flex',
+    flexDirection: 'row',
+    flex: 1,
+    minWidth: 0,
+    minHeight: 0,
+    overflow: 'hidden',
+  },
+  pageBodyMobile: {
+    flexDirection: 'column',
   },
   contentShell: {
     flex: 1,
@@ -70,9 +85,6 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     backgroundColor: opptrixCssVars.canvas,
     overflow: 'hidden',
-  },
-  contentShellElectron: {
-    paddingTop: `calc(${DESKTOP_TITLEBAR_HEIGHT}px + ${opptrixTokens.windowInset})`,
   },
   contentScroll: {
     flex: 1,
@@ -314,6 +326,11 @@ interface SettingsPageProps {
   sidebarVisible?: boolean
   onSidebarClose?: () => void
   initialSection?: SettingsSection
+  /**
+   * Electron left inset when the session sidebar is not occupying the chrome band.
+   * Settings always hides the session sidebar — pass `desktopChromeToolbarReserve(fullscreen)`.
+   */
+  chromeToolbarReserve?: number
 }
 
 export default function SettingsPage(props: SettingsPageProps) {
@@ -329,6 +346,7 @@ function SettingsPageView({
   sidebarVisible = true,
   onSidebarClose,
   initialSection,
+  chromeToolbarReserve = 0,
 }: SettingsPageProps) {
   const toast = useSettingsToast()
   const { confirm } = useOpptrixDialogAlert()
@@ -686,7 +704,21 @@ function SettingsPageView({
   const sectionSubtitle = settingsSectionSubtitle(section)
 
   return (
-    <div className={mergeClasses(s.page, isMobile && s.pageMobile)}>
+    <div className={mergeClasses(
+      s.page,
+      electronChrome && s.pageElectron,
+      isMobile && s.pageMobile,
+    )}
+    >
+      {electronChrome && (
+        <StandaloneElectronTitleBar
+          title="设置"
+          chromeToolbarReserve={chromeToolbarReserve}
+          className="opptrix-settings-title-bar"
+          dragRegionClassName="opptrix-settings-title-drag"
+        />
+      )}
+      <div className={mergeClasses(s.pageBody, isMobile && s.pageBodyMobile)}>
       {!sidebarOverlayMode && (
         <SettingsSidebar
           mode="panel"
@@ -697,6 +729,7 @@ function SettingsPageView({
           onSearchChange={setSearch}
           dynamicSearchEntries={dynamicSearchEntries}
           isMobile={isMobile}
+          titleBarOwned={electronChrome}
         />
       )}
       {sidebarOverlayMode && (
@@ -718,7 +751,6 @@ function SettingsPageView({
         className={mergeClasses(
           s.contentShell,
           'opptrix-settings-content',
-          electronChrome && s.contentShellElectron,
         )}
       >
         <div className={mergeClasses(
@@ -751,6 +783,7 @@ function SettingsPageView({
             </div>
           </div>
         </div>
+      </div>
       </div>
 
       <Dialog open={wizardOpen} onOpenChange={(_, data) => { if (!data.open) closeProviderWizard() }}>

--- a/client-ui/src/pages/experts/ExpertMarketPage.tsx
+++ b/client-ui/src/pages/experts/ExpertMarketPage.tsx
@@ -11,15 +11,14 @@ import {
   DismissRegular,
   SearchRegular,
 } from '@fluentui/react-icons'
-import { electronPlatform } from '../../platform/detect'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
 import { inputShellInteractive, nativeIconInteractive } from '../../theme/mixins'
 import {
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
-  DESKTOP_TITLEBAR_HEIGHT,
 } from '../../desktop/constants'
 import ChromeToolButton from '../../desktop/ChromeToolButton'
+import StandaloneElectronTitleBar from '../../desktop/StandaloneElectronTitleBar'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import OpptrixInput from '../../components/opptrix/OpptrixInput'
 import { useOpptrixDialogAlert } from '../../components/opptrix/OpptrixDialogAlert'
@@ -39,35 +38,6 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: opptrixCssVars.canvas,
     overflow: 'hidden',
-  },
-  electronTitleBar: {
-    flexShrink: 0,
-    height: `${DESKTOP_TITLEBAR_HEIGHT}px`,
-    boxSizing: 'border-box',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    paddingLeft: '12px',
-    borderBottom: `1px solid ${opptrixCssVars.separatorStrong}`,
-    backgroundColor: opptrixCssVars.canvas,
-    position: 'relative',
-  },
-  electronTitleBarMac: { paddingRight: '12px' },
-  electronTitleBarWin: { paddingRight: '132px' },
-  titleBarSpacer: { flex: 1, minWidth: 0 },
-  titleBarPageTitle: {
-    fontSize: 'var(--opptrix-font-base)',
-    fontWeight: 500,
-    letterSpacing: '-0.01em',
-    color: opptrixCssVars.textPrimary,
-    flexShrink: 0,
-    whiteSpace: 'nowrap',
-  },
-  titleBarActions: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-    flexShrink: 0,
   },
   webHead: {
     flexShrink: 0,
@@ -280,10 +250,16 @@ function isPersonalExpert(expert: ExpertCatalogEntry) {
 
 interface Props {
   electronChrome?: boolean
+  /** When sidebar collapsed: `desktopChromeToolbarReserve`; inline: 0 */
+  chromeToolbarReserve?: number
   onSelectExpert: (expertId: string) => void | Promise<void>
 }
 
-export default function ExpertMarketPage({ electronChrome = false, onSelectExpert }: Props) {
+export default function ExpertMarketPage({
+  electronChrome = false,
+  chromeToolbarReserve = 0,
+  onSelectExpert,
+}: Props) {
   const s = useStyles()
   const { confirm } = useOpptrixDialogAlert()
   const [query, setQuery] = useState('')
@@ -359,8 +335,6 @@ export default function ExpertMarketPage({ electronChrome = false, onSelectExper
     await loadExperts(debouncedQuery)
   }
 
-  const electronWin = electronChrome && electronPlatform() !== 'darwin'
-
   const refreshAction = electronChrome ? (
     <ChromeToolButton
       label="刷新"
@@ -384,24 +358,13 @@ export default function ExpertMarketPage({ electronChrome = false, onSelectExper
   return (
     <div className={s.root}>
       {electronChrome ? (
-        <div
-          className={mergeClasses(
-            s.electronTitleBar,
-            'opptrix-experts-title-bar',
-            electronWin ? s.electronTitleBarWin : s.electronTitleBarMac,
-          )}
-        >
-          <Text className={mergeClasses(s.titleBarPageTitle, 'opptrix-panel-title-no-drag')} block>
-            专家
-          </Text>
-          <div
-            className={mergeClasses(s.titleBarSpacer, 'opptrix-experts-title-drag')}
-            aria-hidden
-          />
-          <div className={mergeClasses(s.titleBarActions, 'opptrix-panel-title-no-drag')}>
-            {refreshAction}
-          </div>
-        </div>
+        <StandaloneElectronTitleBar
+          title="专家"
+          chromeToolbarReserve={chromeToolbarReserve}
+          className="opptrix-experts-title-bar"
+          dragRegionClassName="opptrix-experts-title-drag"
+          actions={refreshAction}
+        />
       ) : (
         <div className={s.webHead}>
           <Text className={s.webTitle}>专家</Text>

--- a/client-ui/src/pages/market-dynamics/MarketDynamicsPage.tsx
+++ b/client-ui/src/pages/market-dynamics/MarketDynamicsPage.tsx
@@ -2,13 +2,12 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { ArrowSyncRegular } from '@fluentui/react-icons'
 import ChromeToolButton from '../../desktop/ChromeToolButton'
+import StandaloneElectronTitleBar from '../../desktop/StandaloneElectronTitleBar'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
-import { electronPlatform } from '../../platform/detect'
 import { opptrixCssVars } from '../../theme/tokens'
 import {
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
-  DESKTOP_TITLEBAR_HEIGHT,
 } from '../../desktop/constants'
 import { useMarketDynamics } from './useMarketDynamics'
 import { useMarketInsights } from './useMarketInsights'
@@ -31,37 +30,6 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: opptrixCssVars.canvas,
     overflow: 'hidden',
-  },
-  electronTitleBar: {
-    flexShrink: 0,
-    height: `${DESKTOP_TITLEBAR_HEIGHT}px`,
-    boxSizing: 'border-box',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    paddingLeft: '12px',
-    borderBottom: `1px solid ${opptrixCssVars.separatorStrong}`,
-    backgroundColor: opptrixCssVars.canvas,
-  },
-  electronTitleBarMac: { paddingRight: '12px' },
-  electronTitleBarWin: { paddingRight: '132px' },
-  titleBarSpacer: { flex: 1, minWidth: 0 },
-  titleBarPageTitle: {
-    fontSize: 'var(--opptrix-font-base)',
-    fontWeight: 500,
-    color: opptrixCssVars.textPrimary,
-    flexShrink: 0,
-  },
-  titleBarMeta: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
-    flexShrink: 0,
-  },
-  titleBarActions: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-    flexShrink: 0,
   },
   webHead: {
     flexShrink: 0,
@@ -137,9 +105,11 @@ const useStyles = makeStyles({
 
 type Props = {
   electronChrome?: boolean
+  /** When sidebar collapsed: `desktopChromeToolbarReserve`; inline: 0 */
+  chromeToolbarReserve?: number
 }
 
-function MarketDynamicsContent({ electronChrome = false }: Props) {
+function MarketDynamicsContent({ electronChrome = false, chromeToolbarReserve = 0 }: Props) {
   const s = useStyles()
   const bodyRef = useRef<HTMLDivElement>(null)
   const layout = useMarketDynamicsLayout(bodyRef)
@@ -192,22 +162,14 @@ function MarketDynamicsContent({ electronChrome = false }: Props) {
     void insights.refresh()
   }
 
-  const electronWin = electronChrome && electronPlatform() !== 'darwin'
-
   const titleBar = electronChrome ? (
-    <div
-      className={mergeClasses(
-        s.electronTitleBar,
-        'opptrix-market-dynamics-title-bar',
-        electronWin ? s.electronTitleBarWin : s.electronTitleBarMac,
-      )}
-    >
-      <Text className={mergeClasses(s.titleBarPageTitle, 'opptrix-panel-title-no-drag')} block>
-        市场动态
-      </Text>
-      <div className={mergeClasses(s.titleBarSpacer, 'opptrix-market-dynamics-title-drag')} aria-hidden />
-      <Text className={mergeClasses(s.titleBarMeta, 'opptrix-panel-title-no-drag')}>{statusLabel}</Text>
-      <div className={mergeClasses(s.titleBarActions, 'opptrix-panel-title-no-drag')}>
+    <StandaloneElectronTitleBar
+      title="市场动态"
+      chromeToolbarReserve={chromeToolbarReserve}
+      className="opptrix-market-dynamics-title-bar"
+      dragRegionClassName="opptrix-market-dynamics-title-drag"
+      meta={statusLabel}
+      actions={(
         <ChromeToolButton
           label="刷新"
           iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
@@ -216,8 +178,8 @@ function MarketDynamicsContent({ electronChrome = false }: Props) {
         >
           <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
         </ChromeToolButton>
-      </div>
-    </div>
+      )}
+    />
   ) : null
 
   const webHead = !electronChrome ? (

--- a/client-ui/src/pages/news/NewsCenterPage.tsx
+++ b/client-ui/src/pages/news/NewsCenterPage.tsx
@@ -2,12 +2,11 @@ import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-compone
 import { ArrowSyncRegular, SettingsRegular } from '@fluentui/react-icons'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import ChromeToolButton from '../../desktop/ChromeToolButton'
-import { electronPlatform } from '../../platform/detect'
-import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
+import StandaloneElectronTitleBar from '../../desktop/StandaloneElectronTitleBar'
+import { opptrixCssVars } from '../../theme/tokens'
 import {
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
-  DESKTOP_TITLEBAR_HEIGHT,
 } from '../../desktop/constants'
 import NewsFeedSidebar from './NewsFeedSidebar'
 import NewsArticleDetail from './NewsArticleDetail'
@@ -25,48 +24,6 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: opptrixCssVars.canvas,
     overflow: 'hidden',
-  },
-  electronTitleBar: {
-    flexShrink: 0,
-    height: `${DESKTOP_TITLEBAR_HEIGHT}px`,
-    boxSizing: 'border-box',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '8px',
-    paddingLeft: '12px',
-    borderBottom: `1px solid ${opptrixCssVars.separatorStrong}`,
-    backgroundColor: opptrixCssVars.canvas,
-    position: 'relative',
-  },
-  electronTitleBarMac: {
-    paddingRight: '12px',
-  },
-  electronTitleBarWin: {
-    paddingRight: '132px',
-  },
-  titleBarSpacer: {
-    flex: 1,
-    minWidth: 0,
-  },
-  titleBarPageTitle: {
-    fontSize: 'var(--opptrix-font-base)',
-    fontWeight: 500,
-    letterSpacing: '-0.01em',
-    color: opptrixCssVars.textPrimary,
-    flexShrink: 0,
-    whiteSpace: 'nowrap',
-  },
-  titleBarMeta: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
-    flexShrink: 0,
-    whiteSpace: 'nowrap',
-  },
-  titleBarActions: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-    flexShrink: 0,
   },
   toolbarMeta: {
     fontSize: 'var(--opptrix-font-sm)',
@@ -128,12 +85,15 @@ const useStyles = makeStyles({
 
 type Props = {
   electronChrome?: boolean
+  /** When sidebar collapsed: `desktopChromeToolbarReserve`; inline: 0 */
+  chromeToolbarReserve?: number
   onOpenSettings?: () => void
   onDiscussArticle?: (article: FeedArticle) => void
 }
 
 function NewsCenterContent({
   electronChrome = false,
+  chromeToolbarReserve = 0,
   onOpenSettings,
   onDiscussArticle,
 }: Props) {
@@ -187,41 +147,35 @@ function NewsCenterContent({
       ? `更新 ${updatedLabel}`
       : '尚未刷新'
 
-  const electronWin = electronChrome && electronPlatform() !== 'darwin'
-
   const electronTitleBar = electronChrome ? (
-    <div
-      className={mergeClasses(
-        s.electronTitleBar,
-        'opptrix-news-title-bar',
-        electronWin ? s.electronTitleBarWin : s.electronTitleBarMac,
-      )}
-    >
-      <Text className={mergeClasses(s.titleBarPageTitle, 'opptrix-panel-title-no-drag')} block>
-        新闻中心
-      </Text>
-      <div className={mergeClasses(s.titleBarSpacer, 'opptrix-news-title-drag')} aria-hidden />
-      <Text className={mergeClasses(s.titleBarMeta, 'opptrix-panel-title-no-drag')}>{statusLabel}</Text>
-      <div className={mergeClasses(s.titleBarActions, 'opptrix-panel-title-no-drag')}>
-        {onOpenSettings && (
+    <StandaloneElectronTitleBar
+      title="新闻中心"
+      chromeToolbarReserve={chromeToolbarReserve}
+      className="opptrix-news-title-bar"
+      dragRegionClassName="opptrix-news-title-drag"
+      meta={statusLabel}
+      actions={(
+        <>
+          {onOpenSettings && (
+            <ChromeToolButton
+              label="订阅设置"
+              iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
+              onClick={onOpenSettings}
+            >
+              <SettingsRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+            </ChromeToolButton>
+          )}
           <ChromeToolButton
-            label="订阅设置"
+            label="刷新列表"
             iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
-            onClick={onOpenSettings}
+            disabled={refreshing}
+            onClick={() => { void refresh() }}
           >
-            <SettingsRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+            <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
           </ChromeToolButton>
-        )}
-        <ChromeToolButton
-          label="刷新列表"
-          iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
-          disabled={refreshing}
-          onClick={() => { void refresh() }}
-        >
-          <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-        </ChromeToolButton>
-      </div>
-    </div>
+        </>
+      )}
+    />
   ) : null
 
   const webHead = !electronChrome ? (

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -219,6 +219,8 @@ interface SettingsSidebarProps {
   onSearchChange: (value: string) => void
   dynamicSearchEntries?: SettingsSearchEntry[]
   isMobile?: boolean
+  /** Parent already renders Electron title bar above this sidebar */
+  titleBarOwned?: boolean
 }
 
 export default function SettingsSidebar({
@@ -226,6 +228,7 @@ export default function SettingsSidebar({
   visible = true,
   onClose,
   active, onSelect, onBack, search, onSearchChange, dynamicSearchEntries = [], isMobile = false,
+  titleBarOwned = false,
 }: SettingsSidebarProps) {
   const s = useStyles()
   const { resolvedScheme } = useTheme()
@@ -234,6 +237,7 @@ export default function SettingsSidebar({
   const nativeVibrancy = supportsNativeWindowVibrancy()
   const sidebarGlass = electronChrome && (nativeVibrancy || resolvedScheme !== 'dark')
   const sidebarSolidDark = electronChrome && !nativeVibrancy && resolvedScheme === 'dark'
+  const applyTitleBarInset = electronChrome && !titleBarOwned
 
   const searchActive = Boolean(search.trim()) && !isMobile
 
@@ -365,7 +369,7 @@ export default function SettingsSidebar({
         !electronChrome && !isMobile && s.sidebarWeb,
         electronChrome && s.sidebarElectron,
         sidebarSolidDark && s.sidebarElectronSolid,
-        electronChrome && s.sidebarTopElectron,
+        applyTitleBarInset && s.sidebarTopElectron,
         sidebarGlass && 'opptrix-glass-sidebar',
         'opptrix-settings-sidebar',
         'opptrix-sidebar-edge',

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -290,4 +290,6 @@ Stacking order (low → high), defined in `client-ui/src/desktop/constants.ts` a
 | Toolbar + window controls | `1300` | `DESKTOP_Z_CHROME_TOOLS` — global fixed chrome |
 | Clickable session title | `1310` | `DESKTOP_Z_TITLE_INTERACTIVE` — title text above drag layer |
 
+Standalone pages (news / market / experts / settings) reuse `StandaloneElectronTitleBar` with left inset from `desktopChromeToolbarReserve` when the session sidebar is fully collapsed (same as chat `desktopTitleLeft(false)`), and right inset from `desktopTitleBarActionsRight()`.
+
 Narrow windows (&lt; current session sidebar width × 2.5): left sidebar becomes a **full-height overlay** (`top: 0; bottom: 0`), light glass, **no fullscreen scrim**. At ≥ × 3, growing the window auto-expands the inline sidebar. Sidebar width defaults to 200px, draggable between ~196–360px, persisted in `localStorage` (`opptrix-sidebar-width`). Minimum window width: `DESKTOP_CHAT_MIN_WIDTH` (510px), synced with `apps/desktop/electron/main.cjs`.


### PR DESCRIPTION
## Summary
- 抽出共享 `StandaloneElectronTitleBar`，设置/专家/新闻中心/市场动态统一复用
- 左侧面板完全收起时用 `desktopChromeToolbarReserve` 让开全局工具栏，垂直位置对齐聊天 title（`desktopChromeTopOffset`）
- 非 macOS 右侧用 `desktopTitleBarActionsRight()`，去掉硬编码 padding

## Test plan
- [ ] Electron macOS：侧栏内联 / 完全收起，检查四独立页标题不与左侧 icons 重叠，并与聊天 title 垂直对齐
- [ ] Electron Windows（或非 darwin）：侧栏收起时标题左缘正确；右侧不与窗口按钮重叠
- [ ] 设置页：顶栏「设置」与侧栏无双重顶栏留白；内容分节标题仍正常
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)