### PR TITLE
feat(chat): 整理结果状态行展示估算 token 与总步数

### DIFF
--- a/client-ui/src/chat/ChatProcessTrace.tsx
+++ b/client-ui/src/chat/ChatProcessTrace.tsx
@@ -24,6 +24,7 @@ import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { fadeInUp, motion } from '../theme/mixins'
 import { copyTextToClipboard } from '../platform/clipboard'
 import ThinkingDots from '../components/ThinkingDots'
+import { formatLiveThinkingStatus } from './sessionStreamRuntime'
 
 const useStyles = makeStyles({
   root: {
@@ -603,6 +604,9 @@ function ThinkingSnippetRow({ snippet, active }: ThinkingSnippetRowProps) {
 interface Props {
   steps: ChatToolStep[]
   thinkingLabel?: string
+  /** 阶段文案（不含省略号）；与 estimatedTokens 一起优先拼装状态行 */
+  phaseLabel?: string
+  estimatedTokens?: number
   thinkingSnippet?: string
   live?: boolean
 }
@@ -610,6 +614,8 @@ interface Props {
 export default function ChatProcessTrace({
   steps,
   thinkingLabel,
+  phaseLabel,
+  estimatedTokens,
   thinkingSnippet,
   live = false,
 }: Props) {
@@ -619,9 +625,13 @@ export default function ChatProcessTrace({
   const [historyExpanded, setHistoryExpanded] = useState(false)
   const runningStep = live ? steps.find(st => st.status === 'running') : null
   const modelThinking = live && !runningStep
-  const snippetActive = modelThinking && Boolean(thinkingLabel?.includes('思路'))
+  const statusLabel = live
+    ? (formatLiveThinkingStatus(phaseLabel, estimatedTokens, steps.length) ?? thinkingLabel)
+    : thinkingLabel
+  const phaseHint = phaseLabel ?? thinkingLabel ?? ''
+  const snippetActive = modelThinking && phaseHint.includes('思路')
   const hideStatusForSnippet = snippetActive && Boolean(thinkingSnippet)
-  const showStatusHead = Boolean(thinkingLabel && (live || thinkingSnippet)) && !hideStatusForSnippet
+  const showStatusHead = Boolean(statusLabel && (live || thinkingSnippet)) && !hideStatusForSnippet
   const showLiveSnippet = live && Boolean(thinkingSnippet)
   const showHistorySnippet = Boolean(thinkingSnippet && !live)
 
@@ -659,7 +669,7 @@ export default function ChatProcessTrace({
               )}
               block
             >
-              {thinkingLabel}
+              {statusLabel}
             </Text>
           </div>
         </div>

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -780,6 +780,8 @@ function ChatView({
                   <ChatProcessTrace
                     steps={liveTrace.steps}
                     thinkingLabel={liveTrace.thinkingLabel}
+                    phaseLabel={liveTrace.phaseLabel}
+                    estimatedTokens={liveTrace.estimatedTokens}
                     thinkingSnippet={liveTrace.thinkingSnippet}
                     live
                   />

--- a/client-ui/src/chat/sessionStreamRuntime.ts
+++ b/client-ui/src/chat/sessionStreamRuntime.ts
@@ -1,4 +1,4 @@
-import type { ChatLiveTrace, ChatProgressEvent, ChatUserPromptPayload } from '../types/chatProgress'
+import type { ChatLiveTrace, ChatProgressEvent, ChatToolStep, ChatUserPromptPayload } from '../types/chatProgress'
 import { formatTokenCount } from './formatTokenCount.ts'
 
 export type SessionStreamSnapshot = {
@@ -7,6 +7,72 @@ export type SessionStreamSnapshot = {
   userPromptSubmitting: boolean
   /** 会话内上下文整理轻提示 */
   contextHint: string | null
+}
+
+/** 去掉尾部省略号，得到纯净 phaseLabel */
+export function stripPhaseEllipsis(label: string): string {
+  return label.replace(/[…]+$/u, '').replace(/\.{2,}$/u, '').trim()
+}
+
+/**
+ * 拼装实时状态行：`模型正在整理结果 · 约 1.2k tokens · 共 8 步…`
+ * 无 token 时省略 token 段；steps≤0 时省略步数段。
+ */
+export function formatLiveThinkingStatus(
+  phaseLabel: string | undefined,
+  estimatedTokens: number | undefined,
+  stepCount: number,
+): string | undefined {
+  if (!phaseLabel) return undefined
+  const parts = [phaseLabel]
+  if (estimatedTokens != null) {
+    parts.push(`约 ${formatTokenCount(estimatedTokens)} tokens`)
+  }
+  if (stepCount > 0) {
+    parts.push(`共 ${stepCount} 步`)
+  }
+  return `${parts.join(' · ')}…`
+}
+
+/** 从已有 trace 解析 phaseLabel（兼容仅有 thinkingLabel 的旧快照） */
+function resolvePhaseLabel(trace: ChatLiveTrace | null | undefined, fallback: string): string {
+  if (trace?.phaseLabel) return trace.phaseLabel
+  const raw = trace?.thinkingLabel
+  if (!raw) return fallback
+  const base = stripPhaseEllipsis(raw).split(' · ')[0]?.trim()
+  return base || fallback
+}
+
+function rebuildLiveTrace(
+  prev: ChatLiveTrace | null | undefined,
+  patch: {
+    steps?: ChatToolStep[]
+    phaseLabel?: string
+    /** 显式传入（含 undefined）表示覆盖；不传则保留上一轮 */
+    estimatedTokens?: number | undefined
+    clearEstimatedTokens?: boolean
+    thinkingSnippet?: string | undefined
+  },
+): ChatLiveTrace {
+  const steps = patch.steps ?? prev?.steps ?? []
+  const phaseLabel = patch.phaseLabel ?? resolvePhaseLabel(prev, '')
+  const estimatedTokens = patch.clearEstimatedTokens
+    ? undefined
+    : ('estimatedTokens' in patch ? patch.estimatedTokens : prev?.estimatedTokens)
+  const thinkingSnippet = 'thinkingSnippet' in patch
+    ? patch.thinkingSnippet
+    : prev?.thinkingSnippet
+  return {
+    steps,
+    phaseLabel: phaseLabel || undefined,
+    estimatedTokens,
+    thinkingSnippet,
+    thinkingLabel: formatLiveThinkingStatus(
+      phaseLabel || undefined,
+      estimatedTokens,
+      steps.length,
+    ),
+  }
 }
 
 export function createEmptyStreamSnapshot(): SessionStreamSnapshot {
@@ -19,8 +85,13 @@ export function createEmptyStreamSnapshot(): SessionStreamSnapshot {
 }
 
 export function createThinkingStreamSnapshot(label = '模型正在思考…'): SessionStreamSnapshot {
+  const phaseLabel = stripPhaseEllipsis(label)
   return {
-    liveTrace: { steps: [], thinkingLabel: label },
+    liveTrace: {
+      steps: [],
+      phaseLabel,
+      thinkingLabel: formatLiveThinkingStatus(phaseLabel, undefined, 0),
+    },
     pendingUserPrompt: null,
     userPromptSubmitting: false,
     contextHint: null,
@@ -35,67 +106,61 @@ export function applyChatProgressEvent(
     case 'thinking':
       return {
         ...snapshot,
-        liveTrace: {
-          steps: snapshot.liveTrace?.steps ?? [],
-          thinkingLabel: event.label,
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
+          phaseLabel: stripPhaseEllipsis(event.label),
+          clearEstimatedTokens: true,
           thinkingSnippet: event.snippet ?? snapshot.liveTrace?.thinkingSnippet,
-        },
+        }),
       }
     case 'context_compact':
       return {
         ...snapshot,
         contextHint: event.message,
-        liveTrace: {
-          steps: snapshot.liveTrace?.steps ?? [],
-          thinkingLabel: '正在整理对话要点…',
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
+          phaseLabel: '正在整理对话要点',
           thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
-        },
+        }),
       }
     case 'user_prompt':
       return {
         ...snapshot,
         pendingUserPrompt: event.prompt,
-        liveTrace: {
-          steps: snapshot.liveTrace?.steps ?? [],
-          thinkingLabel: '等待你的确认…',
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
+          phaseLabel: '等待你的确认',
           thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
-        },
+        }),
       }
     case 'tool_start':
       return {
         ...snapshot,
-        liveTrace: {
-          thinkingLabel: snapshot.liveTrace?.thinkingLabel,
-          thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
           steps: [...(snapshot.liveTrace?.steps ?? []), event.step],
-        },
+        }),
       }
     case 'tool_done':
       return {
         ...snapshot,
         pendingUserPrompt: null,
-        liveTrace: {
-          thinkingLabel: snapshot.liveTrace?.thinkingLabel ?? '模型正在整理结果…',
-          thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
+          phaseLabel: '模型正在整理结果',
           steps: (snapshot.liveTrace?.steps ?? []).map(step =>
             step.id === event.step.id ? event.step : step,
           ),
-        },
+        }),
       }
     case 'reply': {
       // 与思考态同位文案；多轮工具后若已是「整理」态则保持，避免回跳
-      const consolidating = (snapshot.liveTrace?.thinkingLabel ?? '').includes('整理')
-      const base = consolidating ? '模型正在整理结果' : '模型正在思考'
-      const thinkingLabel = event.estimatedTokens != null
-        ? `${base} · 约 ${formatTokenCount(event.estimatedTokens)} tokens`
-        : `${base}…`
+      const prevPhase = resolvePhaseLabel(snapshot.liveTrace, '')
+      const consolidating = prevPhase.includes('整理')
+      const phaseLabel = prevPhase || (consolidating ? '模型正在整理结果' : '模型正在思考')
       return {
         ...snapshot,
-        liveTrace: {
-          steps: snapshot.liveTrace?.steps ?? [],
-          thinkingLabel,
-          thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
-        },
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
+          phaseLabel,
+          // reply 无估算时清空，与旧行为一致（不残留假数字）
+          estimatedTokens: event.estimatedTokens,
+          clearEstimatedTokens: event.estimatedTokens == null,
+        }),
       }
     }
     case 'done':

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -82,7 +82,12 @@ export type ChatProgressEvent =
   }
 
 export interface ChatLiveTrace {
+  /** 展示用完整状态行（由 phaseLabel / tokens / 步数拼装） */
   thinkingLabel?: string
+  /** 阶段文案，不含省略号后缀，如「模型正在整理结果」 */
+  phaseLabel?: string
+  /** 当前 LLM 轮次已消耗的估算 token */
+  estimatedTokens?: number
   thinkingSnippet?: string
   steps: ChatToolStep[]
 }

--- a/tests/session-stream-runtime.test.mjs
+++ b/tests/session-stream-runtime.test.mjs
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import {
   applyChatProgressEvent,
   createEmptyStreamSnapshot,
+  formatLiveThinkingStatus,
+  stripPhaseEllipsis,
 } from '../client-ui/src/chat/sessionStreamRuntime.ts'
 
 const pendingPrompt = {
@@ -17,6 +19,35 @@ function snapshotWithPending() {
     pendingUserPrompt: pendingPrompt,
   }
 }
+
+describe('formatLiveThinkingStatus', () => {
+  it('strips trailing ellipsis for phaseLabel', () => {
+    assert.equal(stripPhaseEllipsis('模型正在思考…'), '模型正在思考')
+    assert.equal(stripPhaseEllipsis('模型正在整理结果...'), '模型正在整理结果')
+  })
+
+  it('omits token and step segments when absent', () => {
+    assert.equal(formatLiveThinkingStatus('模型正在思考', undefined, 0), '模型正在思考…')
+  })
+
+  it('includes token estimate when present', () => {
+    assert.equal(
+      formatLiveThinkingStatus('模型正在思考', 128, 0),
+      '模型正在思考 · 约 128 tokens…',
+    )
+  })
+
+  it('includes step count only when > 0', () => {
+    assert.equal(
+      formatLiveThinkingStatus('模型正在整理结果', 1200, 8),
+      '模型正在整理结果 · 约 1.2k tokens · 共 8 步…',
+    )
+    assert.equal(
+      formatLiveThinkingStatus('模型正在整理结果', undefined, 3),
+      '模型正在整理结果 · 共 3 步…',
+    )
+  })
+})
 
 describe('applyChatProgressEvent pendingUserPrompt', () => {
   it('clears pending on tool_done for shell_run', () => {
@@ -89,7 +120,9 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       type: 'reply',
       estimatedTokens: 128,
     })
-    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 128 tokens')
+    assert.equal(next.liveTrace?.phaseLabel, '模型正在思考')
+    assert.equal(next.liveTrace?.estimatedTokens, 128)
+    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 128 tokens…')
   })
 
   it('prefers estimatedTokens label even when content is present', () => {
@@ -98,7 +131,7 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       content: '最终正文',
       estimatedTokens: 1500,
     })
-    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 1.5k tokens')
+    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 1.5k tokens…')
   })
 
   it('falls back to thinking label when reply has no estimatedTokens', () => {
@@ -106,6 +139,7 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       type: 'reply',
       content: '正文',
     })
