### PR TITLE
docs(readme): 用 table 排布 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Opptrix — 全球多市场投研助手
 
-<div align="center" style="display:flex; flex-wrap:wrap; justify-content:center; align-items:center; gap:6px">
+<table align="center"><tr><td align="center">
   <a href="https://github.com/Travisun/Opptrix"><img src="https://img.shields.io/badge/GitHub-%E4%BB%93%E5%BA%93-181717?logo=github&logoColor=white" alt="GitHub" /></a>
   <a href="https://gitee.com/Travisun/Opptrix"><img src="https://img.shields.io/badge/Gitee-%E4%BB%93%E5%BA%93-C71D23?logo=gitee&logoColor=white" alt="Gitee" /></a>
   <a href="https://github.com/Travisun/Opptrix/releases"><img src="https://img.shields.io/badge/%E4%B8%8B%E8%BD%BD-v0.7.0-2ea44f" alt="Download" /></a>
@@ -12,7 +12,7 @@
   <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D24-brightgreen" alt="Node.js" /></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.7-blue" alt="TypeScript" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
-</div>
+</td></tr></table>
 
 <p align="center">
   <img src="screenshot.jpg" alt="Opptrix 主界面：对话投研、工具执行过程与右侧个股行情面板" width="920" />


### PR DESCRIPTION
## Summary
- 将 badge 改为单行 \`table\` 居中排布（不依赖会被 GitHub 剥离的 style/flex）

## Test plan
- [ ] 仓库首页确认 badge 同一行


Made with [Cursor](https://cursor.com)