### PR TITLE
fix(agent): seed 离线日K包 + 专家指标快捷流程

### DIFF
--- a/docs/EXPERT-GUIDE.md
+++ b/docs/EXPERT-GUIDE.md
@@ -75,7 +75,7 @@
 | `equity-analysis` | 个股分析助手 | `fundamentals`, `instrument_analytics` | 单票基本面与趋势（L3） |
 | `news-interpreter` | 资讯解读官 | `news` | 新闻要点与影响路径 |
 | `news-subscription-steward` | 新闻订阅管家 | `news` | RSSHub 三级漏斗找可达节点并添加/整理订阅；禁 GitHub 主路径、禁开场全量扫服 |
-| `offline-data-steward` | 离线数据专家 | `workspace` | 十年日 K 部署到公共区 + `cn-offline-daily-k` 查询挖掘；**禁止**写主库 / market sync；`prepare_fuyao_dump` 成功自动写 `shared/data/cache/offline-k-meta.json`（>10 日未成功更新则全量） |
+| `offline-data-steward` | 离线数据专家 | `workspace` | 十年日 K 部署到公共区 + `cn-offline-daily-k` 查询挖掘；**禁止**写主库 / market sync；`prepare_fuyao_dump` 成功自动写 `shared/data/cache/offline-k-meta.json`（>10 日未成功更新则全量）；部署/增量后须落盘本地指标到 `shared/data/cache/indicators/` |
 
 静态目录与校验：仓库根 `experts/catalog.json` + `experts/{id}.json`；`node scripts/validate-experts.mjs`。离线包模板：`packages/agent-workspace/templates/cn-offline-daily-k/`。
 

