### PR TITLE
fix(ui): 标题栏行内重命名自适应，专家快捷提问常驻

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -972,14 +972,7 @@ app.get<{ Params: { id: string } }>('/api/sessions/:id', async (req, reply) => {
   // 仅读缓存；miss 不阻塞（UI 再异步拉 /context-usage）
   const contextUsage = agent.getCachedSessionContextUsage(req.params.id)
   return {
-    session: {
-      id: session.id,
-      title: session.title,
-      model: session.model,
-      createdAt: session.createdAt,
-      updatedAt: session.updatedAt,
-      usageTotals: session.usageTotals ?? null,
-    },
+    session: agent.sessionMeta(session),
     messages: agent.getDisplayMessages(req.params.id),
     contextRef: session.contextRef ?? null,
     contextUsage,
@@ -1030,25 +1023,13 @@ app.patch<{ Params: { id: string }; Body: { title?: string; model?: string | nul
     if (title !== undefined) {
       const updated = agent.renameSession(req.params.id, title)
       if (!updated) return reply.code(404).send({ error: 'session not found' })
-      return {
-        session: {
-          id: updated.id,
-          title: updated.title,
-          model: updated.model,
-          updatedAt: updated.updatedAt,
-        },
-      }
+      return { session: agent.sessionMeta(updated) }
     }
     if (model !== undefined) {
       const updated = await agent.setSessionModel(req.params.id, model)
       if (!updated) return reply.code(404).send({ error: 'session not found' })
       return {
-        session: {
-          id: updated.session.id,
-          title: updated.session.title,
-          model: updated.session.model,
-          updatedAt: updated.session.updatedAt,
-        },
+        session: agent.sessionMeta(updated.session),
         contextHint: updated.contextHint,
       }
     }
@@ -1112,13 +1093,7 @@ app.post<{ Params: { id: string }; Body: { message_index: number } }>(
     const forked = agent.forkSession(req.params.id, messageIndex)
     if (!forked) return reply.code(404).send({ error: 'session or message not found' })
     return {
-      session: {
-        id: forked.id,
-        title: forked.title,
-        model: forked.model,
-        createdAt: forked.createdAt,
-        updatedAt: forked.updatedAt,
-      },
+      session: agent.sessionMeta(forked),
       messages: agent.getDisplayMessages(forked.id),
       contextRef: forked.contextRef ?? null,
     }
@@ -1134,13 +1109,7 @@ app.patch<{ Params: { id: string }; Body: { contextRef: SessionContextRef | null
     const updated = agent.setSessionContextRef(req.params.id, req.body?.contextRef ?? null)
     if (!updated) return reply.code(404).send({ error: 'session not found' })
     return {
-      session: {
-        id: updated.id,
-        title: updated.title,
-        model: updated.model,
-        createdAt: updated.createdAt,
-        updatedAt: updated.updatedAt,
-      },
+      session: agent.sessionMeta(updated),
       contextRef: updated.contextRef ?? null,
     }
   },
@@ -1150,13 +1119,7 @@ app.delete<{ Params: { id: string } }>('/api/sessions/:id/context', async (req, 
   const updated = agent.clearSessionContextRef(req.params.id)
   if (!updated) return reply.code(404).send({ error: 'session not found' })
   return {
-    session: {
-      id: updated.id,
-      title: updated.title,
-      model: updated.model,
-      createdAt: updated.createdAt,
-      updatedAt: updated.updatedAt,
-    },
+    session: agent.sessionMeta(updated),
     contextRef: null,
   }
 })

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -62,10 +62,12 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     gap: '8px',
     paddingLeft: opptrixTokens.chatComposerPadding,
+  },
+  /** 空态入场；勿写死 opacity:0，否则常驻态关掉动画后会一直隐形 */
+  startersSectionEnter: {
     ...fadeInUp,
     animationDuration: '480ms',
     animationDelay: '0.95s',
-    opacity: 0,
   },
   startersLabel: {
     fontSize: 'var(--opptrix-font-md)',
@@ -274,6 +276,11 @@ interface ChatComposerProps {
   loading: boolean
   error: string
   isEmpty: boolean
+  /**
+   * 为 true 时即使会话非空也展示 starters（专家对话快捷提问常驻）。
+   * 普通对话仍仅在空态展示。
+   */
+  alwaysShowStarters?: boolean
   isMobile?: boolean
   contextRef?: SessionContextRef | null
   starters: Array<{ label: string; text: string }>
@@ -297,6 +304,7 @@ export default function ChatComposer({
   loading,
   error,
   isEmpty,
+  alwaysShowStarters = false,
   isMobile = false,
   contextRef = null,
   starters,
@@ -464,6 +472,7 @@ export default function ChatComposer({
 
   const canSend = (hasContent || attachmentIds.length > 0) && !loading && !userPrompt && !uploading
   const composerLocked = loading || Boolean(userPrompt)
+  const showStarters = starters.length > 0 && (isEmpty || alwaysShowStarters)
 
   const handleSpeechTranscript = useCallback((text: string) => {
     const root = editorRef.current
@@ -593,8 +602,14 @@ export default function ChatComposer({
 
   return (
     <div className={s.wrap}>
-      {isEmpty && starters.length > 0 && (
-        <div key={welcomeKey} className={s.startersSection}>
+      {showStarters && (
+        <div
+          key={isEmpty ? welcomeKey : 'persistent-starters'}
+          className={mergeClasses(
+            s.startersSection,
+            isEmpty && s.startersSectionEnter,
+          )}
+        >
           <Text className={s.startersLabel}>你可以这样问</Text>
           <div className={mergeClasses(s.starters, isMobile && `${s.startersMobile} opptrix-scroll-x`)}>
             {starters.map((st, index) => (
@@ -603,6 +618,7 @@ export default function ChatComposer({
                 className={s.starterChip}
                 variant="pill"
                 size="small"
+                disabled={composerLocked}
                 onClick={() => onSubmit(st.text)}
               >
                 {st.label}

--- a/client-ui/src/chat/ChatSessionTitleTools.tsx
+++ b/client-ui/src/chat/ChatSessionTitleTools.tsx
@@ -11,6 +11,7 @@ import {
 import { createPortal } from 'react-dom'
 import { Input, mergeClasses } from '@fluentui/react-components'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
+import OpptrixInlineEdit from '../components/opptrix/OpptrixInlineEdit'
 import {
   AddRegular,
   ArchiveRegular,
@@ -81,7 +82,7 @@ export default function ChatSessionTitleTools({
   sessionUsageTotal,
 }: ChatSessionTitleToolsProps) {
   const anchorRef = useRef<HTMLButtonElement>(null)
-  const renameInputRef = useRef<HTMLInputElement>(null)
+  const chevronRef = useRef<HTMLSpanElement>(null)
   const primaryPanelRef = useRef<HTMLDivElement>(null)
   const archivePanelRef = useRef<HTMLDivElement>(null)
 
@@ -104,12 +105,6 @@ export default function ChatSessionTitleTools({
   useEffect(() => {
     if (!renaming) setRenameDraft(title)
   }, [title, renaming])
-
-  useEffect(() => {
-    if (!renaming) return
-    renameInputRef.current?.focus()
-    renameInputRef.current?.select()
-  }, [renaming])
 
   useEffect(() => {
     if (!creatingFolder) return
@@ -146,17 +141,17 @@ export default function ChatSessionTitleTools({
     if (!menuOpen || !anchor || !primary) return
 
     const rect = anchor.getBoundingClientRect()
-    const chevron = anchor.querySelector('.opptrix-session-title-btn__chevron')
-    const caretRect = chevron instanceof HTMLElement
-      ? chevron.getBoundingClientRect()
-      : rect
+    // Fluent 图标是 SVG，不能用 HTMLElement 判断；用 chevron 包裹 span 的几何
+    const caretRect = (chevronRef.current ?? anchor).getBoundingClientRect()
     const panelWidth = MENU_WIDTH
     const panelHeight = primary.offsetHeight
     const gap = 6
 
-    // 相对右侧 chevron 右对齐，标题长短变化时菜单仍贴下拉符号
-    let left = caretRect.right - panelWidth
-    left = clamp(left, VIEWPORT_PAD, window.innerWidth - panelWidth - VIEWPORT_PAD)
+    // 面板左侧对齐下拉符号，向右展开；仅在超出视口右侧时左移夹紧
+    let left = caretRect.left
+    const maxLeft = window.innerWidth - panelWidth - VIEWPORT_PAD
+    if (left > maxLeft) left = Math.max(VIEWPORT_PAD, maxLeft)
+    if (left < VIEWPORT_PAD) left = VIEWPORT_PAD
 
     let top = rect.bottom + gap
     if (top + panelHeight > window.innerHeight - VIEWPORT_PAD) {
@@ -242,16 +237,6 @@ export default function ChatSessionTitleTools({
     setRenameDraft(title)
   }, [title])
 
-  const handleRenameKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault()
-      void commitRename()
-    } else if (e.key === 'Escape') {
-      e.preventDefault()
-      cancelRename()
-    }
-  }
-
   const handleTitleClick = () => {
     if (disabled || renaming) return
     if (!canUseTools) return
@@ -329,40 +314,25 @@ export default function ChatSessionTitleTools({
     : style
 
   const titleButton = renaming ? (
-    <div
+    <OpptrixInlineEdit
       className={mergeClasses(
         'opptrix-session-title-inline-edit',
         variant === 'chrome' && 'opptrix-session-title-inline-edit--chrome',
         className,
       )}
       style={titleStyle}
-      onMouseDown={handleTitleMouseDown}
-    >
-      <Input
-        ref={renameInputRef}
-        className="opptrix-session-title-inline-input opptrix-archive-inline-input"
-        value={renameDraft}
-        onChange={(_, data) => setRenameDraft(data.value)}
-        onKeyDown={handleRenameKeyDown}
-        aria-label="重命名对话"
-      />
-      <OpptrixButton
-        variant="icon"
-        className="opptrix-session-title-inline-btn"
-        aria-label="确认重命名"
-        onClick={() => { void commitRename() }}
-      >
-        <CheckmarkRegular fontSize={14} />
-      </OpptrixButton>
-      <OpptrixButton
-        variant="icon"
-        className="opptrix-session-title-inline-btn"
-        aria-label="取消重命名"
-        onClick={cancelRename}
-      >
-        <DismissRegular fontSize={14} />
-      </OpptrixButton>
-    </div>
+      value={renameDraft}
+      onChange={setRenameDraft}
+      onConfirm={() => { void commitRename() }}
+      onCancel={cancelRename}
+      label="重命名对话"
+      sizeMode="auto"
+      minWidth={80}
+      maxWidth={typeof maxWidth === 'number' ? Math.max(120, maxWidth - 8) : 360}
+      confirmLabel="确认重命名"
+      cancelLabel="取消重命名"
+      onMouseDown={e => e.stopPropagation()}
+    />
   ) : (
     <button
       ref={anchorRef}
@@ -386,13 +356,16 @@ export default function ChatSessionTitleTools({
         {title || '新对话'}
       </span>
       {canUseTools && (
-        <ChevronDownRegular
+        <span
+          ref={chevronRef}
           className={mergeClasses(
             'opptrix-session-title-btn__chevron',
             menuOpen && 'opptrix-session-title-btn__chevron--open',
           )}
-          fontSize={14}
-        />
+          aria-hidden
+        >
+          <ChevronDownRegular fontSize={14} />
+        </span>
       )}
     </button>
   )

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -258,9 +258,9 @@ interface ChatViewProps {
   /** 上下文整理轻提示 */
   contextHint?: string
   sessionId?: string | null
-  /** 绑定专家时切换空会话欢迎与快捷提问 */
+  /** 绑定专家时切换欢迎文案，并常驻展示快捷提问 */
   expertId?: string | null
-  /** 编辑专家保存后递增，驱动空态重新拉取定义 */
+  /** 编辑专家保存后递增，驱动重新拉取定义 */
   expertRefreshKey?: number
   welcomeEpoch?: number
   chatScrollEpoch?: number
@@ -327,6 +327,10 @@ function ChatView({
   const [userPromptSubmitting, setUserPromptSubmitting] = useState(false)
   const [expertSummary, setExpertSummary] = useState<string | null>(null)
   const [expertStarters, setExpertStarters] = useState<ExpertStarterPrompt[] | null>(null)
+  const expertStartersCacheRef = useRef(new Map<string, {
+    summary: string
+    starters: ExpertStarterPrompt[]
+  }>())
   const pendingUserPromptRef = useRef(pendingUserPrompt)
   const userPromptSubmittingRef = useRef(userPromptSubmitting)
   pendingUserPromptRef.current = pendingUserPrompt
@@ -477,25 +481,39 @@ function ChatView({
   const isExpertSession = Boolean(expertId)
 
   useEffect(() => {
-    if (!expertId || !isEmpty) {
+    if (!expertId) {
       setExpertSummary(null)
       setExpertStarters(null)
       return
+    }
+    const cached = expertStartersCacheRef.current.get(expertId)
+    if (cached) {
+      setExpertSummary(cached.summary)
+      setExpertStarters(cached.starters)
+    } else {
+      setExpertStarters(null)
     }
     let cancelled = false
     void getExpert(expertId)
       .then(({ expert }) => {
         if (cancelled) return
+        const starters = expert.starterPrompts?.length ? expert.starterPrompts : []
+        expertStartersCacheRef.current.set(expertId, {
+          summary: expert.summary,
+          starters,
+        })
         setExpertSummary(expert.summary)
-        setExpertStarters(expert.starterPrompts?.length ? expert.starterPrompts : [])
+        setExpertStarters(starters)
       })
       .catch(() => {
         if (cancelled) return
-        setExpertSummary(null)
-        setExpertStarters([])
+        if (!cached) {
+          setExpertSummary(null)
+          setExpertStarters([])
+        }
       })
     return () => { cancelled = true }
-  }, [expertId, isEmpty, expertRefreshKey])
+  }, [expertId, expertRefreshKey])
 
   const globalStarters: ComposerStarterChip[] = welcome.starters.map(text => ({ label: text, text }))
   const expertChipStarters: ComposerStarterChip[] = (expertStarters ?? []).map(p => ({
@@ -793,6 +811,7 @@ function ChatView({
               loading={loading}
               error={error}
               isEmpty={isEmpty}
+              alwaysShowStarters={isExpertSession}
               isMobile={isMobile}
               contextRef={contextRef}
               starters={starters}

--- a/client-ui/src/components/opptrix/OpptrixInlineEdit.tsx
+++ b/client-ui/src/components/opptrix/OpptrixInlineEdit.tsx
@@ -1,0 +1,244 @@
+import {
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type MutableRefObject,
+  type ReactNode,
+} from 'react'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import { CheckmarkRegular, DismissRegular } from '@fluentui/react-icons'
+import { opptrixCssVars, opptrixTokens } from '../../theme/tokens'
+import { focusVisibleRing, motion } from '../../theme/mixins'
+import OpptrixButton from './OpptrixButton'
+
+const useStyles = makeStyles({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '4px',
+    minHeight: '28px',
+    maxWidth: '100%',
+    minWidth: 0,
+    padding: '2px 4px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.surfaceHover,
+    boxSizing: 'border-box',
+  },
+  rootFill: {
+    display: 'flex',
+    width: '100%',
+  },
+  field: {
+    position: 'relative',
+    display: 'inline-grid',
+    alignItems: 'center',
+    maxWidth: '100%',
+    minWidth: 0,
+  },
+  fieldFill: {
+    flex: 1,
+    display: 'block',
+    width: '100%',
+  },
+  /** 隐形镜像：与输入同字体，撑开 auto 宽度 */
+  sizer: {
+    gridArea: '1 / 1',
+    visibility: 'hidden',
+    whiteSpace: 'pre',
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 500,
+    fontFamily: 'inherit',
+    lineHeight: '26px',
+    padding: '0 8px',
+    boxSizing: 'border-box',
+    pointerEvents: 'none',
+  },
+  input: {
+    gridArea: '1 / 1',
+    width: '100%',
+    minWidth: 0,
+    height: '26px',
+    margin: 0,
+    padding: '0 8px',
+    border: 'none',
+    outline: 'none',
+    borderRadius: opptrixTokens.radiusSm,
+    backgroundColor: opptrixCssVars.surfaceMuted,
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 500,
+    fontFamily: 'inherit',
+    lineHeight: '26px',
+    boxSizing: 'border-box',
+    transitionProperty: 'background-color',
+    transitionDuration: motion.fast,
+    ...focusVisibleRing,
+  },
+  inputFill: {
+    display: 'block',
+    width: '100%',
+  },
+  action: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '26px',
+    height: '26px',
+    minWidth: '26px',
+    padding: 0,
+    flexShrink: 0,
+    borderRadius: opptrixTokens.radiusMd,
+    color: opptrixCssVars.textSecondary,
+  },
+})
+
+export type OpptrixInlineEditSizeMode = 'auto' | 'fill'
+
+export type OpptrixInlineEditProps = {
+  value: string
+  onChange: (value: string) => void
+  onConfirm: () => void
+  onCancel: () => void
+  /** 输入框无障碍标签 */
+  label: string
+  placeholder?: string
+  className?: string
+  style?: CSSProperties
+  /**
+   * `auto`：宽度随文案伸缩（titlebar 重命名）
+   * `fill`：占满父级剩余宽度（侧栏/归档行内）
+   */
+  sizeMode?: OpptrixInlineEditSizeMode
+  /** auto 模式下的最小内容宽（px） */
+  minWidth?: number
+  /** 整体/输入最大宽（px）；未设则受父级 maxWidth 约束 */
+  maxWidth?: number
+  autoFocus?: boolean
+  selectOnFocus?: boolean
+  confirmLabel?: string
+  cancelLabel?: string
+  confirmIcon?: ReactNode
+  cancelIcon?: ReactNode
+  inputRef?: MutableRefObject<HTMLInputElement | null> | ((instance: HTMLInputElement | null) => void)
+  onMouseDown?: (e: ReactMouseEvent<HTMLDivElement>) => void
+}
+
+/**
+ * 行内编辑：输入 + 确认/取消。
+ * titlebar 会话重命名用 `sizeMode="auto"`，宽度随标题伸缩。
+ */
+export default function OpptrixInlineEdit({
+  value,
+  onChange,
+  onConfirm,
+  onCancel,
+  label,
+  placeholder,
+  className,
+  style,
+  sizeMode = 'auto',
+  minWidth = 72,
+  maxWidth,
+  autoFocus = true,
+  selectOnFocus = true,
+  confirmLabel = '确认',
+  cancelLabel = '取消',
+  confirmIcon,
+  cancelIcon,
+  inputRef,
+  onMouseDown,
+}: OpptrixInlineEditProps) {
+  const s = useStyles()
+  const localRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (!autoFocus) return
+    const el = localRef.current
+    if (!el) return
+    el.focus()
+    if (selectOnFocus) el.select()
+  }, [autoFocus, selectOnFocus])
+
+  const setRefs = (node: HTMLInputElement | null) => {
+    localRef.current = node
+    if (!inputRef) return
+    if (typeof inputRef === 'function') inputRef(node)
+    else inputRef.current = node
+  }
+
+  const handleKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      onConfirm()
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onCancel()
+    }
+  }
+
+  const fill = sizeMode === 'fill'
+  const sizerText = value.length > 0 ? value : (placeholder || ' ')
+  const fieldStyle: CSSProperties | undefined = fill
+    ? undefined
+    : {
+        minWidth: `${minWidth}px`,
+        ...(maxWidth != null ? { maxWidth: `${maxWidth}px` } : null),
+      }
+
+  return (
+    <div
+      className={mergeClasses(
+        'opptrix-inline-edit',
+        s.root,
+        fill && s.rootFill,
+        className,
+      )}
+      style={style}
+      onMouseDown={onMouseDown}
+    >
+      <div
+        className={mergeClasses(s.field, fill && s.fieldFill)}
+        style={fieldStyle}
+      >
+        {!fill && (
+          <span className={s.sizer} aria-hidden>
+            {sizerText}
+          </span>
+        )}
+        <input
+          ref={setRefs}
+          type="text"
+          className={mergeClasses(
+            'opptrix-inline-edit__input',
+            'opptrix-focusable',
+            s.input,
+            fill && s.inputFill,
+          )}
+          value={value}
+          placeholder={placeholder}
+          aria-label={label}
+          onChange={e => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      <OpptrixButton
+        variant="icon"
+        className={mergeClasses('opptrix-inline-edit__action', s.action)}
+        aria-label={confirmLabel}
+        onClick={onConfirm}
+      >
+        {confirmIcon ?? <CheckmarkRegular fontSize={14} />}
+      </OpptrixButton>
+      <OpptrixButton
+        variant="icon"
+        className={mergeClasses('opptrix-inline-edit__action', s.action)}
+        aria-label={cancelLabel}
+        onClick={onCancel}
+      >
+        {cancelIcon ?? <DismissRegular fontSize={14} />}
+      </OpptrixButton>
+    </div>
+  )
+}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -1685,7 +1685,9 @@ select:focus-visible {
 html.opptrix-electron .opptrix-session-title-btn,
 html.opptrix-electron .opptrix-session-title-btn--clickable,
 html.opptrix-electron .opptrix-session-title-inline-edit,
-html.opptrix-electron .opptrix-session-title-inline-input {
+html.opptrix-electron .opptrix-inline-edit,
+html.opptrix-electron .opptrix-inline-edit__input,
+html.opptrix-electron .opptrix-inline-edit__action {
   -webkit-app-region: no-drag !important;
   pointer-events: auto !important;
 }
@@ -1750,7 +1752,10 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
 }
 
 .opptrix-session-title-btn__chevron {
+  display: inline-flex;
+  align-items: center;
   flex-shrink: 0;
+  line-height: 0;
   color: var(--opptrix-text-tertiary, #9A9A9A);
   transition: transform 160ms ease;
 }
@@ -1759,70 +1764,13 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
   transform: rotate(180deg);
 }
 
+/* titlebar 会话重命名：宿主类名挂在 OpptrixInlineEdit 上，样式由组件承担 */
 .opptrix-session-title-inline-edit {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  min-height: 28px;
-  max-width: 100%;
-  min-width: 0;
-  padding: 2px 4px;
-  border-radius: var(--opptrix-radius-md, 8px);
-  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.04));
-  box-sizing: border-box;
   -webkit-app-region: no-drag;
 }
 
 .opptrix-session-title-inline-edit--chrome {
   min-height: 28px;
-}
-
-.opptrix-session-title-inline-input {
-  flex: 1;
-  min-width: 72px;
-  height: 26px;
-  min-height: 26px;
-  font-size: 13px;
-  font-weight: 500;
-}
-
-.opptrix-session-title-inline-input.fui-Input,
-.opptrix-session-title-inline-input.fui-Input:hover,
-.opptrix-session-title-inline-input.fui-Input:focus-within {
-  background-color: var(--opptrix-surface-muted) !important;
-  border: none !important;
-  box-shadow: none !important;
-}
-
-.opptrix-session-title-inline-input.fui-Input::after {
-  display: none !important;
-}
-
-.opptrix-session-title-inline-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  padding: 0;
-  border: none;
-  border-radius: var(--opptrix-radius-md, 8px);
-  background: transparent;
-  color: var(--opptrix-text-secondary, #6B6B6B);
-  cursor: pointer;
-  flex-shrink: 0;
-  line-height: 0;
-}
-
-.opptrix-session-title-inline-btn:hover {
-  background-color: var(--opptrix-surface-hover, rgba(0, 0, 0, 0.06));
-  color: var(--opptrix-text-primary, #1D1D1F);
-}
-
-html.opptrix-electron .opptrix-session-title-inline-edit,
-html.opptrix-electron .opptrix-session-title-inline-btn {
-  -webkit-app-region: no-drag !important;
-  pointer-events: auto !important;
 }
 
 /* Session title tools menus */

--- a/docs/UI-DESIGN-SYSTEM.md
+++ b/docs/UI-DESIGN-SYSTEM.md
@@ -216,6 +216,17 @@ Electron **固定左侧栏**：macOS / Windows 走窗口原生毛玻璃（侧栏
 
 尺寸：`small`（左右 `8px`）/ `medium` / `large`。所有变体共享 hover、active（含轻微缩放）与 focus-visible。
 
+### 7.7.2 OpptrixInlineEdit
+
+行内编辑（`components/opptrix/OpptrixInlineEdit.tsx`）：输入 + 确认/取消，供 titlebar 会话重命名等场景复用。
+
+| `sizeMode` | 行为 | 适用 |
+|------------|------|------|
+| `auto`（默认） | 隐形 sizer 随文案撑宽，`minWidth` / `maxWidth` 可约束 | 标题栏重命名 |
+| `fill` | 输入占满父级剩余宽度 | 侧栏/归档行内 |
+
+Enter 确认、Esc 取消；Electron 宿主需挂 `-webkit-app-region: no-drag`（类名 `.opptrix-inline-edit`）。
+
 ### 7.8 浮层与反馈（统一组件）
 
 | 场景 | 组件 | 样式类 / Provider |
@@ -223,7 +234,7 @@ Electron **固定左侧栏**：macOS / Windows 走窗口原生毛玻璃（侧栏
 | 二次确认（删除、清空等） | `OpptrixDialogAlert`、`useOpptrixDialogAlert()` | `.opptrix-glass-dialog-surface`；根节点 `OpptrixDialogAlertProvider`（`main.tsx`） |
 | 复杂表单 Dialog | Fluent `Dialog` + `OpptrixField` 等 | `.opptrix-dialog-surface` |
 | 操作结果 Toast | `useSettingsToast()` | `SettingsToastProvider`（设置页等）；mixin `glassPanel` |
-| 侧栏内联确认 | 列表行内 `inlineEditRow` + 按钮 | 与行同高，不用 Dialog |
+| 侧栏内联确认 | `OpptrixInlineEdit`（`sizeMode="fill"`）或列表行内按钮 | 与行同高，不用 Dialog |
 | 分段 Tab（胶囊） | `OpptrixSegmentedControl` | `.opptrix-segmented-control`；侧栏用 `variant="embedded"` |
 
 ### 7.9 设置页组件体系


### PR DESCRIPTION
## Summary
- 抽出可复用 `OpptrixInlineEdit`，titlebar 重命名宽度随标题伸缩
- 下拉面板左缘对齐 chevron（修复 SVG 被误判导致贴左）
- 专家对话快捷提问常驻；会话 API 统一 `sessionMeta`，避免切换后丢失 `expertId`

## Test plan
- [ ] titlebar 点重命名：输入框宽度随标题变化，确认/取消正常
- [ ] 打开标题下拉：面板左缘贴着下拉符号，不贴聊天区最左
- [ ] 专家会话：有消息后仍显示「你可以这样问」；切换会话再回来仍保留
- [ ] 普通空会话快捷提问入场动画仍正常


Made with [Cursor](https://cursor.com)