### PR TITLE
fix(experts): 防止快捷提问保存时静默丢失

### DIFF
--- a/client-ui/src/pages/experts/ExpertEditorPage.tsx
+++ b/client-ui/src/pages/experts/ExpertEditorPage.tsx
@@ -274,13 +274,31 @@ function toDraftStarters(prompts: ExpertStarterPrompt[] | undefined): DraftStart
 
 function toPayloadStarters(drafts: DraftStarter[]): ExpertStarterPrompt[] {
   return drafts
-    .map((d, index) => ({
-      id: d.key || `sp-${index + 1}`,
-      title: '',
-      content: d.content.trim(),
-    }))
+    .map((d, index) => {
+      const content = d.content.trim()
+      return {
+        id: d.key || `sp-${index + 1}`,
+        title: content,
+        content,
+      }
+    })
     .filter(p => p.content.length > 0)
     .slice(0, MAX_STARTERS)
+}
+
+/** 保存前以 DOM 为准同步 content，避免 IME 组字中 state 未跟上导致静默丢弃。 */
+function syncStartersFromDom(drafts: DraftStarter[]): DraftStarter[] {
+  const escape = typeof CSS !== 'undefined' && typeof CSS.escape === 'function'
+    ? CSS.escape
+    : (raw: string) => raw.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+  return drafts.map(row => {
+    const root = document.querySelector(`[data-starter-key="${escape(row.key)}"]`)
+    const el = root?.querySelector('input')
+    if (el instanceof HTMLInputElement) {
+      return { ...row, content: el.value }
+    }
+    return row
+  })
 }
 
 function serializeStarters(drafts: DraftStarter[]): string {
@@ -429,12 +447,20 @@ export default function ExpertEditorPage({
   const handleSave = async () => {
     setLoading(true)
     setError('')
+    const syncedStarters = syncStartersFromDom(starters)
+    setStarters(syncedStarters)
+    const starterPrompts = toPayloadStarters(syncedStarters)
+    if (syncedStarters.length > 0 && starterPrompts.length === 0) {
+      setError('请填写提问内容，或删除空白提问')
+      setLoading(false)
+      return
+    }
     const payload = {
       title: title.trim(),
       summary: summary.trim(),
       persona: persona.trim(),
       tags: parseTags(tagsText),
-      starterPrompts: toPayloadStarters(starters),
+      starterPrompts,
     }
     try {
       const result = isEdit && editingId

--- a/tests/expert-starter-prompts.test.mjs
+++ b/tests/expert-starter-prompts.test.mjs
@@ -1,8 +1,11 @@
 /**
- * Expert starterPrompts — normalize + parseExpertDefinition
+ * Expert starterPrompts — normalize + parseExpertDefinition + LocalExpertsRepository 往返
  */
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { normalizeExpertStarterPrompts, MAX_EXPERT_STARTER_PROMPTS } from '../packages/shared/dist/expert.js'
 import { parseExpertDefinition } from '../packages/agent/dist/experts/static-http-provider.js'
 
@@ -82,4 +85,85 @@ test('parseExpertDefinition skips bad starter items without failing whole expert
   assert.ok(parsed)
   assert.equal(parsed.starterPrompts?.length, 1)
   assert.equal(parsed.starterPrompts[0].content, 'ok')
+})
+
+// --- LocalExpertsRepository 往返（临时 OPPTRIX_DATA_DIR）---
+
+const expertsTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-experts-sp-'))
+
+async function withExpertsRepo(fn) {
+  const prevDir = process.env.OPPTRIX_DATA_DIR
+  process.env.OPPTRIX_DATA_DIR = expertsTmpRoot
+  const { UserDataStore, LocalExpertsRepository } = await import('../packages/user-store/dist/index.js')
+  try {
+    try {
+      UserDataStore.getInstance().close()
+    } catch { /* 尚无实例 */ }
+    const store = UserDataStore.getInstance()
+    const repo = new LocalExpertsRepository(store)
+    return await fn(repo)
+  } finally {
+    try {
+      UserDataStore.getInstance().close()
+    } catch { /* ignore */ }
+    if (prevDir === undefined) delete process.env.OPPTRIX_DATA_DIR
+    else process.env.OPPTRIX_DATA_DIR = prevDir
+  }
+}
+
+test.after(() => {
+  fs.rmSync(expertsTmpRoot, { recursive: true, force: true })
+})
+
+test('LocalExpertsRepository create+get keeps starterPrompts when title empty and content set', async () => {
+  await withExpertsRepo(repo => {
+    const created = repo.create(
+      {
+        title: '快捷提问落库专家',
+        summary: '验证 title 空、content 非空仍写入',
+        tags: ['测试'],
+        starterPrompts: [
+          { id: 'sp-1', title: '', content: '帮我梳理这只股票的估值与风险' },
+        ],
+      },
+      '你是一位测试专家。',
+    )
+    assert.ok(created.id)
+    const got = repo.get(created.id)
+    assert.ok(got)
+    assert.ok(got.starterPrompts)
+    assert.ok(got.starterPrompts.length >= 1)
+    assert.equal(got.starterPrompts[0].content, '帮我梳理这只股票的估值与风险')
+    assert.ok(got.starterPrompts[0].title.length > 0)
+  })
+})
+
+test('LocalExpertsRepository save updates starterPrompts roundtrip', async () => {
+  await withExpertsRepo(repo => {
+    const created = repo.create(
+      {
+        title: '更新提问专家',
+        summary: '验证 save 往返',
+        starterPrompts: [
+          { id: 'sp-a', title: '旧提问', content: '旧提问内容' },
+        ],
+      },
+      '你是一位测试专家。',
+    )
+    const saved = repo.save(created.id, {
+      starterPrompts: [
+        { id: 'sp-b', title: '', content: '更新后的快捷提问正文' },
+        { id: 'sp-c', title: '第二条', content: '另一条提问' },
+      ],
+    })
+    assert.equal(saved.starterPrompts?.length, 2)
+    assert.equal(saved.starterPrompts[0].content, '更新后的快捷提问正文')
+    assert.ok(saved.starterPrompts[0].title.length > 0)
+
+    const got = repo.get(created.id)
+    assert.ok(got?.starterPrompts)
+    assert.equal(got.starterPrompts.length, 2)
+    assert.equal(got.starterPrompts[0].content, '更新后的快捷提问正文')
+    assert.equal(got.starterPrompts[1].content, '另一条提问')
+  })
 })


### PR DESCRIPTION
## Summary
- 专家编辑页保存前从输入框同步快捷提问内容，避免输入法/受控状态不同步导致静默丢弃
- 有空白提问行时提示用户，不再当作保存成功
- 补充 LocalExpertsRepository 往返测试

## Test plan
- [ ] 编辑自建专家，添加快捷提问后保存，重新进入编辑页仍可见
- [ ] 添加空白提问行后点保存，出现提示且不离开页面
- [ ] `npm run check:ui` / `node --test tests/expert-starter-prompts.test.mjs`


Made with [Cursor](https://cursor.com)