### PR TITLE
feat(chat): 右侧文件预览面板与附件引用体验

### DIFF
--- a/apps/server/src/session-attachment-routes.ts
+++ b/apps/server/src/session-attachment-routes.ts
@@ -8,12 +8,15 @@ import {
   saveAttachment,
   deleteAttachment,
   readAttachmentMeta,
+  readAttachmentBuffer,
+  readExtractMarkdown,
   resolveAttachmentFilePath,
   validateAttachmentAgainstCapabilities,
   isAttachmentReferenced,
   parseNonNegativeIntHeader,
   resolveUploadMime,
 } from '@opptrix/agent'
+import { decodeTextBuffer, isPlainTextDocument } from '@opptrix/doc-library'
 
 function sanitizeFilename(name: string): string {
   const base = path.basename(name.trim() || 'file')
@@ -138,6 +141,53 @@ export function registerSessionAttachmentRoutes(app: FastifyInstance, agent: Age
       reply.header('Content-Type', meta.mime)
       reply.header('Content-Disposition', `inline; filename="${encodeURIComponent(meta.name)}"`)
       return reply.send(fs.createReadStream(filePath))
+    },
+  )
+
+  app.get<{ Params: { id: string; attachmentId: string } }>(
+    '/api/sessions/:id/attachments/:attachmentId/extract/text',
+    async (req, reply) => {
+      const session = agent.getSession(req.params.id)
+      if (!session) return reply.code(404).send({ error: 'session not found' })
+
+      const meta = readAttachmentMeta(req.params.id, req.params.attachmentId)
+      if (!meta) return reply.code(404).send({ error: 'attachment not found' })
+
+      const md = readExtractMarkdown(req.params.id, req.params.attachmentId)
+      if (md) {
+        // Buffer 发送，避免 Fastify 对 string 走 JSON 序列化坑
+        return reply
+          .type('text/markdown; charset=utf-8')
+          .send(Buffer.from(md, 'utf8'))
+      }
+
+      // 纯文本：无 extract.md 时直接读原文（上传侧多为 kind=document）
+      const plainText =
+        meta.kind === 'text'
+        || isPlainTextDocument(meta.mime, meta.name)
+        || (meta.kind === 'document' && isPlainTextDocument(meta.mime, meta.name))
+      if (plainText) {
+        const buffer = readAttachmentBuffer(req.params.id, req.params.attachmentId)
+        if (buffer) {
+          const text = decodeTextBuffer(buffer)
+          return reply
+            .type('text/plain; charset=utf-8')
+            .send(Buffer.from(text, 'utf8'))
+        }
+      }
+
+      if (meta.extract?.status === 'pending') {
+        return reply.code(202).send({ status: 'pending' })
+      }
+
+      if (meta.extract?.status === 'failed') {
+        return reply.code(422).send({
+          status: 'failed',
+          message: meta.extract?.error ?? '未能整理该文件',
+        })
+      }
+
+      return reply.code(422).send({ status: 'failed', message: '暂不支持预览此文件' })
     },
   )
 

--- a/client-ui/package.json
+++ b/client-ui/package.json
@@ -30,6 +30,7 @@
     "katex": "^0.17.0",
     "lightweight-charts": "^5.0.7",
     "mermaid": "^11.16.0",
+    "pdfjs-dist": "^6.2.108",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -17,6 +17,7 @@ import {
   pickExportDestination,
   saveMarketPackageBlob,
 } from '../platform/saveMarketPackage'
