### PR TITLE
feat(chat): 思考过程条显示动态 token 估算

### DIFF
--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -291,6 +291,8 @@ export default function ChatApp() {
   const sessionStreamGenRef = useRef(new Map<string, number>())
   const stoppingSessionsRef = useRef(new Set<string>())
   const streamingSessionIdsRef = useRef(new Set<string>())
+  /** 流结束后延迟清除过程条的 timer（sessionId → timeout id） */
+  const streamResetTimersRef = useRef(new Map<string, number>())
   /** 本轮生成期间曾失焦/不可见（sessionId → true） */
   const streamAwayDuringGenRef = useRef(new Map<string, boolean>())
   /** 同轮完成通知去重键：`${sessionId}:${streamGen}` */
@@ -395,8 +397,8 @@ export default function ChatApp() {
       }
     }
 
-    // 内容已落定：优先在 reply 触发完成通知，避免等待慢 done（token/工具重建）
-    if (event.type === 'reply') {
+    // 内容已落定：优先在最终 reply（含 content）触发完成通知，避免进度计数误触
+    if (event.type === 'reply' && event.content) {
       maybeNotifyChatDone(targetSessionId, resolveSessionTitle(targetSessionId))
     }
 
@@ -523,6 +525,14 @@ export default function ChatApp() {
   }, [])
 
   const loadSession = useCallback(async (id: string) => {
+    const prevId = activeIdRef.current
+    if (prevId && prevId !== id) {
+      const pending = streamResetTimersRef.current.get(prevId)
+      if (pending != null) {
+        window.clearTimeout(pending)
+        streamResetTimersRef.current.delete(prevId)
+      }
+    }
     pushComposerDraft('')
     const data = await getSession(id)
     setActiveId(id)
@@ -927,6 +937,12 @@ export default function ChatApp() {
 
     if (streamingSessionIdsRef.current.has(sessionId)) return
 
+    const pendingReset = streamResetTimersRef.current.get(sessionId)
+    if (pendingReset != null) {
+      window.clearTimeout(pendingReset)
+      streamResetTimersRef.current.delete(sessionId)
+    }
+
     const streamGen = (sessionStreamGenRef.current.get(sessionId) ?? 0) + 1
     sessionStreamGenRef.current.set(sessionId, streamGen)
     streamAwayDuringGenRef.current.set(sessionId, false)
@@ -1023,7 +1039,17 @@ export default function ChatApp() {
       streamCacheRef.current.delete(sessionId)
       markSessionStreaming(sessionId, false)
       if (activeIdRef.current === sessionId) {
-        streamUiRef.current?.resetStreamUi()
+        // 延迟清除过程条，让用户能看到最后的「约 N tokens」一小会儿
+        const prevTimer = streamResetTimersRef.current.get(sessionId)
+        if (prevTimer != null) window.clearTimeout(prevTimer)
+        const timer = window.setTimeout(() => {
+          streamResetTimersRef.current.delete(sessionId)
+          if (activeIdRef.current !== sessionId) return
+          if (streamGen !== (sessionStreamGenRef.current.get(sessionId) ?? 0)) return
+          if (streamingSessionIdsRef.current.has(sessionId)) return
+          streamUiRef.current?.resetStreamUi()
+        }, 500)
+        streamResetTimersRef.current.set(sessionId, timer)
       }
     }
   }

--- a/client-ui/src/chat/sessionStreamRuntime.ts
+++ b/client-ui/src/chat/sessionStreamRuntime.ts
@@ -1,4 +1,5 @@
 import type { ChatLiveTrace, ChatProgressEvent, ChatUserPromptPayload } from '../types/chatProgress'
+import { formatTokenCount } from './formatTokenCount.ts'
 
 export type SessionStreamSnapshot = {
   liveTrace: ChatLiveTrace | null
@@ -81,15 +82,22 @@ export function applyChatProgressEvent(
           ),
         },
       }
-    case 'reply':
+    case 'reply': {
+      // 与思考态同位文案；多轮工具后若已是「整理」态则保持，避免回跳
+      const consolidating = (snapshot.liveTrace?.thinkingLabel ?? '').includes('整理')
+      const base = consolidating ? '模型正在整理结果' : '模型正在思考'
+      const thinkingLabel = event.estimatedTokens != null
+        ? `${base} · 约 ${formatTokenCount(event.estimatedTokens)} tokens`
+        : `${base}…`
       return {
         ...snapshot,
         liveTrace: {
           steps: snapshot.liveTrace?.steps ?? [],
-          thinkingLabel: '正在生成回复…',
+          thinkingLabel,
           thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
         },
       }
+    }
     case 'done':
     case 'error':
       return {

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -48,7 +48,7 @@ export type ChatProgressEvent =
   | { type: 'tool_start'; step: ChatToolStep }
   | { type: 'tool_done'; step: ChatToolStep }
   | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
-  | { type: 'reply'; content: string }
+  | { type: 'reply'; content?: string; estimatedTokens?: number }
   | {
     type: 'done'
     reply: string

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -98,7 +98,7 @@ export type ChatProgressEvent =
   | { type: 'tool_start'; step: ChatToolStep }
   | { type: 'tool_done'; step: ChatToolStep }
   | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
-  | { type: 'reply'; content: string }
+  | { type: 'reply'; content?: string; estimatedTokens?: number }
   | {
     type: 'done'
     /** Agent 最终回复文本 */

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -59,7 +59,7 @@ import {
   KEEP_RECENT_DEFAULT,
 } from './context/compact.js'
 import { resolveModelContextTokensAsync, resolveModelMediaCapabilitiesAsync } from './llm/models-dev-context.js'
-import { estimateToolsTokens } from './context/token-estimate.js'
+import { estimateToolsTokens, estimateTextTokens } from './context/token-estimate.js'
 import {
   accumulateChatUsage,
   createEmptyChatUsage,
@@ -902,6 +902,7 @@ export class AgentEngine {
       const providerId = providerIdFromModelRef(activeModel)
 
       let overflowRetried = false
+      let lastRoundEstimatedTokens: number | undefined
       const runLlmRound = async (aggressive: boolean) => {
         const budgeted = await this.applyContextBudget(record, {
           modelId,
@@ -920,7 +921,46 @@ export class AgentEngine {
             estimated: budgeted.compactUsageEstimated ?? true,
           })
         }
-        const turn = await llm.chat(budgeted.modelView, openAiTools, signal, { sessionId })
+        let accumulated = ''
+        let stopTokenProgress = false
+        let lastEmitAt = 0
+        let lastTokens = -1
+        let pendingTokens: number | null = null
+        const TOKEN_PROGRESS_THROTTLE_MS = 80
+        const emitTokenProgress = (n: number) => {
+          lastEmitAt = Date.now()
+          lastTokens = n
+          pendingTokens = null
+          emit({ type: 'reply', estimatedTokens: n })
+        }
+        const turn = await llm.chat(budgeted.modelView, openAiTools, signal, {
+          sessionId,
+          onDelta: (delta) => {
+            if (delta.hasToolCalls) {
+              stopTokenProgress = true
+              pendingTokens = null
+              return
+            }
+            if (stopTokenProgress || !delta.text) return
+            accumulated += delta.text
+            const n = estimateTextTokens(accumulated)
+            if (n === lastTokens) return
+            const now = Date.now()
+            if (lastEmitAt > 0 && now - lastEmitAt < TOKEN_PROGRESS_THROTTLE_MS) {
+              pendingTokens = n
+              return
+            }
+            emitTokenProgress(n)
+          },
+        })
+        // 流结束：flush pending，并保证有一次最终 estimatedTokens
+        if (!stopTokenProgress && accumulated) {
+          const n = estimateTextTokens(accumulated)
+          emitTokenProgress(n)
+          lastRoundEstimatedTokens = n
+        } else {
+          lastRoundEstimatedTokens = undefined
+        }
         chatUsage = accumulateChatUsage(chatUsage, resolveTurnUsage(turn, budgeted.modelView))
         return turn
       }
@@ -1084,7 +1124,11 @@ export class AgentEngine {
 
       const reply = chatMessageContentToText(turn.message.content).trim() || '（无回复内容）'
       const outputAttachments = turn.outputAttachments
-      emit({ type: 'reply', content: reply })
+      emit({
+        type: 'reply',
+        content: reply,
+        ...(lastRoundEstimatedTokens != null ? { estimatedTokens: lastRoundEstimatedTokens } : {}),
+      })
       pushAssistant(
         reply,
         toolsUsed,

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -64,12 +64,20 @@ export interface LlmTurn {
   outputAttachments?: import('./../media-types.js').ChatAttachmentMeta[]
 }
 
+export type LlmChatDelta = { text?: string; hasToolCalls?: boolean }
+
+export interface LlmChatOpts {
+  sessionId?: string
+  /** 传入时走 SSE 流式；文本增量与 tool_calls 发现会回调 */
+  onDelta?: (delta: LlmChatDelta) => void
+}
+
 export interface LlmProvider {
   chat(
     messages: ChatMessage[],
     tools?: OpenAiTool[],
     signal?: AbortSignal,
-    opts?: { sessionId?: string },
+    opts?: LlmChatOpts,
   ): Promise<LlmTurn>
   listModels(): Promise<string[]>
 }
@@ -123,6 +131,214 @@ function serializeMessage(m: ChatMessage): Record<string, unknown> {
   }
 }
 
+function httpErrorTurn(status: number, bodyText: string): LlmTurn {
+  const overflow = isContextLengthHttpError(status, bodyText)
+  const msg = status === 401
+    ? '⚠️ API Key 无效'
+    : status === 429
+      ? '⚠️ 请求过于频繁'
+      : overflow
+        ? '对话内容过多，正在整理后重试…'
+        : `⚠️ HTTP ${status}: ${bodyText}`
+  return {
+    message: { role: 'assistant', content: msg },
+    finishReason: 'error',
+    error: overflow ? 'context_length_exceeded' : msg,
+    contextOverflow: overflow,
+  }
+}
+
+function extractDeltaText(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return ''
+  return content
+    .filter((p): p is { type: 'text'; text: string } =>
+      typeof p === 'object' && p !== null && (p as { type?: string }).type === 'text'
+      && typeof (p as { text?: unknown }).text === 'string')
+    .map(p => p.text)
+    .join('')
+}
+
+function turnFromAssistantMessage(
+  raw: {
+    content?: string | null | unknown[]
+    tool_calls?: ToolCall[]
+  },
+  usage: TokenUsage | undefined,
+  sessionId?: string,
+): LlmTurn {
+  if (raw.tool_calls?.length) {
+    return {
+      message: {
+        role: 'assistant',
+        content: typeof raw.content === 'string' ? raw.content : null,
+        tool_calls: raw.tool_calls,
+      },
+      finishReason: 'tool_calls',
+      usage,
+    }
+  }
+
+  if (sessionId && Array.isArray(raw.content)) {
+    const parsed = parseAssistantResponseContent(sessionId, raw.content)
+    return {
+      message: { role: 'assistant', content: parsed.text || '（无回复内容）' },
+      finishReason: 'stop',
+      usage,
+      outputAttachments: parsed.attachments.length ? parsed.attachments : undefined,
+    }
+  }
+
+  const textContent = typeof raw.content === 'string'
+    ? raw.content
+    : Array.isArray(raw.content)
+      ? raw.content
+        .filter((p): p is { type: 'text'; text: string } =>
+          typeof p === 'object' && p !== null && (p as { type?: string }).type === 'text'
+          && typeof (p as { text?: unknown }).text === 'string')
+        .map(p => p.text)
+        .join('\n')
+      : ''
+
+  return {
+    message: { role: 'assistant', content: textContent ?? '' },
+    finishReason: 'stop',
+    usage,
+  }
+}
+
+async function consumeChatCompletionSse(
+  resp: Response,
+  opts: LlmChatOpts | undefined,
+): Promise<LlmTurn> {
+  const onDelta = opts?.onDelta
+  const body = resp.body
+  if (!body) {
+    throw new Error('empty_stream_body')
+  }
+
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let content = ''
+  let finishReason: string | undefined
+  let usage: TokenUsage | undefined
+  let sawToolCalls = false
+  const toolCallsByIndex = new Map<number, ToolCall>()
+
+  const mergeToolCallDelta = (delta: {
+    index?: number
+    id?: string
+    type?: string
+    function?: { name?: string; arguments?: string }
+  }) => {
+    const index = typeof delta.index === 'number' ? delta.index : 0
+    let current = toolCallsByIndex.get(index)
+    if (!current) {
+      current = {
+        id: '',
+        type: 'function',
+        function: { name: '', arguments: '' },
+      }
+      toolCallsByIndex.set(index, current)
+    }
+    if (delta.id) current.id = delta.id
+    if (delta.function?.name) current.function.name += delta.function.name
+    if (delta.function?.arguments) current.function.arguments += delta.function.arguments
+  }
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const lines = buffer.split(/\r?\n/)
+      buffer = lines.pop() ?? ''
+
+      for (const rawLine of lines) {
+        const line = rawLine.trim()
+        if (!line || line.startsWith(':')) continue
+        if (!line.startsWith('data:')) continue
+        const payload = line.slice(5).trim()
+        if (!payload) continue
+        if (payload === '[DONE]') continue
+
+        let parsed: {
+          usage?: unknown
+          choices?: Array<{
+            finish_reason?: string | null
+            delta?: {
+              content?: string | null | unknown[]
+              tool_calls?: Array<{
+                index?: number
+                id?: string
+                type?: string
+                function?: { name?: string; arguments?: string }
+              }>
+            }
+          }>
+        }
+        try {
+          parsed = JSON.parse(payload) as typeof parsed
+        } catch {
+          continue
+        }
+
+        const chunkUsage = parseOpenAiUsage(parsed.usage)
+        if (chunkUsage) usage = chunkUsage
+
+        const choice = parsed.choices?.[0]
+        if (!choice) continue
+        if (choice.finish_reason) finishReason = choice.finish_reason
+
+        const delta = choice.delta
+        if (!delta) continue
+
+        const text = extractDeltaText(delta.content)
+        if (text) {
+          content += text
+          onDelta?.({ text })
+        }
+
+        if (delta.tool_calls?.length) {
+          if (!sawToolCalls) {
+            sawToolCalls = true
+            onDelta?.({ hasToolCalls: true })
+          }
+          for (const tc of delta.tool_calls) {
+            mergeToolCallDelta(tc)
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
+
+  const toolCalls = [...toolCallsByIndex.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([, tc]) => tc)
+    .filter(tc => tc.id || tc.function.name)
+
+  if (toolCalls.length || finishReason === 'tool_calls') {
+    return {
+      message: {
+        role: 'assistant',
+        content: content || null,
+        tool_calls: toolCalls,
+      },
+      finishReason: 'tool_calls',
+      usage,
+    }
+  }
+
+  return turnFromAssistantMessage(
+    { content },
+    usage,
+    opts?.sessionId,
+  )
+}
+
 export class OpenAiCompatibleProvider implements LlmProvider {
   constructor(private cfg: LlmConfig) {}
 
@@ -130,7 +346,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
     messages: ChatMessage[],
     tools?: OpenAiTool[],
     signal?: AbortSignal,
-    opts?: { sessionId?: string },
+    opts?: LlmChatOpts,
   ): Promise<LlmTurn> {
     if (!isConfigured(this.cfg)) {
       return {
@@ -140,7 +356,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       }
     }
     const url = `${this.cfg.baseUrl.replace(/\/$/, '')}/chat/completions`
-    try {
+    const buildBody = (stream: boolean): Record<string, unknown> => {
       const body: Record<string, unknown> = {
         model: this.cfg.model,
         messages: messages.map(serializeMessage),
@@ -151,40 +367,26 @@ export class OpenAiCompatibleProvider implements LlmProvider {
         body.tools = tools
         body.tool_choice = 'auto'
       }
+      if (stream) body.stream = true
+      return body
+    }
 
-      const timeoutSignal = AbortSignal.timeout(this.cfg.timeout ?? 120_000)
-      const requestSignal = signal
-        ? AbortSignal.any([signal, timeoutSignal])
-        : timeoutSignal
+    const timeoutSignal = AbortSignal.timeout(this.cfg.timeout ?? 120_000)
+    const requestSignal = signal
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
 
-      const resp = await outboundFetch(url, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${this.cfg.apiKey}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(body),
-        signal: requestSignal,
-      })
+    const post = (stream: boolean) => outboundFetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.cfg.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(buildBody(stream)),
+      signal: requestSignal,
+    })
 
-      if (!resp.ok) {
-        const text = (await resp.text()).slice(0, 300)
-        const overflow = isContextLengthHttpError(resp.status, text)
-        const msg = resp.status === 401
-          ? '⚠️ API Key 无效'
-          : resp.status === 429
-            ? '⚠️ 请求过于频繁'
-            : overflow
-              ? '对话内容过多，正在整理后重试…'
-              : `⚠️ HTTP ${resp.status}: ${text}`
-        return {
-          message: { role: 'assistant', content: msg },
-          finishReason: 'error',
-          error: overflow ? 'context_length_exceeded' : msg,
-          contextOverflow: overflow,
-        }
-      }
-
+    const parseJsonTurn = async (resp: Response): Promise<LlmTurn> => {
       const data = await resp.json() as {
         usage?: unknown
         choices?: {
@@ -195,8 +397,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
           }
         }[]
       }
-      const choice = data.choices?.[0]
-      const raw = choice?.message
+      const raw = data.choices?.[0]?.message
       const usage = parseOpenAiUsage(data.usage)
       if (!raw) {
         return {
@@ -205,46 +406,57 @@ export class OpenAiCompatibleProvider implements LlmProvider {
           error: 'bad_response',
         }
       }
+      return turnFromAssistantMessage(raw, usage, opts?.sessionId)
+    }
 
-      if (raw.tool_calls?.length) {
-        return {
-          message: {
-            role: 'assistant',
-            content: typeof raw.content === 'string' ? raw.content : null,
-            tool_calls: raw.tool_calls,
-          },
-          finishReason: 'tool_calls',
-          usage,
+    try {
+      if (opts?.onDelta) {
+        let streamConsumeStarted = false
+        try {
+          const streamResp = await post(true)
+          if (!streamResp.ok) {
+            const text = (await streamResp.text()).slice(0, 300)
+            // 部分上游不支持 stream：回退非流式
+            if (streamResp.status === 400 || streamResp.status === 422) {
+              const fallback = await post(false)
+              if (!fallback.ok) {
+                return httpErrorTurn(fallback.status, (await fallback.text()).slice(0, 300))
+              }
+              return await parseJsonTurn(fallback)
+            }
+            return httpErrorTurn(streamResp.status, text)
+          }
+          if (!streamResp.body) {
+            const fallback = await post(false)
+            if (!fallback.ok) {
+              return httpErrorTurn(fallback.status, (await fallback.text()).slice(0, 300))
+            }
+            return await parseJsonTurn(fallback)
+          }
+          streamConsumeStarted = true
+          return await consumeChatCompletionSse(streamResp, opts)
+        } catch (streamErr) {
+          if (signal?.aborted) {
+            const msg = '已取消'
+            return { message: { role: 'assistant', content: msg }, finishReason: 'error', error: 'cancelled' }
+          }
+          // 尚未开始读流时回退非流式；中途失败不再重放整轮
+          if (!streamConsumeStarted) {
+            const fallback = await post(false)
+            if (!fallback.ok) {
+              return httpErrorTurn(fallback.status, (await fallback.text()).slice(0, 300))
+            }
+            return await parseJsonTurn(fallback)
+          }
+          throw streamErr
         }
       }
 
-      const sessionId = opts?.sessionId
-      if (sessionId && Array.isArray(raw.content)) {
-        const parsed = parseAssistantResponseContent(sessionId, raw.content)
-        return {
-          message: { role: 'assistant', content: parsed.text || '（无回复内容）' },
-          finishReason: 'stop',
-          usage,
-          outputAttachments: parsed.attachments.length ? parsed.attachments : undefined,
-        }
+      const resp = await post(false)
+      if (!resp.ok) {
+        return httpErrorTurn(resp.status, (await resp.text()).slice(0, 300))
       }
-
-      const textContent = typeof raw.content === 'string'
-        ? raw.content
-        : Array.isArray(raw.content)
-          ? raw.content
-            .filter((p): p is { type: 'text'; text: string } =>
-              typeof p === 'object' && p !== null && (p as { type?: string }).type === 'text'
-              && typeof (p as { text?: unknown }).text === 'string')
-            .map(p => p.text)
-            .join('\n')
-          : ''
-
-      return {
-        message: { role: 'assistant', content: textContent ?? '' },
-        finishReason: 'stop',
-        usage,
-      }
+      return await parseJsonTurn(resp)
     } catch (e) {
       if (signal?.aborted) {
         const msg = '已取消'

--- a/tests/session-stream-runtime.test.mjs
+++ b/tests/session-stream-runtime.test.mjs
@@ -83,4 +83,49 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
     assert.match(next.contextHint ?? '', /整理/)
     assert.match(next.liveTrace?.thinkingLabel ?? '', /整理/)
   })
+
+  it('shows estimated token progress on reply without content', () => {
+    const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      estimatedTokens: 128,
+    })
+    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 128 tokens')
+  })
+
+  it('prefers estimatedTokens label even when content is present', () => {
+    const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '最终正文',
+      estimatedTokens: 1500,
+    })
+    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 1.5k tokens')
+  })
+
+  it('falls back to thinking label when reply has no estimatedTokens', () => {
+    const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '正文',
+    })
+    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考…')
+  })
+
+  it('keeps consolidating label after tools when reply streams tokens', () => {
+    const withTools = {
+      ...createEmptyStreamSnapshot(),
+      liveTrace: {
+        steps: [],
+        thinkingLabel: '模型正在整理结果…',
+      },
+    }
+    const withTokens = applyChatProgressEvent(withTools, {
+      type: 'reply',
+      estimatedTokens: 64,
+    })
+    assert.equal(withTokens.liveTrace?.thinkingLabel, '模型正在整理结果 · 约 64 tokens')
+
+    const withoutTokens = applyChatProgressEvent(withTools, {
+      type: 'reply',
+    })
+    assert.equal(withoutTokens.liveTrace?.thinkingLabel, '模型正在整理结果…')
+  })
 })


### PR DESCRIPTION
## Summary
- OpenAI 兼容接口开启流式，仅用于估算生成进度，聊天正文仍整段展示
- 过程条在「模型正在思考」同位显示「约 N tokens」并动态上涨
- 工具调用轮不刷正文计数；结束后过程条短暂保留再清除

## Test plan
- [ ] 开发环境重启后端后，发一条少工具的问题
- [ ] 过程条出现「模型正在思考 · 约 N tokens」且数字上涨
- [ ] 完成后整段回复上屏，无逐字 Markdown 渲染
- [ ] 有工具链时，工具执行阶段不出现正文 token 计数干扰
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)