### PR TITLE
fix(settings): 设置侧栏顶部通透对齐会话侧栏

### DIFF
--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -58,9 +58,6 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     backgroundColor: 'transparent',
   },
-  pageElectron: {
-    flexDirection: 'column',
-  },
   pageMobile: {
     flexDirection: 'column',
     backgroundColor: opptrixCssVars.canvas,
@@ -327,8 +324,9 @@ interface SettingsPageProps {
   onSidebarClose?: () => void
   initialSection?: SettingsSection
   /**
-   * Electron left inset when the session sidebar is not occupying the chrome band.
-   * Settings always hides the session sidebar — pass `desktopChromeToolbarReserve(fullscreen)`.
+   * Electron left inset for the content-column title bar when settings sidebar is overlay.
+   * Panel (inline) mode ignores this and uses the compact `DESKTOP_TITLE_GAP` inset.
+   * Pass `desktopChromeToolbarReserve(fullscreen)` from ChatApp.
    */
   chromeToolbarReserve?: number
 }
@@ -545,6 +543,9 @@ function SettingsPageView({
   })()
 
   const contentFlush = isMobile || sidebarOverlayMode
+  // Panel: title sits beside the glass sidebar → compact inset (~12).
+  // Overlay: sidebar is gone → reserve for traffic-light / toolbar chrome.
+  const titleChromeReserve = sidebarOverlayMode ? chromeToolbarReserve : 0
 
   const renderSection = () => {
     if (loading && needsConfig) return <Spinner size="tiny" label="加载配置…" />
@@ -706,18 +707,9 @@ function SettingsPageView({
   return (
     <div className={mergeClasses(
       s.page,
-      electronChrome && s.pageElectron,
       isMobile && s.pageMobile,
     )}
     >
-      {electronChrome && (
-        <StandaloneElectronTitleBar
-          title="设置"
-          chromeToolbarReserve={chromeToolbarReserve}
-          className="opptrix-settings-title-bar"
-          dragRegionClassName="opptrix-settings-title-drag"
-        />
-      )}
       <div className={mergeClasses(s.pageBody, isMobile && s.pageBodyMobile)}>
       {!sidebarOverlayMode && (
         <SettingsSidebar
@@ -729,7 +721,6 @@ function SettingsPageView({
           onSearchChange={setSearch}
           dynamicSearchEntries={dynamicSearchEntries}
           isMobile={isMobile}
-          titleBarOwned={electronChrome}
         />
       )}
       {sidebarOverlayMode && (
@@ -753,6 +744,14 @@ function SettingsPageView({
           'opptrix-settings-content',
         )}
       >
+        {electronChrome && (
+          <StandaloneElectronTitleBar
+            title="设置"
+            chromeToolbarReserve={titleChromeReserve}
+            className="opptrix-settings-title-bar"
+            dragRegionClassName="opptrix-settings-title-drag"
+          />
+        )}
         <div className={mergeClasses(
           s.contentScroll,
           'opptrix-scroll',

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -219,8 +219,6 @@ interface SettingsSidebarProps {
   onSearchChange: (value: string) => void
   dynamicSearchEntries?: SettingsSearchEntry[]
   isMobile?: boolean
-  /** Parent already renders Electron title bar above this sidebar */
-  titleBarOwned?: boolean
 }
 
 export default function SettingsSidebar({
@@ -228,7 +226,6 @@ export default function SettingsSidebar({
   visible = true,
   onClose,
   active, onSelect, onBack, search, onSearchChange, dynamicSearchEntries = [], isMobile = false,
-  titleBarOwned = false,
 }: SettingsSidebarProps) {
   const s = useStyles()
   const { resolvedScheme } = useTheme()
@@ -237,7 +234,6 @@ export default function SettingsSidebar({
   const nativeVibrancy = supportsNativeWindowVibrancy()
   const sidebarGlass = electronChrome && (nativeVibrancy || resolvedScheme !== 'dark')
   const sidebarSolidDark = electronChrome && !nativeVibrancy && resolvedScheme === 'dark'
-  const applyTitleBarInset = electronChrome && !titleBarOwned
 
   const searchActive = Boolean(search.trim()) && !isMobile
 
@@ -369,7 +365,7 @@ export default function SettingsSidebar({
         !electronChrome && !isMobile && s.sidebarWeb,
         electronChrome && s.sidebarElectron,
         sidebarSolidDark && s.sidebarElectronSolid,
-        applyTitleBarInset && s.sidebarTopElectron,
+        electronChrome && s.sidebarTopElectron,
         sidebarGlass && 'opptrix-glass-sidebar',
         'opptrix-settings-sidebar',
         'opptrix-sidebar-edge',

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -468,9 +468,9 @@ html.opptrix-electron-vibrancy .opptrix-glass-sidebar {
 
 /*
  * Windows acrylic alone is too see-through through a fully clear sidebar.
- * Keep material visible under a denser frosted tint (main chat sidebar only).
+ * Keep material visible under a denser frosted tint (chat + settings sidebars).
  */
-html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar:not(.opptrix-settings-sidebar) {
+html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar {
   background: rgba(255, 255, 255, 0.62) !important;
 }
 
@@ -480,17 +480,17 @@ html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar:not
   -webkit-backdrop-filter: none !important;
 }
 
-[data-theme="dark"] html.opptrix-electron-vibrancy .opptrix-glass-sidebar:not(.opptrix-settings-sidebar) {
+[data-theme="dark"] html.opptrix-electron-vibrancy .opptrix-glass-sidebar {
   background: transparent !important;
   backdrop-filter: none !important;
   -webkit-backdrop-filter: none !important;
 }
 
-[data-theme="dark"] html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar:not(.opptrix-settings-sidebar) {
+[data-theme="dark"] html.opptrix-electron-vibrancy.opptrix-platform-win32 .opptrix-glass-sidebar {
   background: rgba(44, 44, 46, 0.72) !important;
 }
 
-/* ── Settings sidebar: ~85% opaque vs main glass, all platforms ── */
+/* ── Settings sidebar: web / non-vibrancy fill; vibrancy matches chat (transparent) ── */
 html .opptrix-settings-sidebar {
   --opptrix-settings-sidebar-fill: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, var(--opptrix-canvas-muted) 15%);
 }
@@ -499,22 +499,15 @@ html:not(.opptrix-electron) .opptrix-settings-sidebar {
   background: var(--opptrix-settings-sidebar-fill) !important;
 }
 
-html.opptrix-electron .opptrix-glass-sidebar.opptrix-settings-sidebar,
-html.opptrix-electron .opptrix-settings-sidebar {
+html.opptrix-electron:not(.opptrix-electron-vibrancy) .opptrix-glass-sidebar.opptrix-settings-sidebar,
+html.opptrix-electron:not(.opptrix-electron-vibrancy) .opptrix-settings-sidebar {
   background: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, transparent) !important;
   backdrop-filter: blur(28px) saturate(150%);
   -webkit-backdrop-filter: blur(28px) saturate(150%);
 }
 
-html.opptrix-electron-vibrancy .opptrix-glass-sidebar.opptrix-settings-sidebar {
-  /* Still denser than main; leftover 15% transparency lets a hint of OS material through */
-  background: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, transparent) !important;
-  backdrop-filter: none !important;
-  -webkit-backdrop-filter: none !important;
-}
-
-[data-theme="dark"] html.opptrix-electron .opptrix-glass-sidebar.opptrix-settings-sidebar,
-[data-theme="dark"] html.opptrix-electron .opptrix-settings-sidebar {
+[data-theme="dark"] html.opptrix-electron:not(.opptrix-electron-vibrancy) .opptrix-glass-sidebar.opptrix-settings-sidebar,
+[data-theme="dark"] html.opptrix-electron:not(.opptrix-electron-vibrancy) .opptrix-settings-sidebar {
   background: color-mix(in srgb, var(--opptrix-canvas-alt) 85%, transparent) !important;
 }
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -290,6 +290,6 @@ Stacking order (low → high), defined in `client-ui/src/desktop/constants.ts` a
 | Toolbar + window controls | `1300` | `DESKTOP_Z_CHROME_TOOLS` — global fixed chrome |
 | Clickable session title | `1310` | `DESKTOP_Z_TITLE_INTERACTIVE` — title text above drag layer |
 
-Standalone pages (news / market / experts / settings) reuse `StandaloneElectronTitleBar` with left inset from `desktopChromeToolbarReserve` when the session sidebar is fully collapsed (same as chat `desktopTitleLeft(false)`), and right inset from `desktopTitleBarActionsRight()`.
+Standalone pages (news / market / experts / settings) reuse `StandaloneElectronTitleBar` with left inset from `desktopChromeToolbarReserve` when the session sidebar is fully collapsed (same as chat `desktopTitleLeft(false)`), and right inset from `desktopTitleBarActionsRight()`. Settings sidebar matches the session sidebar’s top-through glass; `StandaloneElectronTitleBar` only covers the settings content column (panel mode uses the compact title inset; overlay mode keeps `chromeToolbarReserve`).
 
 Narrow windows (&lt; current session sidebar width × 2.5): left sidebar becomes a **full-height overlay** (`top: 0; bottom: 0`), light glass, **no fullscreen scrim**. At ≥ × 3, growing the window auto-expands the inline sidebar. Sidebar width defaults to 200px, draggable between ~196–360px, persisted in `localStorage` (`opptrix-sidebar-width`). Minimum window width: `DESKTOP_CHAT_MIN_WIDTH` (510px), synced with `apps/desktop/electron/main.cjs`.


### PR DESCRIPTION
## Summary
- 将「设置」标题栏收进右侧内容列，左侧侧栏恢复全高 + `sidebarTopElectron`
- vibrancy 下设置侧栏与会话侧栏同为透明；Win acrylic 不再单独加浓
- panel 用紧凑标题 inset；overlay 保留 `chromeToolbarReserve`

## Test plan
- [ ] Electron：设置页左侧 titlebar 区通透，与聊天侧栏观感一致
- [ ] 右侧仍显示「设置」标题；内容区正常
- [ ] 窄窗 overlay：标题不与全局工具栏重叠
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)