### PR TITLE
fix(ui): 选区提问发送钮强制正圆

### DIFF
--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -735,7 +735,7 @@ export default function ChatComposer({
                 />
               )}
               <OpptrixButton
-                className={s.sendBtn}
+                className={mergeClasses(s.sendBtn, 'opptrix-round-icon-btn')}
                 variant="primary"
                 icon={loading ? <PauseFilled fontSize={14} /> : <ArrowUpRegular fontSize={14} />}
                 disabled={loading ? !onStop : !canSend}

--- a/client-ui/src/chat/MessageSelectionToolbar.tsx
+++ b/client-ui/src/chat/MessageSelectionToolbar.tsx
@@ -13,7 +13,7 @@ import OpptrixButton from '../components/opptrix/OpptrixButton'
 import MarkdownMessage from './MarkdownMessage'
 import type { EphemeralAskTurn, MessageSelection } from '../types/chat'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
-import { glassDropdown, motion } from '../theme/mixins'
+import { glassDropdown, motion, primaryInteractive } from '../theme/mixins'
 import { useRotatingPhrase } from '../hooks/useRotatingPhrase'
 import { listRowKey } from '../utils/listRowKey'
 
@@ -135,12 +135,17 @@ const useStyles = makeStyles({
       color: opptrixCssVars.textTertiary,
     },
   },
+  /* 与 ChatComposer 发送钮一致；勿用 size="small"（会触发 .opptrix-btn-sm 的 22px 高 !important） */
   sendBtn: {
+    ...primaryInteractive,
+    borderRadius: opptrixTokens.radiusFull,
     minWidth: '28px',
+    maxWidth: '28px',
     width: '28px',
+    minHeight: '28px',
+    maxHeight: '28px',
     height: '28px',
     padding: 0,
-    borderRadius: opptrixTokens.radiusFull,
     flexShrink: 0,
   },
   thread: {
@@ -444,7 +449,7 @@ export default function MessageSelectionToolbar({
             disabled={loading}
           />
           <OpptrixButton
-            className={s.sendBtn}
+            className={mergeClasses(s.sendBtn, 'opptrix-round-icon-btn')}
             variant="primary"
             icon={<ArrowUpRegular fontSize={14} />}
             disabled={loading || !customInput.trim()}
@@ -504,7 +509,7 @@ export default function MessageSelectionToolbar({
                   disabled={loading}
                 />
                 <OpptrixButton
-                  className={s.sendBtn}
+                  className={mergeClasses(s.sendBtn, 'opptrix-round-icon-btn')}
                   variant="primary"
                   icon={<ArrowUpRegular fontSize={14} />}
                   disabled={loading || !followUpInput.trim()}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -907,6 +907,19 @@ select:focus-visible {
   line-height: 1.2 !important;
 }
 
+/* Circular icon-only send — beat Fluent size padding */
+.opptrix-round-icon-btn.fui-Button {
+  box-sizing: border-box !important;
+  min-width: 28px !important;
+  max-width: 28px !important;
+  width: 28px !important;
+  min-height: 28px !important;
+  max-height: 28px !important;
+  height: 28px !important;
+  padding: 0 !important;
+  border-radius: 9999px !important;
+}
+
 /* ── Dialog (Codex modal) ── */
 .opptrix-dialog-surface.fui-DialogSurface {
   background: var(--opptrix-canvas) !important;


### PR DESCRIPTION
## Summary
- 选区提问面板发送钮改为 28×28 正圆，并用 `.opptrix-round-icon-btn` 压过 Fluent 默认内边距
- 去掉会触发 `.opptrix-btn-sm`（22px 高）的 `size="small"`，避免矮椭圆
- 主输入框发送钮同步加上同一圆形约束类

## Test plan
- [ ] 选中聊天文字 → 提问 → 自定义：右侧发送钮为正圆
- [ ] 临时追问输入行发送钮为正圆
- [ ] 主输入框发送钮仍为正圆


Made with [Cursor](https://cursor.com)