### PR TITLE
docs(readme): badge 同一行居中展示

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 # Opptrix — 全球多市场投研助手
 
-[![GitHub](https://img.shields.io/badge/GitHub-仓库-181717?logo=github&logoColor=white)](https://github.com/Travisun/Opptrix) [![Gitee](https://img.shields.io/badge/Gitee-仓库-C71D23?logo=gitee&logoColor=white)](https://gitee.com/Travisun/Opptrix) [![Download](https://img.shields.io/badge/下载-v0.7.0_·_2026--07--16-2ea44f&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0xMSAxNFY0aDJ2MTBsMy0zIDEgMS01IDUtNS01IDEtMSAzIDN6Ii8+PHBhdGggib3BhY2l0eT0iLjYiIGQ9Ik00IDE4aDE2djJINHoiLz48L3N2Zz4=)](https://github.com/Travisun/Opptrix/releases) [![Born in LINUX.DO](https://img.shields.io/badge/Born%20in-LINUX.DO-009185?style=flat&)](https://linux.do) [![Node.js](https://img.shields.io/badge/node-%3E%3D24-brightgreen)](https://nodejs.org/) [![TypeScript](https://img.shields.io/badge/TypeScript-5.7-blue)](https://www.typescriptlang.org/) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+<p align="center">
+  <a href="https://github.com/Travisun/Opptrix"><img src="https://img.shields.io/badge/GitHub-%E4%BB%93%E5%BA%93-181717?logo=github&logoColor=white" alt="GitHub" /></a>&nbsp;<a href="https://gitee.com/Travisun/Opptrix"><img src="https://img.shields.io/badge/Gitee-%E4%BB%93%E5%BA%93-C71D23?logo=gitee&logoColor=white" alt="Gitee" /></a>&nbsp;<a href="https://github.com/Travisun/Opptrix/releases"><img src="https://img.shields.io/badge/%E4%B8%8B%E8%BD%BD-v0.7.0-2ea44f" alt="Download" /></a>&nbsp;<a href="https://linux.do"><img src="https://img.shields.io/badge/Born%20in-LINUX.DO-009185" alt="Born in LINUX.DO" /></a>&nbsp;<a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D24-brightgreen" alt="Node.js" /></a>&nbsp;<a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.7-blue" alt="TypeScript" /></a>&nbsp;<a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
+</p>
 
 <p align="center">
   <img src="screenshot.jpg" alt="Opptrix 主界面：对话投研、工具执行过程与右侧个股行情面板" width="920" />


### PR DESCRIPTION
## Summary
- README badge 改为居中 HTML + \`&nbsp;\` 连成一行
- 缩短损坏/过长的下载 badge，去掉无效 logo data URI

## Test plan
- [ ] 在 GitHub PR / 仓库页确认 badge 同一行展示


Made with [Cursor](https://cursor.com)