--- a/experts/catalog.json
+++ b/experts/catalog.json
@@ -44,7 +44,7 @@
     {
       "id": "offline-data-steward",
       "title": "离线数据专家",
-      "summary": "把十年日 K 部署到公共区，并用公共包做筛选与板块挖掘",
+      "summary": "部署十年日 K 与本地指标到公共区，并用公共包做筛选与板块挖掘",
       "icon": { "kind": "icon", "value": "expert" },
       "tags": ["离线", "日K", "公共包"],
       "official": true,

--- a/experts/offline-data-steward.json
+++ b/experts/offline-data-steward.json
@@ -1,13 +1,13 @@
 {
   "id": "offline-data-steward",
   "title": "离线数据专家",
-  "summary": "把十年日 K 部署到公共区，并用公共包做筛选与板块挖掘",
+  "summary": "部署十年日 K 与本地指标到公共区，并用公共包做筛选与板块挖掘",
   "icon": { "kind": "icon", "value": "expert" },
   "tags": ["离线", "日K", "公共包"],
   "official": true,
   "version": "1.0.0",
   "source": "builtin",
-  "persona": "你是 Opptrix 离线数据专家：负责把 A 股十年日 K 部署/更新到公共复用区，并用公共包做查询与挖掘。默认 activate_tool_pack([\"workspace\"])。\n\n数据路径只走 prepare_fuyao_dump（full≈十年；incremental≈近 10 日）+ workspace_* / shell_run，读写 root_id=shared。包模板在仓库 templates/cn-offline-daily-k，可复制到 shared/packages/cn-offline-daily-k/。上次成功更新元数据只写 shared/data/cache/offline-k-meta.json；prepare_fuyao_dump 在 full|incremental + local_path 成功后会自动写入该文件（返回 meta_written），一般无需再手动 markUpdateSuccess（仅作补写保留）。若距上次成功更新超过 10 日（或无元数据），必须走 full，不得只做增量。\n\n严格禁止：引导 market sync / dailyDump / importDailyKDump；向 App 主行情库写入；把 API Key / Token 写入沙盒、工作区文件或 README；虚构未加载工具。密钥需求经保险箱（request_secret / secret_refs），扶摇鉴权仅由 prepare_fuyao_dump 在服务端完成。\n\n工作流：① list_local_data_apis / get_local_data_catalog 了解 fuyao.dump 与 shared.packages.cn-offline-daily-k；② 读 offline-k-meta 与 dumps 状态，决定 full 或 incremental；③ prepare_fuyao_dump 落盘 shared/data/dumps（成功即自动写 meta）；④ 用公共包 query/screen 做个股筛选与板块相对强弱/宽度/涨幅龙头。回复说明覆盖范围与数据时效，区分事实与推断。",
+  "persona": "你是 Opptrix 离线数据专家：负责把 A 股十年日 K 部署/更新到公共复用区，并用公共包做查询与挖掘；full/incremental 成功后必须补充计算并保存本地技术指标。默认 activate_tool_pack([\"workspace\"])。\n\n数据路径只走 prepare_fuyao_dump（full≈十年；incremental≈近 10 日）+ workspace_* / shell_run，读写 root_id=shared。包模板在仓库 templates/cn-offline-daily-k，可复制到 shared/packages/cn-offline-daily-k/。上次成功更新元数据只写 shared/data/cache/offline-k-meta.json；prepare_fuyao_dump 在 full|incremental + local_path 成功后会自动写入该文件（返回 meta_written），一般无需再手动 markUpdateSuccess（仅作补写保留）。若距上次成功更新超过 10 日（或无元数据），必须走 full，不得只做增量。\n\n本地指标缓存约定：落盘 shared/data/cache/indicators/（按标的或指标族存 Parquet/JSON，文件组织自定但须可检索）；覆盖范围=全市场全部标的。用 workspace/shell 基于已落盘日 K 自行计算并保存（勿期待包内完整指标引擎）。指标类别须齐全：趋势 SMA(5/10/20/60/120/250)、EMA(12/26/50/200)、MACD、ADX、均线多空、Price vs MA(20/60/200)；动量 RSI(6/14/28)、Stochastic、CCI、W%R、ROC、MFI；波动 BB(20,2)、ATR(14)、HV(20/60)、振幅；量能 OBV、VWAP、量比、换手、CMF(20)；形态/统计 日收益、CumReturn(5/20/60)、MaxDD(60/250)、Sharpe(250)、Skew/Kurt、Beta/Alpha(250 vs 沪深300)；价位 距 N 日高低、52 周高低位置、Percentile(250)。缺辅助数据（流通股本、沪深300 等）时：先 list_local_data_apis / get_local_data_catalog / 标准工具 / prepare 相关 dump 设法获取；仍缺则明确标注缺口，禁止编造。\n\n严格禁止：引导 market sync / dailyDump / importDailyKDump；向 App 主行情库写入；把 API Key / Token 写入沙盒、工作区文件或 README；虚构未加载工具。密钥需求经保险箱（request_secret / secret_refs），扶摇鉴权仅由 prepare_fuyao_dump 在服务端完成。\n\n工作流：① list_local_data_apis / get_local_data_catalog 了解 fuyao.dump 与 shared.packages.cn-offline-daily-k；② 读 offline-k-meta 与 dumps/indicators 状态，决定 full 或 incremental；③ prepare_fuyao_dump 落盘 shared/data/dumps（成功即自动写 meta）；④ 用公共包 query/screen 做个股筛选与板块相对强弱/宽度/涨幅龙头（优先读已落盘指标）；⑤ full/incremental 成功后必须计算全市场指标并写入 shared/data/cache/indicators/，回报覆盖与缺口。回复说明覆盖范围与数据时效，区分事实与推断。",
   "defaultPacks": ["workspace"],
   "defaultResearchTier": "L2",
   "defaultSessionTitle": "离线日K",
@@ -16,27 +16,32 @@
     {
       "id": "offline-deploy-full",
       "title": "部署全量日K",
-      "content": "请把约十年的 A 股日 K 部署到公共区（走数据包准备，不写主库），并告诉我覆盖范围。"
+      "content": "请把约十年的 A 股日 K 部署到公共区（不写主库），部署成功后继续计算全市场本地指标并写入 shared/data/cache/indicators/，回报覆盖范围与缺口。"
     },
     {
       "id": "offline-update-incr",
       "title": "增量更新",
-      "content": "请按元数据判断：若超过 10 天未成功更新则全量，否则增量更新公共区日 K，并回报状态。"
+      "content": "请按元数据判断：若超过 10 天未成功更新则全量，否则增量更新公共区日 K；更新成功后刷新全市场本地指标，并回报状态与缺口。"
     },
     {
       "id": "offline-status",
       "title": "查看状态",
-      "content": "查看公共区离线日 K 的覆盖范围、上次成功更新时间与建议的下一步。"
+      "content": "查看公共区离线日 K 与本地指标目录的覆盖范围、上次成功更新/指标时效，并给出建议的下一步。"
     },
     {
       "id": "offline-screen",
       "title": "个股筛选",
-      "content": "用公共区离线日 K，按均线/分位/波动/放量/回撤帮我筛一批标的，并说明条件与时效。"
+      "content": "优先读取已落盘的本地指标，按均线/分位/波动/放量/回撤帮我筛一批标的，并说明条件与时效；缺指标时再基于日 K 补算。"
     },
     {
       "id": "offline-sector",
       "title": "板块挖掘",
-      "content": "用公共区离线日 K 做板块相对强弱、上涨宽度与涨幅龙头挖掘，给出结构化结论。"
+      "content": "优先读取已落盘的本地指标，做板块相对强弱、上涨宽度与涨幅龙头挖掘，给出结构化结论与时效。"
+    },
+    {
+      "id": "offline-indicators-only",
+      "title": "仅补算指标",
+      "content": "日 K dump 已就绪时，请仅补算全市场本地指标并写入 shared/data/cache/indicators/，回报覆盖与缺口；缺辅助数据请先查接口，勿编造。"
     }
   ]
 }

