### PR TITLE
fix: ask_user 确认模式、RSS 文案、阅读器链接与 titlebar 锚定

### DIFF
--- a/client-ui/src/chat/ChatSessionTitleTools.tsx
+++ b/client-ui/src/chat/ChatSessionTitleTools.tsx
@@ -146,11 +146,16 @@ export default function ChatSessionTitleTools({
     if (!menuOpen || !anchor || !primary) return
 
     const rect = anchor.getBoundingClientRect()
+    const chevron = anchor.querySelector('.opptrix-session-title-btn__chevron')
+    const caretRect = chevron instanceof HTMLElement
+      ? chevron.getBoundingClientRect()
+      : rect
     const panelWidth = MENU_WIDTH
     const panelHeight = primary.offsetHeight
     const gap = 6
 
-    let left = rect.left
+    // 相对右侧 chevron 右对齐，标题长短变化时菜单仍贴下拉符号
+    let left = caretRect.right - panelWidth
     left = clamp(left, VIEWPORT_PAD, window.innerWidth - panelWidth - VIEWPORT_PAD)
 
     let top = rect.bottom + gap

--- a/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
+++ b/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
@@ -20,6 +20,10 @@ export default function ComposerAgentUserPromptPanel({
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [secretValue, setSecretValue] = useState('')
   const isSecret = prompt.kind === 'secret'
+  const isConfirm = !isSecret && prompt.options.length === 0
+  const allowCustom = prompt.allow_custom ?? (isConfirm ? false : true)
+  const rejectLabel = prompt.reject_label?.trim() || '拒绝'
+  const confirmLabel = prompt.confirm_label?.trim() || '确认'
   const allSelected = prompt.options.length > 0
     && selectedIds.length === prompt.options.length
 
@@ -177,6 +181,7 @@ export default function ComposerAgentUserPromptPanel({
     <div
       className={mergeClasses(
         'opptrix-composer-user-prompt-panel',
+        isConfirm && 'opptrix-composer-user-prompt-panel--confirm',
         OPPTRIX_GLASS_PANEL_CLASS,
       )}
       role="region"
@@ -189,7 +194,7 @@ export default function ComposerAgentUserPromptPanel({
         <p className="opptrix-composer-user-prompt-panel__prompt">{prompt.prompt}</p>
       </div>
 
-      {prompt.allowMultiple ? (
+      {!isConfirm && prompt.allowMultiple ? (
         <div className="opptrix-composer-user-prompt-panel__toolbar">
           <OpptrixButton
             variant="ghost"
@@ -202,45 +207,72 @@ export default function ComposerAgentUserPromptPanel({
         </div>
       ) : null}
 
-      <div className="opptrix-composer-user-prompt-panel__options opptrix-scroll">
-        {prompt.options.map(opt => (
-          <button
-            key={opt.id}
-            type="button"
-            className={mergeClasses(
-              'opptrix-composer-user-prompt-panel__option',
-              'opptrix-focusable',
-              prompt.allowMultiple && selectedIds.includes(opt.id)
-                && 'opptrix-composer-user-prompt-panel__option--selected',
-            )}
+      {!isConfirm ? (
+        <div className="opptrix-composer-user-prompt-panel__options opptrix-scroll">
+          {prompt.options.map(opt => (
+            <button
+              key={opt.id}
+              type="button"
+              className={mergeClasses(
+                'opptrix-composer-user-prompt-panel__option',
+                'opptrix-focusable',
+                prompt.allowMultiple && selectedIds.includes(opt.id)
+                  && 'opptrix-composer-user-prompt-panel__option--selected',
+              )}
+              disabled={submitting}
+              onClick={() => {
+                if (prompt.allowMultiple) {
+                  toggleMulti(opt.id)
+                  return
+                }
+                submitOption(opt.id, opt.label)
+              }}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {allowCustom ? (
+        <div className="opptrix-composer-user-prompt-panel__custom">
+          <OpptrixInput
+            className="opptrix-composer-user-prompt-panel__custom-input"
+            value={customText}
             disabled={submitting}
-            onClick={() => {
-              if (prompt.allowMultiple) {
-                toggleMulti(opt.id)
-                return
-              }
-              submitOption(opt.id, opt.label)
-            }}
+            placeholder="其他，输入后按 Enter 提交"
+            onChange={(_e, data) => setCustomText(data.value)}
+            onKeyDown={handleCustomKeyDown}
+            aria-label="自行输入答案"
+          />
+          <span className="opptrix-composer-user-prompt-panel__custom-hint">Enter</span>
+        </div>
+      ) : null}
+
+      {isConfirm ? (
+        <div className="opptrix-composer-user-prompt-panel__actions">
+          <OpptrixButton
+            className="opptrix-composer-user-prompt-panel__action-btn"
+            variant="secondary"
+            size="medium"
+            disabled={submitting}
+            onClick={() => submitOption('reject', rejectLabel)}
           >
-            {opt.label}
-          </button>
-        ))}
-      </div>
+            {rejectLabel}
+          </OpptrixButton>
+          <OpptrixButton
+            className="opptrix-composer-user-prompt-panel__action-btn"
+            variant="primary"
+            size="medium"
+            disabled={submitting}
+            onClick={() => submitOption('confirm', confirmLabel)}
+          >
+            {confirmLabel}
+          </OpptrixButton>
+        </div>
+      ) : null}
 
-      <div className="opptrix-composer-user-prompt-panel__custom">
-        <OpptrixInput
-          className="opptrix-composer-user-prompt-panel__custom-input"
-          value={customText}
-          disabled={submitting}
-          placeholder="其他，输入后按 Enter 提交"
-          onChange={(_e, data) => setCustomText(data.value)}
-          onKeyDown={handleCustomKeyDown}
-          aria-label="自行输入答案"
-        />
-        <span className="opptrix-composer-user-prompt-panel__custom-hint">Enter</span>
-      </div>
-
-      {prompt.allowMultiple && (
+      {!isConfirm && prompt.allowMultiple && (
         <div className="opptrix-composer-user-prompt-panel__confirm">
           <OpptrixButton
             variant="primary"

--- a/client-ui/src/pages/news/NewsArticleDetail.tsx
+++ b/client-ui/src/pages/news/NewsArticleDetail.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react'
 import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { ChatRegular, ImageRegular, TranslateRegular } from '@fluentui/react-icons'
 import type { FeedArticle } from '../../types/schemas'
-import { openExternalUrl } from '../../platform/openUrl'
+import { isHttpUrl, openExternalUrl } from '../../platform/openUrl'
 import { isElectron } from '../../platform/detect'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
 import { ghostInteractive } from '../../theme/mixins'
@@ -318,19 +318,25 @@ export default function NewsArticleDetail({ article, onDiscussArticle }: Props) 
           <Text className={s.meta}>{article.source_title}</Text>
           <span className={s.metaSep} aria-hidden>·</span>
           <Text className={s.meta}>{formatRelativeTime(article.pub_date)}</Text>
-          {article.link && (
-            <>
-              <span className={s.metaSep} aria-hidden>·</span>
-              <a
-                className={s.metaLink}
-                href={article.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={event => openExternalUrl(article.link, event)}
-              >
-                查看原文
-              </a>
-            </>
+          <span className={s.metaSep} aria-hidden>·</span>
+          {isHttpUrl(article.link) ? (
+            <a
+              className={s.metaLink}
+              href={article.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={event => openExternalUrl(article.link, event)}
+            >
+              查看原文
+            </a>
+          ) : (
+            <span
+              className={mergeClasses(s.metaLink, s.metaActionDisabled)}
+              aria-disabled="true"
+              title="暂无可用原文链接"
+            >
+              查看原文
+            </span>
           )}
           {isElectron() && translation.available && (
             <>

--- a/client-ui/src/platform/openUrl.ts
+++ b/client-ui/src/platform/openUrl.ts
@@ -1,6 +1,7 @@
 import { isElectron } from './detect'
 
-function isHttpUrl(url: string): boolean {
+/** True when the string is an absolute http(s) URL. */
+export function isHttpUrl(url: string): boolean {
   return /^https?:\/\//i.test(url.trim())
 }
 

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -6,11 +6,15 @@ export interface ChatUserPromptPayload {
   id: string
   title?: string
   prompt: string
+  /** 空数组 = confirm 模式（底部拒绝/确认） */
   options: Array<{ id: string; label: string }>
   allowMultiple?: boolean
   kind?: 'choice' | 'secret'
   name?: string
   inject_hosts?: string[]
+  reject_label?: string
+  confirm_label?: string
+  allow_custom?: boolean
 }
 
 export interface UserPromptAnswerPayload {

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -165,7 +165,7 @@ Opptrix/
   - **市场（`market` pack）**：`get_market_dynamics`（全景）；`get_macro_series`（中国/国外/行业/油价宏观序列，可翻页）；专项 `get_dragon_tiger` / `get_limit_updown` / `get_market_sentiment`；同花顺独有 `get_cn_market_special`；`get_trade_calendar` / `get_market_session`；`get_instrument_money_flow`
   - **资讯与订阅（`news` pack）**：
     - **只读浏览**：`get_news_center_status` → `list_news_groups` / `list_news_sources` → `list_news_articles` → `get_news_article`；标的公告 `get_instrument_notices` → `get_notice_content`
-    - **RSSHub 路由目录（内置 curated schema v3，三级漏斗）**：`list_rsshub_categories` → `list_rsshub_domains` → `get_rsshub_domain_routes`（返回路由+频道**拉平**后的可订阅叶子，`ask_user(allow_multiple=true)` 直接多选；禁止再先选路由再选频道；叶子过多用 `q` 缩小）→ 拼短名单基址 + `add_news_source`；`search_rsshub_routes` 仅用户已点名媒体时捷径；不依赖 GitHub docs / 全量 radar
+    - **RSS 路由目录（内置 curated schema v3，三级漏斗）**：`list_rsshub_categories` → `list_rsshub_domains` → `get_rsshub_domain_routes`（返回路由+频道**拉平**后的可订阅叶子，`ask_user(allow_multiple=true)` 直接多选；禁止再先选路由再选频道；叶子过多用 `q` 缩小）→ 拼短名单基址 + `add_news_source`；`search_rsshub_routes` 仅用户已点名媒体时捷径；不依赖 GitHub docs / 全量 radar
     - **订阅 CRUD**：`validate_news_source`（添加前探测，不写入）→ `add_news_source`（`url` 必填，可选 `title`/`group_id`）；`create_news_group` / `update_news_group` / `move_news_source` 可直接执行
     - **确认纪律（与 MCP 安装同类）**：`delete_news_source`、`import_news_sources`、`delete_news_group` **须先 `ask_user`，再以相同参数 + `confirmed=true` 重试**；未 confirmed 只返回摘要、不落库。删订阅不可恢复；删分组仅把组内订阅改为未分组，不删订阅本身。导入入参：`schema_version=1` + `subscriptions`，或仅 `subscriptions` 数组（已存在 url 跳过）
     - Hub feature 映射：`news_center_status` / `news_groups_list` / `news_sources_list` / `news_articles_list` / `news_article_detail` / `news_source_add|delete|validate` / `news_sources_import` / `news_group_create|update|delete` / `news_source_move_group`（见 [API.md](./API.md) Hub Features）
@@ -279,7 +279,7 @@ Opptrix/
   - **触发**：每轮 `llm.chat` 前检查；上游 `context_length_exceeded` 等 → 强制 aggressive compact 后**重试 1 次**；`setSessionModel` 换模型后按新窗再检查。
   - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。`done` 可含 `turn_usage`（本轮 LLM 累计用量，含 tool 循环与 structured 压缩）与 `context_usage`（Composer 已用/窗长估算）。测试：`tests/session-context-compact.test.mjs`、`tests/chat-token-usage.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
-- **`ask_user`**：Agent 需用户确认分析方向/范围时调用；SSE 推送 `user_prompt` 事件，客户端在输入框上方展示选择题（预置选项 2–50 个、末项可自由输入；多选支持全选；prompt/label 勿用 emoji），用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
+- **`ask_user`**：Agent 需用户确认分析方向/范围/授权时调用；SSE 推送 `user_prompt` 事件。**确认模式**：省略 `options`（或 `[]`）→ 底部「拒绝/确认」（可用 `reject_label`/`confirm_label` 定制；回传 id 固定 `reject`/`confirm`）；**选择题**：预置选项 2–50 个。`allow_custom` 控制自行输入（确认默认关、选择题默认开）。多选支持全选；prompt/label 勿用 emoji。用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
 - **行业分析**：`industry_mining` / `industry_mermaid`（属 `industry` pack，需播种或 activate）→ 代表公司用 `search_instruments` + `get_instrument_*`
 - **市场宏观**：`get_market_regime` / `get_market_dynamics` / `get_trend_brief` 等属 `market` pack
 - **跨市场搜索**：唯一入口 `search_instruments`（`core` pack，始终可用；`markets` 可过滤 CN/US/HK/CRYPTO）

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -74,11 +74,15 @@ export interface ChatUserPromptPayload {
   id: string
   title?: string
   prompt: string
+  /** 空数组 = confirm 模式（底部拒绝/确认） */
   options: Array<{ id: string; label: string }>
   allowMultiple?: boolean
   kind?: 'choice' | 'secret'
   name?: string
   inject_hosts?: string[]
+  reject_label?: string
+  confirm_label?: string
+  allow_custom?: boolean
 }
 
 export type ChatProgressEvent =
@@ -178,6 +182,10 @@ const TOOL_LABELS: Record<string, string> = {
   delete_news_group: '删除资讯分组',
   move_news_source: '移动资讯订阅',
   validate_news_source: '验证资讯订阅地址',
+  list_rsshub_categories: '浏览 RSS 分类',
+  list_rsshub_domains: '浏览 RSS 网站',
+  search_rsshub_routes: '搜索可订阅 RSS',
+  get_rsshub_domain_routes: '列出网站 RSS 订阅项',
   get_notice_content: '读取公告正文',
   list_tool_packs: '列出可用工具包',
   activate_tool_pack: '激活工具包',
@@ -311,7 +319,8 @@ function truncateLabel(text: string, max = 40): string {
 }
 
 function humanizeToolName(name: string): string {
-  const readable = name.replace(/_/g, ' ').trim()
+  // 屏蔽内部 rsshub 标识，避免过程条 fallback 暴露实现名
+  const readable = name.replace(/_/g, ' ').replace(/\brsshub\b/gi, 'RSS').trim()
   return truncateLabel(readable, 48)
 }
 
@@ -388,7 +397,8 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
     return `调用扩展能力 · ${humanizeToolName(parsed.toolName)}`
   }
 
-  const base = TOOL_LABELS[tool] ?? humanizeToolName(tool)
+  const baseRaw = TOOL_LABELS[tool] ?? humanizeToolName(tool)
+  const base = baseRaw.replace(/rsshub/gi, 'RSS')
   const ref = stockRef(args, result)
 
   switch (tool) {
@@ -416,6 +426,20 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
     case 'get_instrument_cyq': {
       const iref = instrumentRefFromArgs(args) ?? ref
       return iref ? `${base} · ${iref}` : base
+    }
+    case 'list_rsshub_categories':
+      return base
+    case 'list_rsshub_domains': {
+      const category = typeof args.category === 'string' ? args.category.trim() : ''
+      return category ? `${base} · ${truncateLabel(category, 24)}` : base
+    }
+    case 'search_rsshub_routes': {
+      const q = typeof args.q === 'string' ? args.q.trim() : ''
+      return q ? `${base} · ${truncateLabel(q, 24)}` : base
+    }
+    case 'get_rsshub_domain_routes': {
+      const domain = typeof args.domain === 'string' ? args.domain.trim() : ''
+      return domain ? `${base} · ${truncateLabel(domain, 28)}` : base
     }
     case 'search_instruments': {
       const kw = typeof args.keyword === 'string' ? args.keyword.trim() : ''

--- a/packages/agent/src/mcp/tool-route-plan.ts
+++ b/packages/agent/src/mcp/tool-route-plan.ts
@@ -212,7 +212,7 @@ const INTENT_RULES: IntentRule[] = [
   },
   {
     intent: 'rsshub_catalog',
-    // 高于 news_source_add(90)：问「有哪些 RSSHub / 路由目录」先查内置目录
+    // 高于 news_source_add(90)：问「有哪些 RSS / 路由目录」先查内置目录
     priority: 91,
     patterns: [
       /RSSHub/i,
@@ -229,7 +229,7 @@ const INTENT_RULES: IntentRule[] = [
     ],
     avoidTools: ['list_news_articles', 'browser_navigate', 'get_instrument_snapshot'],
     confidence: 'high',
-    hint: '查 RSSHub 路由 → 三级漏斗 list_rsshub_categories → list_rsshub_domains → get_rsshub_domain_routes（拉平叶子多选）；用户已点名媒体才用 search_rsshub_routes',
+    hint: '查 RSS 路由 → 三级漏斗 list_rsshub_categories → list_rsshub_domains → get_rsshub_domain_routes（拉平叶子多选）；用户已点名媒体才用 search_rsshub_routes',
   },
   {
     intent: 'news_source_add',

--- a/packages/agent/src/rsshub/rsshub-tools.ts
+++ b/packages/agent/src/rsshub/rsshub-tools.ts
@@ -30,7 +30,7 @@ const S = (properties: JsonSchema['properties'], required?: string[]): JsonSchem
   ({ type: 'object', properties, required })
 
 /**
- * RSSHub 内置路由目录工具 — 三级漏斗：分类 → 网站 → 拉平多选订阅项 → 拼基址 + add_news_source。
+ * 内置 RSS 路由目录工具 — 三级漏斗：分类 → 网站 → 拉平多选订阅项 → 拼基址 + add_news_source。
  * 不经 Hub；结果已截断，禁止 dump 全量 schema。
  */
 export function buildRsshubTools(): Omit<RsshubToolDef, 'meta'>[] {
@@ -39,7 +39,7 @@ export function buildRsshubTools(): Omit<RsshubToolDef, 'meta'>[] {
       name: 'list_rsshub_categories',
       category: '资讯中心',
       description:
-        '列出内置 RSSHub 路由分类（财经/股票/政策等）及各分类域名与路由数量；添加订阅三级漏斗第 1 步',
+        '列出内置 RSS 路由分类（财经/股票/政策等）及各分类域名与路由数量；添加订阅三级漏斗第 1 步',
       parameters: S({}),
       handler: async () => listCategories(),
     },

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -446,7 +446,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
   list_rsshub_categories: {
     miningEligible: false,
     usageGuide:
-      '添加 RSSHub 订阅三级漏斗第 1 步：列出内置分类后 ask_user 单选分类（option.id 用分类 id，label 可用 description）；再 list_rsshub_domains。',
+      '添加 RSS 订阅三级漏斗第 1 步：列出内置分类后 ask_user 单选分类（option.id 用分类 id，label 可用 description）；再 list_rsshub_domains。',
     compliance: '只读；无参数；返回分类摘要 + hint，不含全量路由。',
   },
   list_rsshub_domains: {
@@ -502,8 +502,10 @@ export const TOOL_META: Record<string, ToolMeta> = {
   },
   ask_user: {
     miningEligible: false,
-    usageGuide: '分析前需用户确认方向、范围或偏好，且上下文无法推断时调用；会在聊天输入框上方展示选择题，用户点选或自行输入后继续。',
-    compliance: 'prompt 必填、面向投资者且勿用 emoji；options 2–50 项且 id 唯一，label 勿用 emoji；allow_multiple 默认 false；同一轮对话最多 1 次；禁止索要密钥。',
+    usageGuide:
+      '分析前需用户确认方向、范围、授权或偏好且上下文无法推断时调用：省略 options 为拒绝/确认双按钮（可用 reject_label/confirm_label）；有 2–50 选项为选择题。',
+    compliance:
+      'prompt 必填、面向投资者且勿用 emoji；options 可省略/[]（确认模式）或 2–50 项且 id 唯一；confirm 回传 id 固定 reject|confirm；allow_custom 确认默认 false、选择题默认 true；同一轮最多 1 次；禁止索要密钥。',
   },
   list_enabled_providers: {
     hubFeature: 'provider_list',

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -607,16 +607,30 @@ export class ToolRegistry {
       {
         name: 'ask_user',
         category: '交互',
-        description: '向用户发起选择题确认；会在输入框上方展示题目与选项，最后一项可自由输入后回车提交，作答后继续分析',
+        description:
+          '向用户发起确认：省略 options（或空数组）为底部「拒绝/确认」双按钮；提供 2–50 个选项为选择题。可用 reject_label/confirm_label 定制按钮文案；allow_custom 控制是否可自行输入（确认模式默认关，选择题默认开）',
         parameters: S({
           title: { type: 'string', description: '可选面板标题，如「分析范围确认」' },
           prompt: { type: 'string', description: '要向用户提出的具体问题（面向投资者，避免技术术语）' },
           options: {
             type: 'array',
-            description: '至少 2 个、最多 50 个预置选项，每项为 { id, label }；id 为稳定标识，label 为展示文案；prompt 与 label 均勿使用 emoji',
+            description:
+              '可选。省略或 [] → 确认模式（回传 selected_ids 为 reject/confirm）；选择题须 2–50 项 { id, label }；prompt 与 label 均勿使用 emoji',
           },
-          allow_multiple: { type: 'boolean', description: '是否允许多选，默认 false' },
-        }, ['prompt', 'options']),
+          allow_multiple: { type: 'boolean', description: '选择题是否允许多选，默认 false；确认模式忽略' },
+          reject_label: {
+            type: 'string',
+            description: '确认模式拒绝按钮文案，默认「拒绝」；回传 id 固定为 reject（授权场景可用「不允许」）',
+          },
+          confirm_label: {
+            type: 'string',
+            description: '确认模式确认按钮文案，默认「确认」；回传 id 固定为 confirm（授权场景可用「授权使用」）',
+          },
+          allow_custom: {
+            type: 'boolean',
+            description: '是否允许「其它，自行输入」；确认模式默认 false，选择题默认 true',
+          },
+        }, ['prompt']),
         handler: async () => ({ error: 'ask_user 由 Agent 引擎直接处理' }),
       },
     ].map(t => ({ ...t, meta: TOOL_META[t.name] }))

--- a/packages/agent/src/user-prompt.ts
+++ b/packages/agent/src/user-prompt.ts
@@ -18,6 +18,7 @@ export interface UserPromptPayload {
   id: string
   title?: string
   prompt: string
+  /** 选择题预置选项；空数组表示 confirm 模式（底部拒绝/确认） */
   options: UserPromptOption[]
   allowMultiple?: boolean
   /** choice=普通选项；secret=保险箱密码录入 */
@@ -26,6 +27,15 @@ export interface UserPromptPayload {
   name?: string
   /** kind=secret 时建议的 inject_hosts */
   inject_hosts?: string[]
+  /** confirm 模式拒绝按钮文案，默认「拒绝」；回传 id 固定为 reject */
+  reject_label?: string
+  /** confirm 模式确认按钮文案，默认「确认」；回传 id 固定为 confirm */
+  confirm_label?: string
+  /**
+   * 是否显示「其它，自行输入」。
+   * confirm 模式默认 false；有 options 的选择题默认 true。
+   */
+  allow_custom?: boolean
 }
 
 /** 用户作答结果 — 回传给 Agent 工具输出（secret 永不含明文） */
@@ -144,6 +154,21 @@ export function normalizeUserPromptOptions(raw: unknown): UserPromptOption[] | n
   return options
 }
 
+function parseOptionalLabel(raw: unknown, field: string): { label?: string; error?: string } {
+  if (raw == null) return {}
+  const label = String(raw).trim()
+  if (!label) return { error: `${field} 不能为空字符串` }
+  return { label }
+}
+
+function parseAllowCustom(raw: unknown, defaultValue: boolean): boolean {
+  if (raw == null) return defaultValue
+  if (typeof raw === 'boolean') return raw
+  if (raw === 'true' || raw === 1 || raw === '1') return true
+  if (raw === 'false' || raw === 0 || raw === '0') return false
+  return Boolean(raw)
+}
+
 export function parseAskUserArgs(args: Record<string, unknown>): {
   payload?: Omit<UserPromptPayload, 'id'>
   error?: string
@@ -151,24 +176,48 @@ export function parseAskUserArgs(args: Record<string, unknown>): {
   const prompt = String(args.prompt ?? args.question ?? '').trim()
   if (!prompt) return { error: 'prompt 不能为空' }
 
+  const titleRaw = args.title
+  const title = titleRaw == null ? undefined : String(titleRaw).trim() || undefined
+
   const rawOptions = args.options
+  const omitOrEmpty = rawOptions == null
+    || (Array.isArray(rawOptions) && rawOptions.length === 0)
+
+  // confirm 模式：省略 options 或传空数组
+  if (omitOrEmpty) {
+    const rejectParsed = parseOptionalLabel(args.reject_label ?? args.rejectLabel, 'reject_label')
+    if (rejectParsed.error) return { error: rejectParsed.error }
+    const confirmParsed = parseOptionalLabel(args.confirm_label ?? args.confirmLabel, 'confirm_label')
+    if (confirmParsed.error) return { error: confirmParsed.error }
+
+    return {
+      payload: {
+        kind: 'choice',
+        prompt,
+        title,
+        options: [],
+        allowMultiple: false,
+        reject_label: rejectParsed.label,
+        confirm_label: confirmParsed.label,
+        allow_custom: parseAllowCustom(args.allow_custom ?? args.allowCustom, false),
+      },
+    }
+  }
+
   if (!Array.isArray(rawOptions)) {
-    return { error: `options 须为 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个对象数组，每项含 id 与 label` }
+    return { error: `options 须为数组：省略/空数组为确认模式，或 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个选项对象` }
   }
   if (rawOptions.length > USER_PROMPT_OPTIONS_MAX) {
     return { error: `选项过多（最多 ${USER_PROMPT_OPTIONS_MAX} 个），请精简后再试` }
   }
   if (rawOptions.length < USER_PROMPT_OPTIONS_MIN) {
-    return { error: `请至少提供 ${USER_PROMPT_OPTIONS_MIN} 个选项` }
+    return { error: `选择题请提供至少 ${USER_PROMPT_OPTIONS_MIN} 个选项，或省略 options 使用确认模式` }
   }
 
   const options = normalizeUserPromptOptions(rawOptions)
   if (!options) {
     return { error: `options 须为 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个对象数组，每项含唯一 id 与非空 label` }
   }
-
-  const titleRaw = args.title
-  const title = titleRaw == null ? undefined : String(titleRaw).trim() || undefined
 
   return {
     payload: {
@@ -177,6 +226,7 @@ export function parseAskUserArgs(args: Record<string, unknown>): {
       title,
       options,
       allowMultiple: Boolean(args.allow_multiple ?? args.allowMultiple),
+      allow_custom: parseAllowCustom(args.allow_custom ?? args.allowCustom, true),
     },
   }
 }

--- a/packages/news-feed/src/parser.ts
+++ b/packages/news-feed/src/parser.ts
@@ -23,6 +23,15 @@ export function articleId(subscriptionId: string, guid: string): string {
   return createHash('sha256').update(`${subscriptionId}:${guid}`).digest('hex').slice(0, 24)
 }
 
+/** Prefer http(s) article links; never treat non-URL guid as link. */
+function resolveArticleLink(link: string, guid: string): string {
+  const candidate = link.trim()
+  if (/^https?:\/\//i.test(candidate)) return candidate
+  const guidCandidate = guid.trim()
+  if (/^https?:\/\//i.test(guidCandidate)) return guidCandidate
+  return ''
+}
+
 function pickContent(item: Record<string, unknown>): { summary?: string; content_html?: string } {
   const encoded = item.contentEncoded as string | undefined
   const content = item.content as string | undefined
@@ -68,7 +77,7 @@ export async function parseFeedXml(
       subscription_id: subscription.id,
       guid: guid || undefined,
       title,
-      link: link || guid,
+      link: resolveArticleLink(link, guid),
       pub_date: parsePubDate(item),
       summary,
       content_html,

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -125,7 +125,7 @@ export function buildNewsRetrievalPlaybook(): string {
     '6) 效率：同一任务 list_news_groups / list_news_sources 各最多 1 次；避免对所有分组逐一遍历',
     '7) A 股个股公告/新闻也可参考 get_instrument_snapshot 内嵌新闻字段（若有），与 RSS 互补而非重复堆砌',
     '【资讯订阅管理 — 写路径与确认纪律】',
-    '8) 添加 RSSHub 订阅 — 三级漏斗（内置目录优先；勿拉 GitHub docs / 全量 radar）：',
+    '8) 添加 RSS 订阅 — 三级漏斗（内置目录优先；勿拉 GitHub docs / 全量 radar）：',
     '   ① 选分类：list_rsshub_categories → ask_user（单选；option.id 用分类 id，label 可用 description）',
     '   ② 选网站：用选中项的 category id 调 list_rsshub_domains({category})（若只有中文分类名也可直接传，工具可解析）→ ask_user（单选网站；单分类域名一般 ≤15，应尽量全量展示，勿只给 3–6 候选）',
     '   ③ 拉平多选：get_rsshub_domain_routes → 返回已展开的可订阅叶子（路由+频道已拉平，如「电报 · 看盘」）；ask_user(allow_multiple=true) 直接勾选；禁止再让用户先选路由再选频道',
@@ -215,10 +215,11 @@ export function buildUserInteractionPlaybook(): string {
   return [
     '【用户确认 — ask_user 内置交互工具】',
     '- 当分析方向、标的范围、时间窗口、偏好（短线/中线、是否含资讯等）存在多种合理路径且无法从上下文推断时，调用 ask_user 而非在正文里罗列选项让用户打字回复',
-    '- 参数：prompt 写一句面向投资者的问题；options 提供至少 2 个、最多 50 个互斥或常见选项（id 英文/数字，label 中文简短）；allow_multiple 仅在「可多选」时设为 true',
-    '- prompt 与 options.label 均不要使用 emoji（界面更清晰、便于朗读与无障碍）',
-    '- 界面会在输入框上方展示题目；最后一项为「自行输入」，用户可直接打字后按 Enter 提交',
-    '- 收到返回的 selected_labels / custom_text 后再继续拉数与分析；同一轮对话最多调用 1 次 ask_user',
+    '- 确认模式：省略 options（或传 []）→ 底部「拒绝/确认」双按钮；回传 selected_ids 固定为 reject / confirm；可用 reject_label / confirm_label 定制文案（如「不允许」「授权使用」）',
+    '- 选择题：options 提供 2–50 个互斥或常见选项（id 英文/数字，label 中文简短）；allow_multiple 仅在「可多选」时设为 true',
+    '- allow_custom：是否允许自行输入；确认模式默认 false，选择题默认 true；可显式覆盖',
+    '- prompt 与 options.label / 按钮文案均不要使用 emoji（界面更清晰、便于朗读与无障碍）',
+    '- 收到返回的 selected_ids / selected_labels / custom_text 后再继续拉数与分析；同一轮对话最多调用 1 次 ask_user',
     '- 禁止用于索要密码等敏感信息（须用 request_secret 写入保险箱）；禁止在已有明确用户指令时重复确认',
   ].join('\n')
 }

--- a/tests/agent-ask-user.test.mjs
+++ b/tests/agent-ask-user.test.mjs
@@ -67,6 +67,55 @@ test('parseAskUserArgs validates prompt and options', () => {
   assert.equal(parsed.error, undefined)
   assert.equal(parsed.payload?.title, '分析范围')
   assert.equal(parsed.payload?.options.length, 2)
+  assert.equal(parsed.payload?.allow_custom, true)
+})
+
+test('parseAskUserArgs confirm mode when options omitted or empty', () => {
+  const omitted = parseAskUserArgs({ prompt: '是否授权使用本对话局域网？' })
+  assert.equal(omitted.error, undefined)
+  assert.deepEqual(omitted.payload?.options, [])
+  assert.equal(omitted.payload?.allow_custom, false)
+  assert.equal(omitted.payload?.reject_label, undefined)
+  assert.equal(omitted.payload?.confirm_label, undefined)
+
+  const empty = parseAskUserArgs({ prompt: '继续？', options: [] })
+  assert.equal(empty.error, undefined)
+  assert.deepEqual(empty.payload?.options, [])
+  assert.equal(empty.payload?.allow_custom, false)
+
+  const customLabels = parseAskUserArgs({
+    prompt: '是否授权？',
+    reject_label: '不允许',
+    confirm_label: '授权使用',
+    allow_custom: true,
+  })
+  assert.equal(customLabels.error, undefined)
+  assert.equal(customLabels.payload?.reject_label, '不允许')
+  assert.equal(customLabels.payload?.confirm_label, '授权使用')
+  assert.equal(customLabels.payload?.allow_custom, true)
+})
+
+test('parseAskUserArgs allow_custom false hides custom for choice mode', () => {
+  const parsed = parseAskUserArgs({
+    prompt: '选一个',
+    options: [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ],
+    allow_custom: false,
+  })
+  assert.equal(parsed.error, undefined)
+  assert.equal(parsed.payload?.allow_custom, false)
+})
+
+test('parseAskUserArgs rejects single option array', () => {
+  assert.match(
+    parseAskUserArgs({
+      prompt: '选一个',
+      options: [{ id: 'a', label: '仅一项' }],
+    }).error ?? '',
+    /至少|确认模式/,
+  )
 })
 
 test('UserPromptBridge resolves submitted answers', async () => {

--- a/tests/chat-progress.test.mjs
+++ b/tests/chat-progress.test.mjs
@@ -109,3 +109,24 @@ test('formatToolLabel covers workspace, fetch, mcp, and namespaced tools', () =>
   assert.match(packLabel, /激活工具包/)
   assert.match(packLabel, /news, etf, workspace/)
 })
+
+test('formatToolLabel RSS tools use RSS wording without rsshub', () => {
+  const cats = formatToolLabel('list_rsshub_categories', {})
+  assert.match(cats, /RSS/)
+  assert.doesNotMatch(cats, /rsshub/i)
+
+  const domains = formatToolLabel('list_rsshub_domains', { category: 'finance' })
+  assert.match(domains, /RSS/)
+  assert.match(domains, /finance/)
+  assert.doesNotMatch(domains, /rsshub/i)
+
+  const search = formatToolLabel('search_rsshub_routes', { q: '财联社' })
+  assert.match(search, /RSS/)
+  assert.match(search, /财联社/)
+  assert.doesNotMatch(search, /rsshub/i)
+
+  const routes = formatToolLabel('get_rsshub_domain_routes', { domain: 'cls.cn' })
+  assert.match(routes, /RSS/)
+  assert.match(routes, /cls\.cn/)
+  assert.doesNotMatch(routes, /rsshub/i)
+})

--- a/tests/news-feed.test.mjs
+++ b/tests/news-feed.test.mjs
@@ -162,3 +162,27 @@ test('parseFeedXml normalizes Twitter items and stores guid', async () => {
     items[1].id,
   )
 })
+
+test('parseFeedXml keeps only http(s) links; non-URL guid is not used as link', async () => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>No link feed</title>
+    <item>
+      <title>仅 guid</title>
+      <guid isPermaLink="false">urn:uuid:abc-123</guid>
+      <description>摘要</description>
+    </item>
+    <item>
+      <title>有链接</title>
+      <link>https://example.com/ok</link>
+      <guid isPermaLink="false">local-id-1</guid>
+    </item>
+  </channel>
+</rss>`
+  const { items } = await parseFeedXml(xml, stubSub)
+  assert.equal(items.length, 2)
+  assert.equal(items[0].link, '')
+  assert.equal(items[0].guid, 'urn:uuid:abc-123')
+  assert.equal(items[1].link, 'https://example.com/ok')
+})


### PR DESCRIPTION
## Summary
- 增强 `ask_user`：可无选项作为确认/授权（底部拒绝/确认，文案可定制，id 固定 `reject`/`confirm`，`allow_custom` 控制自定义输入）
- RSS 相关工具过程文案与元数据统一展示为「RSS」，不再暴露 RSSHub
- 阅读器无有效原文链接时「查看原文」灰色不可点；会话 titlebar 下拉菜单锚定右侧 chevron

## Test plan
- [ ] Agent 调用 ask_user 不传 options → 底部双按钮，点拒绝/确认后继续对话
- [ ] 传 `reject_label`/`confirm_label`/`allow_custom` 验证定制与自定义输入
- [ ] 聊天过程条查看 RSS 四工具标签，无 rsshub 字样
- [ ] 资讯阅读器：无 http(s) 原文时「查看原文」灰不可点；有链接可打开
- [ ] 长短标题下打开会话工具菜单，面板贴右侧下拉符号
- [ ] `npm run build:packages && npm run check:ui`；相关测试通过


Made with [Cursor](https://cursor.com)