+    assert.equal(next.liveTrace?.estimatedTokens, undefined)
     assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考…')
   })
 
@@ -114,6 +148,7 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       ...createEmptyStreamSnapshot(),
       liveTrace: {
         steps: [],
+        phaseLabel: '模型正在整理结果',
         thinkingLabel: '模型正在整理结果…',
       },
     }
@@ -121,11 +156,94 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       type: 'reply',
       estimatedTokens: 64,
     })
-    assert.equal(withTokens.liveTrace?.thinkingLabel, '模型正在整理结果 · 约 64 tokens')
+    assert.equal(withTokens.liveTrace?.thinkingLabel, '模型正在整理结果 · 约 64 tokens…')
 
     const withoutTokens = applyChatProgressEvent(withTools, {
       type: 'reply',
     })
     assert.equal(withoutTokens.liveTrace?.thinkingLabel, '模型正在整理结果…')
+  })
+
+  it('clears prior estimatedTokens on new thinking round', () => {
+    const prior = {
+      ...createEmptyStreamSnapshot(),
+      liveTrace: {
+        steps: [],
+        phaseLabel: '模型正在思考',
+        estimatedTokens: 999,
+        thinkingLabel: '模型正在思考 · 约 999 tokens…',
+      },
+    }
+    const next = applyChatProgressEvent(prior, {
+      type: 'thinking',
+      round: 2,
+      label: '模型正在思考…',
+    })
+    assert.equal(next.liveTrace?.estimatedTokens, undefined)
+    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考…')
+  })
+
+  it('shows total step count with tokens after tool_done and reply', () => {
+    let snap = createEmptyStreamSnapshot()
+    snap = applyChatProgressEvent(snap, {
+      type: 'thinking',
+      round: 1,
+      label: '模型正在思考…',
+    })
+    snap = applyChatProgressEvent(snap, {
+      type: 'tool_start',
+      step: {
+        id: 's1',
+        tool: 'search',
+        label: '搜索',
+        status: 'running',
+        startedAt: new Date().toISOString(),
+      },
+    })
+    snap = applyChatProgressEvent(snap, {
+      type: 'tool_done',
+      step: {
+        id: 's1',
+        tool: 'search',
+        label: '搜索',
+        status: 'done',
+        startedAt: new Date().toISOString(),
+      },
+    })
+    assert.equal(snap.liveTrace?.phaseLabel, '模型正在整理结果')
+    assert.match(snap.liveTrace?.thinkingLabel ?? '', /共 1 步/)
+
+    snap = applyChatProgressEvent(snap, {
+      type: 'reply',
+      estimatedTokens: 1200,
+    })
+    assert.equal(
+      snap.liveTrace?.thinkingLabel,
+      '模型正在整理结果 · 约 1.2k tokens · 共 1 步…',
+    )
+  })
+
+  it('preserves tokens across tool_start while updating step count', () => {
+    let snap = {
+      ...createEmptyStreamSnapshot(),
+      liveTrace: {
+        steps: [],
+        phaseLabel: '模型正在思考',
+        estimatedTokens: 50,
+        thinkingLabel: '模型正在思考 · 约 50 tokens…',
+      },
+    }
+    snap = applyChatProgressEvent(snap, {
+      type: 'tool_start',
+      step: {
+        id: 's1',
+        tool: 'search',
+        label: '搜索',
+        status: 'running',
+        startedAt: new Date().toISOString(),
+      },
+    })
+    assert.equal(snap.liveTrace?.estimatedTokens, 50)
+    assert.equal(snap.liveTrace?.thinkingLabel, '模型正在思考 · 约 50 tokens · 共 1 步…')
   })
 })


### PR DESCRIPTION
## Summary
- 实时状态行结构化拼装：阶段文案 + 本轮估算 token + 累计工具步数
- 新一轮 thinking 清空上一轮 token；有步骤时显示「共 N 步」
- 补充 `sessionStreamRuntime` 单测覆盖

## Test plan
- [x] `node --test tests/session-stream-runtime.test.mjs`
- [x] `npm run check:ui`
- [ ] 聊天长任务：多工具后出现「模型正在整理结果 · 约 X tokens · 共 N 步…」，token 随生成更新


Made with [Cursor](https://cursor.com)