### PR TITLE
fix(desktop): 主窗口改回路线1系统窗形

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -2,7 +2,6 @@ const { app, BrowserWindow, ipcMain, dialog, shell, session, nativeTheme } = req
 const path = require('path')
 const fs = require('fs/promises')
 const fsSync = require('node:fs')
-const os = require('node:os')
 const { pathToFileURL } = require('node:url')
 const { spawn } = require('node:child_process')
 const { APP_NAME, APP_TITLE, VERSION } = require('./app-meta.cjs')
@@ -92,23 +91,7 @@ function setOpaqueWindowBackground(win) {
   win.setBackgroundColor(SPLASH_CANVAS)
 }
 
-/** Windows 11+ build number (10.0.22000). Used for optional OS roundedCorners (shadow assist). */
-function isWindows11OrNewer() {
-  if (process.platform !== 'win32') return false
-  const build = Number(String(os.release()).split('.')[2] ?? 0)
-  return Number.isFinite(build) && build >= 22000
-}
-
-/** Maximized or fullscreen — CSS radius must be removed (squared edges). */
-function isWindowSquared(win) {
-  if (!win || win.isDestroyed()) return false
-  return win.isMaximized() || win.isFullScreen()
-}
-
-/**
- * Shell ready（或缩放结束）后：透明底 + 尽量保留系统毛玻璃。
- * 缩放动画漏底由 will-resize → 临时实色 / resized → 再透明缓解。
- */
+/** macOS vibrancy / Windows acrylic — 勿开 BrowserWindow.transparent，否则缩放动画会漏出桌面空透明。 */
 function enableWindowBlurBackground(win) {
   if (win.isDestroyed()) return
   if (process.platform === 'darwin') {
@@ -117,7 +100,11 @@ function enableWindowBlurBackground(win) {
     } catch {
       /* older Electron */
     }
-  } else if (process.platform === 'win32') {
+    // 透明网页区域露的是 vibrancy 材质层，不是裸桌面；背景色用 0 alpha 才能看见材质
+    win.setBackgroundColor('#00000000')
+    return
+  }
+  if (process.platform === 'win32') {
     try {
       if (typeof win.setBackgroundMaterial === 'function') {
         win.setBackgroundMaterial('acrylic')
@@ -125,8 +112,8 @@ function enableWindowBlurBackground(win) {
     } catch {
       /* unsupported on older Windows */
     }
+    win.setBackgroundColor('#00000000')
   }
-  win.setBackgroundColor('#00000000')
 }
 
 /** @deprecated use enableWindowBlurBackground */
@@ -524,9 +511,8 @@ function buildMainWindowOptions() {
     minWidth: MIN_WIDTH,
     minHeight: MIN_HEIGHT,
     title: APP_TITLE,
-    // 三端统一：无边框 + 透明；启动先实色 splash，shell ready 后再透明
-    frame: false,
-    transparent: true,
+    // Splash / Linux 默认实色；mac/win 有原生毛玻璃时启动阶段仍先用不透明底防闪
+    // 路线 1：系统窗形（圆角/阴影由 OS 提供）；禁止 transparent:true
     backgroundColor: SPLASH_CANVAS,
     show: false,
     center,
@@ -540,12 +526,15 @@ function buildMainWindowOptions() {
   if (process.platform === 'darwin') {
     options.titleBarStyle = 'hiddenInset'
     options.trafficLightPosition = { x: 16, y: 16 }
+    // 系统侧栏毛玻璃。不要设 transparent:true —— 缩放时新区域会短暂变成「空透明」漏桌面。
     options.vibrancy = 'sidebar'
     options.visualEffectState = 'active'
   } else if (process.platform === 'win32') {
+    options.frame = false
+    // 同 mac：用系统材料，避免整窗 transparent 导致缩放漏底；Win11 默认系统圆角
     options.backgroundMaterial = 'acrylic'
-    // Win11+：系统圆角辅助阴影；圆角视觉仍由 CSS `--opptrix-window-radius` 统一
-    options.roundedCorners = isWindows11OrNewer()
+  } else {
+    options.frame = false
   }
 
   return options
@@ -580,30 +569,9 @@ function attachMainWindowHandlers(win) {
   const notifyFullscreen = () => {
     win.webContents.send('window-fullscreen-changed', win.isFullScreen())
   }
-  const notifySquared = () => {
-    win.webContents.send('window-squared-changed', isWindowSquared(win))
-  }
-  win.on('enter-full-screen', () => {
-    notifyFullscreen()
-    notifySquared()
-  })
-  win.on('leave-full-screen', () => {
-    notifyFullscreen()
-    notifySquared()
-  })
-  win.on('maximize', notifySquared)
-  win.on('unmaximize', notifySquared)
-  // 透明窗缩放时新露出区域会短暂空透明漏桌面：缩放中临时实色，结束后再透明
-  win.on('will-resize', () => {
-    setOpaqueWindowBackground(win)
-  })
-  win.on('resized', () => {
-    enableWindowBlurBackground(win)
-  })
-  win.webContents.on('did-finish-load', () => {
-    notifyFullscreen()
-    notifySquared()
-  })
+  win.on('enter-full-screen', notifyFullscreen)
+  win.on('leave-full-screen', notifyFullscreen)
+  win.webContents.on('did-finish-load', notifyFullscreen)
   win.on('closed', () => {
     if (mainWindow === win) mainWindow = null
   })
@@ -843,9 +811,6 @@ function registerWindowIpc() {
   })
   ipcMain.handle('window-is-maximized', (event) => {
     return BrowserWindow.fromWebContents(event.sender)?.isMaximized() ?? false
-  })
-  ipcMain.handle('window-is-squared', (event) => {
-    return isWindowSquared(BrowserWindow.fromWebContents(event.sender))
   })
   ipcMain.handle('window-is-focused', (event) => {
     const win = BrowserWindow.fromWebContents(event.sender)

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -8,7 +8,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
   windowClose: () => ipcRenderer.send('window-close'),
   getIsFullscreen: () => ipcRenderer.invoke('window-is-fullscreen'),
   getIsMaximized: () => ipcRenderer.invoke('window-is-maximized'),
-  getIsWindowSquared: () => ipcRenderer.invoke('window-is-squared'),
   windowIsFocused: () => ipcRenderer.invoke('window-is-focused'),
   pickExportDirectory: () => ipcRenderer.invoke('pick-export-directory'),
   writeBinaryFile: (payload) => ipcRenderer.invoke('write-binary-file', payload),
@@ -45,11 +44,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     const handler = (_event, fullscreen) => callback(Boolean(fullscreen))
     ipcRenderer.on('window-fullscreen-changed', handler)
     return () => ipcRenderer.removeListener('window-fullscreen-changed', handler)
-  },
-  onWindowSquaredChange: (callback) => {
-    const handler = (_event, squared) => callback(Boolean(squared))
-    ipcRenderer.on('window-squared-changed', handler)
-    return () => ipcRenderer.removeListener('window-squared-changed', handler)
   },
   onProtocolOpen: (callback) => {
     const handler = (_event, payload) => callback(payload)

--- a/client-ui/src/main.tsx
+++ b/client-ui/src/main.tsx
@@ -29,15 +29,6 @@ if (isElectron()) {
     document.documentElement.classList.add('opptrix-electron-vibrancy')
   }
 
-  // 三端统一 CSS 圆角；最大化/全屏时挂 squared 去掉圆角
-  document.documentElement.classList.add('opptrix-window-css-radius')
-  const api = window.electronAPI
-  const applySquared = (squared: boolean) => {
-    document.documentElement.classList.toggle('opptrix-window-squared', squared)
-  }
-  void api?.getIsWindowSquared?.().then(applySquared)
-  api?.onWindowSquaredChange?.(applySquared)
-
   window.setTimeout(() => {
     document.documentElement.classList.remove('opptrix-electron-startup')
     window.electronAPI?.signalShellReady?.()

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -8,9 +8,6 @@ declare global {
       windowClose?: () => void
       getIsFullscreen?: () => Promise<boolean>
       getIsMaximized?: () => Promise<boolean>
-      /** true when maximized or fullscreen — CSS radius should be removed */
-      getIsWindowSquared?: () => Promise<boolean>
-      onWindowSquaredChange?: (callback: (squared: boolean) => void) => () => void
       pickExportDirectory?: () => Promise<string | null>
       writeBinaryFile?: (payload: {
         dirPath: string

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -181,19 +181,12 @@ html.opptrix-desktop {
 }
 
 /* ── Electron: 壳层透明以露出窗口材质（vibrancy/acrylic），主内容区自行实底 ──
- * BrowserWindow.transparent:true + 统一 CSS 圆角；缩放漏底由主进程 will-resize 临时实色缓解。
+ * 路线 1：BrowserWindow 本身不开 transparent；圆角/阴影由系统窗形提供。
+ * 网页层透明仅用于 mac vibrancy / win acrylic 透过侧栏等区域。
  */
 html.opptrix-electron {
   --opptrix-app-bg: transparent;
   --opptrix-chrome-bg: transparent;
-  --opptrix-window-radius: 10px;
-}
-
-/* 三端统一 CSS 圆角；最大化/全屏时 .opptrix-window-squared 去掉圆角 */
-html.opptrix-electron.opptrix-window-css-radius:not(.opptrix-window-squared) #root,
-html.opptrix-electron.opptrix-window-css-radius:not(.opptrix-window-squared) .opptrix-app-shell {
-  border-radius: var(--opptrix-window-radius);
-  overflow: hidden;
 }
 
 html.opptrix-electron.opptrix-electron-startup,

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -270,33 +270,17 @@ Renderer：若展示返回失败且权限为 `denied`，聊天页温和提示一
 
 ### Window blur + sidebar
 
+路线 1（系统窗形）：隐藏标题栏，**保留系统圆角与阴影**；**不开**整窗 `transparent: true`，也**不用** CSS 大圆角裁切外轮廓。侧栏毛玻璃仍靠平台材质。
+
 | 平台 | 窗口层 | 固定左侧栏 |
 |------|--------|------------|
-| macOS | `frame: false` + `transparent` + `vibrancy: 'sidebar'` | CSS 透明，露系统毛玻璃；缩放时主进程临时实色缓解漏底 |
-| Windows | `frame: false` + `transparent` + `backgroundMaterial: 'acrylic'` | 同上 |
-| Linux | `frame: false` + `transparent` | 保留 CSS `.opptrix-glass-sidebar` 毛玻璃（无原生 acrylic） |
+| macOS | `titleBarStyle: 'hiddenInset'` + `vibrancy: 'sidebar'`（**不开** `transparent`） | CSS 透明，露系统毛玻璃；缩放不会漏裸桌面 |
+| Windows | `frame: false` + `backgroundMaterial: 'acrylic'`（**不开** `transparent`） | 同上；Win11 系统圆角默认开启 |
+| Linux | `frame: false` + 实色窗口底 | 保留 CSS `.opptrix-glass-sidebar` 毛玻璃（无原生 acrylic） |
+
+启动时窗口底先实色 splash（`SPLASH_CANVAS`）；shell ready 后 mac/win 将 `backgroundColor` 设为 `#00000000`，仅让网页透明区透出 vibrancy/acrylic（窗口本身仍非 transparent）。最大化/全屏时系统窗形自动直角，无需 CSS squared 逻辑。
 
 窄窗浮层侧栏仍盖在实色主内容上，继续用 CSS 毛玻璃。文档标记类：`html.opptrix-electron-vibrancy`。
-
-### 窗口圆角
-
-三端统一：`frame: false` + `transparent: true` + 渲染侧 CSS 圆角（`--opptrix-window-radius: 10px`）。
-
-| 阶段 | 行为 |
-|------|------|
-| 启动 | 窗口底先实色 `SPLASH_CANVAS`（`#F5F5F7`），展示 splash |
-| Shell ready | 主进程 `enableWindowBlurBackground` → 背景 `#00000000`，尽量保留 vibrancy / acrylic |
-| 缩放中 | `will-resize` → 临时实色；`resized` → 再透明（缓解透明窗缩放漏桌面） |
-| 常态 | `html.opptrix-window-css-radius` 对 `#root` / `.opptrix-app-shell` 设 `border-radius` + `overflow: hidden` |
-| 最大化 / 全屏 | 主进程推送 `window-squared-changed`，挂 `html.opptrix-window-squared`，圆角为 0 |
-
-平台差异（仅材质/辅助，不改变圆角策略）：
-
-- **macOS**：保留 `titleBarStyle: 'hiddenInset'`、`trafficLightPosition`、`vibrancy`
-- **Windows 11+**：可保留 `roundedCorners: true` 辅助系统阴影；圆角视觉仍由 CSS 统一
-- **Windows 10 / Linux**：无系统圆角依赖，纯 CSS
-
-IPC：`getIsWindowSquared` / `onWindowSquaredChange`（对齐既有 `window-is-fullscreen` / `window-fullscreen-changed`）。不再按平台分支 native/css 圆角模式。
 
 ### Title bar z-index
 


### PR DESCRIPTION
## Summary
- 去掉整窗 transparent、CSS 大圆角与 squared IPC，避免假边框与缩放漏底
- 恢复 mac hiddenInset + vibrancy、Windows frame false + acrylic，圆角/阴影交系统处理
- 更新 DESKTOP.md 为路线 1 约定

## Test plan
- [ ] macOS：系统圆角与阴影正常，红绿灯可用，侧栏毛玻璃正常，缩放不漏桌面
- [ ] Windows 11：系统圆角大致正常；Win10 可为直角（预期）
- [ ] Linux：无边框可用，侧栏 CSS 毛玻璃
- [ ] npm run check:ui 通过


Made with [Cursor](https://cursor.com)