### PR TITLE
feat(chat): 提示编排队列与工具 bridge 竞态修复

### DIFF
--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -10,6 +10,18 @@ import {
   syncStreamSnapshotToUi,
   type SessionStreamSnapshot,
 } from './sessionStreamRuntime'
+import {
+  clearSessionPromptQueue,
+  enqueueQueuedPrompt,
+  listQueuedPrompts,
+  promoteQueuedPrompt,
+  removeQueuedPrompt,
+  resolveDrainAction,
+  shiftQueuedPrompt,
+  takeQueuedPromptById,
+  type DrainIntent,
+  type QueuedPrompt,
+} from './sessionPromptQueue'
 import type { ChatProgressEvent } from '../types/chatProgress'
 import SettingsPage from '../pages/SettingsPage'
 import NewsCenterPage from '../pages/news/NewsCenterPage'
@@ -292,6 +304,10 @@ export default function ChatApp() {
   const sessionStreamGenRef = useRef(new Map<string, number>())
   const stoppingSessionsRef = useRef(new Set<string>())
   const streamingSessionIdsRef = useRef(new Set<string>())
+  /** 每会话 drain 意图：Stop=none；失败/成功=auto；打断指定项=runItem */
+  const drainIntentRef = useRef(new Map<string, DrainIntent>())
+  /** 当前会话排队提示（localStorage 镜像） */
+  const [promptQueue, setPromptQueue] = useState<QueuedPrompt[]>([])
   /** 流结束后延迟清除过程条的 timer（sessionId → timeout id） */
   const streamResetTimersRef = useRef(new Map<string, number>())
   /** 本轮生成期间曾失焦/不可见（sessionId → true） */
@@ -448,6 +464,20 @@ export default function ChatApp() {
       syncStreamSnapshotToUi(next, streamUiRef.current)
     }
   }, [])