--- a/packages/agent-workspace/package.json
+++ b/packages/agent-workspace/package.json
@@ -11,8 +11,12 @@
       "import": "./dist/index.js"
     }
   },
+  "files": [
+    "dist",
+    "templates"
+  ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json && node -e \"import('node:fs').then(({cpSync})=>cpSync('templates','dist/templates',{recursive:true}))\""
   },
   "dependencies": {
     "@anthropic-ai/sandbox-runtime": "^0.0.67",

--- a/packages/agent-workspace/src/index.ts
+++ b/packages/agent-workspace/src/index.ts
@@ -14,6 +14,8 @@ export {
 } from './paths.js'
 export {
   ensureSharedWorkspaceLayout,
+  seedBuiltinSharedPackages,
+  resolveBuiltinSharedPackageTemplateDir,
   sharedDumpsDir,
   resetSharedWorkspaceLayoutCacheForTests,
 } from './shared-workspace.js'

--- a/packages/agent-workspace/src/service.ts
+++ b/packages/agent-workspace/src/service.ts
@@ -180,10 +180,21 @@ export class WorkspaceService {
   async listDir(sessionId: string, rootId: string, relPath = ''): Promise<{
     entries: Array<{ name: string; type: 'file' | 'directory'; size?: number }>
     path: string
+    /** 目标路径尚不存在（非权限/穿越错误）时为 true，避免把裸 ENOENT 抛给 MCP */
+    missing?: boolean
   }> {
     const { grant, abs } = await this.gatePath(sessionId, rootId, relPath)
     assertReadable(grant)
-    const names = await fs.readdir(abs)
+    let names: string[]
+    try {
+      names = await fs.readdir(abs)
+    } catch (err) {
+      const code = err && typeof err === 'object' && 'code' in err ? String(err.code) : ''
+      if (code === 'ENOENT') {
+        return { entries: [], path: relPath || '.', missing: true }
+      }
+      throw err
+    }
     const entries = await Promise.all(names.map(async name => {
       const full = path.join(abs, name)
       const st = await fs.stat(full)

--- a/packages/agent-workspace/src/shared-workspace.ts
+++ b/packages/agent-workspace/src/shared-workspace.ts
@@ -4,6 +4,7 @@
  */
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { ensureDirectory } from './path-gate.js'
 import { resolveSharedWorkspaceRoot } from './paths.js'
 
@@ -16,6 +17,7 @@ const SHARED_README = `# Opptrix Agent 公共复用区
 | 路径 | 用途 |
 |------|------|
 | \`packages/<name>/\` | 可复用脚本/包（须含 README） |
+| \`packages/cn-offline-daily-k/\` | 内置：A 股离线日 K（初始化 shared 时自动落入） |
 | \`data/dumps/\` | 扶摇 Parquet 等离线大数据（经 prepare_fuyao_dump） |
 | \`data/exports/\` | 导出 CSV/JSON 等结果 |
 | \`data/cache/\` | 可删中间缓存 |
@@ -82,9 +84,92 @@ python -m src.main
 - 勿将 API Key / Token 写入本目录或代码
 `
 
+/** 随包发布的内置 shared 包（源在 templates/<name>/） */
+const BUILTIN_SHARED_PACKAGES = ['cn-offline-daily-k'] as const
+
 let ensuredRoots = new Set<string>()
 
-/** 幂等初始化 shared 目录树与 README */
+/**
+ * 解析内置模板目录。
+ * 编译产物在 dist/：优先包根 `../templates/<name>`；构建会再复制到 `dist/templates/`，
+ * 以便桌面只带 dist 时仍能找到。
+ */
+export async function resolveBuiltinSharedPackageTemplateDir(
+  packageName: string,
+): Promise<string | null> {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const candidates = [
+    path.join(here, '..', 'templates', packageName),
+    path.join(here, 'templates', packageName),
+  ]
+  for (const candidate of candidates) {
+    try {
+      const st = await fs.stat(candidate)
+      if (st.isDirectory()) return candidate
+    } catch {
+      /* try next */
+    }
+  }
+  return null
+}
+
+/**
+ * WHY: 用户可能已改过 shared 下的包文件；只补缺失路径，绝不覆盖已有内容。
+ */
+async function copyTreeFillMissing(srcDir: string, destDir: string): Promise<void> {
+  await ensureDirectory(destDir)
+  const entries = await fs.readdir(srcDir, { withFileTypes: true })
+  for (const ent of entries) {
+    const src = path.join(srcDir, ent.name)
+    const dest = path.join(destDir, ent.name)
+    if (ent.isDirectory()) {
+      await copyTreeFillMissing(src, dest)
+      continue
+    }
+    if (!ent.isFile()) continue
+    try {
+      await fs.access(dest)
+    } catch {
+      await fs.copyFile(src, dest)
+    }
+  }
+}
+
+/**
+ * 幂等 seed：把内置模板落到 shared/packages/<name>/。
+ * - 目标不存在 → 完整 cp
+ * - 已存在 → 仅补齐缺失文件（含缺 package.json / src/index.js 的残缺目录）
+ */
+export async function seedBuiltinSharedPackages(sharedRoot: string): Promise<void> {
+  const packagesRoot = path.join(sharedRoot, 'packages')
+  await ensureDirectory(packagesRoot)
+
+  for (const name of BUILTIN_SHARED_PACKAGES) {
+    const templateDir = await resolveBuiltinSharedPackageTemplateDir(name)
+    if (!templateDir) {
+      console.warn(`[agent-workspace] 内置模板缺失，跳过 seed: ${name}`)
+      continue
+    }
+
+    const dest = path.join(packagesRoot, name)
+    let destExists = false
+    try {
+      await fs.access(dest)
+      destExists = true
+    } catch {
+      /* new */
+    }
+
+    if (!destExists) {
+      await fs.cp(templateDir, dest, { recursive: true })
+      continue
+    }
+
+    await copyTreeFillMissing(templateDir, dest)
+  }
+}
+
+/** 幂等初始化 shared 目录树与 README，并 seed 内置 packages */
 export async function ensureSharedWorkspaceLayout(): Promise<string> {
   const root = resolveSharedWorkspaceRoot()
   if (ensuredRoots.has(root)) return root
@@ -109,6 +194,8 @@ export async function ensureSharedWorkspaceLayout(): Promise<string> {
   } catch {
     await fs.writeFile(templatePath, PACKAGE_README_TEMPLATE, 'utf8')
   }
+
+  await seedBuiltinSharedPackages(root)
 
   ensuredRoots.add(root)
   return root

--- a/packages/agent-workspace/templates/cn-offline-daily-k/README.md
+++ b/packages/agent-workspace/templates/cn-offline-daily-k/README.md
@@ -17,7 +17,8 @@ Agent 侧典型流程：
 
 1. `prepare_fuyao_dump({ dump_kind: "full"|"incremental" })`（服务端持 Key 落盘；**成功会自动写** `data/cache/offline-k-meta.json`）
 2. （可选）本包 `markUpdateSuccess(...)` 仅作手动补写
-3. `shell_run` + 本包 `query` / `screen` 做挖掘
+3. full/incr 成功后补算全市场指标并写入 `data/cache/indicators/`
+4. `shell_run` + 本包 `query` / `screen` 做挖掘（优先读已落盘指标）
 
 ## 入参 / 出参
 
@@ -28,6 +29,7 @@ Agent 侧典型流程：
 | `data/dumps/cn-daily-k-full.parquet` | 全量（≈10y） |
 | `data/dumps/cn-daily-k-incr.parquet` | 增量（≈10d） |
 | `data/cache/offline-k-meta.json` | **唯一**「上次成功更新」元数据 |
+| `data/cache/indicators/` | 本地技术指标缓存（按标的或指标族 Parquet/JSON；full/incr 后由 Agent 补算，非本包内置引擎） |
 
 ### `decideDumpKind(meta, now?)`
 
@@ -86,4 +88,4 @@ const status = await getDeployStatus({
 - **勿存密钥**：禁止 API Key / Token 写入本目录或代码
 - **勿写主库**：禁止引导 sync / `importDailyKDump` / 写入 App SQLite 行情库
 - 元数据只写 `shared/data/cache/offline-k-meta.json`
-- 本目录是 **仓库模板**；运行时请复制到 `shared/packages/cn-offline-daily-k/`
+- 本目录是 **仓库内置模板**；初始化 shared 时会自动落到 `packages/cn-offline-daily-k/`

--- a/packages/agent/src/experts/catalog.mock.json
+++ b/packages/agent/src/experts/catalog.mock.json
@@ -181,7 +181,7 @@
     {
       "id": "offline-data-steward",
       "title": "离线数据专家",
-      "summary": "把十年日 K 部署到公共区，并用公共包做筛选与板块挖掘",
+      "summary": "部署十年日 K 与本地指标到公共区，并用公共包做筛选与板块挖掘",
       "icon": {
         "kind": "icon",
         "value": "expert"
@@ -193,7 +193,7 @@
       ],
       "official": true,
       "version": "1.0.0",
-      "persona": "你是 Opptrix 离线数据专家：负责把 A 股十年日 K 部署/更新到公共复用区，并用公共包做查询与挖掘。默认 activate_tool_pack([\"workspace\"])。\n\n数据路径只走 prepare_fuyao_dump（full≈十年；incremental≈近 10 日）+ workspace_* / shell_run，读写 root_id=shared。包模板在仓库 templates/cn-offline-daily-k，可复制到 shared/packages/cn-offline-daily-k/。上次成功更新元数据只写 shared/data/cache/offline-k-meta.json；prepare_fuyao_dump 在 full|incremental + local_path 成功后会自动写入该文件（返回 meta_written），一般无需再手动 markUpdateSuccess（仅作补写保留）。若距上次成功更新超过 10 日（或无元数据），必须走 full，不得只做增量。\n\n严格禁止：引导 market sync / dailyDump / importDailyKDump；向 App 主行情库写入；把 API Key / Token 写入沙盒、工作区文件或 README；虚构未加载工具。密钥需求经保险箱（request_secret / secret_refs），扶摇鉴权仅由 prepare_fuyao_dump 在服务端完成。\n\n工作流：① list_local_data_apis / get_local_data_catalog 了解 fuyao.dump 与 shared.packages.cn-offline-daily-k；② 读 offline-k-meta 与 dumps 状态，决定 full 或 incremental；③ prepare_fuyao_dump 落盘 shared/data/dumps（成功即自动写 meta）；④ 用公共包 query/screen 做个股筛选与板块相对强弱/宽度/涨幅龙头。回复说明覆盖范围与数据时效，区分事实与推断。",
+      "persona": "你是 Opptrix 离线数据专家：负责把 A 股十年日 K 部署/更新到公共复用区，并用公共包做查询与挖掘；full/incremental 成功后必须补充计算并保存本地技术指标。默认 activate_tool_pack([\"workspace\"])。\n\n数据路径只走 prepare_fuyao_dump（full≈十年；incremental≈近 10 日）+ workspace_* / shell_run，读写 root_id=shared。包模板在仓库 templates/cn-offline-daily-k，可复制到 shared/packages/cn-offline-daily-k/。上次成功更新元数据只写 shared/data/cache/offline-k-meta.json；prepare_fuyao_dump 在 full|incremental + local_path 成功后会自动写入该文件（返回 meta_written），一般无需再手动 markUpdateSuccess（仅作补写保留）。若距上次成功更新超过 10 日（或无元数据），必须走 full，不得只做增量。\n\n本地指标缓存约定：落盘 shared/data/cache/indicators/（按标的或指标族存 Parquet/JSON，文件组织自定但须可检索）；覆盖范围=全市场全部标的。用 workspace/shell 基于已落盘日 K 自行计算并保存（勿期待包内完整指标引擎）。指标类别须齐全：趋势 SMA(5/10/20/60/120/250)、EMA(12/26/50/200)、MACD、ADX、均线多空、Price vs MA(20/60/200)；动量 RSI(6/14/28)、Stochastic、CCI、W%R、ROC、MFI；波动 BB(20,2)、ATR(14)、HV(20/60)、振幅；量能 OBV、VWAP、量比、换手、CMF(20)；形态/统计 日收益、CumReturn(5/20/60)、MaxDD(60/250)、Sharpe(250)、Skew/Kurt、Beta/Alpha(250 vs 沪深300)；价位 距 N 日高低、52 周高低位置、Percentile(250)。缺辅助数据（流通股本、沪深300 等）时：先 list_local_data_apis / get_local_data_catalog / 标准工具 / prepare 相关 dump 设法获取；仍缺则明确标注缺口，禁止编造。\n\n严格禁止：引导 market sync / dailyDump / importDailyKDump；向 App 主行情库写入；把 API Key / Token 写入沙盒、工作区文件或 README；虚构未加载工具。密钥需求经保险箱（request_secret / secret_refs），扶摇鉴权仅由 prepare_fuyao_dump 在服务端完成。\n\n工作流：① list_local_data_apis / get_local_data_catalog 了解 fuyao.dump 与 shared.packages.cn-offline-daily-k；② 读 offline-k-meta 与 dumps/indicators 状态，决定 full 或 incremental；③ prepare_fuyao_dump 落盘 shared/data/dumps（成功即自动写 meta）；④ 用公共包 query/screen 做个股筛选与板块相对强弱/宽度/涨幅龙头（优先读已落盘指标）；⑤ full/incremental 成功后必须计算全市场指标并写入 shared/data/cache/indicators/，回报覆盖与缺口。回复说明覆盖范围与数据时效，区分事实与推断。",
       "defaultPacks": [
         "workspace"
       ],
@@ -204,27 +204,32 @@
         {
           "id": "offline-deploy-full",
           "title": "部署全量日K",
-          "content": "请把约十年的 A 股日 K 部署到公共区（走数据包准备，不写主库），并告诉我覆盖范围。"
+          "content": "请把约十年的 A 股日 K 部署到公共区（不写主库），部署成功后继续计算全市场本地指标并写入 shared/data/cache/indicators/，回报覆盖范围与缺口。"
         },
         {
           "id": "offline-update-incr",
           "title": "增量更新",
-          "content": "请按元数据判断：若超过 10 天未成功更新则全量，否则增量更新公共区日 K，并回报状态。"
+          "content": "请按元数据判断：若超过 10 天未成功更新则全量，否则增量更新公共区日 K；更新成功后刷新全市场本地指标，并回报状态与缺口。"
         },
         {
           "id": "offline-status",
           "title": "查看状态",
-          "content": "查看公共区离线日 K 的覆盖范围、上次成功更新时间与建议的下一步。"
+          "content": "查看公共区离线日 K 与本地指标目录的覆盖范围、上次成功更新/指标时效，并给出建议的下一步。"
         },
         {
           "id": "offline-screen",
           "title": "个股筛选",
-          "content": "用公共区离线日 K，按均线/分位/波动/放量/回撤帮我筛一批标的，并说明条件与时效。"
+          "content": "优先读取已落盘的本地指标，按均线/分位/波动/放量/回撤帮我筛一批标的，并说明条件与时效；缺指标时再基于日 K 补算。"
         },
         {
           "id": "offline-sector",
           "title": "板块挖掘",
-          "content": "用公共区离线日 K 做板块相对强弱、上涨宽度与涨幅龙头挖掘，给出结构化结论。"
+          "content": "优先读取已落盘的本地指标，做板块相对强弱、上涨宽度与涨幅龙头挖掘，给出结构化结论与时效。"
+        },
+        {
+          "id": "offline-indicators-only",
+          "title": "仅补算指标",
+          "content": "日 K dump 已就绪时，请仅补算全市场本地指标并写入 shared/data/cache/indicators/，回报覆盖与缺口；缺辅助数据请先查接口，勿编造。"
         }
       ]
     }

--- a/packages/agent/src/local-data-catalog.ts
+++ b/packages/agent/src/local-data-catalog.ts
@@ -314,7 +314,7 @@ const SHARED_PACKAGES: LocalDataApiDetail = {
   ],
 }
 
-/** 仓库模板 → 复制到 shared/packages/cn-offline-daily-k/ */
+/** 内置模板；ensureSharedWorkspaceLayout 时自动落到 shared/packages/cn-offline-daily-k/ */
 const CN_OFFLINE_DAILY_K: LocalDataApiDetail = {
   api_id: 'shared.packages.cn-offline-daily-k',
   category: 'shared_packages',
@@ -322,10 +322,10 @@ const CN_OFFLINE_DAILY_K: LocalDataApiDetail = {
   summary: 'A 股离线十年日 K：prepare_fuyao_dump 部署到公共区，查询/筛选/板块挖掘（不写主库）',
   access: 'shared',
   how_to_call:
-    '模板：packages/agent-workspace/templates/cn-offline-daily-k/；运行时复制到 shared/packages/cn-offline-daily-k/。'
-    + '先 decideDumpKind（>10 日未成功更新则 full）→ prepare_fuyao_dump（full|incremental + local_path 成功会自动写 data/cache/offline-k-meta.json）→ query/screen；'
+    '初始化 shared 时自动落到 packages/cn-offline-daily-k（内置模板，不覆盖用户已改文件）。'
+    + '先 decideDumpKind（>10 日未成功更新则 full）→ prepare_fuyao_dump（full|incremental + local_path 成功会自动写 data/cache/offline-k-meta.json）→ 计算全市场指标落盘 data/cache/indicators/ → query/screen；'
     + 'markUpdateSuccess 仅作手动补写保留',
-  layer_entry: 'templates/cn-offline-daily-k → shared/packages/cn-offline-daily-k',
+  layer_entry: 'templates/cn-offline-daily-k → shared/packages/cn-offline-daily-k（auto-seed）',
   params: [
     { name: 'dump_kind', type: 'string', required: true, description: 'full（≈10y）| incremental（≈10d）；由 decideDumpKind 决定' },
     { name: 'meta_path', type: 'string', description: '仅 shared/data/cache/offline-k-meta.json' },
@@ -334,6 +334,7 @@ const CN_OFFLINE_DAILY_K: LocalDataApiDetail = {
     '禁止 market sync / importDailyKDump / 写 App 主行情库',
     '禁止 API Key 进沙盒；扶摇鉴权仅经 prepare_fuyao_dump',
     '元数据只写 shared/data/cache/offline-k-meta.json',
+    '本地指标缓存约定：shared/data/cache/indicators/（按标的或指标族 Parquet/JSON；Agent 自行计算，非包内引擎）',
   ],
   examples: [
     'get_local_data_catalog({ api_id: "shared.packages.cn-offline-daily-k" })',

--- a/tests/agent-workspace.test.mjs
+++ b/tests/agent-workspace.test.mjs
@@ -18,6 +18,7 @@ import {
   SHARED_ROOT_ID,
   resolveSharedWorkspaceRoot,
   resetSharedWorkspaceLayoutCacheForTests,
+  ensureSharedWorkspaceLayout,
 } from '../packages/agent-workspace/dist/index.js'
 
 async function withTmpDataDir(fn) {
@@ -248,6 +249,49 @@ test('shared workspace auto-granted and survives clearSession', async () => {
     svc.clearSession(sessionId)
     await new Promise(r => setTimeout(r, 50))
     assert.equal(await fs.readFile(path.join(sharedRoot, 'data', 'dumps', 'keep.txt'), 'utf8'), 'persist')
+  })
+})
+
+test('ensureSharedWorkspaceLayout seeds cn-offline-daily-k and is idempotent', async () => {
+  await withTmpDataDir(async () => {
+    resetSharedWorkspaceLayoutCacheForTests()
+    const root = await ensureSharedWorkspaceLayout()
+    const pkgJson = path.join(root, 'packages', 'cn-offline-daily-k', 'package.json')
+    const indexJs = path.join(root, 'packages', 'cn-offline-daily-k', 'src', 'index.js')
+    await fs.access(pkgJson)
+    await fs.access(indexJs)
+    const original = await fs.readFile(pkgJson, 'utf8')
+    assert.match(original, /cn-offline-daily-k/)
+
+    await fs.writeFile(pkgJson, '{"name":"user-edited","version":"9.9.9"}\n')
+    resetSharedWorkspaceLayoutCacheForTests()
+    await ensureSharedWorkspaceLayout()
+    assert.equal(
+      await fs.readFile(pkgJson, 'utf8'),
+      '{"name":"user-edited","version":"9.9.9"}\n',
+    )
+
+    await fs.rm(indexJs)
+    resetSharedWorkspaceLayoutCacheForTests()
+    await ensureSharedWorkspaceLayout()
+    await fs.access(indexJs)
+    assert.equal(
+      await fs.readFile(pkgJson, 'utf8'),
+      '{"name":"user-edited","version":"9.9.9"}\n',
+    )
+  })
+})
+
+test('listDir missing path returns empty entries with missing flag', async () => {
+  await withTmpDataDir(async () => {
+    resetSharedWorkspaceLayoutCacheForTests()
+    const svc = new WorkspaceService()
+    const sessionId = 'listdir-missing'
+    await svc.ensureDefaultRoot(sessionId)
+    const result = await svc.listDir(sessionId, SHARED_ROOT_ID, 'packages/does-not-exist-xyz')
+    assert.deepEqual(result.entries, [])
+    assert.equal(result.missing, true)
+    assert.equal(result.path, 'packages/does-not-exist-xyz')
   })
 })
 


### PR DESCRIPTION
## Summary
- 初始化 shared 时幂等 seed `cn-offline-daily-k` 到 `shared/packages/`，避免 workspace_list ENOENT
- `listDir` 对缺失路径返回 `{ entries: [], missing: true }`
- 离线专家 persona/快捷提问：全量/增量后须算全市场本地指标并写入 `shared/data/cache/indicators/`；新增「仅补算指标」

## Test plan
- [x] `node scripts/validate-experts.mjs`
- [x] `node --test tests/agent-workspace.test.mjs`（含 seed / listDir）
- [ ] 冒烟：专家快捷「部署全量日K」文案含指标落盘；`packages/cn-offline-daily-k` 可列目录


Made with [Cursor](https://cursor.com)