### PR TITLE
feat(chat): 优化 ask_user 选项面板与数量约束

### DIFF
--- a/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
+++ b/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
@@ -20,6 +20,8 @@ export default function ComposerAgentUserPromptPanel({
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [secretValue, setSecretValue] = useState('')
   const isSecret = prompt.kind === 'secret'
+  const allSelected = prompt.options.length > 0
+    && selectedIds.length === prompt.options.length
 
   useEffect(() => {
     setCustomText('')
@@ -52,6 +54,15 @@ export default function ComposerAgentUserPromptPanel({
       prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
     ))
   }, [])
+
+  const toggleSelectAll = useCallback(() => {
+    if (submitting) return
+    if (allSelected) {
+      setSelectedIds([])
+      return
+    }
+    setSelectedIds(prompt.options.map(opt => opt.id))
+  }, [allSelected, prompt.options, submitting])
 
   const submitMultiple = useCallback(() => {
     if (submitting || !selectedIds.length) return
@@ -178,7 +189,20 @@ export default function ComposerAgentUserPromptPanel({
         <p className="opptrix-composer-user-prompt-panel__prompt">{prompt.prompt}</p>
       </div>
 
-      <div className="opptrix-composer-user-prompt-panel__options">
+      {prompt.allowMultiple ? (
+        <div className="opptrix-composer-user-prompt-panel__toolbar">
+          <OpptrixButton
+            variant="ghost"
+            size="medium"
+            disabled={submitting || prompt.options.length === 0}
+            onClick={toggleSelectAll}
+          >
+            {allSelected ? '取消全选' : '全选'}
+          </OpptrixButton>
+        </div>
+      ) : null}
+
+      <div className="opptrix-composer-user-prompt-panel__options opptrix-scroll">
         {prompt.options.map(opt => (
           <button
             key={opt.id}
@@ -201,26 +225,26 @@ export default function ComposerAgentUserPromptPanel({
             {opt.label}
           </button>
         ))}
+      </div>
 
-        <div className="opptrix-composer-user-prompt-panel__custom">
-          <OpptrixInput
-            className="opptrix-composer-user-prompt-panel__custom-input"
-            value={customText}
-            disabled={submitting}
-            placeholder="其他，输入后按 Enter 提交"
-            onChange={(_e, data) => setCustomText(data.value)}
-            onKeyDown={handleCustomKeyDown}
-            aria-label="自行输入答案"
-          />
-          <span className="opptrix-composer-user-prompt-panel__custom-hint">Enter</span>
-        </div>
+      <div className="opptrix-composer-user-prompt-panel__custom">
+        <OpptrixInput
+          className="opptrix-composer-user-prompt-panel__custom-input"
+          value={customText}
+          disabled={submitting}
+          placeholder="其他，输入后按 Enter 提交"
+          onChange={(_e, data) => setCustomText(data.value)}
+          onKeyDown={handleCustomKeyDown}
+          aria-label="自行输入答案"
+        />
+        <span className="opptrix-composer-user-prompt-panel__custom-hint">Enter</span>
       </div>
 
       {prompt.allowMultiple && (
         <div className="opptrix-composer-user-prompt-panel__confirm">
           <OpptrixButton
             variant="primary"
-            size="small"
+            size="medium"
             disabled={submitting || selectedIds.length === 0}
             onClick={submitMultiple}
           >

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -1384,6 +1384,19 @@ select:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 4px;
+  max-height: 248px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+}
+
+.opptrix-composer-user-prompt-panel__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: -2px;
 }
 
 .opptrix-composer-user-prompt-panel__option {
@@ -1391,15 +1404,16 @@ select:focus-visible {
   align-items: center;
   justify-content: flex-start;
   width: 100%;
-  padding: 8px 10px;
+  min-height: 36px;
+  padding: 10px 12px;
   border: none;
   border-radius: 8px;
   background: transparent;
   text-align: left;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 500;
-  line-height: 1.35;
+  line-height: 1.4;
   color: var(--opptrix-text, #1A1A1A);
   transition: background-color 140ms ease, box-shadow 140ms ease;
 }
@@ -1432,7 +1446,7 @@ select:focus-visible {
   align-items: center;
   gap: 8px;
   width: 100%;
-  margin-top: 4px;
+  margin-top: 0;
   padding-top: 8px;
   border-top: 1px solid rgba(0, 0, 0, 0.06);
 }
@@ -1455,6 +1469,7 @@ select:focus-visible {
 
 .opptrix-composer-user-prompt-panel__confirm {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
   gap: 10px;
 }

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -278,7 +278,7 @@ Opptrix/
   - **触发**：每轮 `llm.chat` 前检查；上游 `context_length_exceeded` 等 → 强制 aggressive compact 后**重试 1 次**；`setSessionModel` 换模型后按新窗再检查。
   - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。`done` 可含 `turn_usage`（本轮 LLM 累计用量，含 tool 循环与 structured 压缩）与 `context_usage`（Composer 已用/窗长估算）。测试：`tests/session-context-compact.test.mjs`、`tests/chat-token-usage.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
-- **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（末项可自由输入），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
+- **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（预置选项 2–50 个、末项可自由输入；多选支持全选；prompt/label 勿用 emoji），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
 - **行业分析**：`industry_mining` / `industry_mermaid`（属 `industry` pack，需播种或 activate）→ 代表公司用 `search_instruments` + `get_instrument_*`
 - **市场宏观**：`get_market_regime` / `get_market_dynamics` / `get_trend_brief` 等属 `market` pack
 - **跨市场搜索**：唯一入口 `search_instruments`（`core` pack，始终可用；`markets` 可过滤 CN/US/HK/CRYPTO）

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -477,7 +477,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
   ask_user: {
     miningEligible: false,
     usageGuide: '分析前需用户确认方向、范围或偏好，且上下文无法推断时调用；会在聊天输入框上方展示选择题，用户点选或自行输入后继续。',
-    compliance: 'prompt 必填、面向投资者；options 2–5 项且 id 唯一；allow_multiple 默认 false；同一轮对话最多 1 次；禁止索要密钥。',
+    compliance: 'prompt 必填、面向投资者且勿用 emoji；options 2–50 项且 id 唯一，label 勿用 emoji；allow_multiple 默认 false；同一轮对话最多 1 次；禁止索要密钥。',
   },
   list_enabled_providers: {
     hubFeature: 'provider_list',

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -611,7 +611,7 @@ export class ToolRegistry {
           prompt: { type: 'string', description: '要向用户提出的具体问题（面向投资者，避免技术术语）' },
           options: {
             type: 'array',
-            description: '2–5 个预置选项，每项为 { id, label }；id 为稳定标识，label 为展示文案',
+            description: '至少 2 个、最多 50 个预置选项，每项为 { id, label }；id 为稳定标识，label 为展示文案；prompt 与 label 均勿使用 emoji',
           },
           allow_multiple: { type: 'boolean', description: '是否允许多选，默认 false' },
         }, ['prompt', 'options']),

--- a/packages/agent/src/user-prompt.ts
+++ b/packages/agent/src/user-prompt.ts
@@ -122,8 +122,15 @@ export function createUserPromptId() {
   return randomUUID()
 }
 
+/** 预置选项下限（单选体验需要至少两项） */
+export const USER_PROMPT_OPTIONS_MIN = 2
+/** 预置选项软上限（防滥用；超过拒绝） */
+export const USER_PROMPT_OPTIONS_MAX = 50
+
 export function normalizeUserPromptOptions(raw: unknown): UserPromptOption[] | null {
-  if (!Array.isArray(raw) || raw.length < 2 || raw.length > 5) return null
+  if (!Array.isArray(raw) || raw.length < USER_PROMPT_OPTIONS_MIN || raw.length > USER_PROMPT_OPTIONS_MAX) {
+    return null
+  }
   const options: UserPromptOption[] = []
   for (const item of raw) {
     if (!item || typeof item !== 'object') return null
@@ -144,9 +151,20 @@ export function parseAskUserArgs(args: Record<string, unknown>): {
   const prompt = String(args.prompt ?? args.question ?? '').trim()
   if (!prompt) return { error: 'prompt 不能为空' }
 
-  const options = normalizeUserPromptOptions(args.options)
+  const rawOptions = args.options
+  if (!Array.isArray(rawOptions)) {
+    return { error: `options 须为 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个对象数组，每项含 id 与 label` }
+  }
+  if (rawOptions.length > USER_PROMPT_OPTIONS_MAX) {
+    return { error: `选项过多（最多 ${USER_PROMPT_OPTIONS_MAX} 个），请精简后再试` }
+  }
+  if (rawOptions.length < USER_PROMPT_OPTIONS_MIN) {
+    return { error: `请至少提供 ${USER_PROMPT_OPTIONS_MIN} 个选项` }
+  }
+
+  const options = normalizeUserPromptOptions(rawOptions)
   if (!options) {
-    return { error: 'options 须为 2–5 个对象数组，每项含 id 与 label' }
+    return { error: `options 须为 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个对象数组，每项含唯一 id 与非空 label` }
   }
 
   const titleRaw = args.title

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -208,7 +208,8 @@ export function buildUserInteractionPlaybook(): string {
   return [
     '【用户确认 — ask_user 内置交互工具】',
     '- 当分析方向、标的范围、时间窗口、偏好（短线/中线、是否含资讯等）存在多种合理路径且无法从上下文推断时，调用 ask_user 而非在正文里罗列选项让用户打字回复',
-    '- 参数：prompt 写一句面向投资者的问题；options 提供 2–5 个互斥或常见选项（id 英文/数字，label 中文简短）；allow_multiple 仅在「可多选」时设为 true',
+    '- 参数：prompt 写一句面向投资者的问题；options 提供至少 2 个、最多 50 个互斥或常见选项（id 英文/数字，label 中文简短）；allow_multiple 仅在「可多选」时设为 true',
+    '- prompt 与 options.label 均不要使用 emoji（界面更清晰、便于朗读与无障碍）',
     '- 界面会在输入框上方展示题目；最后一项为「自行输入」，用户可直接打字后按 Enter 提交',
     '- 收到返回的 selected_labels / custom_text 后再继续拉数与分析；同一轮对话最多调用 1 次 ask_user',
     '- 禁止用于索要密码等敏感信息（须用 request_secret 写入保险箱）；禁止在已有明确用户指令时重复确认',

--- a/tests/agent-ask-user.test.mjs
+++ b/tests/agent-ask-user.test.mjs
@@ -5,9 +5,10 @@ import {
   parseAskUserArgs,
   normalizeUserPromptOptions,
   UserPromptCancelledError,
+  USER_PROMPT_OPTIONS_MAX,
 } from '../packages/agent/dist/user-prompt.js'
 
-test('normalizeUserPromptOptions accepts 2–5 unique options', () => {
+test('normalizeUserPromptOptions accepts 2–50 unique options', () => {
   const ok = normalizeUserPromptOptions([
     { id: 'a', label: '选项 A' },
     { id: 'b', label: '选项 B' },
@@ -17,15 +18,44 @@ test('normalizeUserPromptOptions accepts 2–5 unique options', () => {
     { id: 'b', label: '选项 B' },
   ])
 
+  const six = Array.from({ length: 6 }, (_, i) => ({
+    id: `o${i}`,
+    label: `选项 ${i + 1}`,
+  }))
+  assert.equal(normalizeUserPromptOptions(six)?.length, 6)
+
+  const many = Array.from({ length: USER_PROMPT_OPTIONS_MAX }, (_, i) => ({
+    id: `o${i}`,
+    label: `选项 ${i + 1}`,
+  }))
+  assert.equal(normalizeUserPromptOptions(many)?.length, USER_PROMPT_OPTIONS_MAX)
+
   assert.equal(normalizeUserPromptOptions([{ id: 'a', label: '仅一项' }]), null)
   assert.equal(normalizeUserPromptOptions([
     { id: 'a', label: 'A' },
     { id: 'a', label: '重复' },
   ]), null)
+  assert.equal(
+    normalizeUserPromptOptions([
+      ...many,
+      { id: 'overflow', label: '超出' },
+    ]),
+    null,
+  )
 })
 
 test('parseAskUserArgs validates prompt and options', () => {
   assert.match(parseAskUserArgs({ prompt: '', options: [] }).error ?? '', /prompt/)
+  assert.match(
+    parseAskUserArgs({
+      prompt: '选一个',
+      options: Array.from({ length: USER_PROMPT_OPTIONS_MAX + 1 }, (_, i) => ({
+        id: `o${i}`,
+        label: `选项 ${i + 1}`,
+      })),
+    }).error ?? '',
+    /最多|精简/,
+  )
   const parsed = parseAskUserArgs({
     prompt: '你想分析哪类标的？',
     title: '分析范围',


### PR DESCRIPTION
## Summary
- ask_user 选项取消硬上限 5（≥2、软上限 50），选项区纵向滚动
- 多选支持全选/取消全选；确认按钮改为 medium
- schema/playbook 同步并约束勿用 emoji

## Test plan
- [x] `npm run check:ui`
- [x] `node --test tests/agent-ask-user.test.mjs`
- [ ] 应用内：单选/多选、长选项列表滚动、全选后确认


Made with [Cursor](https://cursor.com)