### PR TITLE
fix(desktop): 三端透明无边框统一窗口圆角

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain, dialog, shell, session, nativeTheme } = req
 const path = require('path')
 const fs = require('fs/promises')
 const fsSync = require('node:fs')
+const os = require('node:os')
 const { pathToFileURL } = require('node:url')
 const { spawn } = require('node:child_process')
 const { APP_NAME, APP_TITLE, VERSION } = require('./app-meta.cjs')
@@ -91,7 +92,23 @@ function setOpaqueWindowBackground(win) {
   win.setBackgroundColor(SPLASH_CANVAS)
 }
 
-/** macOS vibrancy / Windows acrylic — 勿开 BrowserWindow.transparent，否则缩放动画会漏出桌面空透明。 */
+/** Windows 11+ build number (10.0.22000). Used for optional OS roundedCorners (shadow assist). */
+function isWindows11OrNewer() {
+  if (process.platform !== 'win32') return false
+  const build = Number(String(os.release()).split('.')[2] ?? 0)
+  return Number.isFinite(build) && build >= 22000
+}
+
+/** Maximized or fullscreen — CSS radius must be removed (squared edges). */
+function isWindowSquared(win) {
+  if (!win || win.isDestroyed()) return false
+  return win.isMaximized() || win.isFullScreen()
+}
+
+/**
+ * Shell ready（或缩放结束）后：透明底 + 尽量保留系统毛玻璃。
+ * 缩放动画漏底由 will-resize → 临时实色 / resized → 再透明缓解。
+ */
 function enableWindowBlurBackground(win) {
   if (win.isDestroyed()) return
   if (process.platform === 'darwin') {
@@ -100,11 +117,7 @@ function enableWindowBlurBackground(win) {
     } catch {
       /* older Electron */
     }
-    // 透明网页区域露的是 vibrancy 材质层，不是裸桌面；背景色用 0 alpha 才能看见材质
-    win.setBackgroundColor('#00000000')
-    return
-  }
-  if (process.platform === 'win32') {
+  } else if (process.platform === 'win32') {
     try {
       if (typeof win.setBackgroundMaterial === 'function') {
         win.setBackgroundMaterial('acrylic')
@@ -112,8 +125,8 @@ function enableWindowBlurBackground(win) {
     } catch {
       /* unsupported on older Windows */
     }
-    win.setBackgroundColor('#00000000')
   }
+  win.setBackgroundColor('#00000000')
 }
 
 /** @deprecated use enableWindowBlurBackground */
@@ -511,7 +524,9 @@ function buildMainWindowOptions() {
     minWidth: MIN_WIDTH,
     minHeight: MIN_HEIGHT,
     title: APP_TITLE,
-    // Splash / Linux 默认实色；mac/win 有原生毛玻璃时启动阶段仍先用不透明底防闪
+    // 三端统一：无边框 + 透明；启动先实色 splash，shell ready 后再透明
+    frame: false,
+    transparent: true,
     backgroundColor: SPLASH_CANVAS,
     show: false,
     center,
@@ -525,15 +540,12 @@ function buildMainWindowOptions() {
   if (process.platform === 'darwin') {
     options.titleBarStyle = 'hiddenInset'
     options.trafficLightPosition = { x: 16, y: 16 }
-    // 系统侧栏毛玻璃。不要设 transparent:true —— 缩放时新区域会短暂变成「空透明」漏桌面。
     options.vibrancy = 'sidebar'
     options.visualEffectState = 'active'
   } else if (process.platform === 'win32') {
-    options.frame = false
-    // 同 mac：用系统材料，避免整窗 transparent 导致缩放漏底
     options.backgroundMaterial = 'acrylic'
-  } else {
-    options.frame = false
+    // Win11+：系统圆角辅助阴影；圆角视觉仍由 CSS `--opptrix-window-radius` 统一
+    options.roundedCorners = isWindows11OrNewer()
   }
 
   return options
@@ -568,9 +580,30 @@ function attachMainWindowHandlers(win) {
   const notifyFullscreen = () => {
     win.webContents.send('window-fullscreen-changed', win.isFullScreen())
   }
-  win.on('enter-full-screen', notifyFullscreen)
-  win.on('leave-full-screen', notifyFullscreen)
-  win.webContents.on('did-finish-load', notifyFullscreen)
+  const notifySquared = () => {
+    win.webContents.send('window-squared-changed', isWindowSquared(win))
+  }
+  win.on('enter-full-screen', () => {
+    notifyFullscreen()
+    notifySquared()
+  })
+  win.on('leave-full-screen', () => {
+    notifyFullscreen()
+    notifySquared()
+  })
+  win.on('maximize', notifySquared)
+  win.on('unmaximize', notifySquared)
+  // 透明窗缩放时新露出区域会短暂空透明漏桌面：缩放中临时实色，结束后再透明
+  win.on('will-resize', () => {
+    setOpaqueWindowBackground(win)
+  })
+  win.on('resized', () => {
+    enableWindowBlurBackground(win)
+  })
+  win.webContents.on('did-finish-load', () => {
+    notifyFullscreen()
+    notifySquared()
+  })
   win.on('closed', () => {
     if (mainWindow === win) mainWindow = null
   })
@@ -807,6 +840,12 @@ function registerWindowIpc() {
   })
   ipcMain.handle('window-is-fullscreen', (event) => {
     return BrowserWindow.fromWebContents(event.sender)?.isFullScreen() ?? false
+  })
+  ipcMain.handle('window-is-maximized', (event) => {
+    return BrowserWindow.fromWebContents(event.sender)?.isMaximized() ?? false
+  })
+  ipcMain.handle('window-is-squared', (event) => {
+    return isWindowSquared(BrowserWindow.fromWebContents(event.sender))
   })
   ipcMain.handle('window-is-focused', (event) => {
     const win = BrowserWindow.fromWebContents(event.sender)

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -7,6 +7,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   windowMaximize: () => ipcRenderer.send('window-maximize'),
   windowClose: () => ipcRenderer.send('window-close'),
   getIsFullscreen: () => ipcRenderer.invoke('window-is-fullscreen'),
+  getIsMaximized: () => ipcRenderer.invoke('window-is-maximized'),
+  getIsWindowSquared: () => ipcRenderer.invoke('window-is-squared'),
   windowIsFocused: () => ipcRenderer.invoke('window-is-focused'),
   pickExportDirectory: () => ipcRenderer.invoke('pick-export-directory'),
   writeBinaryFile: (payload) => ipcRenderer.invoke('write-binary-file', payload),
@@ -43,6 +45,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const handler = (_event, fullscreen) => callback(Boolean(fullscreen))
     ipcRenderer.on('window-fullscreen-changed', handler)
     return () => ipcRenderer.removeListener('window-fullscreen-changed', handler)
+  },
+  onWindowSquaredChange: (callback) => {
+    const handler = (_event, squared) => callback(Boolean(squared))
+    ipcRenderer.on('window-squared-changed', handler)
+    return () => ipcRenderer.removeListener('window-squared-changed', handler)
   },
   onProtocolOpen: (callback) => {
     const handler = (_event, payload) => callback(payload)

--- a/client-ui/src/main.tsx
+++ b/client-ui/src/main.tsx
@@ -28,6 +28,16 @@ if (isElectron()) {
   if (platform === 'darwin' || platform === 'win32') {
     document.documentElement.classList.add('opptrix-electron-vibrancy')
   }
+
+  // 三端统一 CSS 圆角；最大化/全屏时挂 squared 去掉圆角
+  document.documentElement.classList.add('opptrix-window-css-radius')
+  const api = window.electronAPI
+  const applySquared = (squared: boolean) => {
+    document.documentElement.classList.toggle('opptrix-window-squared', squared)
+  }
+  void api?.getIsWindowSquared?.().then(applySquared)
+  api?.onWindowSquaredChange?.(applySquared)
+
   window.setTimeout(() => {
     document.documentElement.classList.remove('opptrix-electron-startup')
     window.electronAPI?.signalShellReady?.()

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -7,6 +7,10 @@ declare global {
       windowMaximize?: () => void
       windowClose?: () => void
       getIsFullscreen?: () => Promise<boolean>
+      getIsMaximized?: () => Promise<boolean>
+      /** true when maximized or fullscreen — CSS radius should be removed */
+      getIsWindowSquared?: () => Promise<boolean>
+      onWindowSquaredChange?: (callback: (squared: boolean) => void) => () => void
       pickExportDirectory?: () => Promise<string | null>
       writeBinaryFile?: (payload: {
         dirPath: string

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -181,11 +181,19 @@ html.opptrix-desktop {
 }
 
 /* ── Electron: 壳层透明以露出窗口材质（vibrancy/acrylic），主内容区自行实底 ──
- * 注意：BrowserWindow 本身不应 transparent:true，否则缩放动画漏出桌面。
+ * BrowserWindow.transparent:true + 统一 CSS 圆角；缩放漏底由主进程 will-resize 临时实色缓解。
  */
 html.opptrix-electron {
   --opptrix-app-bg: transparent;
   --opptrix-chrome-bg: transparent;
+  --opptrix-window-radius: 10px;
+}
+
+/* 三端统一 CSS 圆角；最大化/全屏时 .opptrix-window-squared 去掉圆角 */
+html.opptrix-electron.opptrix-window-css-radius:not(.opptrix-window-squared) #root,
+html.opptrix-electron.opptrix-window-css-radius:not(.opptrix-window-squared) .opptrix-app-shell {
+  border-radius: var(--opptrix-window-radius);
+  overflow: hidden;
 }
 
 html.opptrix-electron.opptrix-electron-startup,

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -272,11 +272,31 @@ Renderer：若展示返回失败且权限为 `denied`，聊天页温和提示一
 
 | 平台 | 窗口层 | 固定左侧栏 |
 |------|--------|------------|
-| macOS | `vibrancy: 'sidebar'`（**不开** `transparent`） | CSS 透明，露的是系统毛玻璃材质；缩放时不会漏裸桌面 |
-| Windows | `backgroundMaterial: 'acrylic'`（**不开** `transparent`） | 同上 |
-| Linux | 实色窗口底 | 保留 CSS `.opptrix-glass-sidebar` 毛玻璃（无原生 acrylic） |
+| macOS | `frame: false` + `transparent` + `vibrancy: 'sidebar'` | CSS 透明，露系统毛玻璃；缩放时主进程临时实色缓解漏底 |
+| Windows | `frame: false` + `transparent` + `backgroundMaterial: 'acrylic'` | 同上 |
+| Linux | `frame: false` + `transparent` | 保留 CSS `.opptrix-glass-sidebar` 毛玻璃（无原生 acrylic） |
 
 窄窗浮层侧栏仍盖在实色主内容上，继续用 CSS 毛玻璃。文档标记类：`html.opptrix-electron-vibrancy`。
+
+### 窗口圆角
+
+三端统一：`frame: false` + `transparent: true` + 渲染侧 CSS 圆角（`--opptrix-window-radius: 10px`）。
+
+| 阶段 | 行为 |
+|------|------|
+| 启动 | 窗口底先实色 `SPLASH_CANVAS`（`#F5F5F7`），展示 splash |
+| Shell ready | 主进程 `enableWindowBlurBackground` → 背景 `#00000000`，尽量保留 vibrancy / acrylic |
+| 缩放中 | `will-resize` → 临时实色；`resized` → 再透明（缓解透明窗缩放漏桌面） |
+| 常态 | `html.opptrix-window-css-radius` 对 `#root` / `.opptrix-app-shell` 设 `border-radius` + `overflow: hidden` |
+| 最大化 / 全屏 | 主进程推送 `window-squared-changed`，挂 `html.opptrix-window-squared`，圆角为 0 |
+
+平台差异（仅材质/辅助，不改变圆角策略）：
+
+- **macOS**：保留 `titleBarStyle: 'hiddenInset'`、`trafficLightPosition`、`vibrancy`
+- **Windows 11+**：可保留 `roundedCorners: true` 辅助系统阴影；圆角视觉仍由 CSS 统一
+- **Windows 10 / Linux**：无系统圆角依赖，纯 CSS
+
+IPC：`getIsWindowSquared` / `onWindowSquaredChange`（对齐既有 `window-is-fullscreen` / `window-fullscreen-changed`）。不再按平台分支 native/css 圆角模式。
 
 ### Title bar z-index
 


### PR DESCRIPTION
## Summary
- 全平台 `frame: false` + `transparent: true`，用同一套 CSS 圆角（10px）统一观感
- 缩放时临时实色底，缓解透明窗漏出桌面；最大化/全屏去掉圆角
- mac 保留红绿灯与 vibrancy，Windows 保留 acrylic

## Test plan
- [ ] macOS / Windows / Linux：主窗口圆角一致，非最大化时可见圆角
- [ ] mac：红绿灯仍可用；侧栏毛玻璃大致正常
- [ ] 拖拽缩放：尽量不长时间漏出桌面
- [ ] 最大化/全屏：直角；还原后圆角恢复
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)