### PR TITLE
fix(agent): ask_user 支持开放文本模式

### DIFF
--- a/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
+++ b/client-ui/src/chat/ComposerAgentUserPromptPanel.tsx
@@ -20,12 +20,26 @@ export default function ComposerAgentUserPromptPanel({
   const [selectedIds, setSelectedIds] = useState<string[]>([])
   const [secretValue, setSecretValue] = useState('')
   const isSecret = prompt.kind === 'secret'
-  const isConfirm = !isSecret && prompt.options.length === 0
-  const allowCustom = prompt.allow_custom ?? (isConfirm ? false : true)
+  // 解析层应写出 mode；旧载荷无 mode 时按 options / allow_custom 推导
+  const resolvedMode = prompt.mode ?? (
+    prompt.options.length === 0
+      ? (prompt.allow_custom === true ? 'text' : 'confirm')
+      : 'choice'
+  )
+  const isConfirm = !isSecret && resolvedMode === 'confirm'
+  const isText = !isSecret && resolvedMode === 'text'
+  const allowCustom = isText
+    ? true
+    : (prompt.allow_custom ?? (isConfirm ? false : true))
   const rejectLabel = prompt.reject_label?.trim() || '拒绝'
   const confirmLabel = prompt.confirm_label?.trim() || '确认'
   const allSelected = prompt.options.length > 0
     && selectedIds.length === prompt.options.length
+  const defaultTitle = isText ? '请补充' : '请确认'
+  const customPlaceholder = isText
+    ? '请输入你的回答'
+    : '其他，输入后按 Enter 提交'
+  const regionLabel = isText ? 'Agent 填空问题' : 'Agent 确认问题'
 
   useEffect(() => {
     setCustomText('')
@@ -52,6 +66,15 @@ export default function ComposerAgentUserPromptPanel({
       custom_text: text,
     })
   }, [customText, onSubmit, submitting])
+
+  const cancelText = useCallback(() => {
+    if (submitting) return
+    onSubmit({
+      kind: 'custom',
+      selected_ids: ['cancel'],
+      selected_labels: ['取消'],
+    })
+  }, [onSubmit, submitting])
 
   const toggleMulti = useCallback((id: string) => {
     setSelectedIds(prev => (
@@ -182,19 +205,20 @@ export default function ComposerAgentUserPromptPanel({
       className={mergeClasses(
         'opptrix-composer-user-prompt-panel',
         isConfirm && 'opptrix-composer-user-prompt-panel--confirm',
+        isText && 'opptrix-composer-user-prompt-panel--text',
         OPPTRIX_GLASS_PANEL_CLASS,
       )}
       role="region"
-      aria-label="Agent 确认问题"
+      aria-label={regionLabel}
     >
       <div className="opptrix-composer-user-prompt-panel__head">
         <span className="opptrix-composer-user-prompt-panel__title">
-          {prompt.title?.trim() || '请确认'}
+          {prompt.title?.trim() || defaultTitle}
         </span>
         <p className="opptrix-composer-user-prompt-panel__prompt">{prompt.prompt}</p>
       </div>
 
-      {!isConfirm && prompt.allowMultiple ? (
+      {!isConfirm && !isText && prompt.allowMultiple ? (
         <div className="opptrix-composer-user-prompt-panel__toolbar">
           <OpptrixButton
             variant="ghost"
@@ -207,7 +231,7 @@ export default function ComposerAgentUserPromptPanel({
         </div>
       ) : null}
 
-      {!isConfirm ? (
+      {!isConfirm && !isText ? (
         <div className="opptrix-composer-user-prompt-panel__options opptrix-scroll">
           {prompt.options.map(opt => (
             <button
@@ -240,12 +264,35 @@ export default function ComposerAgentUserPromptPanel({
             className="opptrix-composer-user-prompt-panel__custom-input"
             value={customText}
             disabled={submitting}
-            placeholder="其他，输入后按 Enter 提交"
+            placeholder={customPlaceholder}
             onChange={(_e, data) => setCustomText(data.value)}
             onKeyDown={handleCustomKeyDown}
-            aria-label="自行输入答案"
+            aria-label={isText ? '输入回答' : '自行输入答案'}
           />
           <span className="opptrix-composer-user-prompt-panel__custom-hint">Enter</span>
+        </div>
+      ) : null}
+
+      {isText ? (
+        <div className="opptrix-composer-user-prompt-panel__actions">
+          <OpptrixButton
+            className="opptrix-composer-user-prompt-panel__action-btn"
+            variant="secondary"
+            size="medium"
+            disabled={submitting}
+            onClick={cancelText}
+          >
+            取消
+          </OpptrixButton>
+          <OpptrixButton
+            className="opptrix-composer-user-prompt-panel__action-btn"
+            variant="primary"
+            size="medium"
+            disabled={submitting || !customText.trim()}
+            onClick={submitCustom}
+          >
+            提交
+          </OpptrixButton>
         </div>
       ) : null}
 
@@ -272,7 +319,7 @@ export default function ComposerAgentUserPromptPanel({
         </div>
       ) : null}
 
-      {!isConfirm && prompt.allowMultiple && (
+      {!isConfirm && !isText && prompt.allowMultiple && (
         <div className="opptrix-composer-user-prompt-panel__confirm">
           <OpptrixButton
             variant="primary"

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -6,9 +6,11 @@ export interface ChatUserPromptPayload {
   id: string
   title?: string
   prompt: string
-  /** 空数组 = confirm 模式（底部拒绝/确认） */
+  /** confirm/text 为空数组；choice 为 2–50 项 */
   options: Array<{ id: string; label: string }>
   allowMultiple?: boolean
+  /** confirm=拒绝/确认；choice=选项；text=开放填空 */
+  mode?: 'confirm' | 'choice' | 'text'
   kind?: 'choice' | 'secret'
   name?: string
   inject_hosts?: string[]

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -282,7 +282,7 @@ Opptrix/
   - **触发**：每轮 `llm.chat` 前检查；上游 `context_length_exceeded` 等 → 强制 aggressive compact 后**重试 1 次**；`setSessionModel` 换模型后按新窗再检查。
   - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。`done` 可含 `turn_usage`（本轮 LLM 累计用量，含 tool 循环与 structured 压缩）与 `context_usage`（Composer 已用/窗长估算）。测试：`tests/session-context-compact.test.mjs`、`tests/chat-token-usage.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
-- **`ask_user`**：Agent 需用户确认分析方向/范围/授权时调用；SSE 推送 `user_prompt` 事件。**确认模式**：省略 `options`（或 `[]`）→ 底部「拒绝/确认」（可用 `reject_label`/`confirm_label` 定制；回传 id 固定 `reject`/`confirm`）；**选择题**：预置选项 2–50 个。`allow_custom` 控制自行输入（确认默认关、选择题默认开）。多选支持全选；prompt/label 勿用 emoji。用户作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
+- **`ask_user`**：Agent 需用户确认/选择/填空时调用；SSE 推送 `user_prompt`。**confirm**：省略 `options`（或 `[]`）且未设 `mode=text`/`allow_custom=true` → 底部「拒绝/确认」（可用 `reject_label`/`confirm_label`；回传 id 固定 `reject`/`confirm`）。**choice**：预置选项 2–50。**text**：`mode:"text"` 或空 options + `allow_custom=true` → 仅开放填空，无授权双钮。禁止用 confirm 收集开放答案。`allow_custom`：confirm 默认关、choice 默认开。多选支持全选；prompt/label 勿用 emoji。作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
 - **行业分析**：`industry_mining` / `industry_mermaid`（属 `industry` pack，需播种或 activate）→ 代表公司用 `search_instruments` + `get_instrument_*`
 - **市场宏观**：`get_market_regime` / `get_market_dynamics` / `get_trend_brief` 等属 `market` pack
 - **跨市场搜索**：唯一入口 `search_instruments`（`core` pack，始终可用；`markets` 可过滤 CN/US/HK/CRYPTO）

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -74,9 +74,11 @@ export interface ChatUserPromptPayload {
   id: string
   title?: string
   prompt: string
-  /** 空数组 = confirm 模式（底部拒绝/确认） */
+  /** confirm/text 为空数组；choice 为 2–50 项 */
   options: Array<{ id: string; label: string }>
   allowMultiple?: boolean
+  /** confirm=拒绝/确认；choice=选项；text=开放填空（解析层应始终写出） */
+  mode?: 'confirm' | 'choice' | 'text'
   kind?: 'choice' | 'secret'
   name?: string
   inject_hosts?: string[]

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,6 +11,7 @@ export {
   type UserPromptAnswer,
   type UserPromptOption,
   type UserPromptPayload,
+  type UserPromptMode,
   UserPromptBridge,
   UserPromptCancelledError,
   createUserPromptId,

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -504,9 +504,9 @@ export const TOOL_META: Record<string, ToolMeta> = {
   ask_user: {
     miningEligible: false,
     usageGuide:
-      '分析前需用户确认方向、范围、授权或偏好且上下文无法推断时调用：省略 options 为拒绝/确认双按钮（可用 reject_label/confirm_label）；有 2–50 选项为选择题。',
+      '需用户确认/选择/填空且上下文无法推断时调用。confirm=授权或是否继续；choice=有限选项 2–50；text=开放填空（mode:"text" 或空 options+allow_custom=true）。禁止用 confirm 收集开放答案。',
     compliance:
-      'prompt 必填、面向投资者且勿用 emoji；options 可省略/[]（确认模式）或 2–50 项且 id 唯一；confirm 回传 id 固定 reject|confirm；allow_custom 确认默认 false、选择题默认 true；同一轮最多 1 次；禁止索要密钥。',
+      'prompt 必填、面向投资者且勿用 emoji；mode（或别名 interaction）为 confirm|choice|text；空 options 默认 confirm（兼容），空 options+allow_custom=true 或 mode=text 为开放输入；choice 须 2–50 项且 id 唯一；confirm 回传 reject|confirm；同一轮最多 1 次；禁止索要密钥。',
   },
   list_enabled_providers: {
     hubFeature: 'provider_list',

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -608,27 +608,33 @@ export class ToolRegistry {
         name: 'ask_user',
         category: '交互',
         description:
-          '向用户发起确认：省略 options（或空数组）为底部「拒绝/确认」双按钮；提供 2–50 个选项为选择题。可用 reject_label/confirm_label 定制按钮文案；allow_custom 控制是否可自行输入（确认模式默认关，选择题默认开）',
+          '向用户提问：mode=confirm（或空 options 默认）为拒绝/确认授权；mode=choice + 2–50 options 为选择题；mode=text（或空 options+allow_custom=true）为开放填空。禁止用 confirm 收集开放答案；禁止索要密钥',
         parameters: S({
-          title: { type: 'string', description: '可选面板标题，如「分析范围确认」' },
+          title: { type: 'string', description: '可选面板标题；text 模式默认「请补充」，confirm 默认「请确认」' },
           prompt: { type: 'string', description: '要向用户提出的具体问题（面向投资者，避免技术术语）' },
+          mode: {
+            type: 'string',
+            description:
+              'confirm | choice | text（亦可用参数别名 interaction）。开放填空用 text；授权/危险操作用 confirm；有限选项用 choice',
+          },
           options: {
             type: 'array',
             description:
-              '可选。省略或 [] → 确认模式（回传 selected_ids 为 reject/confirm）；选择题须 2–50 项 { id, label }；prompt 与 label 均勿使用 emoji',
+              '可选。省略/[] 且未设 text/allow_custom → confirm（回传 reject/confirm）；空 options+allow_custom=true → text；选择题须 2–50 项 { id, label }；勿用 emoji',
           },
-          allow_multiple: { type: 'boolean', description: '选择题是否允许多选，默认 false；确认模式忽略' },
+          allow_multiple: { type: 'boolean', description: '选择题是否允许多选，默认 false；confirm/text 忽略' },
           reject_label: {
             type: 'string',
-            description: '确认模式拒绝按钮文案，默认「拒绝」；回传 id 固定为 reject（授权场景可用「不允许」）',
+            description: 'confirm 模式拒绝按钮文案，默认「拒绝」；回传 id 固定为 reject（授权场景可用「不允许」）',
           },
           confirm_label: {
             type: 'string',
-            description: '确认模式确认按钮文案，默认「确认」；回传 id 固定为 confirm（授权场景可用「授权使用」）',
+            description: 'confirm 模式确认按钮文案，默认「确认」；回传 id 固定为 confirm（授权场景可用「授权使用」）',
           },
           allow_custom: {
             type: 'boolean',
-            description: '是否允许「其它，自行输入」；确认模式默认 false，选择题默认 true',
+            description:
+              '是否允许自行输入；confirm 默认 false，choice 默认 true；空 options 且为 true 时进入 text 开放填空（无授权双钮）',
           },
         }, ['prompt']),
         handler: async () => ({ error: 'ask_user 由 Agent 引擎直接处理' }),

--- a/packages/agent/src/user-prompt.ts
+++ b/packages/agent/src/user-prompt.ts
@@ -13,14 +13,22 @@ export interface UserPromptOption {
   label: string
 }
 
+/** ask_user 交互模式：确认授权 / 选择题 / 开放填空 */
+export type UserPromptMode = 'confirm' | 'choice' | 'text'
+
 /** 推送给客户端的问答面板载荷 */
 export interface UserPromptPayload {
   id: string
   title?: string
   prompt: string
-  /** 选择题预置选项；空数组表示 confirm 模式（底部拒绝/确认） */
+  /** 选择题预置选项；confirm/text 模式为空数组 */
   options: UserPromptOption[]
   allowMultiple?: boolean
+  /**
+   * 交互模式（解析层始终写出，便于 UI 只读 mode）。
+   * confirm=拒绝/确认；choice=选项列表；text=仅开放填空。
+   */
+  mode?: UserPromptMode
   /** choice=普通选项；secret=保险箱密码录入 */
   kind?: 'choice' | 'secret'
   /** kind=secret 时的保险箱条目名 */
@@ -33,7 +41,7 @@ export interface UserPromptPayload {
   confirm_label?: string
   /**
    * 是否显示「其它，自行输入」。
-   * confirm 模式默认 false；有 options 的选择题默认 true。
+   * confirm 默认 false；choice 默认 true；text 固定 true。
    */
   allow_custom?: boolean
 }
@@ -169,6 +177,17 @@ function parseAllowCustom(raw: unknown, defaultValue: boolean): boolean {
   return Boolean(raw)
 }
 
+/** 解析 mode（亦接受参数别名 interaction） */
+function parseUserPromptMode(raw: unknown): UserPromptMode | undefined {
+  if (raw == null) return undefined
+  const s = String(raw).trim().toLowerCase()
+  if (s === 'confirm' || s === 'choice' || s === 'text') return s
+  if (s === 'yesno' || s === 'yes_no' || s === 'authorization') return 'confirm'
+  if (s === 'select' || s === 'options') return 'choice'
+  if (s === 'input' || s === 'open' || s === 'freeform') return 'text'
+  return undefined
+}
+
 export function parseAskUserArgs(args: Record<string, unknown>): {
   payload?: Omit<UserPromptPayload, 'id'>
   error?: string
@@ -178,13 +197,39 @@ export function parseAskUserArgs(args: Record<string, unknown>): {
 
   const titleRaw = args.title
   const title = titleRaw == null ? undefined : String(titleRaw).trim() || undefined
+  const explicitMode = parseUserPromptMode(args.mode ?? args.interaction)
 
   const rawOptions = args.options
   const omitOrEmpty = rawOptions == null
     || (Array.isArray(rawOptions) && rawOptions.length === 0)
 
-  // confirm 模式：省略 options 或传空数组
+  // 无 options：confirm（默认/兼容）或 text（开放填空）
   if (omitOrEmpty) {
+    if (explicitMode === 'choice') {
+      return {
+        error: `choice 模式须提供 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个 options`,
+      }
+    }
+
+    const allowCustom = parseAllowCustom(args.allow_custom ?? args.allowCustom, false)
+    // text：显式 mode=text，或空 options 且 allow_custom=true（且未强制 confirm）
+    const isText = explicitMode === 'text'
+      || (explicitMode !== 'confirm' && allowCustom)
+
+    if (isText) {
+      return {
+        payload: {
+          kind: 'choice',
+          mode: 'text',
+          prompt,
+          title,
+          options: [],
+          allowMultiple: false,
+          allow_custom: true,
+        },
+      }
+    }
+
     const rejectParsed = parseOptionalLabel(args.reject_label ?? args.rejectLabel, 'reject_label')
     if (rejectParsed.error) return { error: rejectParsed.error }
     const confirmParsed = parseOptionalLabel(args.confirm_label ?? args.confirmLabel, 'confirm_label')
@@ -193,35 +238,43 @@ export function parseAskUserArgs(args: Record<string, unknown>): {
     return {
       payload: {
         kind: 'choice',
+        mode: 'confirm',
         prompt,
         title,
         options: [],
         allowMultiple: false,
         reject_label: rejectParsed.label,
         confirm_label: confirmParsed.label,
-        allow_custom: parseAllowCustom(args.allow_custom ?? args.allowCustom, false),
+        allow_custom: allowCustom,
       },
     }
   }
 
   if (!Array.isArray(rawOptions)) {
-    return { error: `options 须为数组：省略/空数组为确认模式，或 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个选项对象` }
+    return {
+      error: `options 须为数组：省略/空数组为 confirm 或 text，或 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个选项对象`,
+    }
   }
   if (rawOptions.length > USER_PROMPT_OPTIONS_MAX) {
     return { error: `选项过多（最多 ${USER_PROMPT_OPTIONS_MAX} 个），请精简后再试` }
   }
   if (rawOptions.length < USER_PROMPT_OPTIONS_MIN) {
-    return { error: `选择题请提供至少 ${USER_PROMPT_OPTIONS_MIN} 个选项，或省略 options 使用确认模式` }
+    return {
+      error: `选择题请提供至少 ${USER_PROMPT_OPTIONS_MIN} 个选项，或省略 options 使用 confirm/text 模式`,
+    }
   }
 
   const options = normalizeUserPromptOptions(rawOptions)
   if (!options) {
-    return { error: `options 须为 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个对象数组，每项含唯一 id 与非空 label` }
+    return {
+      error: `options 须为 ${USER_PROMPT_OPTIONS_MIN}–${USER_PROMPT_OPTIONS_MAX} 个对象数组，每项含唯一 id 与非空 label`,
+    }
   }
 
   return {
     payload: {
       kind: 'choice',
+      mode: 'choice',
       prompt,
       title,
       options,

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -217,12 +217,12 @@ export function buildUserInteractionPlaybook(): string {
   return [
     '【用户确认 — ask_user 内置交互工具】',
     '- 当分析方向、标的范围、时间窗口、偏好（短线/中线、是否含资讯等）存在多种合理路径且无法从上下文推断时，调用 ask_user 而非在正文里罗列选项让用户打字回复',
-    '- 确认模式：省略 options（或传 []）→ 底部「拒绝/确认」双按钮；回传 selected_ids 固定为 reject / confirm；可用 reject_label / confirm_label 定制文案（如「不允许」「授权使用」）',
-    '- 选择题：options 提供 2–50 个互斥或常见选项（id 英文/数字，label 中文简短）；allow_multiple 仅在「可多选」时设为 true',
-    '- allow_custom：是否允许自行输入；确认模式默认 false，选择题默认 true；可显式覆盖',
-    '- prompt 与 options.label / 按钮文案均不要使用 emoji（界面更清晰、便于朗读与无障碍）',
-    '- 收到返回的 selected_ids / selected_labels / custom_text 后再继续拉数与分析；同一轮对话最多调用 1 次 ask_user',
-    '- 禁止用于索要密码等敏感信息（须用 request_secret 写入保险箱）；禁止在已有明确用户指令时重复确认',
+    '- 三种 mode（亦可用参数别名 interaction）：',
+    '  · confirm：授权/是否继续/危险操作 → mode:"confirm"，或省略 options（空/[]）且不设 mode=text、不设 allow_custom=true；底部「拒绝/确认」；回传 id 固定 reject/confirm；可用 reject_label/confirm_label',
+    '  · choice：有限选项 → options 2–50（id 英文/数字，label 中文简短），mode:"choice"；allow_multiple 仅在可多选时为 true；allow_custom 默认 true',
+    '  · text：开放式/需用户填内容 → mode:"text"（推荐），或空 options + allow_custom=true；仅文本输入，无拒绝/确认授权钮',
+    '- 禁止用 confirm 收集开放答案；禁止用 ask_user 索要密钥（须用 request_secret）；禁止在已有明确用户指令时重复确认',
+    '- prompt 与 options.label / 按钮文案均不要使用 emoji；收到 selected_ids / selected_labels / custom_text 后再继续；同一轮最多 1 次 ask_user',
   ].join('\n')
 }
 

--- a/tests/agent-ask-user.test.mjs
+++ b/tests/agent-ask-user.test.mjs
@@ -67,6 +67,7 @@ test('parseAskUserArgs validates prompt and options', () => {
   assert.equal(parsed.error, undefined)
   assert.equal(parsed.payload?.title, '分析范围')
   assert.equal(parsed.payload?.options.length, 2)
+  assert.equal(parsed.payload?.mode, 'choice')
   assert.equal(parsed.payload?.allow_custom, true)
 })
 
@@ -74,6 +75,7 @@ test('parseAskUserArgs confirm mode when options omitted or empty', () => {
   const omitted = parseAskUserArgs({ prompt: '是否授权使用本对话局域网？' })
   assert.equal(omitted.error, undefined)
   assert.deepEqual(omitted.payload?.options, [])
+  assert.equal(omitted.payload?.mode, 'confirm')
   assert.equal(omitted.payload?.allow_custom, false)
   assert.equal(omitted.payload?.reject_label, undefined)
   assert.equal(omitted.payload?.confirm_label, undefined)
@@ -81,18 +83,59 @@ test('parseAskUserArgs confirm mode when options omitted or empty', () => {
   const empty = parseAskUserArgs({ prompt: '继续？', options: [] })
   assert.equal(empty.error, undefined)
   assert.deepEqual(empty.payload?.options, [])
+  assert.equal(empty.payload?.mode, 'confirm')
   assert.equal(empty.payload?.allow_custom, false)
 
   const customLabels = parseAskUserArgs({
     prompt: '是否授权？',
+    mode: 'confirm',
     reject_label: '不允许',
     confirm_label: '授权使用',
-    allow_custom: true,
   })
   assert.equal(customLabels.error, undefined)
+  assert.equal(customLabels.payload?.mode, 'confirm')
   assert.equal(customLabels.payload?.reject_label, '不允许')
   assert.equal(customLabels.payload?.confirm_label, '授权使用')
-  assert.equal(customLabels.payload?.allow_custom, true)
+  assert.equal(customLabels.payload?.allow_custom, false)
+})
+
+test('parseAskUserArgs text mode via mode=text or empty options + allow_custom', () => {
+  const byMode = parseAskUserArgs({
+    prompt: '请补充关注的行业',
+    mode: 'text',
+  })
+  assert.equal(byMode.error, undefined)
+  assert.equal(byMode.payload?.mode, 'text')
+  assert.deepEqual(byMode.payload?.options, [])
+  assert.equal(byMode.payload?.allow_custom, true)
+  assert.equal(byMode.payload?.reject_label, undefined)
+  assert.equal(byMode.payload?.confirm_label, undefined)
+
+  const byAllowCustom = parseAskUserArgs({
+    prompt: '还有哪些偏好？',
+    options: [],
+    allow_custom: true,
+  })
+  assert.equal(byAllowCustom.error, undefined)
+  assert.equal(byAllowCustom.payload?.mode, 'text')
+  assert.equal(byAllowCustom.payload?.allow_custom, true)
+
+  const byAlias = parseAskUserArgs({
+    prompt: '请填写备注',
+    interaction: 'text',
+  })
+  assert.equal(byAlias.error, undefined)
+  assert.equal(byAlias.payload?.mode, 'text')
+
+  // 显式 confirm 优先于 allow_custom=true
+  const confirmWins = parseAskUserArgs({
+    prompt: '是否继续？',
+    mode: 'confirm',
+    allow_custom: true,
+  })
+  assert.equal(confirmWins.error, undefined)
+  assert.equal(confirmWins.payload?.mode, 'confirm')
+  assert.equal(confirmWins.payload?.allow_custom, true)
 })
 
 test('parseAskUserArgs allow_custom false hides custom for choice mode', () => {
@@ -105,6 +148,7 @@ test('parseAskUserArgs allow_custom false hides custom for choice mode', () => {
     allow_custom: false,
   })
   assert.equal(parsed.error, undefined)
+  assert.equal(parsed.payload?.mode, 'choice')
   assert.equal(parsed.payload?.allow_custom, false)
 })
 
@@ -114,7 +158,14 @@ test('parseAskUserArgs rejects single option array', () => {
       prompt: '选一个',
       options: [{ id: 'a', label: '仅一项' }],
     }).error ?? '',
-    /至少|确认模式/,
+    /至少|confirm|text/,
+  )
+})
+
+test('parseAskUserArgs rejects choice mode without options', () => {
+  assert.match(
+    parseAskUserArgs({ prompt: '选一个', mode: 'choice' }).error ?? '',
+    /choice|options/,
   )
 })
 


### PR DESCRIPTION
## Summary
- `ask_user` 增加 `mode: text | confirm | choice`，开放填空不再被误判为授权双按钮
- 空 options 默认仍为 confirm（兼容删除/联网等确认流）
- UI、tool-meta、system 引导与测试已同步

## Test plan
- [x] `node --test tests/agent-ask-user.test.mjs`
- [x] `npm run check:ui`
- [ ] 冒烟：`mode=text` 出现输入框；空 options 仍为拒绝/确认


Made with [Cursor](https://cursor.com)