+import { decodeTextBufferBytes } from '../utils/decodeTextBuffer'
 
 /** Vite dev/preview proxies /api → backend (default :8711). */
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
@@ -1643,6 +1644,52 @@ export async function fetchSessionAttachmentMeta(
   return jsonFetch<{ attachment: ChatAttachmentMeta }>(
     `/sessions/${sessionId}/attachments/${attachmentId}/meta`,
   ).then(r => r.attachment)
+}
+
+export type AttachmentPreviewTextResult =
+  | { ok: true; text: string }
+  | { ok: false; status: 'pending' | 'failed'; message?: string }
+
+export async function fetchAttachmentPreviewText(
+  sessionId: string,
+  attachmentId: string,
+): Promise<AttachmentPreviewTextResult> {
+  const resp = await fetchWithTimeout(
+    `${API_BASE}/sessions/${sessionId}/attachments/${attachmentId}/extract/text`,
+    { method: 'GET' },
+  )
+
+  if (resp.ok) {
+    return { ok: true, text: await resp.text() }
+  }
+
+  if (resp.status === 202) {
+    return { ok: false, status: 'pending' }
+  }
+
+  if (resp.status === 422) {
+    const data = await resp.json().catch(() => ({})) as { message?: string }
+    return { ok: false, status: 'failed', message: data.message }
+  }
+
+  throw new Error(`提取预览文本失败 (${resp.status})`)
+}
+
+/** 直读附件原文并本地解码（纯文本预览回退，不依赖 extract） */
+export async function fetchAttachmentRawText(
+  sessionId: string,
+  attachmentId: string,
+): Promise<{ ok: true; text: string } | { ok: false }> {
+  const resp = await fetchWithTimeout(sessionAttachmentUrl(sessionId, attachmentId), {
+    method: 'GET',
+  })
+  if (!resp.ok) return { ok: false }
+  try {
+    const buf = await resp.arrayBuffer()
+    return { ok: true, text: decodeTextBufferBytes(buf) }
+  } catch {
+    return { ok: false }
+  }
 }
 
 export async function deleteSessionAttachment(sessionId: string, attachmentId: string) {

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -205,13 +205,33 @@ export default function ChatApp() {
     canToggleChatColumn,
     beginDrag,
     collapseRightPanel,
+    closePreview,
     toggleRightPanel: handleToggleRightPanel,
     toggleChatColumn: handleToggleChatColumn,
+    mode,
+    openPreview,
+    openMarket,
   } = useWorkspaceSplit({ enabled: splitEnabled })
 
   const workspaceMinWidth = splitEnabled && rightPanelVisible
     ? WORKSPACE_CHAT_RIGHT_MIN_WIDTH
     : WORKSPACE_CHAT_MIN_WIDTH
+
+  const [preview, setPreview] = useState<{ sessionId: string; attachment: ChatAttachmentMeta } | null>(null)
+
+  useEffect(() => {
+    if (mode === 'market') setPreview(null)
+  }, [mode])
+
+  const handleOpenFilePreview = useCallback((sessionId: string, attachment: ChatAttachmentMeta) => {
+    setPreview({ sessionId, attachment })
+    openPreview()
+  }, [openPreview])
+
+  const handleClosePreview = useCallback(() => {
+    setPreview(null)
+    closePreview()
+  }, [closePreview])
 
   const {
     width: sidebarWidth,
@@ -927,7 +947,7 @@ export default function ChatApp() {
     if (action.type === 'stock') {
       restoreChatColumn()
       setFocusStockCode(normalizeWatchlistItem({ code: action.code, name: action.name }).code)
-      if (!rightPanelVisible) handleToggleRightPanel()
+      openMarket()
       if (view !== 'chat') navigate('chat')
       return
     }
@@ -940,8 +960,7 @@ export default function ChatApp() {
     navigate,
     restoreChatColumn,
     closeDrawer,
-    rightPanelVisible,
-    handleToggleRightPanel,
+    openMarket,
     view,
   ])
 
@@ -1752,6 +1771,7 @@ export default function ChatApp() {
                   chatColumnVisible={chatVisible}
                   onToggleRightPanel={!isMobile ? handleToggleRightPanel : undefined}
                   onToggleChatColumn={!isMobile && canToggleChatColumn ? handleToggleChatColumn : undefined}
+                  onOpenFilePreview={!isMobile ? handleOpenFilePreview : undefined}
                   onStreamError={handleStreamError}
                   resolveStreamSnapshot={resolveStreamSnapshot}
                   onClearPendingUserPrompt={clearPendingUserPrompt}
@@ -1783,6 +1803,8 @@ export default function ChatApp() {
               onToggleRightPanel={handleToggleRightPanel}
               onToggleChatColumn={canToggleChatColumn ? handleToggleChatColumn : undefined}
               onDiscussInChat={handleStockDiscuss}
+              preview={preview}
+              onClosePreview={handleClosePreview}
             />
           )}
         </div>

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -326,6 +326,7 @@ interface ChatComposerProps {
   promptQueue?: QueuedPrompt[]
   onPromptQueueRemove?: (id: string) => void
   onPromptQueueRunNow?: (id: string) => void
+  onOpenPreview?: (sessionId: string, attachment: ChatAttachmentMeta) => void
 }
 
 /** 供 ChatView 在消息区 drop 时调用，避免重复 pin 状态 */
@@ -358,6 +359,7 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
   promptQueue = [],
   onPromptQueueRemove,
   onPromptQueueRunNow,
+  onOpenPreview,
 }, ref) {
   const s = useStyles()
   const editorRef = useRef<HTMLDivElement>(null)
@@ -771,6 +773,7 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
               items={pinned}
               sessionId={sessionId}
               onRemove={removePinned}
+              onPreview={onOpenPreview && sessionId ? (item) => onOpenPreview(sessionId, item) : undefined}
             />
             <div className={s.editorRow}>
               <span ref={mentionAnchorRef} className={s.mentionAnchor} aria-hidden />

--- a/client-ui/src/chat/ChatMessageItem.tsx
+++ b/client-ui/src/chat/ChatMessageItem.tsx
@@ -146,9 +146,10 @@ interface Props {
   sessionId?: string | null
   isMobile?: boolean
   onFork?: () => void
+  onOpenPreview?: (sessionId: string, attachment: ChatAttachmentMeta) => void
 }
 
-function ChatMessageItem({ message, index, sessionId, isMobile = false, onFork }: Props) {
+function ChatMessageItem({ message, index, sessionId, isMobile = false, onFork, onOpenPreview }: Props) {
   const s = useStyles()
   const [copied, setCopied] = useState(false)
   const [previewAttachment, setPreviewAttachment] = useState<ChatAttachmentMeta | null>(null)
@@ -247,7 +248,13 @@ function ChatMessageItem({ message, index, sessionId, isMobile = false, onFork }
         {message.attachments && message.attachments.length > 0 && (
           <MessageAttachmentStrip
             items={message.attachments}
-            onOpen={setPreviewAttachment}
+            onOpen={(item) => {
+              if (isMobile || !onOpenPreview) {
+                setPreviewAttachment(item)
+                return
+              }
+              if (sessionId) onOpenPreview(sessionId, item)
+            }}
           />
         )}
         {isUser

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -318,6 +318,7 @@ interface ChatViewProps {
   onToggleSidebar?: () => void
   rightPanelOpen?: boolean
   onToggleRightPanel?: () => void
+  onOpenFilePreview?: (sessionId: string, attachment: ChatAttachmentMeta) => void
   chatColumnVisible?: boolean
   onToggleChatColumn?: () => void
   onStreamError?: (message: string) => void
@@ -338,6 +339,7 @@ function ChatView({
   onOpenSidebar, onNewChat, onOpenSettings,
   rightPanelOpen = false,
   onToggleRightPanel,
+  onOpenFilePreview,
   chatColumnVisible = true,
   onToggleChatColumn,
   onStreamError,
@@ -880,6 +882,7 @@ function ChatView({
                   sessionId={sessionId}
                   isMobile={isMobile}
                   onFork={onForkMessage ? () => onForkMessage(i) : undefined}
+                  onOpenPreview={onOpenFilePreview}
                 />
               ))}
 
@@ -942,6 +945,7 @@ function ChatView({
               promptQueue={promptQueue}
               onPromptQueueRemove={onPromptQueueRemove}
               onPromptQueueRunNow={onPromptQueueRunNow}
+              onOpenPreview={onOpenFilePreview}
             />
           </div>
         </div>

--- a/client-ui/src/chat/ComposerAttachmentStrip.tsx
+++ b/client-ui/src/chat/ComposerAttachmentStrip.tsx
@@ -1,29 +1,28 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
-import { makeStyles, mergeClasses } from '@fluentui/react-components'
-import {
-  DocumentPdfRegular,
-  MusicNote2Regular,
-  VideoRegular,
-  ImageRegular,
-  DismissRegular,
-} from '@fluentui/react-icons'
-import type { ChatAttachmentMeta, MediaKind } from '../types/chat'
-import { formatBytesShort } from './mediaCapabilities'
+import { makeStyles, mergeClasses, Spinner } from '@fluentui/react-components'
+import { DismissRegular } from '@fluentui/react-icons'
+import type { ChatAttachmentMeta } from '../types/chat'
+import { attachmentKindIcon } from './attachmentKindIcon'
 import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+
+const CHIP_WIDTH = 168
+const NAME_MAX_CHARS = 16
 
 const useStyles = makeStyles({
   strip: {
     display: 'flex',
     flexWrap: 'wrap',
-    gap: '8px',
+    gap: '6px',
     padding: '0 2px 4px',
   },
   chip: {
     display: 'inline-flex',
     alignItems: 'center',
-    gap: '8px',
-    maxWidth: '220px',
-    padding: '6px 8px 6px 6px',
+    gap: '6px',
+    width: `${CHIP_WIDTH}px`,
+    maxWidth: `${CHIP_WIDTH}px`,
+    boxSizing: 'border-box',
+    padding: '3px 4px 3px 3px',
     borderRadius: opptrixTokens.radiusMd,
     border: `1px solid ${opptrixCssVars.border}`,
     backgroundColor: opptrixCssVars.canvasAlt,
@@ -31,16 +30,16 @@ const useStyles = makeStyles({
     color: opptrixCssVars.textSecondary,
   },
   thumb: {
-    width: '36px',
-    height: '36px',
+    width: '26px',
+    height: '26px',
     borderRadius: opptrixTokens.radiusSm,
     objectFit: 'cover',
     flexShrink: 0,
     backgroundColor: opptrixCssVars.canvas,
   },
   iconBox: {
-    width: '36px',
-    height: '36px',
+    width: '26px',
+    height: '26px',
     borderRadius: opptrixTokens.radiusSm,
     display: 'inline-flex',
     alignItems: 'center',
@@ -49,71 +48,85 @@ const useStyles = makeStyles({
     backgroundColor: opptrixCssVars.canvas,
     color: opptrixCssVars.textTertiary,
   },
-  meta: {
-    minWidth: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '2px',
-  },
   name: {
+    flex: 1,
+    minWidth: 0,
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     color: opptrixCssVars.textPrimary,
-    fontSize: 'var(--opptrix-font-base)',
-  },
-  size: {
     fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
+    lineHeight: '18px',
   },
   remove: {
     border: 'none',
     background: 'transparent',
     padding: 0,
-    marginLeft: '2px',
+    marginLeft: '0',
     color: opptrixCssVars.textTertiary,
     cursor: 'pointer',
     display: 'inline-flex',
+    flexShrink: 0,
     ':hover': { color: opptrixCssVars.textSecondary },
   },
 })
 
-function kindIcon(kind: MediaKind) {
-  switch (kind) {
-    case 'pdf': return <DocumentPdfRegular fontSize={18} />
-    case 'document': return <DocumentPdfRegular fontSize={18} />
-    case 'video': return <VideoRegular fontSize={18} />
-    case 'audio': return <MusicNote2Regular fontSize={18} />
-    default: return <ImageRegular fontSize={18} />
+/** 中间省略文件名，尽量保留扩展名 */
+export function middleEllipsisFilename(name: string, maxChars = NAME_MAX_CHARS): string {
+  if (name.length <= maxChars) return name
+  const dot = name.lastIndexOf('.')
+  const ext = dot > 0 && name.length - dot <= 8 ? name.slice(dot) : ''
+  const base = ext ? name.slice(0, dot) : name
+  const budget = maxChars - ext.length - 1
+  if (budget < 4) {
+    return `${name.slice(0, Math.max(1, maxChars - 1))}…`
   }
+  const head = Math.ceil(budget / 2)
+  const tail = Math.floor(budget / 2)
+  return `${base.slice(0, head)}…${base.slice(-tail)}${ext}`
 }
 
-function attachmentStatusLabel(item: ChatAttachmentMeta): string {
+function isAttachmentProcessing(item: ChatAttachmentMeta): boolean {
+  if (item.optimistic || item.id.startsWith('local-')) return true
   if (item.kind === 'pdf' || item.kind === 'document' || item.kind === 'image') {
-    const status = item.extract?.status
-    if (status === 'pending') {
-      if (item.kind === 'image') return '正在识别文字…'
-      const phase = item.extract?.phase
-      if (phase === 'converting') return '正在转换文档…'
-      if (phase === 'ocr') {
-        const done = item.extract?.ocrDone
-        const total = item.extract?.ocrTotal
-        if (typeof done === 'number' && typeof total === 'number' && total > 0) {
-          return `正在识别图片文字（${done}/${total}）…`
-        }
-        return '正在识别图片文字…'
-      }
-      const msg = item.extract?.message?.trim()
-      if (msg) return msg
-      return '正在整理…'
-    }
-    if (status === 'ready') {
-      const pages = item.extract?.pageCount
-      return pages != null ? `已整理，共 ${pages} 页` : '已整理'
-    }
-    if (status === 'failed') return item.extract?.error || '整理失败，请换可读文件后重试'
+    return (item.extract?.status ?? 'pending') === 'pending'
   }
-  return formatBytesShort(item.size)
+  return false
+}
+
+function attachmentTitle(item: ChatAttachmentMeta): string {
+  if (item.extract?.status === 'failed') {
+    const reason = item.extract.error?.trim() || '整理失败，请换可读文件后重试'
+    return `${item.name}（${reason}）`
+  }
+  return item.name
+}
+
+function AttachmentIcon({
+  item,
+  thumbUrl,
+  iconBoxClass,
+  thumbClass,
+}: {
+  item: ChatAttachmentMeta
+  thumbUrl?: string
+  iconBoxClass: string
+  thumbClass: string
+}) {
+  if (isAttachmentProcessing(item)) {
+    return (
+      <span className={iconBoxClass} aria-label="正在处理">
+        <Spinner size="tiny" />
+      </span>
+    )
+  }
+  if (item.kind === 'image' && thumbUrl) {
+    return <img src={thumbUrl} alt="" className={thumbClass} />
+  }
+  return (
+    <span className={iconBoxClass}>
+      {attachmentKindIcon(item.kind, item.name, 14)}
+    </span>
+  )
 }
 
 interface Props {
@@ -121,6 +134,7 @@ interface Props {
   sessionId?: string | null
   onRemove?: (id: string) => void
   getUrl?: (attachmentId: string) => string
+  onPreview?: (item: ChatAttachmentMeta) => void
   className?: string
 }
 
@@ -129,6 +143,7 @@ export default function ComposerAttachmentStrip({
   sessionId,
   onRemove,
   getUrl,
+  onPreview,
   className,
 }: Props) {
   const s = useStyles()
@@ -146,6 +161,8 @@ export default function ComposerAttachmentStrip({
     const next: Record<string, string> = {}
     for (const item of items) {
       if (item.kind !== 'image') continue
+      if (item.optimistic || item.id.startsWith('local-')) continue
+      if (isAttachmentProcessing(item)) continue
       const url = resolveUrl(item.id)
       if (!url) continue
       next[item.id] = url
@@ -162,24 +179,45 @@ export default function ComposerAttachmentStrip({
   return (
     <div className={mergeClasses(s.strip, className)}>
       {items.map(item => (
-        <div key={item.id} className={s.chip}>
-          {item.kind === 'image' && thumbUrls[item.id] ? (
-            <img src={thumbUrls[item.id]} alt="" className={s.thumb} />
-          ) : (
-            <span className={s.iconBox}>{kindIcon(item.kind)}</span>
-          )}
-          <span className={s.meta}>
-            <span className={s.name} title={item.name}>{item.name}</span>
-            <span className={s.size}>{attachmentStatusLabel(item)}</span>
+        <div
+          key={item.id}
+          className={s.chip}
+          {...(onPreview && !item.optimistic && !item.id.startsWith('local-') ? {
+            role: 'button',
+            tabIndex: 0,
+            title: attachmentTitle(item),
+            style: { cursor: 'pointer' },
+            onClick: () => onPreview(item),
+            onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onPreview(item)
+              }
+            },
+          } : {
+            title: attachmentTitle(item),
+          })}
+        >
+          <AttachmentIcon
+            item={item}
+            thumbUrl={thumbUrls[item.id]}
+            iconBoxClass={s.iconBox}
+            thumbClass={s.thumb}
+          />
+          <span className={s.name} title={attachmentTitle(item)}>
+            {middleEllipsisFilename(item.name)}
           </span>
           {onRemove ? (
             <button
               type="button"
               className={s.remove}
               aria-label={`移除 ${item.name}`}
-              onClick={() => onRemove(item.id)}
+              onClick={(e) => {
+                e.stopPropagation()
+                onRemove(item.id)
+              }}
             >
-              <DismissRegular fontSize={14} />
+              <DismissRegular fontSize={12} />
             </button>
           ) : null}
         </div>
@@ -205,13 +243,15 @@ export function MessageAttachmentStrip({
           type="button"
           className={s.chip}
           onClick={() => onOpen(item)}
+          title={attachmentTitle(item)}
           aria-label={`查看 ${item.name}`}
         >
-          <span className={s.iconBox}>{kindIcon(item.kind)}</span>
-          <span className={s.meta}>
-            <span className={s.name}>{item.name}</span>
-            <span className={s.size}>{attachmentStatusLabel(item)}</span>
-          </span>
+          <AttachmentIcon
+            item={item}
+            iconBoxClass={s.iconBox}
+            thumbClass={s.thumb}
+          />
+          <span className={s.name}>{middleEllipsisFilename(item.name)}</span>
         </button>
       ))}
     </div>

--- a/client-ui/src/chat/ComposerAttachmentStrip.tsx
+++ b/client-ui/src/chat/ComposerAttachmentStrip.tsx
@@ -18,11 +18,11 @@ const useStyles = makeStyles({
   chip: {
     display: 'inline-flex',
     alignItems: 'center',
-    gap: '6px',
-    width: `${CHIP_WIDTH}px`,
+    gap: '2px',
+    width: 'fit-content',
     maxWidth: `${CHIP_WIDTH}px`,
     boxSizing: 'border-box',
-    padding: '3px 4px 3px 3px',
+    padding: '3px 5px',
     borderRadius: opptrixTokens.radiusMd,
     border: `1px solid ${opptrixCssVars.border}`,
     backgroundColor: opptrixCssVars.canvasAlt,
@@ -38,18 +38,33 @@ const useStyles = makeStyles({
     backgroundColor: opptrixCssVars.canvas,
   },
   iconBox: {
-    width: '26px',
-    height: '26px',
+    width: '18px',
+    height: '18px',
     borderRadius: opptrixTokens.radiusSm,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
-    backgroundColor: opptrixCssVars.canvas,
     color: opptrixCssVars.textTertiary,
   },
+  /** processing：无底色方块，尺寸贴合文字行高 */
+  spinnerSlot: {
+    width: '16px',
+    height: '16px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    // Fluent Spinner：color = 旋转弧，backgroundColor = 轨道
+    '& .fui-Spinner__spinner': {
+      width: '12px',
+      height: '12px',
+      color: opptrixCssVars.textPrimary,
+      backgroundColor: opptrixCssVars.separator,
+    },
+  },
   name: {
-    flex: 1,
+    flex: '0 1 auto',
     minWidth: 0,
     overflow: 'hidden',
     whiteSpace: 'nowrap',
@@ -105,16 +120,18 @@ function AttachmentIcon({
   item,
   thumbUrl,
   iconBoxClass,
+  spinnerSlotClass,
   thumbClass,
 }: {
   item: ChatAttachmentMeta
   thumbUrl?: string
   iconBoxClass: string
+  spinnerSlotClass: string
   thumbClass: string
 }) {
   if (isAttachmentProcessing(item)) {
     return (
-      <span className={iconBoxClass} aria-label="正在处理">
+      <span className={spinnerSlotClass} aria-label="正在处理">
         <Spinner size="tiny" />
       </span>
     )
@@ -202,6 +219,7 @@ export default function ComposerAttachmentStrip({
             item={item}
             thumbUrl={thumbUrls[item.id]}
             iconBoxClass={s.iconBox}
+            spinnerSlotClass={s.spinnerSlot}
             thumbClass={s.thumb}
           />
           <span className={s.name} title={attachmentTitle(item)}>
@@ -249,6 +267,7 @@ export function MessageAttachmentStrip({
           <AttachmentIcon
             item={item}
             iconBoxClass={s.iconBox}
+            spinnerSlotClass={s.spinnerSlot}
             thumbClass={s.thumb}
           />
           <span className={s.name}>{middleEllipsisFilename(item.name)}</span>

--- a/client-ui/src/chat/FilePreviewPanel.tsx
+++ b/client-ui/src/chat/FilePreviewPanel.tsx
@@ -1,0 +1,458 @@
+import { useEffect, useState } from 'react'
+import { Spinner, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { DismissRegular } from '@fluentui/react-icons'
+import type { ChatAttachmentMeta, MediaKind } from '../types/chat'
+import {
+  fetchAttachmentPreviewText,
+  fetchAttachmentRawText,
+  fetchSessionAttachmentMeta,
+  sessionAttachmentUrl,
+} from '../api/client'
+import { attachmentKindIcon } from './attachmentKindIcon'
+import MarkdownMessage from './MarkdownMessage'
+import PdfPreviewViewer from './PdfPreviewViewer'
+import { formatBytesShort } from './mediaCapabilities'
+import { DESKTOP_TITLEBAR_HEIGHT, DESKTOP_Z_PANEL_TITLE } from '../desktop/constants'
+import { electronPlatform } from '../platform/detect'
+import { opptrixCssVars } from '../theme/tokens'
+import { ghostInteractive } from '../theme/mixins'
+
+const MONO_FONT = 'ui-monospace, SFMono-Regular, Menlo, monospace'
+
+const KIND_LABEL: Record<MediaKind, string> = {
+  text: '文本',
+  image: '图片',
+  pdf: 'PDF',
+  document: '文档',
+  video: '视频',
+  audio: '音频',
+}
+
+const useStyles = makeStyles({
+  root: {
+    height: '100%',
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: opptrixCssVars.canvas,
+  },
+  header: {
+    flexShrink: 0,
+    height: `${DESKTOP_TITLEBAR_HEIGHT}px`,
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '0',
+    paddingLeft: '0',
+    paddingRight: '8px',
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    backgroundColor: opptrixCssVars.canvas,
+    position: 'relative',
+    zIndex: DESKTOP_Z_PANEL_TITLE,
+  },
+  headerWeb: {
+    height: '40px',
+    zIndex: 1,
+  },
+  headerElectronWin: {
+    paddingRight: '12px',
+  },
+  headerElectronMac: {
+    paddingRight: '12px',
+  },
+  titleBarDragLead: {
+    flex: '0 0 auto',
+    alignSelf: 'stretch',
+    minWidth: '8px',
+  },
+  titleCluster: {
+    flex: '0 1 auto',
+    minWidth: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    paddingLeft: '14px',
+    overflow: 'hidden',
+  },
+  headerIcon: {
+    flexShrink: 0,
+    display: 'inline-flex',
+    color: opptrixCssVars.textSecondary,
+  },
+  name: {
+    flex: '0 1 auto',
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-base)',
+  },
+  metaLabel: {
+    flexShrink: 0,
+    color: opptrixCssVars.textTertiary,
+    fontSize: 'var(--opptrix-font-sm)',
+    whiteSpace: 'nowrap',
+  },
+  dragFill: {
+    flex: '1 1 auto',
+    minWidth: '8px',
+    alignSelf: 'stretch',
+  },
+  close: {
+    ...ghostInteractive,
+    flexShrink: 0,
+    width: '28px',
+    height: '28px',
+    minWidth: '28px',
+    minHeight: '28px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+    color: opptrixCssVars.textSecondary,
+    WebkitAppRegion: 'no-drag',
+    pointerEvents: 'auto',
+  },
+  body: {
+    flex: 1,
+    minHeight: 0,
+    overflow: 'auto',
+    padding: '16px',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  bodyFlush: {
+    padding: 0,
+    overflow: 'hidden',
+  },
+  imageWrap: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  image: {
+    maxWidth: '100%',
+    maxHeight: '100%',
+    objectFit: 'contain',
+  },
+  loading: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  pre: {
+    margin: 0,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    fontFamily: 'inherit',
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-md)',
+    lineHeight: '1.6',
+  },
+  preMono: {
+    fontFamily: MONO_FONT,
+  },
+  unsupported: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '6px',
+    textAlign: 'center',
+    padding: '16px',
+  },
+  unsupportedTitle: {
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-base)',
+  },
+  unsupportedHint: {
+    color: opptrixCssVars.textTertiary,
+    fontSize: 'var(--opptrix-font-sm)',
+  },
+  unsupportedDetail: {
+    color: opptrixCssVars.textTertiary,
+    fontSize: 'var(--opptrix-font-sm)',
+    wordBreak: 'break-word',
+  },
+})
+
+export interface FilePreviewTarget {
+  sessionId: string
+  attachment: ChatAttachmentMeta
+}
+
+interface Props {
+  sessionId: string
+  attachment: ChatAttachmentMeta
+  panelVisible: boolean
+  onClose: () => void
+  electronChrome?: boolean
+  chatColumnVisible?: boolean
+  /** Skip left global toolbar band when sidebar overlay + panel spans full width. */
+  chromeToolbarReserve?: number
+  /** Right panel occupies full workspace width (chat column hidden). */
+  panelFullWidth?: boolean
+}
+
+function headerLabel(attachment: ChatAttachmentMeta): string {
+  const kind = KIND_LABEL[attachment.kind] ?? '文件'
+  return `${kind} · ${formatBytesShort(attachment.size)}`
+}
+
+function isMarkdown(name: string): boolean {
+  return /\.(md|markdown)$/i.test(name)
+}
+
+function isMonospaceText(name: string): boolean {
+  return /\.(txt|csv|json)$/i.test(name)
+}
+
+function isPlainTextAttachment(attachment: ChatAttachmentMeta): boolean {
+  if (attachment.kind === 'text') return true
+  const mime = attachment.mime.toLowerCase().split(';')[0]?.trim() ?? ''
+  if (
+    mime === 'text/plain'
+    || mime === 'text/markdown'
+    || mime === 'text/x-markdown'
+    || mime === 'text/csv'
+    || mime === 'application/json'
+    || mime === 'application/xml'
+    || mime === 'text/xml'
+    || mime === 'text/html'
+  ) {
+    return true
+  }
+  return /\.(txt|md|markdown|csv|json|xml|html|htm|log)$/i.test(attachment.name)
+}
+
+async function fetchDocumentPreviewResult(
+  sessionId: string,
+  attachment: ChatAttachmentMeta,
+): Promise<{ phase: 'ready'; text: string } | { phase: 'failed'; message: string | null } | { phase: 'pending' }> {
+  const meta = await fetchSessionAttachmentMeta(sessionId, attachment.id)
+  const status = meta.extract?.status
+  const plainText = isPlainTextAttachment(meta) || isPlainTextAttachment(attachment)
+
+  // 纯文本：先试 extract/text；失败则直读原文（不依赖服务端 extract）
+  if (plainText) {
+    const res = await fetchAttachmentPreviewText(sessionId, attachment.id)
+    if (res.ok) return { phase: 'ready', text: res.text }
+    const raw = await fetchAttachmentRawText(sessionId, attachment.id)
+    if (raw.ok) return { phase: 'ready', text: raw.text }
+    // 仅展示固定友好短句，不透传技术向 extract 错误
+    return { phase: 'failed', message: null }
+  }
+
+  if (status === 'ready') {
+    const res = await fetchAttachmentPreviewText(sessionId, attachment.id)
+    if (res.ok) return { phase: 'ready', text: res.text }
+    if (res.status === 'failed') return { phase: 'failed', message: res.message ?? null }
+    return { phase: 'pending' }
+  }
+
+  if (status === 'failed') {
+    return { phase: 'failed', message: meta.extract?.error ?? null }
+  }
+  return { phase: 'pending' }
+}
+
+function UnsupportedState({
+  title = '暂不支持预览此文件',
+  hint,
+  detail,
+}: {
+  title?: string
+  hint?: string
+  detail?: string
+}) {
+  const s = useStyles()
+  return (
+    <div className={s.unsupported}>
+      <span className={s.unsupportedTitle}>{title}</span>
+      {hint ? <span className={s.unsupportedHint}>{hint}</span> : null}
+      {detail ? <span className={s.unsupportedDetail}>{detail}</span> : null}
+    </div>
+  )
+}
+
+function useDocumentText(
+  sessionId: string,
+  attachment: ChatAttachmentMeta,
+  panelVisible: boolean,
+) {
+  const [phase, setPhase] = useState<'pending' | 'ready' | 'failed'>('pending')
+  const [text, setText] = useState('')
+  const [failed, setFailed] = useState<string | null>(null)
+  const { id, extract } = attachment
+  const plainText = isPlainTextAttachment(attachment)
+
+  useEffect(() => {
+    if (!panelVisible) return
+    let cancelled = false
+    let timer: number | undefined
+    let consecutiveErrors = 0
+    const stop = () => {
+      if (timer != null) window.clearInterval(timer)
+      timer = undefined
+    }
+    const finish = (next: { phase: 'ready'; text: string } | { phase: 'failed'; message: string | null }) => {
+      stop()
+      setPhase(next.phase)
+      if (next.phase === 'ready') setText(next.text)
+      else setFailed(next.message)
+    }
+    // 纯文本即使 meta 已标 failed，仍尝试拉原文预览
+    if (extract?.status === 'failed' && !plainText) {
+      finish({ phase: 'failed', message: extract.error ?? null })
+      return
+    }
+    const poll = async () => {
+      if (cancelled) return
+      try {
+        const result = await fetchDocumentPreviewResult(sessionId, attachment)
+        if (cancelled) return
+        consecutiveErrors = 0
+        if (result.phase === 'pending') return
+        finish(result)
+      } catch {
+        if (++consecutiveErrors > 6) finish({ phase: 'failed', message: '该文件暂时无法预览' })
+      }
+    }
+    setPhase('pending')
+    void poll()
+    timer = window.setInterval(() => { void poll() }, 1200)
+    return () => { cancelled = true; stop() }
+  }, [panelVisible, sessionId, id, extract, plainText, attachment.kind, attachment.mime, attachment.name])
+
+  return { phase, text, failed, plainText }
+}
+
+function DocumentPreview({
+  sessionId,
+  attachment,
+  panelVisible,
+}: {
+  sessionId: string
+  attachment: ChatAttachmentMeta
+  panelVisible: boolean
+}) {
+  const s = useStyles()
+  const { phase, text, failed, plainText } = useDocumentText(sessionId, attachment, panelVisible)
+
+  if (phase === 'failed') {
+    return (
+      <UnsupportedState
+        title={plainText ? '暂时无法预览' : '文档未能整理'}
+        hint={plainText ? '暂时读不出这份文本，请换一份或稍后再试' : '可尝试上传可读文件后重新预览'}
+        detail={failed ?? undefined}
+      />
+    )
+  }
+  if (phase === 'pending') {
+    return (
+      <div className={s.loading}>
+        <Spinner size="small" label={plainText ? '正在加载文本…' : '正在整理文档，请稍候…'} />
+      </div>
+    )
+  }
+  if (isMarkdown(attachment.name)) {
+    return <MarkdownMessage content={text} />
+  }
+  return (
+    <pre className={mergeClasses(s.pre, isMonospaceText(attachment.name) && s.preMono)}>
+      {text}
+    </pre>
+  )
+}
+
+export default function FilePreviewPanel({
+  sessionId,
+  attachment,
+  panelVisible,
+  onClose,
+  electronChrome = false,
+  chatColumnVisible = true,
+  chromeToolbarReserve = 0,
+  panelFullWidth = false,
+}: Props) {
+  const s = useStyles()
+  const url = sessionAttachmentUrl(sessionId, attachment.id)
+  const isPdf = attachment.kind === 'pdf'
+  const electronWin = electronChrome && electronPlatform() !== 'darwin'
+  /** Full-width panel: reserve global toolbar band as a dedicated drag zone. */
+  const titleBarDragLeadWidth = electronChrome
+    && panelFullWidth
+    && !chatColumnVisible
+    && chromeToolbarReserve > 0
+    ? chromeToolbarReserve
+    : 0
+
+  return (
+    <div className={s.root}>
+      <div
+        className={mergeClasses(
+          s.header,
+          !electronChrome && s.headerWeb,
+          electronChrome && 'opptrix-right-panel-title-bar',
+          electronChrome && (electronWin ? s.headerElectronWin : s.headerElectronMac),
+        )}
+      >
+        {titleBarDragLeadWidth > 0 && (
+          <div
+            className={mergeClasses(s.titleBarDragLead, 'opptrix-right-panel-title-drag')}
+            style={{ width: `${titleBarDragLeadWidth}px` }}
+            aria-hidden
+          />
+        )}
+        <div className={mergeClasses(s.titleCluster, 'opptrix-panel-title-no-drag')}>
+          <span className={s.headerIcon}>{attachmentKindIcon(attachment.kind, attachment.name)}</span>
+          <span className={s.name} title={attachment.name}>
+            {attachment.name}
+          </span>
+          <span className={s.metaLabel}>{headerLabel(attachment)}</span>
+        </div>
+        <div
+          className={mergeClasses(
+            s.dragFill,
+            electronChrome && 'opptrix-right-panel-title-drag',
+          )}
+          aria-hidden
+        />
+        <button
+          type="button"
+          className={mergeClasses(s.close, 'opptrix-panel-title-no-drag')}
+          onClick={onClose}
+          aria-label="关闭预览"
+          title="关闭预览"
+        >
+          <DismissRegular fontSize={18} />
+        </button>
+      </div>
+      <div className={mergeClasses(s.body, isPdf && s.bodyFlush)}>
+        {attachment.kind === 'image' ? (
+          <div className={s.imageWrap}>
+            <img src={url} alt={attachment.name} className={s.image} />
+          </div>
+        ) : isPdf ? (
+          <PdfPreviewViewer url={url} panelVisible={panelVisible} />
+        ) : attachment.kind === 'document' ? (
+          <DocumentPreview
+            sessionId={sessionId}
+            attachment={attachment}
+            panelVisible={panelVisible}
+          />
+        ) : attachment.kind === 'video' || attachment.kind === 'audio' ? (
+          <UnsupportedState hint="您可以直接发送该文件继续对话" />
+        ) : (
+          <UnsupportedState />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/client-ui/src/chat/MediaPreviewBox.tsx
+++ b/client-ui/src/chat/MediaPreviewBox.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef } from 'react'
-import { makeStyles } from '@fluentui/react-components'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
 import { DismissRegular } from '@fluentui/react-icons'
 import type { ChatAttachmentMeta } from '../types/chat'
 import { sessionAttachmentUrl } from '../api/client'
 import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+import PdfPreviewViewer from './PdfPreviewViewer'
 
 const useStyles = makeStyles({
   backdrop: {
@@ -55,15 +56,16 @@ const useStyles = makeStyles({
     padding: '16px',
     overflow: 'auto',
   },
+  bodyPdf: {
+    padding: 0,
+    overflow: 'hidden',
+    alignItems: 'stretch',
+    height: '78vh',
+  },
   image: {
     maxWidth: '100%',
     maxHeight: '78vh',
     objectFit: 'contain',
-  },
-  pdf: {
-    width: '100%',
-    height: '78vh',
-    border: 'none',
   },
   media: {
     width: '100%',
@@ -94,6 +96,7 @@ export default function MediaPreviewBox({ open, sessionId, attachment, onClose }
   if (!open || !attachment) return null
 
   const url = sessionAttachmentUrl(sessionId, attachment.id)
+  const isPdf = attachment.kind === 'pdf'
 
   return (
     <div
@@ -113,11 +116,11 @@ export default function MediaPreviewBox({ open, sessionId, attachment, onClose }
             <DismissRegular fontSize={18} />
           </button>
         </div>
-        <div className={s.body}>
+        <div className={mergeClasses(s.body, isPdf && s.bodyPdf)}>
           {attachment.kind === 'image' ? (
             <img src={url} alt={attachment.name} className={s.image} />
-          ) : attachment.kind === 'pdf' ? (
-            <iframe src={url} title={attachment.name} className={s.pdf} />
+          ) : isPdf ? (
+            <PdfPreviewViewer url={url} panelVisible={open} />
           ) : attachment.kind === 'video' ? (
             <video src={url} controls className={s.media} />
           ) : attachment.kind === 'audio' ? (

--- a/client-ui/src/chat/PdfPreviewViewer.tsx
+++ b/client-ui/src/chat/PdfPreviewViewer.tsx
@@ -1,0 +1,859 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { Spinner, makeStyles, mergeClasses } from '@fluentui/react-components'
+import {
+  ArrowFitRegular,
+  ChevronLeftRegular,
+  ChevronRightRegular,
+  TextBulletListTreeRegular,
+  ZoomInRegular,
+  ZoomOutRegular,
+} from '@fluentui/react-icons'
+import {
+  GlobalWorkerOptions,
+  getDocument,
+  type PDFDocumentLoadingTask,
+  type PDFDocumentProxy,
+  type RenderTask,
+} from 'pdfjs-dist'
+import pdfWorker from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
+import { opptrixCssVars } from '../theme/tokens'
+import { ghostInteractive } from '../theme/mixins'
+
+GlobalWorkerOptions.workerSrc = pdfWorker
+
+const FAIL_MESSAGE = '暂时无法打开这份文档，请稍后重试'
+const LOADING_LABEL = '正在打开文档…'
+const ZOOM_STEP = 1.2
+const ZOOM_MIN = 0.5
+const ZOOM_MAX = 3
+const OUTLINE_WIDTH = 170
+/** A4 高宽比，未渲染页占位用 */
+const DEFAULT_PAGE_ASPECT = 1.414
+
+interface Props {
+  url: string
+  panelVisible?: boolean
+}
+
+/** pdf.js outline dest：命名目标、显式数组，或页面 Ref */
+type OutlineDest = string | unknown[] | { num: number; gen: number } | null
+
+interface OutlineNode {
+  title: string
+  dest: OutlineDest
+  items: OutlineNode[]
+}
+
+type LoadPhase = 'idle' | 'loading' | 'ready' | 'failed'
+
+function isRefProxy(v: unknown): v is { num: number; gen: number } {
+  if (typeof v !== 'object' || v === null) return false
+  const rec = v as { num?: unknown; gen?: unknown }
+  return typeof rec.num === 'number' && typeof rec.gen === 'number'
+}
+
+function normalizeOutlineDest(dest: unknown): OutlineDest {
+  if (dest == null) return null
+  if (typeof dest === 'string') return dest
+  if (Array.isArray(dest)) return dest
+  if (isRefProxy(dest)) return { num: dest.num, gen: dest.gen }
+  return null
+}
+
+function mapOutline(raw: unknown): OutlineNode[] {
+  if (raw == null || !Array.isArray(raw)) return []
+  const out: OutlineNode[] = []
+  for (const item of raw) {
+    if (typeof item !== 'object' || item === null) continue
+    const rec = item as {
+      title?: unknown
+      dest?: unknown
+      items?: unknown
+    }
+    const rawTitle = typeof rec.title === 'string' ? rec.title.trim() : ''
+    out.push({
+      title: rawTitle || '未命名',
+      dest: normalizeOutlineDest(rec.dest),
+      items: mapOutline(rec.items),
+    })
+  }
+  return out
+}
+
+async function resolveDestPage(
+  pdf: PDFDocumentProxy,
+  dest: OutlineDest,
+): Promise<number | null> {
+  if (dest == null) return null
+  try {
+    let explicit: unknown[] | null = null
+    if (typeof dest === 'string') {
+      const named = await pdf.getDestination(dest)
+      explicit = Array.isArray(named) ? named : null
+    } else if (Array.isArray(dest)) {
+      explicit = dest
+    } else if (isRefProxy(dest)) {
+      try {
+        const index = await pdf.getPageIndex(dest)
+        return index + 1
+      } catch {
+        return null
+      }
+    } else {
+      return null
+    }
+    if (!Array.isArray(explicit) || explicit.length === 0) return null
+    const first = explicit[0]
+    if (isRefProxy(first)) {
+      const index = await pdf.getPageIndex(first)
+      return index + 1
+    }
+    if (typeof first === 'number' && Number.isFinite(first)) {
+      return Math.floor(first) + 1
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+const useStyles = makeStyles({
+  root: {
+    flex: 1,
+    minHeight: 0,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: opptrixCssVars.canvas,
+  },
+  toolbar: {
+    flexShrink: 0,
+    height: '34px',
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '2px',
+    padding: '0 8px',
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    backgroundColor: opptrixCssVars.canvas,
+  },
+  toolBtn: {
+    ...ghostInteractive,
+    width: '28px',
+    height: '28px',
+    minWidth: '28px',
+    minHeight: '28px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+    color: opptrixCssVars.textSecondary,
+    cursor: 'pointer',
+    ':disabled': {
+      opacity: 0.35,
+      cursor: 'default',
+      ':hover': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+  toolBtnActive: {
+    backgroundColor: opptrixCssVars.surfaceHover,
+    color: opptrixCssVars.textPrimary,
+  },
+  pageLabel: {
+    flexShrink: 0,
+    minWidth: '52px',
+    textAlign: 'center',
+    color: opptrixCssVars.textSecondary,
+    fontSize: 'var(--opptrix-font-sm)',
+    fontVariantNumeric: 'tabular-nums',
+    userSelect: 'none',
+  },
+  spacer: {
+    flex: 1,
+    minWidth: '4px',
+  },
+  main: {
+    flex: 1,
+    minHeight: 0,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'row',
+    overflow: 'hidden',
+  },
+  outline: {
+    flexShrink: 0,
+    width: `${OUTLINE_WIDTH}px`,
+    boxSizing: 'border-box',
+    borderRight: `1px solid ${opptrixCssVars.separator}`,
+    overflow: 'auto',
+    padding: '6px 0',
+    backgroundColor: opptrixCssVars.canvasAlt,
+  },
+  outlineItem: {
+    ...ghostInteractive,
+    display: 'block',
+    width: '100%',
+    boxSizing: 'border-box',
+    textAlign: 'left',
+    padding: '5px 10px',
+    border: 'none',
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-sm)',
+    lineHeight: 1.35,
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  pageArea: {
+    flex: 1,
+    minWidth: 0,
+    minHeight: 0,
+    overflow: 'auto',
+    padding: '8px',
+    backgroundColor: opptrixCssVars.canvasMuted,
+  },
+  pagesColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
+    width: '100%',
+  },
+  pageSlot: {
+    display: 'flex',
+    justifyContent: 'center',
+    width: '100%',
+    flexShrink: 0,
+  },
+  canvas: {
+    display: 'block',
+    maxWidth: '100%',
+    height: 'auto',
+    backgroundColor: opptrixCssVars.canvas,
+    boxShadow: `0 0 0 1px ${opptrixCssVars.border}`,
+  },
+  status: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '16px',
+    textAlign: 'center',
+    color: opptrixCssVars.textSecondary,
+    fontSize: 'var(--opptrix-font-base)',
+  },
+})
+
+function OutlineTree({
+  nodes,
+  depth,
+  onNavigate,
+  className,
+}: {
+  nodes: OutlineNode[]
+  depth: number
+  onNavigate: (node: OutlineNode) => void
+  className: string
+}): ReactNode {
+  if (!nodes.length) return null
+  return (
+    <>
+      {nodes.map((node, index) => {
+        const key = `${depth}-${index}-${node.title}`
+        return (
+          <div key={key}>
+            <button
+              type="button"
+              className={className}
+              style={{ paddingLeft: `${10 + depth * 12}px` }}
+              title={node.title}
+              onClick={() => onNavigate(node)}
+            >
+              {node.title}
+            </button>
+            <OutlineTree
+              nodes={node.items}
+              depth={depth + 1}
+              onNavigate={onNavigate}
+              className={className}
+            />
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+function PdfPageSlot({
+  pdf,
+  pageNumber,
+  zoom,
+  containerWidth,
+  active,
+  className,
+  canvasClassName,
+  onRegister,
+}: {
+  pdf: PDFDocumentProxy
+  pageNumber: number
+  zoom: number
+  containerWidth: number
+  active: boolean
+  className: string
+  canvasClassName: string
+  onRegister: (pageNumber: number, el: HTMLDivElement | null) => void
+}) {
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const renderTaskRef = useRef<RenderTask | null>(null)
+  const [slotHeight, setSlotHeight] = useState<number | undefined>()
+
+  useEffect(() => {
+    const el = wrapRef.current
+    onRegister(pageNumber, el)
+    return () => onRegister(pageNumber, null)
+  }, [pageNumber, onRegister])
+
+  useEffect(() => {
+    if (!active || containerWidth <= 0) {
+      const task = renderTaskRef.current
+      renderTaskRef.current = null
+      if (task) {
+        try {
+          task.cancel()
+        } catch {
+          // ignore cancel races
+        }
+      }
+      return
+    }
+
+    const canvas = canvasRef.current
+    if (!canvas) return
+
+    let cancelled = false
+
+    const run = async () => {
+      const prev = renderTaskRef.current
+      if (prev) {
+        try {
+          prev.cancel()
+        } catch {
+          // ignore
+        }
+        renderTaskRef.current = null
+      }
+
+      try {
+        const pdfPage = await pdf.getPage(pageNumber)
+        if (cancelled) return
+
+        const baseViewport = pdfPage.getViewport({ scale: 1 })
+        const available = Math.max(containerWidth - 16, 40)
+        const fitScale = available / baseViewport.width
+        const scale = fitScale * zoom
+        const viewport = pdfPage.getViewport({ scale })
+        const outputScale = window.devicePixelRatio || 1
+
+        const cssWidth = Math.floor(viewport.width)
+        const cssHeight = Math.floor(viewport.height)
+        setSlotHeight(cssHeight)
+
+        canvas.width = Math.floor(viewport.width * outputScale)
+        canvas.height = Math.floor(viewport.height * outputScale)
+        canvas.style.width = `${cssWidth}px`
+        canvas.style.height = `${cssHeight}px`
+
+        const transform =
+          outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : undefined
+
+        const renderTask = pdfPage.render({
+          canvas,
+          viewport,
+          ...(transform ? { transform } : {}),
+        })
+        renderTaskRef.current = renderTask
+        await renderTask.promise
+        if (!cancelled) renderTaskRef.current = null
+      } catch (err) {
+        const name = err instanceof Error ? err.name : ''
+        if (name === 'RenderingCancelledException' || cancelled) return
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+      const task = renderTaskRef.current
+      renderTaskRef.current = null
+      if (task) {
+        try {
+          task.cancel()
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }, [active, pdf, pageNumber, zoom, containerWidth])
+
+  const available = Math.max(containerWidth - 16, 40)
+  const placeholderHeight = slotHeight ?? Math.floor(available * DEFAULT_PAGE_ASPECT * zoom)
+
+  return (
+    <div
+      ref={wrapRef}
+      data-page={pageNumber}
+      className={className}
+      style={{ minHeight: placeholderHeight }}
+    >
+      {active ? <canvas ref={canvasRef} className={canvasClassName} /> : null}
+    </div>
+  )
+}
+
+export default function PdfPreviewViewer({ url, panelVisible = true }: Props) {
+  const s = useStyles()
+  const [phase, setPhase] = useState<LoadPhase>('idle')
+  const [pageCount, setPageCount] = useState(0)
+  const [page, setPage] = useState(1)
+  const [zoom, setZoom] = useState(1)
+  const [outlineOpen, setOutlineOpen] = useState(false)
+  const [outline, setOutline] = useState<OutlineNode[]>([])
+  const [containerWidth, setContainerWidth] = useState(0)
+  const [activePages, setActivePages] = useState<Set<number>>(() => new Set([1]))
+
+  const pdfRef = useRef<PDFDocumentProxy | null>(null)
+  const loadingTaskRef = useRef<PDFDocumentLoadingTask | null>(null)
+  const pageAreaRef = useRef<HTMLDivElement | null>(null)
+  const pageElsRef = useRef<Map<number, HTMLDivElement>>(new Map())
+  const visiblePagesRef = useRef<Set<number>>(new Set())
+  const pageRef = useRef(page)
+  const scrollingToPageRef = useRef<number | null>(null)
+  const scrollRafRef = useRef(0)
+  const observerRef = useRef<IntersectionObserver | null>(null)
+
+  pageRef.current = page
+
+  const destroyDoc = useCallback(() => {
+    pdfRef.current = null
+    const task = loadingTaskRef.current
+    loadingTaskRef.current = null
+    if (task) {
+      void task.destroy().catch(() => {})
+    }
+  }, [])
+
+  const recomputeActivePages = useCallback((pageCountValue: number) => {
+    const next = new Set<number>()
+    const seed = new Set(visiblePagesRef.current)
+    const current = pageRef.current
+    seed.add(current)
+    for (const p of seed) {
+      for (let d = -1; d <= 1; d++) {
+        const n = p + d
+        if (n >= 1 && n <= pageCountValue) next.add(n)
+      }
+    }
+    if (next.size === 0 && pageCountValue > 0) next.add(1)
+    setActivePages((prev) => {
+      if (prev.size === next.size) {
+        let same = true
+        for (const n of next) {
+          if (!prev.has(n)) {
+            same = false
+            break
+          }
+        }
+        if (same) return prev
+      }
+      return next
+    })
+  }, [])
+
+  const registerPageEl = useCallback((pageNumber: number, el: HTMLDivElement | null) => {
+    const prev = pageElsRef.current.get(pageNumber)
+    if (prev && observerRef.current) {
+      try {
+        observerRef.current.unobserve(prev)
+      } catch {
+        // ignore
+      }
+    }
+    if (el) {
+      pageElsRef.current.set(pageNumber, el)
+      observerRef.current?.observe(el)
+    } else {
+      pageElsRef.current.delete(pageNumber)
+    }
+  }, [])
+
+  const scrollToPage = useCallback((target: number) => {
+    const el = pageElsRef.current.get(target)
+    if (!el) {
+      setPage(target)
+      return
+    }
+    scrollingToPageRef.current = target
+    setPage(target)
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    window.setTimeout(() => {
+      if (scrollingToPageRef.current === target) {
+        scrollingToPageRef.current = null
+      }
+    }, 400)
+  }, [])
+
+  const updatePageFromScroll = useCallback(() => {
+    if (scrollingToPageRef.current != null) return
+    const area = pageAreaRef.current
+    if (!area || pageCount <= 0) return
+    const areaRect = area.getBoundingClientRect()
+    const areaMid = (areaRect.top + areaRect.bottom) / 2
+    let best = pageRef.current
+    let bestDist = Infinity
+    for (let n = 1; n <= pageCount; n++) {
+      const el = pageElsRef.current.get(n)
+      if (!el) continue
+      const rect = el.getBoundingClientRect()
+      const mid = (rect.top + rect.bottom) / 2
+      const dist = Math.abs(mid - areaMid)
+      if (dist < bestDist) {
+        bestDist = dist
+        best = n
+      }
+    }
+    if (best !== pageRef.current) setPage(best)
+  }, [pageCount])
+
+  useEffect(() => {
+    if (!panelVisible || !url) {
+      destroyDoc()
+      setPhase('idle')
+      setPageCount(0)
+      setPage(1)
+      setOutline([])
+      setOutlineOpen(false)
+      setZoom(1)
+      setActivePages(new Set([1]))
+      visiblePagesRef.current = new Set()
+      return
+    }
+
+    let cancelled = false
+    destroyDoc()
+    setPhase('loading')
+    setPage(1)
+    setZoom(1)
+    setOutlineOpen(false)
+    setOutline([])
+    setActivePages(new Set([1]))
+    visiblePagesRef.current = new Set()
+
+    const task = getDocument({ url, withCredentials: false })
+    loadingTaskRef.current = task
+
+    void task.promise
+      .then(async (pdf) => {
+        if (cancelled) {
+          await task.destroy().catch(() => {})
+          return
+        }
+        pdfRef.current = pdf
+        setPageCount(pdf.numPages)
+        try {
+          const rawOutline = await pdf.getOutline()
+          if (!cancelled) setOutline(mapOutline(rawOutline))
+        } catch {
+          if (!cancelled) setOutline([])
+        }
+        if (!cancelled) setPhase('ready')
+      })
+      .catch(() => {
+        if (!cancelled) {
+          pdfRef.current = null
+          loadingTaskRef.current = null
+          setPhase('failed')
+        }
+      })
+
+    return () => {
+      cancelled = true
+      destroyDoc()
+    }
+  }, [url, panelVisible, destroyDoc])
+
+  useEffect(() => {
+    if (phase !== 'ready') return
+    const area = pageAreaRef.current
+    if (!area) return
+
+    const measure = () => {
+      setContainerWidth(area.clientWidth)
+    }
+    measure()
+
+    const resizeObserver = typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(measure)
+      : null
+    resizeObserver?.observe(area)
+
+    const onScroll = () => {
+      if (scrollRafRef.current) return
+      scrollRafRef.current = window.requestAnimationFrame(() => {
+        scrollRafRef.current = 0
+        updatePageFromScroll()
+        recomputeActivePages(pageCount)
+      })
+    }
+    area.addEventListener('scroll', onScroll, { passive: true })
+
+    // Chromium/Electron：触控板捏合会以 ctrlKey + wheel 上报；拦截以免整窗缩放
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return
+      e.preventDefault()
+      const factor = Math.exp(-e.deltaY * 0.01)
+      setZoom((z) => {
+        const next = Math.round(z * factor * 100) / 100
+        return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, next))
+      })
+    }
+    area.addEventListener('wheel', onWheel, { passive: false })
+
+    return () => {
+      resizeObserver?.disconnect()
+      area.removeEventListener('scroll', onScroll)
+      area.removeEventListener('wheel', onWheel)
+      if (scrollRafRef.current) {
+        window.cancelAnimationFrame(scrollRafRef.current)
+        scrollRafRef.current = 0
+      }
+    }
+  }, [phase, pageCount, updatePageFromScroll, recomputeActivePages])
+
+  useEffect(() => {
+    if (phase !== 'ready' || pageCount <= 0) return
+    const area = pageAreaRef.current
+    if (!area) return
+
+    const observer = typeof IntersectionObserver !== 'undefined'
+      ? new IntersectionObserver(
+        (entries) => {
+          for (const entry of entries) {
+            const raw = (entry.target as HTMLElement).dataset.page
+            const n = raw ? Number(raw) : NaN
+            if (!Number.isFinite(n)) continue
+            if (entry.isIntersecting) visiblePagesRef.current.add(n)
+            else visiblePagesRef.current.delete(n)
+          }
+          recomputeActivePages(pageCount)
+          updatePageFromScroll()
+        },
+        { root: area, rootMargin: '240px 0px', threshold: 0 },
+      )
+      : null
+
+    observerRef.current = observer
+    for (const el of pageElsRef.current.values()) {
+      observer?.observe(el)
+    }
+    recomputeActivePages(pageCount)
+
+    return () => {
+      observerRef.current = null
+      observer?.disconnect()
+    }
+  }, [phase, pageCount, recomputeActivePages, updatePageFromScroll])
+
+  useEffect(() => {
+    if (phase === 'ready' && pageCount > 0) {
+      recomputeActivePages(pageCount)
+    }
+  }, [phase, pageCount, page, recomputeActivePages])
+
+  const goPrev = () => {
+    if (page <= 1) return
+    scrollToPage(page - 1)
+  }
+  const goNext = () => {
+    if (page >= pageCount) return
+    scrollToPage(page + 1)
+  }
+  const zoomIn = () => setZoom((z) => Math.min(ZOOM_MAX, Math.round(z * ZOOM_STEP * 100) / 100))
+  const zoomOut = () => setZoom((z) => Math.max(ZOOM_MIN, Math.round(z / ZOOM_STEP * 100) / 100))
+  const fitWidth = () => setZoom(1)
+
+  const onOutlineNavigate = useCallback(async (node: OutlineNode) => {
+    const pdf = pdfRef.current
+    if (!pdf) return
+    try {
+      const target = await resolveDestPage(pdf, node.dest)
+      if (target != null && target >= 1 && target <= pdf.numPages) {
+        scrollToPage(target)
+      }
+    } catch {
+      // ignore bad outline destinations
+    }
+  }, [scrollToPage])
+
+  if (!panelVisible) {
+    return <div className={s.root} aria-hidden />
+  }
+
+  if (phase === 'loading' || phase === 'idle') {
+    return (
+      <div className={s.root}>
+        <div className={s.status}>
+          <Spinner size="small" label={LOADING_LABEL} />
+        </div>
+      </div>
+    )
+  }
+
+  if (phase === 'failed') {
+    return (
+      <div className={s.root}>
+        <div className={s.status}>{FAIL_MESSAGE}</div>
+      </div>
+    )
+  }
+
+  const pdf = pdfRef.current
+  const hasOutline = outline.length > 0
+  const outlineToggleLabel = hasOutline
+    ? (outlineOpen ? '收起目录' : '打开目录')
+    : (outlineOpen ? '收起页码目录' : '打开页码目录')
+
+  return (
+    <div className={s.root}>
+      <div className={s.toolbar} role="toolbar" aria-label="文档预览">
+        <button
+          type="button"
+          className={s.toolBtn}
+          onClick={goPrev}
+          disabled={page <= 1}
+          aria-label="上一页"
+          title="上一页"
+        >
+          <ChevronLeftRegular fontSize={16} />
+        </button>
+        <span className={s.pageLabel}>
+          {page}
+          {' / '}
+          {pageCount}
+        </span>
+        <button
+          type="button"
+          className={s.toolBtn}
+          onClick={goNext}
+          disabled={page >= pageCount}
+          aria-label="下一页"
+          title="下一页"
+        >
+          <ChevronRightRegular fontSize={16} />
+        </button>
+        <span className={s.spacer} />
+        <button
+          type="button"
+          className={s.toolBtn}
+          onClick={zoomOut}
+          disabled={zoom <= ZOOM_MIN}
+          aria-label="缩小"
+          title="缩小"
+        >
+          <ZoomOutRegular fontSize={16} />
+        </button>
+        <button
+          type="button"
+          className={s.toolBtn}
+          onClick={fitWidth}
+          aria-label="适合宽度"
+          title="适合宽度"
+        >
+          <ArrowFitRegular fontSize={16} />
+        </button>
+        <button
+          type="button"
+          className={s.toolBtn}
+          onClick={zoomIn}
+          disabled={zoom >= ZOOM_MAX}
+          aria-label="放大"
+          title="放大"
+        >
+          <ZoomInRegular fontSize={16} />
+        </button>
+        <button
+          type="button"
+          className={mergeClasses(s.toolBtn, outlineOpen && s.toolBtnActive)}
+          onClick={() => setOutlineOpen((v) => !v)}
+          aria-label={outlineToggleLabel}
+          title={outlineToggleLabel}
+          aria-pressed={outlineOpen}
+        >
+          <TextBulletListTreeRegular fontSize={16} />
+        </button>
+      </div>
+      <div className={s.main}>
+        {outlineOpen ? (
+          <nav className={s.outline} aria-label={hasOutline ? '文档目录' : '页码目录'}>
+            {hasOutline ? (
+              <OutlineTree
+                nodes={outline}
+                depth={0}
+                onNavigate={(node) => { void onOutlineNavigate(node) }}
+                className={s.outlineItem}
+              />
+            ) : (
+              Array.from({ length: pageCount }, (_, i) => {
+                const n = i + 1
+                return (
+                  <button
+                    key={n}
+                    type="button"
+                    className={s.outlineItem}
+                    title={`第 ${n} 页`}
+                    onClick={() => scrollToPage(n)}
+                  >
+                    {`第 ${n} 页`}
+                  </button>
+                )
+              })
+            )}
+          </nav>
+        ) : null}
+        <div className={s.pageArea} ref={pageAreaRef}>
+          <div className={s.pagesColumn}>
+            {pdf
+              ? Array.from({ length: pageCount }, (_, i) => {
+                const pageNumber = i + 1
+                return (
+                  <PdfPageSlot
+                    key={pageNumber}
+                    pdf={pdf}
+                    pageNumber={pageNumber}
+                    zoom={zoom}
+                    containerWidth={containerWidth}
+                    active={activePages.has(pageNumber)}
+                    className={s.pageSlot}
+                    canvasClassName={s.canvas}
+                    onRegister={registerPageEl}
+                  />
+                )
+              })
+              : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client-ui/src/chat/RightPanel.tsx
+++ b/client-ui/src/chat/RightPanel.tsx
@@ -7,6 +7,7 @@ import {
   WORKSPACE_RIGHT_PANEL_DEFAULT_WIDTH,
 } from '../desktop/constants'
 import RightMarketPanel from '../market/RightMarketPanel'
+import FilePreviewPanel, { type FilePreviewTarget } from './FilePreviewPanel'
 import type { StockDiscussPayload } from '../market/StockDecisionCard'
 
 const useStyles = makeStyles({
@@ -65,6 +66,8 @@ interface Props {
   onToggleRightPanel?: () => void
   onToggleChatColumn?: () => void
   onDiscussInChat?: (payload: StockDiscussPayload) => void
+  preview?: FilePreviewTarget | null
+  onClosePreview?: () => void
 }
 
 function RightPanel({
@@ -80,6 +83,8 @@ function RightPanel({
   onToggleRightPanel,
   onToggleChatColumn,
   onDiscussInChat,
+  preview = null,
+  onClosePreview,
 }: Props) {
   const s = useStyles()
 
@@ -107,18 +112,31 @@ function RightPanel({
         aria-label="行情与自选"
         aria-hidden={!visible}
       >
-        <RightMarketPanel
-          panelVisible={visible}
-          electronChrome={electronChrome}
-          chatColumnVisible={chatColumnVisible}
-          chromeToolbarReserve={chromeToolbarReserve}
-          panelFullWidth={fullWidth}
-          focusStockCode={focusStockCode}
-          onFocusStockConsumed={onFocusStockConsumed}
-          onToggleRightPanel={visible ? onToggleRightPanel : undefined}
-          onToggleChatColumn={visible ? onToggleChatColumn : undefined}
-          onDiscussInChat={visible ? onDiscussInChat : undefined}
-        />
+        {preview ? (
+          <FilePreviewPanel
+            sessionId={preview.sessionId}
+            attachment={preview.attachment}
+            panelVisible={visible}
+            onClose={onClosePreview ?? (() => {})}
+            electronChrome={electronChrome}
+            chatColumnVisible={chatColumnVisible}
+            chromeToolbarReserve={chromeToolbarReserve}
+            panelFullWidth={fullWidth}
+          />
+        ) : (
+          <RightMarketPanel
+            panelVisible={visible}
+            electronChrome={electronChrome}
+            chatColumnVisible={chatColumnVisible}
+            chromeToolbarReserve={chromeToolbarReserve}
+            panelFullWidth={fullWidth}
+            focusStockCode={focusStockCode}
+            onFocusStockConsumed={onFocusStockConsumed}
+            onToggleRightPanel={visible ? onToggleRightPanel : undefined}
+            onToggleChatColumn={visible ? onToggleChatColumn : undefined}
+            onDiscussInChat={visible ? onDiscussInChat : undefined}
+          />
+        )}
       </aside>
     </div>
   )

--- a/client-ui/src/chat/attachmentKindIcon.tsx
+++ b/client-ui/src/chat/attachmentKindIcon.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from 'react'
+import {
+  DocumentDataRegular,
+  DocumentPdfRegular,
+  DocumentRegular,
+  DocumentTextRegular,
+  ImageRegular,
+  MusicNote2Regular,
+  SlideTextRegular,
+  VideoRegular,
+} from '@fluentui/react-icons'
+import type { MediaKind } from '../types/chat'
+
+function extOfFilename(name: string): string {
+  const dot = name.lastIndexOf('.')
+  if (dot < 0) return ''
+  return name.slice(dot).toLowerCase()
+}
+
+function documentIconByExt(ext: string, fontSize: number): ReactElement {
+  if (ext === '.txt' || ext === '.log' || ext === '.md' || ext === '.markdown') {
+    return <DocumentTextRegular fontSize={fontSize} />
+  }
+  if (ext === '.csv' || ext === '.json' || ext === '.xml') {
+    return <DocumentDataRegular fontSize={fontSize} />
+  }
+  if (ext === '.docx' || ext === '.doc') {
+    return <DocumentRegular fontSize={fontSize} />
+  }
+  if (ext === '.pptx' || ext === '.ppt') {
+    return <SlideTextRegular fontSize={fontSize} />
+  }
+  return <DocumentRegular fontSize={fontSize} />
+}
+
+/** 附件 kind + 文件名 → Fluent 图标（消息条 / 输入条 / 预览头共用） */
+export function attachmentKindIcon(
+  kind: MediaKind,
+  name: string,
+  fontSize = 18,
+): ReactElement {
+  switch (kind) {
+    case 'pdf':
+      return <DocumentPdfRegular fontSize={fontSize} />
+    case 'image':
+      return <ImageRegular fontSize={fontSize} />
+    case 'video':
+      return <VideoRegular fontSize={fontSize} />
+    case 'audio':
+      return <MusicNote2Regular fontSize={fontSize} />
+    case 'document':
+    case 'text':
+      return documentIconByExt(extOfFilename(name), fontSize)
+    default:
+      return <DocumentRegular fontSize={fontSize} />
+  }
+}

--- a/client-ui/src/chat/useComposerAttachments.ts
+++ b/client-ui/src/chat/useComposerAttachments.ts
@@ -1,7 +1,21 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { ChatAttachmentMeta, ModelMediaCapabilities } from '../types/chat'
 import { uploadSessionAttachment, deleteSessionAttachment, fetchSessionAttachmentMeta } from '../api/client'
-import { validateFileForModel, partitionPinsForModel } from './mediaCapabilities'
+import {
+  validateFileForModel,
+  partitionPinsForModel,
+  resolveFileMime,
+  mimeToKind,
+  isLibraryIngestKind,
+} from './mediaCapabilities'
+
+function isLocalAttachmentId(id: string): boolean {
+  return id.startsWith('local-')
+}
+
+function isServerAttachment(item: ChatAttachmentMeta): boolean {
+  return !item.optimistic && !isLocalAttachmentId(item.id)
+}
 
 export function useComposerAttachments(
   sessionId: string | null | undefined,
@@ -26,10 +40,11 @@ export function useComposerAttachments(
     if (sessionId) effectiveSessionIdRef.current = sessionId
   }, [sessionId])
 
-  // 轮询研报库整理状态（PDF / 文档 / 图片 OCR）
+  // 轮询研报库整理状态（PDF / 文档 / 图片 OCR）；跳过尚未入库的乐观项
   useEffect(() => {
     const pending = pinned.filter(p =>
-      (p.kind === 'pdf' || p.kind === 'document' || p.kind === 'image')
+      isServerAttachment(p)
+      && (p.kind === 'pdf' || p.kind === 'document' || p.kind === 'image')
       && (p.extract?.status ?? 'pending') === 'pending',
     )
     if (!pending.length) return
@@ -90,23 +105,65 @@ export function useComposerAttachments(
       return
     }
 
+    let next = [...pinned]
+    let total = next.reduce((sum, p) => sum + p.size, 0)
+    const queue: Array<{ localId: string; file: File }> = []
+
+    for (const file of list) {
+      const err = validateFileForModel(file, media, next.length, total)
+      if (err) {
+        clearToastLater(err)
+        continue
+      }
+      const mime = resolveFileMime(file)
+      const kind = mimeToKind(mime, file.name)
+      if (!kind) {
+        clearToastLater('不支持此文件类型')
+        continue
+      }
+      const localId = `local-${crypto.randomUUID()}`
+      const optimistic: ChatAttachmentMeta = {
+        id: localId,
+        kind,
+        mime,
+        name: file.name,
+        size: file.size,
+        createdAt: new Date().toISOString(),
+        optimistic: true,
+        ...(isLibraryIngestKind(kind) ? { extract: { status: 'pending' as const } } : {}),
+      }
+      next = [...next, optimistic]
+      total += file.size
+      queue.push({ localId, file })
+    }
+
+    if (!queue.length) return
+
+    // 每个文件在上传前即出现在列表
+    setPinned(next)
     setUploading(true)
     try {
-      let next = [...pinned]
-      let total = next.reduce((sum, p) => sum + p.size, 0)
-      for (const file of list) {
-        const err = validateFileForModel(file, media, next.length, total)
-        if (err) {
-          clearToastLater(err)
-          continue
+      let uploadedCount = pinned.filter(isServerAttachment).length
+      let uploadedTotal = pinned.filter(isServerAttachment).reduce((sum, p) => sum + p.size, 0)
+
+      for (const { localId, file } of queue) {
+        try {
+          const meta = await uploadSessionAttachment(sid, file, uploadedCount, uploadedTotal)
+          uploadedCount += 1
+          uploadedTotal += meta.size
+          setPinned(prev => {
+            if (!prev.some(p => p.id === localId)) {
+              // 上传完成前已被移除：清理服务端残留
+              void deleteSessionAttachment(sid, meta.id).catch(() => {})
+              return prev
+            }
+            return prev.map(p => (p.id === localId ? meta : p))
+          })
+        } catch (e) {
+          setPinned(prev => prev.filter(p => p.id !== localId))
+          clearToastLater(e instanceof Error ? e.message : '上传失败，请稍后重试')
         }
-        const meta = await uploadSessionAttachment(sid, file, next.length, total)
-        next = [...next, meta]
-        total += meta.size
       }
-      setPinned(next)
-    } catch (e) {
-      clearToastLater(e instanceof Error ? e.message : '上传失败，请稍后重试')
     } finally {
       setUploading(false)
     }
@@ -114,6 +171,7 @@ export function useComposerAttachments(
 
   const removePinned = useCallback(async (id: string) => {
     setPinned(prev => prev.filter(p => p.id !== id))
+    if (isLocalAttachmentId(id)) return
     const sid = effectiveSessionIdRef.current ?? sessionId
     if (sid) {
       try {
@@ -135,6 +193,7 @@ export function useComposerAttachments(
       const sid = effectiveSessionIdRef.current ?? sessionId
       if (sid) {
         for (const id of removedIds) {
+          if (isLocalAttachmentId(id)) continue
           void deleteSessionAttachment(sid, id).catch(() => {})
         }
       }
@@ -157,6 +216,6 @@ export function useComposerAttachments(
     reconcileWithModel,
     clearPinned,
     openFilePicker,
-    attachmentIds: pinned.map(p => p.id),
+    attachmentIds: pinned.filter(isServerAttachment).map(p => p.id),
   }
 }

--- a/client-ui/src/desktop/constants.ts
+++ b/client-ui/src/desktop/constants.ts
@@ -79,6 +79,9 @@ export const WORKSPACE_CHAT_MIN_WIDTH = 350
 /** Default right panel width — slightly narrower than 2× sidebar */
 export const WORKSPACE_RIGHT_PANEL_DEFAULT_WIDTH = 360
 export const WORKSPACE_RIGHT_PANEL_MIN_WIDTH = 200
+/** Default right-side file-preview panel width — wider than market info panel */
+export const WORKSPACE_PREVIEW_PANEL_DEFAULT_WIDTH = 520
+export const WORKSPACE_PREVIEW_PANEL_MIN_WIDTH = 460
 export const WORKSPACE_SPLITTER_WIDTH = 1
 /** Invisible drag padding on each side of the 1px splitter line (overlay; no layout gap) */
 export const WORKSPACE_SPLITTER_HIT_SLOP = 1

--- a/client-ui/src/hooks/useWorkspaceSplit.ts
+++ b/client-ui/src/hooks/useWorkspaceSplit.ts
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   WORKSPACE_CHAT_MIN_WIDTH,
   WORKSPACE_CHAT_RIGHT_MIN_WIDTH,
+  WORKSPACE_PREVIEW_PANEL_DEFAULT_WIDTH,
+  WORKSPACE_PREVIEW_PANEL_MIN_WIDTH,
   WORKSPACE_RIGHT_PANEL_DEFAULT_WIDTH,
   WORKSPACE_RIGHT_PANEL_MIN_WIDTH,
   WORKSPACE_RIGHT_PANEL_RESTORE_WIDTH,
@@ -12,27 +14,33 @@ import { ensureWindowContentWidth } from '../platform/ensureWindowContentWidth'
 interface Options {
   enabled?: boolean
   defaultRightWidth?: number
+  previewDefaultWidth?: number
+  previewMinWidth?: number
 }
 
-function clampRightWidth(width: number, wsWidth: number): number {
+function clampRightWidth(width: number, wsWidth: number, minWidth: number): number {
   const maxRight = wsWidth - WORKSPACE_CHAT_MIN_WIDTH - WORKSPACE_SPLITTER_WIDTH
-  const minRight = WORKSPACE_RIGHT_PANEL_MIN_WIDTH
-  if (maxRight < minRight) return minRight
-  return Math.max(minRight, Math.min(width, maxRight))
+  if (maxRight < minWidth) return minWidth
+  return Math.max(minWidth, Math.min(width, maxRight))
 }
 
 export function useWorkspaceSplit({
   enabled = true,
   defaultRightWidth = WORKSPACE_RIGHT_PANEL_DEFAULT_WIDTH,
+  previewDefaultWidth = WORKSPACE_PREVIEW_PANEL_DEFAULT_WIDTH,
+  previewMinWidth = WORKSPACE_PREVIEW_PANEL_MIN_WIDTH,
 }: Options = {}) {
   const workspaceRef = useRef<HTMLDivElement>(null)
   const [workspaceWidth, setWorkspaceWidth] = useState(0)
   const [rightPanelOpen, setRightPanelOpen] = useState(true)
   const [chatVisible, setChatVisible] = useState(true)
   const [rightPanelWidth, setRightPanelWidth] = useState(defaultRightWidth)
+  const [mode, setMode] = useState<'market' | 'preview'>('market')
   const [isDragging, setIsDragging] = useState(false)
   const savedRightWidthRef = useRef(defaultRightWidth)
+  const savedPreviewWidthRef = useRef(0)
   const rightPanelWidthRef = useRef(defaultRightWidth)
+  const modeRef = useRef<'market' | 'preview'>('market')
   const autoCollapsedByWidthRef = useRef(false)
   /** Skip auto-collapse while we widen the window to fit an intentional open. */
   const expandForOpenRef = useRef(false)
@@ -50,6 +58,10 @@ export function useWorkspaceSplit({
   useEffect(() => {
     rightPanelWidthRef.current = rightPanelWidth
   }, [rightPanelWidth])
+
+  useEffect(() => {
+    modeRef.current = mode
+  }, [mode])
 
   useEffect(() => () => clearExpandForOpen(), [clearExpandForOpen])
 
@@ -76,18 +88,36 @@ export function useWorkspaceSplit({
   const canFitRightPanel = workspaceWidth <= 0 || workspaceWidth >= WORKSPACE_CHAT_RIGHT_MIN_WIDTH
 
   const commitWidth = useCallback((nextWidth: number, wsWidth: number) => {
-    const clamped = clampRightWidth(nextWidth, wsWidth)
-    savedRightWidthRef.current = clamped
+    const minWidth =
+      modeRef.current === 'preview' ? previewMinWidth : WORKSPACE_RIGHT_PANEL_MIN_WIDTH
+    const clamped = clampRightWidth(nextWidth, wsWidth, minWidth)
+    if (modeRef.current === 'preview') {
+      savedPreviewWidthRef.current = clamped
+    } else {
+      savedRightWidthRef.current = clamped
+    }
     setRightPanelWidth(clamped)
-  }, [])
+  }, [previewMinWidth])
 
   const collapseRightPanel = useCallback((markAuto = true) => {
     if (!rightPanelOpen) return
-    savedRightWidthRef.current = rightPanelWidthRef.current
+    if (modeRef.current === 'preview') {
+      savedPreviewWidthRef.current = rightPanelWidthRef.current
+    } else {
+      savedRightWidthRef.current = rightPanelWidthRef.current
+    }
     if (markAuto) autoCollapsedByWidthRef.current = true
     setRightPanelOpen(false)
     setChatVisible(true)
   }, [rightPanelOpen])
+
+  const closePreview = useCallback(() => {
+    if (modeRef.current === 'preview') {
+      savedPreviewWidthRef.current = rightPanelWidthRef.current
+      setMode('market')
+    }
+    collapseRightPanel()
+  }, [collapseRightPanel])
 
   const beginDrag = useCallback((clientX: number) => {
     if (!enabled || !chatVisible || !rightPanelOpen) return
@@ -113,7 +143,9 @@ export function useWorkspaceSplit({
       if (!drag || !ws) return
 
       const delta = drag.startX - e.clientX
-      const next = clampRightWidth(drag.startWidth + delta, ws.clientWidth)
+      const minWidth =
+        modeRef.current === 'preview' ? previewMinWidth : WORKSPACE_RIGHT_PANEL_MIN_WIDTH
+      const next = clampRightWidth(drag.startWidth + delta, ws.clientWidth, minWidth)
       setRightPanelWidth(next)
     }
 
@@ -133,7 +165,7 @@ export function useWorkspaceSplit({
       window.removeEventListener('mouseup', onUp)
       endDrag()
     }
-  }, [commitWidth, enabled, endDrag])
+  }, [commitWidth, enabled, endDrag, previewMinWidth])
 
   useEffect(() => {
     if (!enabled || isDragging || workspaceWidth <= 0) return
@@ -154,7 +186,11 @@ export function useWorkspaceSplit({
       && workspaceWidth >= WORKSPACE_RIGHT_PANEL_RESTORE_WIDTH
     ) {
       autoCollapsedByWidthRef.current = false
-      setRightPanelWidth(savedRightWidthRef.current || defaultRightWidth)
+      const restored =
+        modeRef.current === 'preview'
+          ? savedPreviewWidthRef.current || previewDefaultWidth
+          : savedRightWidthRef.current || defaultRightWidth
+      setRightPanelWidth(restored)
       setRightPanelOpen(true)
       setChatVisible(true)
       return
@@ -162,7 +198,11 @@ export function useWorkspaceSplit({
 
     if (!rightPanelOpen || !chatVisible) return
 
-    const clamped = clampRightWidth(rightPanelWidth, workspaceWidth)
+    const clamped = clampRightWidth(
+      rightPanelWidth,
+      workspaceWidth,
+      mode === 'preview' ? previewMinWidth : WORKSPACE_RIGHT_PANEL_MIN_WIDTH,
+    )
     if (clamped !== rightPanelWidth) {
       commitWidth(clamped, workspaceWidth)
     }
@@ -174,28 +214,21 @@ export function useWorkspaceSplit({
     defaultRightWidth,
     enabled,
     isDragging,
+    mode,
+    previewDefaultWidth,
+    previewMinWidth,
     rightPanelOpen,
     rightPanelWidth,
     workspaceWidth,
   ])
 
-  const toggleRightPanel = useCallback(() => {
-    if (rightPanelOpen) {
-      clearExpandForOpen()
-      savedRightWidthRef.current = rightPanelWidthRef.current
-      autoCollapsedByWidthRef.current = false
-      setRightPanelOpen(false)
-      setChatVisible(true)
-      return
-    }
-
-    const targetRight = savedRightWidthRef.current || defaultRightWidth
+  const openWithWidth = useCallback((targetWidth: number) => {
     const neededWorkspace =
-      WORKSPACE_CHAT_MIN_WIDTH + WORKSPACE_SPLITTER_WIDTH + targetRight
+      WORKSPACE_CHAT_MIN_WIDTH + WORKSPACE_SPLITTER_WIDTH + targetWidth
 
     const openPanel = () => {
       autoCollapsedByWidthRef.current = false
-      setRightPanelWidth(targetRight)
+      setRightPanelWidth(targetWidth)
       setRightPanelOpen(true)
       setChatVisible(true)
     }
@@ -217,18 +250,62 @@ export function useWorkspaceSplit({
     }
 
     openPanel()
-  }, [clearExpandForOpen, defaultRightWidth, enabled, rightPanelOpen, workspaceWidth])
+  }, [enabled, workspaceWidth])
+
+  const toggleRightPanel = useCallback(() => {
+    if (mode === 'preview') {
+      savedPreviewWidthRef.current = rightPanelWidthRef.current
+      setMode('market')
+      openWithWidth(savedRightWidthRef.current || defaultRightWidth)
+      return
+    }
+
+    if (rightPanelOpen) {
+      clearExpandForOpen()
+      savedRightWidthRef.current = rightPanelWidthRef.current
+      autoCollapsedByWidthRef.current = false
+      setRightPanelOpen(false)
+      setChatVisible(true)
+      return
+    }
+
+    openWithWidth(savedRightWidthRef.current || defaultRightWidth)
+  }, [clearExpandForOpen, defaultRightWidth, mode, openWithWidth, rightPanelOpen])
+
+  const openPreview = useCallback(() => {
+    if (mode === 'market') {
+      savedRightWidthRef.current = rightPanelWidthRef.current
+    }
+    setMode('preview')
+    openWithWidth(savedPreviewWidthRef.current || previewDefaultWidth)
+  }, [mode, openWithWidth, previewDefaultWidth])
+
+  const openMarket = useCallback(() => {
+    if (mode === 'preview') {
+      savedPreviewWidthRef.current = rightPanelWidthRef.current
+    }
+    setMode('market')
+    openWithWidth(savedRightWidthRef.current || defaultRightWidth)
+  }, [defaultRightWidth, mode, openWithWidth])
 
   const toggleChatColumn = useCallback(() => {
     if (!rightPanelOpen) return
     if (chatVisible) {
-      savedRightWidthRef.current = rightPanelWidthRef.current
+      if (modeRef.current === 'preview') {
+        savedPreviewWidthRef.current = rightPanelWidthRef.current
+      } else {
+        savedRightWidthRef.current = rightPanelWidthRef.current
+      }
       setChatVisible(false)
       return
     }
-    setRightPanelWidth(savedRightWidthRef.current || defaultRightWidth)
+    const restored =
+      modeRef.current === 'preview'
+        ? savedPreviewWidthRef.current || previewDefaultWidth
+        : savedRightWidthRef.current || defaultRightWidth
+    setRightPanelWidth(restored)
     setChatVisible(true)
-  }, [chatVisible, defaultRightWidth, rightPanelOpen])
+  }, [chatVisible, defaultRightWidth, previewDefaultWidth, rightPanelOpen])
 
   const canToggleChatColumn = rightPanelOpen
 
@@ -238,6 +315,7 @@ export function useWorkspaceSplit({
     rightPanelOpen,
     chatVisible,
     rightPanelWidth,
+    mode,
     showSplitter,
     chatWidth,
     isDragging,
@@ -245,7 +323,10 @@ export function useWorkspaceSplit({
     canFitRightPanel,
     beginDrag,
     collapseRightPanel,
+    closePreview,
     toggleRightPanel,
     toggleChatColumn,
+    openPreview,
+    openMarket,
   }
 }

--- a/client-ui/src/types/chat.ts
+++ b/client-ui/src/types/chat.ts
@@ -120,6 +120,8 @@ export interface ChatAttachmentMeta {
   height?: number
   duration?: number
   extract?: AttachmentExtractMeta
+  /** 前端乐观插入标记；服务端不会返回此字段 */
+  optimistic?: boolean
 }
 
 export interface ModelMediaCapabilities {

--- a/client-ui/src/utils/decodeTextBuffer.ts
+++ b/client-ui/src/utils/decodeTextBuffer.ts
@@ -1,0 +1,98 @@
+/**
+ * 浏览器侧纯文本解码（UTF-16/UTF-8 BOM；无 BOM 时启发式 UTF-8 vs GB18030/GBK）。
+ * 逻辑对齐 packages/doc-library text-l0.decodeTextBuffer；勿依赖 Node Buffer / @opptrix/doc-library。
+ */
+
+const CJK_START = 0x4e00
+const CJK_END = 0x9fff
+const REPLACEMENT = 0xfffd
+/** UTF-8 与最佳候选分差在此以内时优先 UTF-8，避免误伤纯 ASCII */
+const UTF8_PREFER_MARGIN = 8
+
+function scoreDecodedText(text: string): number {
+  let score = 0
+  for (let i = 0; i < text.length; i++) {
+    const cp = text.charCodeAt(i)
+    if (cp === REPLACEMENT) {
+      score -= 50
+      continue
+    }
+    if (cp >= CJK_START && cp <= CJK_END) {
+      score += 3
+      continue
+    }
+    if (cp === 0x09 || cp === 0x0a || cp === 0x0d || (cp >= 0x20 && cp <= 0x7e)) {
+      score += 1
+      continue
+    }
+    if (cp >= 0xa0 && cp < 0xd800) {
+      score += 1
+    }
+  }
+  return score
+}
+
+function tryDecodeLabel(bytes: Uint8Array, label: string): string | null {
+  try {
+    return new TextDecoder(label, { fatal: false }).decode(bytes)
+  } catch {
+    return null
+  }
+}
+
+function decodeTextBufferHeuristic(bytes: Uint8Array): string {
+  const candidates: Array<{ label: string; text: string; score: number }> = []
+
+  for (const label of ['utf-8', 'gb18030', 'gbk'] as const) {
+    if (label === 'gbk' && candidates.some(c => c.label === 'gb18030')) continue
+    const text = tryDecodeLabel(bytes, label)
+    if (text == null) continue
+    candidates.push({ label, text, score: scoreDecodedText(text) })
+  }
+
+  if (candidates.length === 0) {
+    return tryDecodeLabel(bytes, 'utf-8') ?? ''
+  }
+
+  const utf8 = candidates.find(c => c.label === 'utf-8')
+  let best = candidates[0]!
+  for (let i = 1; i < candidates.length; i++) {
+    const c = candidates[i]!
+    if (c.score > best.score) best = c
+  }
+
+  if (utf8 && utf8.score + UTF8_PREFER_MARGIN >= best.score) {
+    return utf8.text
+  }
+  return best.text
+}
+
+function toBytes(input: ArrayBuffer | Uint8Array): Uint8Array {
+  if (input instanceof ArrayBuffer) return new Uint8Array(input)
+  // 复制为独立视图：Node 池化 Buffer 的 byteOffset 会导致 TextDecoder 读错区间
+  const out = new Uint8Array(input.byteLength)
+  out.set(input)
+  return out
+}
+
+/** 解码纯文本 bytes（UTF-8 / UTF-16 BOM；无 BOM 时启发式 UTF-8 vs GB18030） */
+export function decodeTextBufferBytes(input: ArrayBuffer | Uint8Array): string {
+  const bytes = toBytes(input)
+  if (bytes.length >= 2) {
+    if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+      return new TextDecoder('utf-16le', { fatal: false }).decode(bytes.subarray(2))
+    }
+    if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+      const swapped = new Uint8Array(bytes.length - 2)
+      for (let i = 2; i + 1 < bytes.length; i += 2) {
+        swapped[i - 2] = bytes[i + 1] ?? 0
+        swapped[i - 1] = bytes[i] ?? 0
+      }
+      return new TextDecoder('utf-16le', { fatal: false }).decode(swapped)
+    }
+  }
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return new TextDecoder('utf-8', { fatal: false }).decode(bytes.subarray(3))
+  }
+  return decodeTextBufferHeuristic(bytes)
+}

--- a/client-ui/vite.config.ts
+++ b/client-ui/vite.config.ts
@@ -36,6 +36,7 @@ export default defineConfig({
       'rehype-sanitize',
       'katex',
       'mermaid',
+      'pdfjs-dist',
     ],
   },
   build: {

--- a/docs/API.md
+++ b/docs/API.md
@@ -844,6 +844,7 @@ Content-Type: application/json
 | GET | `/api/sessions/:id/attachments/:attachmentId` | 流式返回附件二进制（`Content-Type` 来自元数据；路径规范化防穿越） |
 | GET | `/api/sessions/:id/attachments/:attachmentId/meta` | 返回最新 `{ attachment: ChatAttachmentMeta }`（含 PDF `extract` 整理状态与可选 `documentId`，供 UI 轮询） |
 | GET | `/api/sessions/:id/attachments/:attachmentId/extract` | 返回 `{ attachment_id, name, kind, extract }` 整理摘要（`extract` 同下表，含 `documentId?`） |
+| GET | `/api/sessions/:id/attachments/:attachmentId/extract/text` | 返回整理后的文本/Markdown（`text/markdown`）；整理中 202 `{ status: 'pending' }`；失败 422 `{ status: 'failed', message? }`；供右侧文件预览面板渲染 Word/PPT/Markdown/Txt |
 | DELETE | `/api/sessions/:id/attachments/:attachmentId` | 删除未入 turns 引用的附件；已引用 → 409 |
 | POST | `/api/sessions/:id/chat/stream` | SSE 聊天；body `{ message, model?, attachments?: string[] }`（`attachments` 为已上传附件 id 列表） |
 | POST | `/api/sessions/:id/chat` | 同步聊天；body 同上 |

--- a/docs/UI-LAYOUT.md
+++ b/docs/UI-LAYOUT.md
@@ -42,8 +42,9 @@
 - **浮层模式**：窗口宽度 &lt; 当前侧栏宽度 × 2.5 时侧栏浮于内容之上；≥ × 3 时窗口放大可自动展开内联侧栏
 - **右侧顶栏**：关注 / 组合 / 详情为文字 Tab；进入详情时显示「详情」Tab
 - **窗口标题栏**：macOS 沿用 `hiddenInset` 系统红绿灯；Windows / Linux 在窗口最顶部额外一条与左侧栏同色毛玻璃的 frame titlebar：左侧 App 图标 + 模拟原生菜单（文件 / 编辑 / 视图 / 窗口 / 帮助），右侧为 Win11 风格 caption 按钮（高满条、宽 46px；关闭 hover 红底白标，其余灰底深色标）。左侧栏分割线不向上贯穿该 frame titlebar。
+- **附件 PDF 预览**：右侧面板内嵌紧凑阅读器（翻页 / 缩放 / 适合宽度），目录默认收起，可手动展开跳页
 
-代码：`client-ui/src/chat/ChatApp.tsx`、`client-ui/src/market/RightMarketPanel.tsx`、`client-ui/src/desktop/WindowFrameTitleBar.tsx`。
+代码：`client-ui/src/chat/ChatApp.tsx`、`client-ui/src/market/RightMarketPanel.tsx`、`client-ui/src/desktop/WindowFrameTitleBar.tsx`、`client-ui/src/chat/FilePreviewPanel.tsx`、`client-ui/src/chat/PdfPreviewViewer.tsx`。
 
 ### 1.2 新闻中心
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,6 +153,7 @@
         "katex": "^0.17.0",
         "lightweight-charts": "^5.0.7",
         "mermaid": "^11.16.0",
+        "pdfjs-dist": "^6.2.108",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -6246,6 +6247,256 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas/-/canvas-1.0.3.tgz",
+      "integrity": "sha512-OlI657a5XXvKGFX7kNeIzJ8rO7IXt87Mqu2H8rXE46viAuOfum/JA7ysX7+eBhxNKznT+RCZh418mndlcFX3+w==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "1.0.3",
+        "@napi-rs/canvas-darwin-arm64": "1.0.3",
+        "@napi-rs/canvas-darwin-x64": "1.0.3",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "1.0.3",
+        "@napi-rs/canvas-linux-arm64-gnu": "1.0.3",
+        "@napi-rs/canvas-linux-arm64-musl": "1.0.3",
+        "@napi-rs/canvas-linux-riscv64-gnu": "1.0.3",
+        "@napi-rs/canvas-linux-x64-gnu": "1.0.3",
+        "@napi-rs/canvas-linux-x64-musl": "1.0.3",
+        "@napi-rs/canvas-win32-arm64-msvc": "1.0.3",
+        "@napi-rs/canvas-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-7kSCdUhoXiO+AaIMXdBGdtp6EctZNkmF62Rea/BmVQlwKaM3bBhOzyGUzxyxz9dv5vdBfpyAaxhSRSJF4kqK4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-ds14V1BPagLszQyaDTeggny5fNeTCqsUQ5QhFj9VDxSEfzrVxXtdbR0LoFyKa0Siaaw8KvqSk4t7k/WoZJwvbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-qof3LRAAycmkV2I1izZo9RoSHF8kCQr5O05sFwv0jK8rSdYV6KHVwimo6Qb7RxZj40WHKbLHm5JDaUF0o5XUAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-FU2kKZLmolHA9+KcUA+l1+xH3WTLUUTQDU/kLv9SEUr2TrRPu94aytOeizFJDHPs/QBcw4QL1mCQhetQXYBbag==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-GVSjntxKeA+/y/ZKf1F+cmUw1WeIkE5aMRPqnZUlBTBvBcrvgWccJAWuYCKPX4QJQwZILIIwhgdAbl51yj6fpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-J51oK/axyZ13kxycumSMfLiDZMdWdOVvqDFI28BpuViZHE3A0bQfr8B5vg8YnPEnqLD3BSn1hkdlh2buspEcNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-1.0.3.tgz",
+      "integrity": "sha512-CtQgQjoVTX67jS9XuCTtJ40Sl7wRLMguoFnnGnfDmCWf7kzKFZVwj5ynqUOIGKFMSB61ZCuQlwPvVNxYTTseaw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jtfzAHFp+FRaR7zGT4jyCe6wUgAG/dVb5A4Apd8FY9jKarntDfUAlJXscugiH7ZF5kKnu7/lHFk9LaDPcrGEVQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-xTzaUCKUHTY4bCGadeeRZggbRVbGUT1petg7Z8r9AJR2+D9Bqu6nQAgqBGC6D47tA70LjaaaLTrJ7wNY1T74dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-ktVLuBkI6QVOm5BwO/WbdGwxgeetAMJa7TTmR8qBarXF0OU2NKjvjUtPJAl2y8t+zBRczJl/1VOl9gua6WcK2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-SGhlQ8bDjL1Cz2KnsKMasr/5sTcwG/SZkB6WCJxLsmSm/3aS2C+3p39bA7iZ2/94+NkVDySZfbiGoaSZSFHYxA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "2.2.0",
@@ -17108,6 +17359,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/mehmet-kozan"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "6.2.108",
+      "resolved": "https://registry.npmmirror.com/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^1.0.0"
       }
     },
     "node_modules/pe-library": {

--- a/packages/doc-library/src/document-kind.ts
+++ b/packages/doc-library/src/document-kind.ts
@@ -57,3 +57,8 @@ export function documentKindFromMime(mime: string, filename?: string): DocumentK
   }
   return 'other'
 }
+
+/** 是否应按纯文本路径处理（预览直读 / text-l0，禁止走 PDF） */
+export function isPlainTextDocument(mime: string, filename?: string): boolean {
+  return documentKindFromMime(mime, filename) === 'text'
+}

--- a/packages/doc-library/src/engines/text-l0.ts
+++ b/packages/doc-library/src/engines/text-l0.ts
@@ -6,7 +6,78 @@ import { buildPageChunks } from './chunk-text.js'
 
 export const TEXT_L0_ENGINE_VERSION = '1.0.0'
 
-function decodeTextBuffer(blob: Buffer): string {
+const CJK_START = 0x4e00
+const CJK_END = 0x9fff
+const REPLACEMENT = 0xfffd
+/** UTF-8 与最佳候选分差在此以内时优先 UTF-8，避免误伤纯 ASCII */
+const UTF8_PREFER_MARGIN = 8
+
+function scoreDecodedText(text: string): number {
+  let score = 0
+  for (let i = 0; i < text.length; i++) {
+    const cp = text.charCodeAt(i)
+    if (cp === REPLACEMENT) {
+      score -= 50
+      continue
+    }
+    if (cp >= CJK_START && cp <= CJK_END) {
+      score += 3
+      continue
+    }
+    // 可打印 ASCII + 常见空白
+    if (cp === 0x09 || cp === 0x0a || cp === 0x0d || (cp >= 0x20 && cp <= 0x7e)) {
+      score += 1
+      continue
+    }
+    // 其他常见可打印 Unicode（拉丁扩展等）
+    if (cp >= 0xa0 && cp < 0xd800) {
+      score += 1
+    }
+  }
+  return score
+}
+
+function tryDecodeLabel(bytes: Uint8Array, label: string): string | null {
+  try {
+    return new TextDecoder(label, { fatal: false }).decode(bytes)
+  } catch {
+    return null
+  }
+}
+
+/** 无 BOM：启发式 UTF-8 vs GB18030/GBK */
+function decodeTextBufferHeuristic(blob: Buffer): string {
+  const bytes = new Uint8Array(blob.buffer, blob.byteOffset, blob.byteLength)
+  const candidates: Array<{ label: string; text: string; score: number }> = []
+
+  for (const label of ['utf-8', 'gb18030', 'gbk'] as const) {
+    // gb18030 已成功时跳过 gbk（超集）
+    if (label === 'gbk' && candidates.some(c => c.label === 'gb18030')) continue
+    const text = tryDecodeLabel(bytes, label)
+    if (text == null) continue
+    candidates.push({ label, text, score: scoreDecodedText(text) })
+  }
+
+  if (candidates.length === 0) {
+    return blob.toString('utf8')
+  }
+
+  const utf8 = candidates.find(c => c.label === 'utf-8')
+  let best = candidates[0]!
+  for (let i = 1; i < candidates.length; i++) {
+    const c = candidates[i]!
+    if (c.score > best.score) best = c
+  }
+
+  // UTF-8 分数接近或更好时优先（避免误伤纯 ASCII）
+  if (utf8 && utf8.score + UTF8_PREFER_MARGIN >= best.score) {
+    return utf8.text
+  }
+  return best.text
+}
+
+/** 解码纯文本 buffer（UTF-8 / UTF-16 BOM；无 BOM 时启发式 UTF-8 vs GB18030） */
+export function decodeTextBuffer(blob: Buffer): string {
   if (blob.length >= 2) {
     if (blob[0] === 0xff && blob[1] === 0xfe) {
       return blob.subarray(2).toString('utf16le')
@@ -23,7 +94,7 @@ function decodeTextBuffer(blob: Buffer): string {
   if (blob.length >= 3 && blob[0] === 0xef && blob[1] === 0xbb && blob[2] === 0xbf) {
     return blob.subarray(3).toString('utf8')
   }
-  return blob.toString('utf8')
+  return decodeTextBufferHeuristic(blob)
 }
 
 export function extractTextL0(blob: Buffer): ParseRunResult {

--- a/packages/doc-library/src/index.ts
+++ b/packages/doc-library/src/index.ts
@@ -20,7 +20,7 @@ export {
 export { DOC_LIBRARY_SCHEMA_VERSION as SCHEMA_VERSION } from './schema.js'
 export type { SchemaMigrationStep } from './schema-migrate.js'
 export * from './types.js'
-export { documentKindFromMime, extOfFilename } from './document-kind.js'
+export { documentKindFromMime, extOfFilename, isPlainTextDocument } from './document-kind.js'
 export { DocLibraryRepository } from './repository.js'
 export { DocLibraryService } from './service.js'
 export type { LegacyExtractWriter, ParseLifecycleHooks } from './service.js'
@@ -96,6 +96,7 @@ export {
   createTextL0Runner,
   TEXT_L0_ENGINE_VERSION,
   extractTextL0,
+  decodeTextBuffer,
 } from './engines/text-l0.js'
 export {
   createOfficeL0Runner,

--- a/packages/doc-library/src/parse-router.ts
+++ b/packages/doc-library/src/parse-router.ts
@@ -4,6 +4,7 @@
  */
 import type { DocumentKind, ParseEngineId, ParseRunOpts, ParseRunResult, ParseRunner } from './types.js'
 import { isOcrEngineId } from './types.js'
+import { documentKindFromMime } from './document-kind.js'
 import {
   isWeakText,
   metricsFromParseResult,
@@ -40,24 +41,13 @@ function ocrAvailableOf(input: SelectEngineInput): boolean {
 }
 
 function resolveKind(input: SelectEngineInput): DocumentKind {
-  if (input.kind) return input.kind
-  const mime = (input.mime ?? '').toLowerCase()
-  const name = (input.filename ?? '').toLowerCase()
-  if (mime === 'application/pdf' || name.endsWith('.pdf')) return 'pdf'
-  if (mime.startsWith('image/')) return 'image'
-  if (mime.includes('wordprocessingml') || name.endsWith('.docx')) return 'docx'
-  if (mime === 'application/msword' || name.endsWith('.doc')) return 'doc'
-  if (mime.includes('presentationml') || name.endsWith('.pptx')) return 'pptx'
-  if (mime.includes('ms-powerpoint') || name.endsWith('.ppt')) return 'ppt'
-  if (
-    mime.startsWith('text/')
-    || name.endsWith('.txt')
-    || name.endsWith('.md')
-    || name.endsWith('.markdown')
-  ) {
-    return 'text'
-  }
-  return 'pdf'
+  const fromMime = documentKindFromMime(input.mime ?? '', input.filename)
+  // 硬性：mime/扩展名像纯文本时绝不能落到 PDF
+  if (fromMime === 'text' || input.kind === 'text') return 'text'
+  if (input.kind && input.kind !== 'other') return input.kind
+  if (fromMime !== 'other') return fromMime
+  // other / 未知：保持 PDF 路径（与历史行为一致）
+  return input.kind === 'other' ? 'other' : 'pdf'
 }
 
 function available(engine: ParseEngineId, input: SelectEngineInput): boolean {

--- a/packages/doc-library/src/service.ts
+++ b/packages/doc-library/src/service.ts
@@ -21,6 +21,7 @@ import { EmbeddingService, getEmbeddingService } from './embedding.js'
 import { getVectorStore, type VectorStore } from './vector-store.js'
 import { searchHybridChunks } from './hybrid-search.js'
 import { extractTextL0, TEXT_L0_ENGINE_VERSION } from './engines/text-l0.js'
+import { isPlainTextDocument } from './document-kind.js'
 
 export type LegacyExtractWriter = (
   sessionId: string,
@@ -95,6 +96,7 @@ export class DocLibraryService {
     let documentId: string
     let reused = false
     const forceReparse = Boolean(input.deepParse || input.forceEngine)
+    const textLike = input.kind === 'text' || isPlainTextDocument(input.mime, input.name)
 
     if (existing) {
       documentId = existing.id
@@ -107,16 +109,21 @@ export class DocLibraryService {
         content_sha256: contentSha256,
         name: input.name,
         mime: input.mime,
-        kind: input.kind,
+        kind: textLike ? 'text' : input.kind,
         byte_size: input.data.length,
         blob_path: blobPath,
       })
-      if (this.parseRunner) {
+      if (this.parseRunner && !textLike) {
         this.repo.upsertParsePending(documentId, this.parseRunner.engineId, this.parseRunner.engineVersion)
       }
     }
 
     this.repo.linkSession(input.sessionId, documentId, input.attachmentId)
+
+    // 纯文本：同步 text-l0 → ready/legacy → 异步 embed（跳过 PDF 异步队列）
+    if (textLike) {
+      return this.finishTextAttachmentSync(documentId, contentSha256, input, reused, forceReparse)
+    }
 
     const artifact = this.repo.getParseArtifact(documentId)
     const parseStatus: ParseStatus = artifact?.status ?? 'pending'
@@ -140,6 +147,110 @@ export class DocLibraryService {
       charCount: artifact?.char_count ?? undefined,
       error: artifact?.error ?? undefined,
       readyAt: artifact?.ready_at ?? undefined,
+    }
+  }
+
+  /**
+   * 附件纯文本快路径：同步切块入库，立刻可预览；向量仍异步。
+   */
+  private finishTextAttachmentSync(
+    documentId: string,
+    contentSha256: string,
+    input: IngestFromAttachmentInput,
+    reused: boolean,
+    forceReparse: boolean,
+  ): IngestFromAttachmentResult {
+    const artifact = this.repo.getParseArtifact(documentId)
+    if (reused && artifact?.status === 'ready' && !forceReparse) {
+      if (input.source === 'attachment' && this.legacyWriter) {
+        const chunks = this.repo.getChunks(documentId)
+        const md = this.repo.readMarkdown(documentId)
+        if (md && chunks.length) {
+          this.legacyWriter(input.sessionId, input.attachmentId, {
+            pageCount: artifact.page_count ?? 1,
+            charCount: artifact.char_count ?? md.length,
+            markdown: md,
+            chunks: chunks.map(r => ({
+              id: `c${r.seq}`,
+              page: r.page,
+              offset: r.offset,
+              text: r.text,
+            })),
+          })
+        }
+      }
+      return {
+        documentId,
+        contentSha256,
+        reused,
+        parseStatus: 'ready',
+        pageCount: artifact.page_count ?? undefined,
+        charCount: artifact.char_count ?? undefined,
+        readyAt: artifact.ready_at ?? undefined,
+      }
+    }
+
+    const parsed = extractTextL0(input.data)
+    if (parsed.charCount < MIN_USEFUL_CHARS || !parsed.chunks.length) {
+      const err = parsed.error
+        ?? (parsed.charCount > 0
+          ? '内容过短，暂时无法加入检索；你仍可预览原文'
+          : '文件似乎没有可读内容，请确认后重试')
+      this.repo.upsertParsePending(documentId, 'text-l0', TEXT_L0_ENGINE_VERSION)
+      this.repo.markParseFailed(documentId, err, {
+        pageCount: parsed.pageCount,
+        charCount: parsed.charCount,
+      })
+      this.lifecycleHooks?.onFailed?.(input, err, {
+        pageCount: parsed.pageCount,
+        charCount: parsed.charCount,
+      })
+      return {
+        documentId,
+        contentSha256,
+        reused,
+        parseStatus: 'failed',
+        pageCount: parsed.pageCount || undefined,
+        charCount: parsed.charCount || undefined,
+        error: err,
+      }
+    }
+
+    this.repo.upsertParsePending(documentId, 'text-l0', TEXT_L0_ENGINE_VERSION)
+    const chunkRows = this.repo.markParseReady(documentId, {
+      pageCount: parsed.pageCount,
+      charCount: parsed.charCount,
+      markdown: parsed.markdown,
+      chunks: parsed.chunks,
+      engineId: 'text-l0',
+      engineVersion: TEXT_L0_ENGINE_VERSION,
+    })
+
+    if (input.source === 'attachment' && this.legacyWriter) {
+      this.legacyWriter(input.sessionId, input.attachmentId, {
+        pageCount: parsed.pageCount,
+        charCount: parsed.charCount,
+        markdown: parsed.markdown,
+        chunks: chunkRows.map(r => ({
+          id: `c${r.seq}`,
+          page: r.page,
+          offset: r.offset,
+          text: r.text,
+        })),
+      })
+    }
+
+    void this.scheduleEmbed(documentId)
+
+    const ready = this.repo.getParseArtifact(documentId)
+    return {
+      documentId,
+      contentSha256,
+      reused,
+      parseStatus: ready?.status ?? 'ready',
+      pageCount: ready?.page_count ?? parsed.pageCount,
+      charCount: ready?.char_count ?? parsed.charCount,
+      readyAt: ready?.ready_at ?? undefined,
     }
   }
 

--- a/tests/decode-text-buffer-client.test.mjs
+++ b/tests/decode-text-buffer-client.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { decodeTextBufferBytes } from '../client-ui/src/utils/decodeTextBuffer.ts'
+import { decodeTextBuffer } from '../packages/doc-library/dist/index.js'
+
+describe('client decodeTextBufferBytes', () => {
+  it('decodes utf8', () => {
+    const bytes = new TextEncoder().encode('你好世界')
+    assert.equal(decodeTextBufferBytes(bytes), '你好世界')
+  })
+
+  it('strips utf8 BOM', () => {
+    const body = new TextEncoder().encode('标题')
+    const bytes = new Uint8Array(3 + body.length)
+    bytes[0] = 0xef
+    bytes[1] = 0xbb
+    bytes[2] = 0xbf
+    bytes.set(body, 3)
+    assert.equal(decodeTextBufferBytes(bytes), '标题')
+  })
+
+  it('decodes utf16le BOM', () => {
+    const buf = Buffer.from([0xff, 0xfe, 0x60, 0x4f, 0x7d, 0x59]) // 你好
+    assert.equal(decodeTextBufferBytes(buf), '你好')
+  })
+
+  it('matches doc-library GBK heuristic', () => {
+    // GBK 字节：你好
+    const gbkNiHao = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
+    assert.equal(decodeTextBuffer(gbkNiHao), '你好')
+    assert.equal(decodeTextBufferBytes(gbkNiHao), decodeTextBuffer(gbkNiHao))
+  })
+
+  it('prefers utf8 for ascii', () => {
+    const ascii = new TextEncoder().encode('hello\nworld')
+    assert.equal(decodeTextBufferBytes(ascii), 'hello\nworld')
+  })
+})

--- a/tests/doc-extract-engines.test.mjs
+++ b/tests/doc-extract-engines.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import JSZip from 'jszip'
 import {
   extractTextL0,
+  decodeTextBuffer,
   extractDocxL0,
   extractDocL0,
   extractPptxL0,
@@ -25,6 +26,39 @@ describe('text-l0 extract', () => {
     const result = extractTextL0(Buffer.from('\uFEFF标题\n正文', 'utf8'))
     assert.ok(result.markdown.includes('标题'))
     assert.ok(!result.error)
+  })
+
+  it('decodes GBK Chinese without BOM (你好 = C4 E3 BA C3)', () => {
+    const gbkNiHao = Buffer.from([0xc4, 0xe3, 0xba, 0xc3])
+    assert.equal(decodeTextBuffer(gbkNiHao), '你好')
+    const result = extractTextL0(gbkNiHao)
+    assert.ok(result.markdown.includes('你好'))
+    assert.ok(!result.error)
+  })
+
+  it('decodes GB18030 Chinese without BOM', () => {
+    // 「中文」GB18030/GBK：D6 D0 CE C4
+    const buf = Buffer.from([0xd6, 0xd0, 0xce, 0xc4])
+    assert.equal(decodeTextBuffer(buf), '中文')
+    const result = extractTextL0(buf)
+    assert.ok(result.markdown.includes('中文'))
+    assert.ok(!result.error)
+  })
+
+  it('keeps UTF-8 Chinese preferred over GBK mis-decode', () => {
+    const utf8 = Buffer.from('你好世界', 'utf8')
+    assert.equal(decodeTextBuffer(utf8), '你好世界')
+  })
+
+  it('decodes UTF-16 LE BOM', () => {
+    const le = Buffer.from([0xff, 0xfe, 0x60, 0x4f, 0x7d, 0x59]) // 你好
+    assert.equal(decodeTextBuffer(le), '你好')
+    const result = extractTextL0(le)
+    assert.ok(result.markdown.includes('你好'))
+  })
+
+  it('keeps pure ASCII as UTF-8', () => {
+    assert.equal(decodeTextBuffer(Buffer.from('hello\nworld', 'utf8')), 'hello\nworld')
   })
 })
 
@@ -92,6 +126,14 @@ describe('documentKindFromMime legacy office', () => {
       ),
       'pptx',
     )
+  })
+
+  it('maps txt/md/csv/json to text', () => {
+    assert.equal(documentKindFromMime('text/plain', 'a.txt'), 'text')
+    assert.equal(documentKindFromMime('text/markdown', 'a.md'), 'text')
+    assert.equal(documentKindFromMime('text/csv', 'a.csv'), 'text')
+    assert.equal(documentKindFromMime('application/json', 'a.json'), 'text')
+    assert.equal(documentKindFromMime('application/octet-stream', 'notes.txt'), 'text')
   })
 })
 

--- a/tests/document-library.test.mjs
+++ b/tests/document-library.test.mjs
@@ -425,6 +425,33 @@ describe('doc-library ingest + FTS + session filter', () => {
     assert.equal(second.parseStatus, 'ready')
   })
 
+  it('sync text-l0 for txt/csv/json without waiting async parse', () => {
+    for (const [name, mime, body] of [
+      ['notes.txt', 'text/plain', '纯文本附件正文足够长用于入库预览与检索'],
+      ['table.csv', 'text/csv', 'col1,col2\na,b\nc,d\nenough_chars_here_ok'],
+      ['data.json', 'application/json', '{"title":"demo","body":"enough characters for useful text"}'],
+    ]) {
+      const data = Buffer.from(body, 'utf8')
+      const ing = svc.ingestFromAttachment({
+        sessionId: `sess-text-${name}`,
+        attachmentId: `att-${name}`,
+        name,
+        mime,
+        kind: 'other',
+        data,
+        source: 'import',
+      })
+      assert.equal(ing.parseStatus, 'ready', name)
+      assert.ok((ing.charCount ?? 0) >= 24, name)
+      const st = svc.getParseStatus(ing.documentId)
+      assert.equal(st?.status, 'ready', name)
+      const artifact = svc.getRepository().getParseArtifact(ing.documentId)
+      assert.equal(artifact?.engine_id, 'text-l0', name)
+      const md = svc.getRepository().readMarkdown(ing.documentId)
+      assert.ok(md && md.includes(body.slice(0, 8)), name)
+    }
+  })
+
   it('FTS search respects session filter', async () => {
     const dataA = Buffer.from('ALPHATERM999-only-in-session-a')
     const dataB = Buffer.from('BETATERM888-only-in-session-b')

--- a/tests/parse-router.test.mjs
+++ b/tests/parse-router.test.mjs
@@ -83,6 +83,53 @@ describe('parse-router selectEngine', () => {
     assert.equal(next, 'text-l0')
   })
 
+  it('routes csv/json/txt mime or ext to text-l0 even when kind is other', () => {
+    assert.equal(selectEngine({
+      current: null,
+      tried: [],
+      kind: 'other',
+      mime: 'text/csv',
+      filename: 'data.csv',
+      ocrAvailable: false,
+    }), 'text-l0')
+    assert.equal(selectEngine({
+      current: null,
+      tried: [],
+      kind: 'other',
+      mime: 'application/json',
+      filename: 'notes.json',
+      ocrAvailable: false,
+    }), 'text-l0')
+    assert.equal(selectEngine({
+      current: null,
+      tried: [],
+      mime: 'application/octet-stream',
+      filename: 'readme.txt',
+      ocrAvailable: false,
+    }), 'text-l0')
+    assert.equal(selectEngine({
+      current: null,
+      tried: [],
+      mime: 'text/markdown',
+      filename: 'note.md',
+      ocrAvailable: false,
+    }), 'text-l0')
+  })
+
+  it('never routes plain text filename to pdf-extract', () => {
+    const next = selectEngine({
+      current: null,
+      tried: [],
+      kind: 'other',
+      filename: 'plain.txt',
+      mime: 'application/octet-stream',
+      ocrAvailable: true,
+      deepParse: true,
+    })
+    assert.equal(next, 'text-l0')
+    assert.notEqual(next, 'pdf-extract-l0')
+  })
+
   it('routes docx/doc/pptx/ppt to office-l0', () => {
     for (const kind of ['docx', 'doc', 'pptx', 'ppt']) {
       assert.equal(selectEngine({
@@ -334,6 +381,42 @@ describe('parse-router run cascade', () => {
       },
     })
     const result = await router.run(Buffer.from('hello'), { kind: 'text' })
+    assert.equal(result.usedEngineId, 'text-l0')
+    assert.ok(result.markdown.includes('hello'))
+  })
+
+  it('other+json mime uses text runner, not pdf', async () => {
+    let pdfCalls = 0
+    const router = new ParseRouter({
+      text: {
+        engineId: 'text-l0',
+        engineVersion: 't',
+        async run(blob) {
+          return {
+            pageCount: 1,
+            charCount: blob.length + 20,
+            markdown: `<!-- page:1 -->\n${blob.toString('utf8')}`,
+            chunks: [{ page: 1, offset: 0, text: blob.toString('utf8') }],
+            emptyPageRatio: 0,
+          }
+        },
+      },
+      pdf: {
+        engineId: 'pdf-extract-l0',
+        engineVersion: 't',
+        async run() {
+          pdfCalls += 1
+          throw new Error('Invalid PDF structure')
+        },
+      },
+    })
+    const body = Buffer.from('{"hello":"world","enough_chars_for_preview":true}')
+    const result = await router.run(body, {
+      kind: 'other',
+      mime: 'application/json',
+      filename: 'data.json',
+    })
+    assert.equal(pdfCalls, 0)
     assert.equal(result.usedEngineId, 'text-l0')
     assert.ok(result.markdown.includes('hello'))
   })


### PR DESCRIPTION
## Summary
- 右侧面板支持会话附件预览（PDF 紧凑阅读器、纯文本解码回退、Electron 顶栏空白拖拽）
- 附件条即时展示、按类型图标区分，引用 chip 自适应宽度与更紧凑间距
- 纯文本入库/预览链路与相关测试补充

## Test plan
- [ ] 拖拽/选择 PDF、文本进输入框，附件条即时出现并可点开右侧预览
- [ ] 桌面端预览顶栏空白可拖窗口；关闭按钮可点
- [ ] 短/长文件名引用 chip 宽度与间距正常；加载中无方块底、spinner 贴字色
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)