+
+  const syncPromptQueueUi = useCallback((sessionId: string | null) => {
+    if (!sessionId) {
+      setPromptQueue([])
+      return
+    }
+    if (activeIdRef.current === sessionId) {
+      setPromptQueue(listQueuedPrompts(sessionId))
+    }
+  }, [])
+
+  useEffect(() => {
+    syncPromptQueueUi(activeId)
+  }, [activeId, syncPromptQueueUi])
 
   const abortSessionStream = useCallback(async (sessionId: string) => {
     sessionStreamGenRef.current.set(
@@ -689,6 +719,9 @@ export default function ChatApp() {
       if (streamingSessionIdsRef.current.has(id)) {
         await abortSessionStream(id)
       }
+      clearSessionPromptQueue(id)
+      drainIntentRef.current.delete(id)
+      syncPromptQueueUi(activeIdRef.current === id ? null : activeIdRef.current)
       await deleteSession(id)
       const list = await refreshSessions()
       if (activeId === id) {
@@ -731,6 +764,8 @@ export default function ChatApp() {
   const handleArchive = useCallback(async (id: string, folderId: string) => {
     try {
       await archiveSession(id, folderId)
+      clearSessionPromptQueue(id)
+      drainIntentRef.current.delete(id)
       const list = await refreshSessions()
       setSessions(list)
       void refreshArchived()
@@ -904,6 +939,7 @@ export default function ChatApp() {
   const handleStop = useCallback(async () => {
     const sid = activeId
     if (!sid || !streamingSessionIdsRef.current.has(sid) || stoppingSessionsRef.current.has(sid)) return
+    drainIntentRef.current.set(sid, { kind: 'none' })
     await abortSessionStream(sid)
   }, [abortSessionStream, activeId])
 
@@ -917,6 +953,41 @@ export default function ChatApp() {
   sessionModelRef.current = sessionModel
 
   const submitImplRef = useRef<(text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => Promise<void>>(async () => {})
+
+  const drainPromptQueueAfterStream = useCallback((sessionId: string) => {
+    const intent = drainIntentRef.current.get(sessionId) ?? { kind: 'auto' }
+    drainIntentRef.current.delete(sessionId)
+
+    const pendingAsk = Boolean(streamCacheRef.current.get(sessionId)?.pendingUserPrompt)
+    const decision = resolveDrainAction(intent, {
+      hasPendingUserPrompt: pendingAsk,
+      alreadyStreaming: streamingSessionIdsRef.current.has(sessionId)
+        || streamHandlesRef.current.has(sessionId),
+    })
+    if (decision.action === 'skip') {
+      syncPromptQueueUi(sessionId)
+      return
+    }
+
+    let next: QueuedPrompt | null = null
+    if (decision.action === 'take') {
+      next = takeQueuedPromptById(sessionId, decision.itemId).item
+    } else {
+      next = shiftQueuedPrompt(sessionId).item
+    }
+    syncPromptQueueUi(sessionId)
+    if (!next) return
+
+    // 微任务：确保本流 finally 的 streaming 清理已完成
+    queueMicrotask(() => {
+      if (streamingSessionIdsRef.current.has(sessionId)) return
+      void submitImplRef.current(
+        next.text || undefined,
+        next.attachmentIds,
+        next.attachmentMetas,
+      )
+    })
+  }, [syncPromptQueueUi])
 
   submitImplRef.current = async (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => {
     const msg = (text ?? '').trim()
@@ -936,7 +1007,18 @@ export default function ChatApp() {
       }
     }
 
-    if (streamingSessionIdsRef.current.has(sessionId)) return
+    if (streamingSessionIdsRef.current.has(sessionId)) {
+      const result = enqueueQueuedPrompt(sessionId, {
+        text: msg,
+        attachmentIds: ids,
+        attachmentMetas,
+      })
+      syncPromptQueueUi(sessionId)
+      if (!result.ok && result.reason === 'full') {
+        setError('排队已满，请先处理或删除后再添加')
+      }
+      return
+    }
 
     const pendingReset = streamResetTimersRef.current.get(sessionId)
     if (pendingReset != null) {
@@ -950,6 +1032,8 @@ export default function ChatApp() {
     for (const key of [...doneNotifiedGensRef.current]) {
       if (key.startsWith(`${sessionId}:`)) doneNotifiedGensRef.current.delete(key)
     }
+    // 新一轮默认自动续跑下一条；Stop / runNow 会在本轮中途覆盖
+    drainIntentRef.current.set(sessionId, { kind: 'auto' })
     const initialSnapshot = createThinkingStreamSnapshot()
     streamCacheRef.current.set(sessionId, initialSnapshot)
     markSessionStreaming(sessionId, true)
@@ -1000,47 +1084,43 @@ export default function ChatApp() {
         }
       }, sessionModelRef.current, abortController.signal, ids.length ? ids : undefined)
 
-      if (isStreamStale()) return
-
-      const sid = resolvedSessionId
-      if (sid !== sessionId && activeIdRef.current === sessionId) {
-        setActiveId(sid)
+      if (!isStreamStale()) {
+        const sid = resolvedSessionId
+        if (sid !== sessionId && activeIdRef.current === sessionId) {
+          setActiveId(sid)
+        }
+        await applyFreshSession(sid)
       }
-      await applyFreshSession(sid)
     } catch (e) {
       const aborted = (
         (e instanceof DOMException && e.name === 'AbortError')
         || (e instanceof Error && e.name === 'AbortError')
       )
       if (aborted) {
-        if (isStreamStale()) return
         try {
           await applyFreshSession(sessionId)
         } catch {
           /* keep current messages */
         }
-        return
-      }
-      if (isStreamStale()) return
-      if (activeIdRef.current === sessionId) {
-        pushComposerDraft(msg)
-        setError(e instanceof Error ? e.message : '发送失败')
-      }
-      try {
-        await applyFreshSession(sessionId)
-      } catch {
-        if (isStreamStale()) return
+      } else if (!isStreamStale()) {
         if (activeIdRef.current === sessionId) {
-          setMessages(prev => prev.slice(0, -1))
+          setError(e instanceof Error ? e.message : '发送失败')
+        }
+        try {
+          await applyFreshSession(sessionId)
+        } catch {
+          if (!isStreamStale() && activeIdRef.current === sessionId) {
+            setMessages(prev => prev.slice(0, -1))
+          }
         }
       }
     } finally {
       streamHandlesRef.current.delete(sessionId)
       stoppingSessionsRef.current.delete(sessionId)
+      const hadPendingAsk = Boolean(streamCacheRef.current.get(sessionId)?.pendingUserPrompt)
       streamCacheRef.current.delete(sessionId)
       markSessionStreaming(sessionId, false)
       if (activeIdRef.current === sessionId) {
-        // 延迟清除过程条，让用户能看到最后的「约 N tokens」一小会儿
         const prevTimer = streamResetTimersRef.current.get(sessionId)
         if (prevTimer != null) window.clearTimeout(prevTimer)
         const timer = window.setTimeout(() => {
@@ -1052,12 +1132,47 @@ export default function ChatApp() {
         }, 500)
         streamResetTimersRef.current.set(sessionId, timer)
       }
+      if (hadPendingAsk) {
+        const intent = drainIntentRef.current.get(sessionId)
+        if (!intent || intent.kind === 'auto') {
+          drainIntentRef.current.set(sessionId, { kind: 'none' })
+        }
+      }
+      drainPromptQueueAfterStream(sessionId)
     }
   }
 
   const handleSubmit = useCallback((text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => {
     void submitImplRef.current(text, attachmentIds, attachmentMetas)
   }, [])
+
+  const handlePromptQueueRemove = useCallback((id: string) => {
+    const sid = activeIdRef.current
+    if (!sid) return
+    removeQueuedPrompt(sid, id)
+    syncPromptQueueUi(sid)
+  }, [syncPromptQueueUi])
+
+  const handlePromptQueueRunNow = useCallback((id: string) => {
+    const sid = activeIdRef.current
+    if (!sid) return
+    const pendingAsk = Boolean(streamCacheRef.current.get(sid)?.pendingUserPrompt)
+      || Boolean(streamUiRef.current?.readPendingUserPrompt?.())
+    if (pendingAsk) return
+
+    if (!streamingSessionIdsRef.current.has(sid)) {
+      const { item } = takeQueuedPromptById(sid, id)
+      syncPromptQueueUi(sid)
+      if (!item) return
+      void submitImplRef.current(item.text || undefined, item.attachmentIds, item.attachmentMetas)
+      return
+    }
+
+    promoteQueuedPrompt(sid, id)
+    syncPromptQueueUi(sid)
+    drainIntentRef.current.set(sid, { kind: 'runItem', itemId: id })
+    void abortSessionStream(sid)
+  }, [abortSessionStream, syncPromptQueueUi])
 
   const ensureSession = useCallback(async (): Promise<string> => {
     if (activeIdRef.current) return activeIdRef.current
@@ -1598,6 +1713,9 @@ export default function ChatApp() {
                   onSubmit={handleSubmit}
                   ensureSession={ensureSession}
                   onStop={handleStop}
+                  promptQueue={promptQueue}
+                  onPromptQueueRemove={handlePromptQueueRemove}
+                  onPromptQueueRunNow={handlePromptQueueRunNow}
                   onForkMessage={handleForkFromMessage}
                   onQuoteSelection={activeId ? handleQuoteSelection : undefined}
                   onEphemeralAsk={activeId ? handleEphemeralAsk : undefined}

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -8,7 +8,9 @@ import ComposerQuickTasks from './ComposerQuickTasks'
 import ChatWorkspaceGrants from './ChatWorkspaceGrants'
 import ComposerStockMentionList from './ComposerStockMentionList'
 import ComposerAgentUserPromptPanel from './ComposerAgentUserPromptPanel'
+import ComposerPromptQueuePanel from './ComposerPromptQueuePanel'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
+import type { QueuedPrompt } from './sessionPromptQueue'
 import { useWatchlist } from '../market/useWatchlist'
 import { useStockMention } from './useStockMention'
 import type { AvailableModel, ChatAttachmentMeta, ChatContextUsage, SessionContextRef } from '../types/chat'
@@ -84,6 +86,26 @@ const useStyles = makeStyles({
     flexWrap: 'nowrap',
     overflowX: 'auto',
   },
+  /** 专家快捷：贴在 composer 输入区顶部；与「接下来」分区（无标题，省纵向空间） */
+  expertStarterBar: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    boxSizing: 'border-box',
+    margin: '0 0 2px',
+    padding: '0 0 8px',
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    overflow: 'hidden',
+  },
+  expertStarterTrack: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
+    gap: '8px',
+    width: '100%',
+    overflowX: 'auto',
+    overflowY: 'hidden',
+  },
   starterChip: {
     borderRadius: opptrixTokens.radiusFull,
     fontWeight: 500,
@@ -105,6 +127,9 @@ const useStyles = makeStyles({
       outline: `${opptrixTokens.focusRingWidth} solid ${opptrixCssVars.inputBorderFocus}`,
       outlineOffset: opptrixTokens.focusRingOffset,
     },
+  },
+  expertStarterChip: {
+    backgroundColor: 'transparent',
   },
   panelWrap: {
     position: 'relative',
@@ -296,6 +321,10 @@ interface ChatComposerProps {
   userPrompt?: ChatUserPromptPayload | null
   userPromptSubmitting?: boolean
   onUserPromptSubmit?: (answer: UserPromptAnswerPayload) => void
+  /** 当前会话待执行任务（pin 在 composer 上方） */
+  promptQueue?: QueuedPrompt[]
+  onPromptQueueRemove?: (id: string) => void
+  onPromptQueueRunNow?: (id: string) => void
 }
 
 export default function ChatComposer({
@@ -320,6 +349,9 @@ export default function ChatComposer({
   userPrompt = null,
   userPromptSubmitting = false,
   onUserPromptSubmit,
+  promptQueue = [],
+  onPromptQueueRemove,
+  onPromptQueueRunNow,
 }: ChatComposerProps) {
   const s = useStyles()
   const editorRef = useRef<HTMLDivElement>(null)
@@ -464,15 +496,26 @@ export default function ChatComposer({
     }
     const root = editorRef.current
     const composed = root ? getSendText(root).trim() : ''
-    if ((!composed && !attachmentIds.length) || loading) return
+    if ((!composed && !attachmentIds.length) || userPrompt || uploading) return
     onSubmit(composed || undefined, ids, metas)
     clearEditorContent()
     clearPinned()
-  }, [attachmentIds, clearEditorContent, clearPinned, loading, onSubmit, pinned])
+  }, [attachmentIds, clearEditorContent, clearPinned, onSubmit, pinned, uploading, userPrompt])
 
-  const canSend = (hasContent || attachmentIds.length > 0) && !loading && !userPrompt && !uploading
-  const composerLocked = loading || Boolean(userPrompt)
-  const showStarters = starters.length > 0 && (isEmpty || alwaysShowStarters)
+  const hasSendPayload = hasContent || attachmentIds.length > 0
+  const canEnqueueOrSend = hasSendPayload && !userPrompt && !uploading
+  const canSend = canEnqueueOrSend && !loading
+  /** 仅 ask_user / 上传中锁定编辑；执行中仍可输入以加入排队 */
+  const composerLocked = Boolean(userPrompt) || uploading
+  const showWelcomeStarters = starters.length > 0 && isEmpty && !alwaysShowStarters
+  const showExpertStarterBar = alwaysShowStarters && starters.length > 0
+  const sendBusy = loading
+  const sendButtonDisabled = sendBusy
+    ? !(canEnqueueOrSend || onStop)
+    : !canSend
+  const sendAriaLabel = sendBusy
+    ? (canEnqueueOrSend ? '加入排队' : '停止生成')
+    : '发送'
 
   const handleSpeechTranscript = useCallback((text: string) => {
     const root = editorRef.current
@@ -582,9 +625,9 @@ export default function ChatComposer({
         }
         return
       }
-      // 普通 Enter：发送。
+      // 普通 Enter：发送或加入排队。
       e.preventDefault()
-      if (canSend) handleSubmitMessage()
+      if (canEnqueueOrSend) handleSubmitMessage()
     }
   }
 
@@ -602,12 +645,12 @@ export default function ChatComposer({
 
   return (
     <div className={s.wrap}>
-      {showStarters && (
+      {showWelcomeStarters && (
         <div
-          key={isEmpty ? welcomeKey : 'persistent-starters'}
+          key={welcomeKey}
           className={mergeClasses(
             s.startersSection,
-            isEmpty && s.startersSectionEnter,
+            s.startersSectionEnter,
           )}
         >
           <Text className={s.startersLabel}>你可以这样问</Text>
@@ -618,7 +661,7 @@ export default function ChatComposer({
                 className={s.starterChip}
                 variant="pill"
                 size="small"
-                disabled={composerLocked}
+                disabled={Boolean(userPrompt) || uploading}
                 onClick={() => onSubmit(st.text)}
               >
                 {st.label}
@@ -653,6 +696,38 @@ export default function ChatComposer({
           onDrop={handleDrop}
           onDragOver={handleDragOver}
         >
+          {promptQueue.length > 0 && onPromptQueueRemove && onPromptQueueRunNow && (
+            <ComposerPromptQueuePanel
+              items={promptQueue}
+              runNowDisabled={Boolean(userPrompt)}
+              waitingConfirmHint={Boolean(userPrompt)}
+              onRunNow={onPromptQueueRunNow}
+              onRemove={onPromptQueueRemove}
+            />
+          )}
+          {showExpertStarterBar && (
+            <div
+              className={s.expertStarterBar}
+              role="region"
+              aria-label="快捷提问"
+              data-composer-section="starters"
+            >
+              <div className={mergeClasses(s.expertStarterTrack, 'opptrix-scroll-x')}>
+                {starters.map((st, index) => (
+                  <OpptrixButton
+                    key={listRowKey(index, st.label, st.text)}
+                    className={mergeClasses(s.starterChip, s.expertStarterChip)}
+                    variant="pill"
+                    size="small"
+                    disabled={Boolean(userPrompt) || uploading}
+                    onClick={() => onSubmit(st.text)}
+                  >
+                    {st.label}
+                  </OpptrixButton>
+                ))}
+              </div>
+            </div>
+          )}
           <input
             ref={fileInputRef}
             type="file"
@@ -691,7 +766,11 @@ export default function ChatComposer({
                 role="textbox"
                 aria-multiline="true"
                 aria-label="输入问题，@ 选择关注股票"
-                data-placeholder={isMobile ? '输入问题，@ 选择股票…' : '输入问题，@ 选择关注股票，Enter 发送…'}
+                data-placeholder={
+                  loading
+                    ? (isMobile ? '继续输入，将加入排队…' : '继续输入，发送后加入排队…')
+                    : (isMobile ? '输入问题，@ 选择股票…' : '输入问题，@ 选择关注股票，Enter 发送…')
+                }
                 data-empty={hasContent ? undefined : 'true'}
                 onInput={handleInput}
                 onKeyDown={handleKeyDown}
@@ -753,13 +832,22 @@ export default function ChatComposer({
               <OpptrixButton
                 className={mergeClasses(s.sendBtn, 'opptrix-round-icon-btn')}
                 variant="primary"
-                icon={loading ? <PauseFilled fontSize={14} /> : <ArrowUpRegular fontSize={14} />}
-                disabled={loading ? !onStop : !canSend}
+                icon={sendBusy && !canEnqueueOrSend
+                  ? <PauseFilled fontSize={14} />
+                  : <ArrowUpRegular fontSize={14} />}
+                disabled={sendButtonDisabled}
                 onClick={() => {
-                  if (loading) onStop?.()
-                  else handleSubmitMessage()
+                  if (sendBusy && canEnqueueOrSend) {
+                    handleSubmitMessage()
+                    return
+                  }
+                  if (sendBusy) {
+                    onStop?.()
+                    return
+                  }
+                  handleSubmitMessage()
                 }}
-                aria-label={loading ? '停止生成' : '发送'}
+                aria-label={sendAriaLabel}
               />
             </div>
           </div>

--- a/client-ui/src/chat/ChatProcessTrace.tsx
+++ b/client-ui/src/chat/ChatProcessTrace.tsx
@@ -169,20 +169,20 @@ const useStyles = makeStyles({
     fontSize: 'var(--opptrix-font-base)',
     lineHeight: 1.45,
     color: opptrixCssVars.textSecondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   stepLabelRunning: {
     color: opptrixCssVars.textPrimary,
-    backgroundImage: `linear-gradient(90deg, ${opptrixCssVars.textSecondary} 0%, ${opptrixCssVars.textPrimary} 45%, ${opptrixCssVars.textSecondary} 90%)`,
-    backgroundSize: '220% 100%',
-    backgroundClip: 'text',
-    WebkitBackgroundClip: 'text',
-    WebkitTextFillColor: 'transparent',
-    animationDuration: '1.8s',
+    // 避免 background-clip:text：长状态（含 token / 步数）会被裁成透明看不见
+    opacity: 1,
+    animationDuration: '1.6s',
     animationTimingFunction: 'ease-in-out',
     animationIterationCount: 'infinite',
     animationName: {
-      '0%': { backgroundPosition: '120% center' },
-      '100%': { backgroundPosition: '-120% center' },
+      '0%, 100%': { opacity: 0.72 },
+      '50%': { opacity: 1 },
     },
   },
   stepLabelError: {
@@ -637,7 +637,7 @@ export default function ChatProcessTrace({
 
   // 实时执行时跟随最新步骤滚动到底部（步骤新增或内容/状态更新时）。
   const liveProgressKey = live
-    ? `${steps.length}:${steps.map(st => st.status).join(',')}`
+    ? `${steps.length}:${steps.map(st => st.status).join(',')}:${estimatedTokens ?? ''}:${phaseLabel ?? ''}`
     : ''
   useEffect(() => {
     if (!live) return

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState, memo } from 'react'
+import { useRef, useEffect, useLayoutEffect, useCallback, useState, memo } from 'react'
 import {
   Text, makeStyles, mergeClasses,
 } from '@fluentui/react-components'
@@ -10,6 +10,7 @@ import type { ChatLiveTrace, ChatUserPromptPayload, UserPromptAnswerPayload } fr
 import { getExpert, submitUserPromptResponse } from '../api/client'
 import type { ChatStreamUiRef } from './chatStreamUiBridge'
 import type { SessionStreamSnapshot } from './sessionStreamRuntime'
+import type { QueuedPrompt } from './sessionPromptQueue'
 import MobileTopBar from './MobileTopBar'
 import ChatComposer from './ChatComposer'
 import ChatMessageItem from './ChatMessageItem'
@@ -70,7 +71,8 @@ const useStyles = makeStyles({
   },
   contentColumn: {
     width: '100%',
-    padding: `8px 0 ${opptrixTokens.chatThreadScrollPadBottom}`,
+    paddingTop: '8px',
+    paddingBottom: 0,
     display: 'flex',
     flexDirection: 'column',
     gap: '5px',
@@ -80,7 +82,7 @@ const useStyles = makeStyles({
     paddingTop: '4px',
   },
   contentColumnMobile: {
-    padding: `8px 0 ${opptrixTokens.chatThreadScrollPadBottomMobile}`,
+    paddingTop: '8px',
     gap: '5px',
   },
   composerDock: {
@@ -279,6 +281,9 @@ interface ChatViewProps {
   backendOk?: boolean
   onSubmit: (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => void
   onStop?: () => void
+  promptQueue?: QueuedPrompt[]
+  onPromptQueueRemove?: (id: string) => void
+  onPromptQueueRunNow?: (id: string) => void
   onForkMessage?: (messageIndex: number) => void
   ensureSession?: () => Promise<string>
   onQuoteSelection?: (selection: MessageSelection) => void
@@ -310,7 +315,7 @@ function ChatView({
   isMobile = false,
   llmLabel = '',
   backendOk = false,
-  onSubmit, onStop, onForkMessage, onQuoteSelection, onEphemeralAsk, onClearContextRef, onModelChange,
+  onSubmit, onStop, promptQueue = [], onPromptQueueRemove, onPromptQueueRunNow, onForkMessage, onQuoteSelection, onEphemeralAsk, onClearContextRef, onModelChange,
   ensureSession,
   onOpenSidebar, onNewChat, onOpenSettings,
   rightPanelOpen = false,
@@ -391,9 +396,16 @@ function ChatView({
   }, [dismissPendingUserPrompt, onStreamError, sessionId])
   const chatBoxRef = useRef<HTMLDivElement>(null)
   const bodyShellRef = useRef<HTMLDivElement>(null)
+  const composerInnerRef = useRef<HTMLDivElement>(null)
   const stickToBottomRef = useRef(true)
   const prevLoadingRef = useRef(false)
   const [scrollbarHalfOffset, setScrollbarHalfOffset] = useState(0)
+  /** 随 composer 实际高度（含「接下来」/快捷提问）动态抬高线程底部留白 */
+  const [threadScrollPadBottom, setThreadScrollPadBottom] = useState(() => (
+    typeof window !== 'undefined' && window.innerWidth < 768
+      ? Number.parseInt(opptrixTokens.chatThreadScrollPadBottomMobile, 10) || 196
+      : Number.parseInt(opptrixTokens.chatThreadScrollPadBottom, 10) || 212
+  ))
   const [pinnedToolbar, setPinnedToolbar] = useState<{
     selection: MessageSelection
     anchor: MessageSelectionAnchor
@@ -544,6 +556,32 @@ function ChatView({
     setScrollbarHalfOffset(hasScrollbar && gutter > 0 ? gutter / 2 : 0)
   }, [])
 
+  const syncThreadScrollPad = useCallback(() => {
+    const el = composerInnerRef.current
+    if (!el) return
+    const next = Math.ceil(el.getBoundingClientRect().height)
+    if (next > 0) setThreadScrollPadBottom(next)
+  }, [])
+
+  useLayoutEffect(() => {
+    syncThreadScrollPad()
+    const el = composerInnerRef.current
+    if (!el) return
+    const observer = new ResizeObserver(() => syncThreadScrollPad())
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [
+    syncThreadScrollPad,
+    promptQueue.length,
+    pendingUserPrompt,
+    starters.length,
+    isExpertSession,
+    isEmpty,
+    error,
+    loading,
+    contextRef,
+  ])
+
   useEffect(() => {
     syncScrollbarHalfOffset()
     const el = chatBoxRef.current
@@ -568,6 +606,11 @@ function ChatView({
     if (!el) return
     el.scrollTo({ top: el.scrollHeight, behavior })
   }, [])
+
+  useEffect(() => {
+    if (!stickToBottomRef.current) return
+    scrollToBottom('auto')
+  }, [threadScrollPadBottom, scrollToBottom])
 
   const scrollToMessageStart = useCallback((messageIndex: number, behavior: ScrollBehavior = 'auto') => {
     const container = chatBoxRef.current
@@ -726,6 +769,7 @@ function ChatView({
                 isMobile && s.contentColumnMobile,
                 electronChrome && s.contentColumnElectron,
               )}
+              style={{ paddingBottom: `${threadScrollPadBottom}px` }}
             >
               {isEmpty && (
                 <div
@@ -802,6 +846,7 @@ function ChatView({
 
         <div className={s.composerDock}>
           <div
+            ref={composerInnerRef}
             className={mergeClasses(s.composerInner, isMobile && s.composerInnerMobile)}
             style={scrollbarHalfOffset > 0
               ? { transform: `translateX(-${scrollbarHalfOffset}px)` }
@@ -829,6 +874,9 @@ function ChatView({
               userPrompt={pendingUserPrompt}
               userPromptSubmitting={userPromptSubmitting}
               onUserPromptSubmit={pendingUserPrompt ? handleUserPromptSubmit : undefined}
+              promptQueue={promptQueue}
+              onPromptQueueRemove={onPromptQueueRemove}
+              onPromptQueueRunNow={onPromptQueueRunNow}
             />
           </div>
         </div>

--- a/client-ui/src/chat/ComposerPromptQueuePanel.tsx
+++ b/client-ui/src/chat/ComposerPromptQueuePanel.tsx
@@ -1,0 +1,187 @@
+import { Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { DismissRegular, ArrowUpRegular } from '@fluentui/react-icons'
+import OpptrixButton from '../components/opptrix/OpptrixButton'
+import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+import { motion } from '../theme/mixins'
+import type { QueuedPrompt } from './sessionPromptQueue'
+
+const useStyles = makeStyles({
+  /** 嵌入 composer 顶部的编排区（与快捷提问分区） */
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+    width: '100%',
+    boxSizing: 'border-box',
+    margin: '0 0 2px',
+    padding: '0 0 8px',
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+  },
+  head: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: '8px',
+    minHeight: '16px',
+    paddingInline: '2px',
+  },
+  title: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    color: opptrixCssVars.textTertiary,
+    letterSpacing: '0.02em',
+  },
+  hint: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    opacity: 0.85,
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+    maxHeight: '140px',
+    overflowY: 'auto',
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    minHeight: '30px',
+    padding: '2px 4px 2px 6px',
+    borderRadius: opptrixTokens.radiusMd,
+    boxSizing: 'border-box',
+    transitionProperty: 'background-color',
+    transitionDuration: motion.fast,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+    },
+  },
+  rowNext: {
+    backgroundColor: opptrixCssVars.accentSoft,
+  },
+  index: {
+    flexShrink: 0,
+    width: '14px',
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    color: opptrixCssVars.textTertiary,
+    textAlign: 'center',
+    fontVariantNumeric: 'tabular-nums',
+  },
+  text: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 'var(--opptrix-font-base)',
+    lineHeight: 1.35,
+    color: opptrixCssVars.textPrimary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  actions: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '2px',
+    flexShrink: 0,
+  },
+  iconBtn: {
+    minWidth: '26px',
+    maxWidth: '26px',
+    width: '26px',
+    minHeight: '26px',
+    maxHeight: '26px',
+    height: '26px',
+    padding: 0,
+    color: opptrixCssVars.textTertiary,
+    ':hover': {
+      color: opptrixCssVars.textPrimary,
+    },
+  },
+  iconBtnPlay: {
+    ':hover': {
+      color: opptrixCssVars.accent,
+    },
+  },
+})
+
+function previewText(item: QueuedPrompt): string {
+  const text = item.text.trim()
+  if (text) return text
+  const n = item.attachmentIds?.length ?? 0
+  if (n > 0) return n === 1 ? '（1 个附件）' : `（${n} 个附件）`
+  return '（空提示）'
+}
+
+interface Props {
+  items: QueuedPrompt[]
+  /** ask_user 进行中：禁止打断执行 */
+  runNowDisabled?: boolean
+  waitingConfirmHint?: boolean
+  onRunNow: (id: string) => void
+  onRemove: (id: string) => void
+}
+
+export default function ComposerPromptQueuePanel({
+  items,
+  runNowDisabled = false,
+  waitingConfirmHint = false,
+  onRunNow,
+  onRemove,
+}: Props) {
+  const s = useStyles()
+  if (!items.length) return null
+
+  return (
+    <div
+      className={s.root}
+      role="region"
+      aria-label="接下来"
+      data-composer-section="queue"
+    >
+      <div className={s.head}>
+        <Text className={s.title} block>
+          接下来 · {items.length}
+        </Text>
+        {waitingConfirmHint ? (
+          <Text className={s.hint} block>确认后继续</Text>
+        ) : (
+          <Text className={s.hint} block>完成后自动下一条</Text>
+        )}
+      </div>
+      <div className={mergeClasses(s.list, 'opptrix-scroll')}>
+        {items.map((item, index) => (
+          <div
+            key={item.id}
+            className={mergeClasses(s.row, index === 0 && s.rowNext)}
+            data-queue-item={item.id}
+          >
+            <span className={s.index} aria-hidden>{index + 1}</span>
+            <Text className={s.text} title={previewText(item)} block>
+              {previewText(item)}
+            </Text>
+            <div className={s.actions}>
+              <OpptrixButton
+                className={mergeClasses(s.iconBtn, s.iconBtnPlay, 'opptrix-round-icon-btn')}
+                variant="ghost"
+                size="small"
+                icon={<ArrowUpRegular fontSize={13} />}
+                disabled={runNowDisabled}
+                aria-label="打断并立即执行"
+                onClick={() => onRunNow(item.id)}
+              />
+              <OpptrixButton
+                className={mergeClasses(s.iconBtn, 'opptrix-round-icon-btn')}
+                variant="ghost"
+                size="small"
+                icon={<DismissRegular fontSize={13} />}
+                aria-label="从排队移除"
+                onClick={() => onRemove(item.id)}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/client-ui/src/chat/sessionPromptQueue.ts
+++ b/client-ui/src/chat/sessionPromptQueue.ts
@@ -1,0 +1,223 @@
+/**
+ * 会话级提示词编排队列（对标 Codex：执行中可排队，完成后串行 drain）。
+ * 持久化到 localStorage；权威 transcript 仍由服务端会话消息承担。
+ */
+
+import type { ChatAttachmentMeta } from '../types/chat'
+
+export const PROMPT_QUEUE_STORAGE_KEY = 'opptrix-chat-prompt-queue-v1'
+export const PROMPT_QUEUE_MAX_PER_SESSION = 20
+
+export type QueuedPrompt = {
+  id: string
+  text: string
+  attachmentIds?: string[]
+  attachmentMetas?: ChatAttachmentMeta[]
+  createdAt: number
+}
+
+export type EnqueueResult =
+  | { ok: true; item: QueuedPrompt; items: QueuedPrompt[] }
+  | { ok: false; reason: 'empty' | 'full'; items: QueuedPrompt[] }
+
+type QueueStore = Record<string, QueuedPrompt[]>
+
+function newId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `q_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+}
+
+function isAttachmentMeta(raw: unknown): raw is ChatAttachmentMeta {
+  if (!raw || typeof raw !== 'object') return false
+  const o = raw as Record<string, unknown>
+  return typeof o.id === 'string' && typeof o.name === 'string'
+}
+
+export function normalizeQueuedPrompt(raw: unknown): QueuedPrompt | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+  const text = typeof o.text === 'string' ? o.text.trim() : ''
+  const id = typeof o.id === 'string' && o.id.trim() ? o.id.trim() : newId()
+  const createdAt = typeof o.createdAt === 'number' && Number.isFinite(o.createdAt)
+    ? o.createdAt
+    : Date.now()
+  const attachmentIds = Array.isArray(o.attachmentIds)
+    ? o.attachmentIds.filter((x): x is string => typeof x === 'string' && Boolean(x.trim()))
+    : undefined
+  const attachmentMetas = Array.isArray(o.attachmentMetas)
+    ? o.attachmentMetas.filter(isAttachmentMeta)
+    : undefined
+  if (!text && !(attachmentIds?.length)) return null
+  return {
+    id,
+    text,
+    createdAt,
+    ...(attachmentIds?.length ? { attachmentIds } : {}),
+    ...(attachmentMetas?.length ? { attachmentMetas } : {}),
+  }
+}
+
+function normalizeStore(raw: unknown): QueueStore {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
+  const out: QueueStore = {}
+  for (const [sessionId, list] of Object.entries(raw as Record<string, unknown>)) {
+    if (!sessionId || !Array.isArray(list)) continue
+    const items = list
+      .map(normalizeQueuedPrompt)
+      .filter((x): x is QueuedPrompt => x != null)
+      .slice(0, PROMPT_QUEUE_MAX_PER_SESSION)
+    if (items.length) out[sessionId] = items
+  }
+  return out
+}
+
+function canUseLocalStorage(): boolean {
+  try {
+    return typeof globalThis.localStorage?.getItem === 'function'
+      && typeof globalThis.localStorage?.setItem === 'function'
+  } catch {
+    return false
+  }
+}
+
+export function readPromptQueueStore(): QueueStore {
+  if (!canUseLocalStorage()) return {}
+  try {
+    const raw = localStorage.getItem(PROMPT_QUEUE_STORAGE_KEY)
+    if (!raw) return {}
+    return normalizeStore(JSON.parse(raw))
+  } catch {
+    return {}
+  }
+}
+
+export function writePromptQueueStore(store: QueueStore): void {
+  if (!canUseLocalStorage()) return
+  try {
+    const cleaned: QueueStore = {}
+    for (const [sessionId, items] of Object.entries(store)) {
+      if (!sessionId || !items.length) continue
+      cleaned[sessionId] = items.slice(0, PROMPT_QUEUE_MAX_PER_SESSION)
+    }
+    localStorage.setItem(PROMPT_QUEUE_STORAGE_KEY, JSON.stringify(cleaned))
+  } catch {
+    /* quota / private mode */
+  }
+}
+
+function mutateSession(
+  sessionId: string,
+  fn: (items: QueuedPrompt[]) => QueuedPrompt[],
+): QueuedPrompt[] {
+  const store = readPromptQueueStore()
+  const next = fn([...(store[sessionId] ?? [])])
+  if (next.length) store[sessionId] = next
+  else delete store[sessionId]
+  writePromptQueueStore(store)
+  return next
+}
+
+export function listQueuedPrompts(sessionId: string): QueuedPrompt[] {
+  if (!sessionId) return []
+  return [...(readPromptQueueStore()[sessionId] ?? [])]
+}
+
+export function enqueueQueuedPrompt(
+  sessionId: string,
+  input: {
+    text?: string
+    attachmentIds?: string[]
+    attachmentMetas?: ChatAttachmentMeta[]
+  },
+): EnqueueResult {
+  const text = (input.text ?? '').trim()
+  const attachmentIds = input.attachmentIds?.filter(Boolean) ?? []
+  const attachmentMetas = input.attachmentMetas?.filter(m => attachmentIds.includes(m.id))
+  const current = listQueuedPrompts(sessionId)
+  if (!text && !attachmentIds.length) {
+    return { ok: false, reason: 'empty', items: current }
+  }
+  if (current.length >= PROMPT_QUEUE_MAX_PER_SESSION) {
+    return { ok: false, reason: 'full', items: current }
+  }
+  const item: QueuedPrompt = {
+    id: newId(),
+    text,
+    createdAt: Date.now(),
+    ...(attachmentIds.length ? { attachmentIds } : {}),
+    ...(attachmentMetas?.length ? { attachmentMetas } : {}),
+  }
+  const items = mutateSession(sessionId, prev => [...prev, item])
+  return { ok: true, item, items }
+}
+
+export function removeQueuedPrompt(sessionId: string, id: string): QueuedPrompt[] {
+  return mutateSession(sessionId, prev => prev.filter(item => item.id !== id))
+}
+
+export function clearSessionPromptQueue(sessionId: string): void {
+  if (!sessionId) return
+  const store = readPromptQueueStore()
+  if (!(sessionId in store)) return
+  delete store[sessionId]
+  writePromptQueueStore(store)
+}
+
+/** 将指定项移到队首（打断立即执行前调用） */
+export function promoteQueuedPrompt(sessionId: string, id: string): QueuedPrompt[] {
+  return mutateSession(sessionId, prev => {
+    const idx = prev.findIndex(item => item.id === id)
+    if (idx < 0) return prev
+    const next = [...prev]
+    const [item] = next.splice(idx, 1)
+    if (!item) return prev
+    next.unshift(item)
+    return next
+  })
+}
+
+export function shiftQueuedPrompt(sessionId: string): {
+  item: QueuedPrompt | null
+  items: QueuedPrompt[]
+} {
+  const current = listQueuedPrompts(sessionId)
+  if (!current.length) return { item: null, items: current }
+  const [item, ...rest] = current
+  mutateSession(sessionId, () => rest)
+  return { item: item ?? null, items: rest }
+}
+
+export function takeQueuedPromptById(sessionId: string, id: string): {
+  item: QueuedPrompt | null
+  items: QueuedPrompt[]
+} {
+  const current = listQueuedPrompts(sessionId)
+  const item = current.find(x => x.id === id) ?? null
+  if (!item) return { item: null, items: current }
+  const items = removeQueuedPrompt(sessionId, id)
+  return { item, items }
+}
+
+/** Drain 意图：Stop=none；自然结束/失败=auto；打断指定项=runItem */
+export type DrainIntent =
+  | { kind: 'auto' }
+  | { kind: 'none' }
+  | { kind: 'runItem'; itemId: string }
+
+export function resolveDrainAction(
+  intent: DrainIntent,
+  opts: {
+    /** 流结束后是否仍有 pending ask_user（不应续跑） */
+    hasPendingUserPrompt: boolean
+    /** 同会话是否已有新流在跑 */
+    alreadyStreaming: boolean
+  },
+): { action: 'skip' } | { action: 'shift' } | { action: 'take'; itemId: string } {
+  if (opts.alreadyStreaming) return { action: 'skip' }
+  if (opts.hasPendingUserPrompt) return { action: 'skip' }
+  if (intent.kind === 'none') return { action: 'skip' }
+  if (intent.kind === 'runItem') return { action: 'take', itemId: intent.itemId }
+  return { action: 'shift' }
+}

--- a/client-ui/src/chat/sessionStreamRuntime.ts
+++ b/client-ui/src/chat/sessionStreamRuntime.ts
@@ -15,7 +15,7 @@ export function stripPhaseEllipsis(label: string): string {
 }
 
 /**
- * 拼装实时状态行：`模型正在整理结果 · 约 1.2k tokens · 共 8 步…`
+ * 拼装实时状态行：`模型正在整理结果 · 约 1.2k tokens · 第 8 步…`
  * 无 token 时省略 token 段；steps≤0 时省略步数段。
  */
 export function formatLiveThinkingStatus(
@@ -25,11 +25,11 @@ export function formatLiveThinkingStatus(
 ): string | undefined {
   if (!phaseLabel) return undefined
   const parts = [phaseLabel]
-  if (estimatedTokens != null) {
+  if (estimatedTokens != null && Number.isFinite(estimatedTokens)) {
     parts.push(`约 ${formatTokenCount(estimatedTokens)} tokens`)
   }
   if (stepCount > 0) {
-    parts.push(`共 ${stepCount} 步`)
+    parts.push(`第 ${stepCount} 步`)
   }
   return `${parts.join(' · ')}…`
 }

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -51,8 +51,10 @@ import {
 } from './experts/prompt-assembler.js'
 import {
   bindWorkspaceToolBridge,
+  unbindWorkspaceToolBridge,
   type WorkspaceToolBridge,
 } from './mcp/workspace-tools.js'
+import { runInToolSession } from './mcp/tool-session-context.js'
 import {
   CONTEXT_COMPACT_HINT,
   ensureContextBudget,
@@ -256,7 +258,7 @@ export class AgentEngine {
     return { broker, openAiTools }
   }
 
-  private bindWorkspaceBridge(sessionId: string, emit: (event: ChatProgressEvent) => void, signal?: AbortSignal) {
+  private bindWorkspaceBridge(sessionId: string, emit: (event: ChatProgressEvent) => void, signal?: AbortSignal): number {
     const bridge: WorkspaceToolBridge = {
       sessionId,
       signal,
@@ -313,7 +315,7 @@ export class AgentEngine {
         return this.userPromptBridge.waitForAnswer(sessionId, promptId, signal)
       },
     }
-    bindWorkspaceToolBridge(bridge)
+    return bindWorkspaceToolBridge(bridge)
   }
 
   listWorkspaceGrants(sessionId: string) {
@@ -335,8 +337,8 @@ export class AgentEngine {
     return this.workspaceService.removeGrant(sessionId, grantId)
   }
 
-  private bindPackBridge(sessionId: string) {
-    this.tools.bindPackSession({
+  private bindPackBridge(sessionId: string): number {
+    return this.tools.bindPackSession({
       sessionId,
       listPacks: () => listToolPacksPayload(this.lastRoundPackIds),
       activatePacks: (packIds: string[]) => {
@@ -917,8 +919,8 @@ export class AgentEngine {
       contextRef: record.contextRef,
     })
     this.seedExpertDefaultPacks(sessionId, record)
-    this.bindPackBridge(sessionId)
-    this.bindWorkspaceBridge(sessionId, emit, signal)
+    const packBridgeGen = this.bindPackBridge(sessionId)
+    const workspaceBridgeGen = this.bindWorkspaceBridge(sessionId, emit, signal)
     this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
     let activeNames = toolNamesForPacks(this.lastRoundPackIds)
     let { broker, openAiTools } = await this.rebuildRoundTools(activeNames)
@@ -1115,7 +1117,7 @@ export class AgentEngine {
             } else if (!activeSet.has(fn) && !parseNamespacedMcpTool(fn)) {
               result = { error: unloadedToolHint(fn) }
             } else {
-              result = await broker.call(fn, args, { signal })
+              result = await runInToolSession(sessionId, () => broker.call(fn, args, { signal }))
               if (
                 fn === 'activate_tool_pack'
                 || fn === 'enable_mcp_server'
@@ -1193,8 +1195,8 @@ export class AgentEngine {
     return { reply, toolsUsed, sessionId, title: record.title }
     } finally {
       await broker.close().catch(() => {})
-      this.tools.clearPackSession()
-      bindWorkspaceToolBridge(null)
+      this.tools.clearPackSession(sessionId, packBridgeGen)
+      unbindWorkspaceToolBridge(sessionId, workspaceBridgeGen)
     }
     } catch (e) {
       if (

--- a/packages/agent/src/mcp/tool-session-context.ts
+++ b/packages/agent/src/mcp/tool-session-context.ts
@@ -1,0 +1,12 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+/** 工具调用期间的会话上下文（避免全局 bridge 在并发/打断重发时串台） */
+const toolSessionAls = new AsyncLocalStorage<string>()
+
+export function runInToolSession<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+  return toolSessionAls.run(sessionId, fn)
+}
+
+export function currentToolSessionId(): string | undefined {
+  return toolSessionAls.getStore()
+}

--- a/packages/agent/src/mcp/workspace-tools.ts
+++ b/packages/agent/src/mcp/workspace-tools.ts
@@ -24,6 +24,7 @@ import { TOOL_META } from '../tool-meta.js'
 import { getLocalDataCatalog, listLocalDataApis } from '../local-data-catalog.js'
 import type { UserPromptAnswer, UserPromptOption } from '../user-prompt.js'
 import { normalizeVaultSecretName } from '../user-prompt.js'
+import { currentToolSessionId } from './tool-session-context.js'
 
 type JsonSchema = {
   type: 'object'
@@ -65,10 +66,34 @@ export interface WorkspaceToolBridge {
   }) => Promise<UserPromptAnswer>
 }
 
-let bridge: WorkspaceToolBridge | null = null
+type BoundWorkspaceBridge = {
+  bridge: WorkspaceToolBridge
+  gen: number
+}
 
-export function bindWorkspaceToolBridge(next: WorkspaceToolBridge | null) {
-  bridge = next
+let bridgeGenSeq = 0
+const bridgesBySession = new Map<string, BoundWorkspaceBridge>()
+
+/**
+ * 绑定会话级 workspace bridge，返回 generation。
+ * 解绑须带同一 gen，避免同会话打断重发时旧 chat finally 清掉新 bridge。
+ */
+export function bindWorkspaceToolBridge(next: WorkspaceToolBridge): number {
+  const gen = ++bridgeGenSeq
+  bridgesBySession.set(next.sessionId, { bridge: next, gen })
+  return gen
+}
+
+export function unbindWorkspaceToolBridge(sessionId: string, gen: number): void {
+  const cur = bridgesBySession.get(sessionId)
+  if (cur && cur.gen === gen) {
+    bridgesBySession.delete(sessionId)
+  }
+}
+
+/** @deprecated 仅兼容旧调用；请改用 unbindWorkspaceToolBridge(sessionId, gen) */
+export function clearWorkspaceToolBridge(): void {
+  bridgesBySession.clear()
 }
 
 const S = (properties: JsonSchema['properties'], required?: string[]): JsonSchema =>
@@ -168,10 +193,15 @@ function parseInjectHostsArg(raw: unknown): string[] | undefined {
 }
 
 function requireBridge(): WorkspaceToolBridge {
-  if (!bridge) {
+  const sessionId = currentToolSessionId()
+  if (!sessionId) {
     throw new Error('workspace 工具需在聊天会话中调用')
   }
-  return bridge
+  const bound = bridgesBySession.get(sessionId)
+  if (!bound) {
+    throw new Error('workspace 工具需在聊天会话中调用')
+  }
+  return bound.bridge
 }
 
 function parseHeaders(raw: unknown): Record<string, string> | undefined {

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -18,6 +18,7 @@ import {
 } from './unified-mcp-tools.js'
 import { buildBrowserTools } from './mcp/browser-tools.js'
 import { buildWorkspaceTools } from './mcp/workspace-tools.js'
+import { currentToolSessionId } from './mcp/tool-session-context.js'
 import { buildRsshubTools } from './rsshub/rsshub-tools.js'
 import { resolveInstrumentFromParams, resolveOpptrixAppVersion } from '@opptrix/shared'
 import { assembleSystemPrompt } from './experts/prompt-assembler.js'
@@ -105,12 +106,16 @@ export interface OpenAiTool {
 export class ToolRegistry {
   readonly tools: ToolDef[]
   private appContext: AgentAppContext
-  /** 聊天会话的 tool-pack 桥接（list/activate）；由 AgentEngine 在 chat 前绑定 */
-  private packBridge: {
-    sessionId: string
-    listPacks: () => unknown
-    activatePacks: (packIds: string[]) => unknown
-  } | null = null
+  /** 聊天会话的 tool-pack 桥接（list/activate）；按 session+gen 绑定，避免打断重发竞态 */
+  private packBridges = new Map<string, {
+    bridge: {
+      sessionId: string
+      listPacks: () => unknown
+      activatePacks: (packIds: string[]) => unknown
+    }
+    gen: number
+  }>()
+  private packBridgeGenSeq = 0
 
   constructor(private hub: ResearchHub, appContext?: AgentAppContext) {
     this.appContext = appContext ?? createDefaultAppContext()
@@ -123,12 +128,31 @@ export class ToolRegistry {
     ]
   }
 
-  bindPackSession(bridge: NonNullable<ToolRegistry['packBridge']>) {
-    this.packBridge = bridge
+  bindPackSession(bridge: {
+    sessionId: string
+    listPacks: () => unknown
+    activatePacks: (packIds: string[]) => unknown
+  }): number {
+    const gen = ++this.packBridgeGenSeq
+    this.packBridges.set(bridge.sessionId, { bridge, gen })
+    return gen
   }
 
-  clearPackSession() {
-    this.packBridge = null
+  clearPackSession(sessionId: string, gen: number): void {
+    const cur = this.packBridges.get(sessionId)
+    if (cur && cur.gen === gen) {
+      this.packBridges.delete(sessionId)
+    }
+  }
+
+  private requirePackBridge(): {
+    sessionId: string
+    listPacks: () => unknown
+    activatePacks: (packIds: string[]) => unknown
+  } | null {
+    const sessionId = currentToolSessionId()
+    if (!sessionId) return null
+    return this.packBridges.get(sessionId)?.bridge ?? null
   }
 
   list() { return this.tools }
@@ -653,10 +677,11 @@ export class ToolRegistry {
         description: '列出可用 MCP 工具包（id/标题/说明/工具数/是否已加载），不含完整 schema',
         parameters: S({}),
         handler: async () => {
-          if (!this.packBridge) {
+          const pack = this.requirePackBridge()
+          if (!pack) {
             return { error: 'list_tool_packs 需在聊天会话中调用' }
           }
-          return this.packBridge.listPacks()
+          return pack.listPacks()
         },
       },
       {
@@ -671,7 +696,8 @@ export class ToolRegistry {
           },
         }, ['pack_ids']),
         handler: async (a: Record<string, unknown>) => {
-          if (!this.packBridge) {
+          const pack = this.requirePackBridge()
+          if (!pack) {
             return { error: 'activate_tool_pack 需在聊天会话中调用' }
           }
           const raw = a.pack_ids ?? a.packIds
@@ -680,7 +706,7 @@ export class ToolRegistry {
             : typeof raw === 'string'
               ? [raw]
               : []
-          return this.packBridge.activatePacks(packIds)
+          return pack.activatePacks(packIds)
         },
       },
       {

--- a/tests/session-prompt-queue.test.mjs
+++ b/tests/session-prompt-queue.test.mjs
@@ -1,0 +1,141 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  PROMPT_QUEUE_MAX_PER_SESSION,
+  PROMPT_QUEUE_STORAGE_KEY,
+  clearSessionPromptQueue,
+  enqueueQueuedPrompt,
+  listQueuedPrompts,
+  normalizeQueuedPrompt,
+  promoteQueuedPrompt,
+  removeQueuedPrompt,
+  resolveDrainAction,
+  shiftQueuedPrompt,
+  takeQueuedPromptById,
+  writePromptQueueStore,
+} from '../client-ui/src/chat/sessionPromptQueue.ts'
+
+const SESSION = 'sess-test-queue'
+
+function installMemoryLocalStorage() {
+  const map = new Map()
+  globalThis.localStorage = {
+    getItem: (key) => (map.has(key) ? map.get(key) : null),
+    setItem: (key, value) => { map.set(key, String(value)) },
+    removeItem: (key) => { map.delete(key) },
+    clear: () => { map.clear() },
+    key: (i) => [...map.keys()][i] ?? null,
+    get length() { return map.size },
+  }
+}
+
+describe('sessionPromptQueue', () => {
+  beforeEach(() => {
+    installMemoryLocalStorage()
+    writePromptQueueStore({})
+  })
+
+  afterEach(() => {
+    writePromptQueueStore({})
+  })
+
+  it('normalizes valid and rejects empty prompts', () => {
+    assert.equal(normalizeQueuedPrompt(null), null)
+    assert.equal(normalizeQueuedPrompt({ text: '  ' }), null)
+    const ok = normalizeQueuedPrompt({ id: 'a', text: ' hello ', createdAt: 1 })
+    assert.deepEqual(ok, { id: 'a', text: 'hello', createdAt: 1 })
+  })
+
+  it('enqueues, lists, removes, and clears by session', () => {
+    const a = enqueueQueuedPrompt(SESSION, { text: '第一句' })
+    assert.equal(a.ok, true)
+    const b = enqueueQueuedPrompt(SESSION, { text: '第二句' })
+    assert.equal(b.ok, true)
+    assert.equal(listQueuedPrompts(SESSION).length, 2)
+
+    removeQueuedPrompt(SESSION, a.ok ? a.item.id : '')
+    assert.equal(listQueuedPrompts(SESSION).length, 1)
+    assert.equal(listQueuedPrompts(SESSION)[0]?.text, '第二句')
+
+    clearSessionPromptQueue(SESSION)
+    assert.equal(listQueuedPrompts(SESSION).length, 0)
+  })
+
+  it('rejects when queue is full', () => {
+    for (let i = 0; i < PROMPT_QUEUE_MAX_PER_SESSION; i += 1) {
+      const r = enqueueQueuedPrompt(SESSION, { text: `t${i}` })
+      assert.equal(r.ok, true)
+    }
+    const full = enqueueQueuedPrompt(SESSION, { text: 'overflow' })
+    assert.equal(full.ok, false)
+    if (!full.ok) assert.equal(full.reason, 'full')
+    assert.equal(listQueuedPrompts(SESSION).length, PROMPT_QUEUE_MAX_PER_SESSION)
+  })
+
+  it('promotes item to front and shifts next', () => {
+    enqueueQueuedPrompt(SESSION, { text: 'a' })
+    enqueueQueuedPrompt(SESSION, { text: 'b' })
+    const third = enqueueQueuedPrompt(SESSION, { text: 'c' })
+    assert.equal(third.ok, true)
+    if (!third.ok) return
+
+    promoteQueuedPrompt(SESSION, third.item.id)
+    assert.equal(listQueuedPrompts(SESSION)[0]?.id, third.item.id)
+
+    const shifted = shiftQueuedPrompt(SESSION)
+    assert.equal(shifted.item?.id, third.item.id)
+    assert.equal(shifted.items.length, 2)
+    assert.equal(shifted.items[0]?.text, 'a')
+  })
+
+  it('takeQueuedPromptById removes specific item', () => {
+    const first = enqueueQueuedPrompt(SESSION, { text: 'a' })
+    const second = enqueueQueuedPrompt(SESSION, { text: 'b' })
+    assert.equal(first.ok && second.ok, true)
+    if (!first.ok || !second.ok) return
+
+    const taken = takeQueuedPromptById(SESSION, second.item.id)
+    assert.equal(taken.item?.id, second.item.id)
+    assert.equal(taken.items.length, 1)
+    assert.equal(taken.items[0]?.id, first.item.id)
+  })
+
+  it('persists to localStorage key', () => {
+    enqueueQueuedPrompt(SESSION, { text: 'persist-me' })
+    const raw = localStorage.getItem(PROMPT_QUEUE_STORAGE_KEY)
+    assert.ok(raw)
+    const parsed = JSON.parse(raw)
+    assert.equal(parsed[SESSION][0].text, 'persist-me')
+  })
+})
+
+describe('resolveDrainAction', () => {
+  it('skips when already streaming, pending ask, or stop intent', () => {
+    assert.deepEqual(
+      resolveDrainAction({ kind: 'auto' }, { hasPendingUserPrompt: false, alreadyStreaming: true }),
+      { action: 'skip' },
+    )
+    assert.deepEqual(
+      resolveDrainAction({ kind: 'auto' }, { hasPendingUserPrompt: true, alreadyStreaming: false }),
+      { action: 'skip' },
+    )
+    assert.deepEqual(
+      resolveDrainAction({ kind: 'none' }, { hasPendingUserPrompt: false, alreadyStreaming: false }),
+      { action: 'skip' },
+    )
+  })
+
+  it('shifts on auto and takes on runItem', () => {
+    assert.deepEqual(
+      resolveDrainAction({ kind: 'auto' }, { hasPendingUserPrompt: false, alreadyStreaming: false }),
+      { action: 'shift' },
+    )
+    assert.deepEqual(
+      resolveDrainAction(
+        { kind: 'runItem', itemId: 'x' },
+        { hasPendingUserPrompt: false, alreadyStreaming: false },
+      ),
+      { action: 'take', itemId: 'x' },
+    )
+  })
+})

--- a/tests/session-stream-runtime.test.mjs
+++ b/tests/session-stream-runtime.test.mjs
@@ -40,11 +40,11 @@ describe('formatLiveThinkingStatus', () => {
   it('includes step count only when > 0', () => {
     assert.equal(
       formatLiveThinkingStatus('模型正在整理结果', 1200, 8),
-      '模型正在整理结果 · 约 1.2k tokens · 共 8 步…',
+      '模型正在整理结果 · 约 1.2k tokens · 第 8 步…',
     )
     assert.equal(
       formatLiveThinkingStatus('模型正在整理结果', undefined, 3),
-      '模型正在整理结果 · 共 3 步…',
+      '模型正在整理结果 · 第 3 步…',
     )
   })
 })
@@ -211,7 +211,7 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       },
     })
     assert.equal(snap.liveTrace?.phaseLabel, '模型正在整理结果')
-    assert.match(snap.liveTrace?.thinkingLabel ?? '', /共 1 步/)
+    assert.match(snap.liveTrace?.thinkingLabel ?? '', /第 1 步/)
 
     snap = applyChatProgressEvent(snap, {
       type: 'reply',
@@ -219,7 +219,7 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
     })
     assert.equal(
       snap.liveTrace?.thinkingLabel,
-      '模型正在整理结果 · 约 1.2k tokens · 共 1 步…',
+      '模型正在整理结果 · 约 1.2k tokens · 第 1 步…',
     )
   })
 
@@ -244,6 +244,6 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
       },
     })
     assert.equal(snap.liveTrace?.estimatedTokens, 50)
-    assert.equal(snap.liveTrace?.thinkingLabel, '模型正在思考 · 约 50 tokens · 共 1 步…')
+    assert.equal(snap.liveTrace?.thinkingLabel, '模型正在思考 · 约 50 tokens · 第 1 步…')
   })
 })

--- a/tests/tool-session-bridge-race.test.mjs
+++ b/tests/tool-session-bridge-race.test.mjs
@@ -1,0 +1,84 @@
+/**
+ * 同会话打断重发时，旧 chat finally 不得清掉新一轮的 workspace / pack bridge。
+ * 依赖：先 npm run build -w @opptrix/agent
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  bindWorkspaceToolBridge,
+  unbindWorkspaceToolBridge,
+  clearWorkspaceToolBridge,
+  buildWorkspaceTools,
+} from '../packages/agent/dist/mcp/workspace-tools.js'
+import { runInToolSession } from '../packages/agent/dist/mcp/tool-session-context.js'
+import { ToolRegistry } from '../packages/agent/dist/tools.js'
+
+function stubBridge(sessionId) {
+  return {
+    sessionId,
+    confirm: async () => ({ selected_ids: [] }),
+  }
+}
+
+test('unbind 旧 gen 不清除同会话新 bind 的 workspace bridge', async () => {
+  clearWorkspaceToolBridge()
+  const sessionId = 'sess-race-ws'
+  const tools = buildWorkspaceTools()
+  const folderAccess = tools.find(t => t.name === 'request_folder_access')
+  assert.ok(folderAccess)
+
+  const gen1 = bindWorkspaceToolBridge(stubBridge(sessionId))
+  const gen2 = bindWorkspaceToolBridge(stubBridge(sessionId))
+  assert.notEqual(gen1, gen2)
+
+  // 模拟被 abort 的旧 chat finally：只应卸掉 gen1
+  unbindWorkspaceToolBridge(sessionId, gen1)
+
+  const ok = await runInToolSession(sessionId, () => folderAccess.handler({}))
+  assert.equal(ok.awaiting_user_grant, true)
+
+  // 卸掉正确 gen 后应报会话错误
+  unbindWorkspaceToolBridge(sessionId, gen2)
+  const fail = await runInToolSession(sessionId, () => folderAccess.handler({}))
+  assert.match(String(fail.error ?? ''), /workspace 工具需在聊天会话中调用/)
+
+  // 无 ALS 上下文同样失败
+  const noCtx = await folderAccess.handler({})
+  assert.match(String(noCtx.error ?? ''), /workspace 工具需在聊天会话中调用/)
+
+  clearWorkspaceToolBridge()
+})
+
+test('clearPackSession 旧 gen 不清除同会话新 bind', async () => {
+  const hub = { dispatch: async () => ({ success: true, data: {} }) }
+  const registry = new ToolRegistry(hub)
+  const sessionId = 'sess-race-pack'
+  const activate = registry.get('activate_tool_pack')
+  assert.ok(activate)
+
+  const gen1 = registry.bindPackSession({
+    sessionId,
+    listPacks: () => ({ packs: [] }),
+    activatePacks: () => ({ ok: true, activated: ['news'] }),
+  })
+  const gen2 = registry.bindPackSession({
+    sessionId,
+    listPacks: () => ({ packs: [] }),
+    activatePacks: () => ({ ok: true, activated: ['etf'] }),
+  })
+  assert.notEqual(gen1, gen2)
+
+  registry.clearPackSession(sessionId, gen1)
+
+  const ok = await runInToolSession(sessionId, () =>
+    activate.handler({ pack_ids: ['etf'] }),
+  )
+  assert.equal(ok.ok, true)
+  assert.deepEqual(ok.activated, ['etf'])
+
+  registry.clearPackSession(sessionId, gen2)
+  const fail = await runInToolSession(sessionId, () =>
+    activate.handler({ pack_ids: ['etf'] }),
+  )
+  assert.match(String(fail.error ?? ''), /activate_tool_pack 需在聊天会话中调用/)
+})


### PR DESCRIPTION
## Summary
- 执行中可继续输入并串行排队提示（客户端编排；Stop 只停当前、保留队列；失败跳过下一条）
- 修复历史对话打断/重发时 `workspace` / `activate_tool_pack` 因旧 `finally` 清掉新 bridge 报错
- 状态行改为「第 N 步」，修复 token 文案被透明裁切；去掉快捷提问标题以省纵向空间

## Test plan
- [ ] 流式生成中再发一条 → 出现「接下来 · N」，当前结束后自动续跑
- [ ] Stop 后队列仍在；失败一条后继续下一条
- [ ] 历史会话打断后立刻再发并调用 workspace / activate_tool_pack → 不再报「需在聊天会话中调用」
- [ ] `node --test tests/session-prompt-queue.test.mjs tests/tool-session-bridge-race.test.mjs`
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)