### PR TITLE
feat(chat): 消息目录轨与本对话附件抽屉

### DIFF
--- a/apps/server/src/session-attachment-routes.ts
+++ b/apps/server/src/session-attachment-routes.ts
@@ -13,6 +13,7 @@ import {
   resolveAttachmentFilePath,
   validateAttachmentAgainstCapabilities,
   isAttachmentReferenced,
+  listSessionAttachmentMetas,
   parseNonNegativeIntHeader,
   resolveUploadMime,
 } from '@opptrix/agent'
@@ -41,6 +42,21 @@ export function registerSessionAttachmentRoutes(app: FastifyInstance, agent: Age
     'application/octet-stream',
     { parseAs: 'buffer' },
     (_req, body, done) => { done(null, body) },
+  )
+
+  app.get<{ Params: { id: string } }>(
+    '/api/sessions/:id/attachments',
+    async (req, reply) => {
+      const session = agent.getSession(req.params.id)
+      if (!session) return reply.code(404).send({ error: 'session not found' })
+
+      const metas = listSessionAttachmentMetas(req.params.id)
+      const attachments = metas.map(meta => ({
+        ...meta,
+        referenced: isAttachmentReferenced(meta.id, session.turns),
+      }))
+      return { attachments }
+    },
   )
 
   app.post<{ Params: { id: string } }>(

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -9,7 +9,7 @@ import type {
   ValidateFeedResult,
 } from '../types/schemas'
 import type { ChatProgressEvent } from '../types/chatProgress'
-import type { ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, SessionContextRef, SessionMeta, AvailableModel, ChatAttachmentMeta } from '../types/chat'
+import type { ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, SessionContextRef, SessionMeta, AvailableModel, ChatAttachmentMeta, SessionAttachmentListItem } from '../types/chat'
 import { resolveFileMime } from '../chat/mediaCapabilities'
 import type { ExportDestination, ExportPackageResult } from '../platform/saveMarketPackage'
 import {
@@ -1606,6 +1606,15 @@ export async function submitUserPromptResponse(
       ...answer,
     }),
   }, CHAT_REQUEST_TIMEOUT)
+}
+
+export async function listSessionAttachments(
+  sessionId: string,
+): Promise<SessionAttachmentListItem[]> {
+  const data = await jsonFetch<{ attachments: SessionAttachmentListItem[] }>(
+    `/sessions/${sessionId}/attachments`,
+  )
+  return data.attachments
 }
 
 export async function uploadSessionAttachment(

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -56,10 +56,12 @@ import { useWorkspaceSplit } from '../hooks/useWorkspaceSplit'
 import { useSessionSidebarWidth } from '../hooks/useSessionSidebarWidth'
 import { useAppNavigation } from '../hooks/useAppNavigation'
 import DesktopWindowChrome from '../desktop/DesktopWindowChrome'
+import ChromeToolButton from '../desktop/ChromeToolButton'
 import OverlaySidebarEdgeTrigger from '../desktop/OverlaySidebarEdgeTrigger'
 import { useOpptrixDialogAlert } from '../components/opptrix/OpptrixDialogAlert'
 import ChatSessionTitleTools from './ChatSessionTitleTools'
 import SessionRolePersonaDrawer from './SessionRolePersonaDrawer'
+import { BoxRegular } from '@fluentui/react-icons'
 import { sessionToMarkdown } from './sessionExportMarkdown'
 import { saveTextFileWithDialog } from '../platform/saveTextFile'
 import { desktopChromeToolbarReserve } from '../desktop/layout'
@@ -74,7 +76,17 @@ import {
   resolveWindowFocused,
 } from '../platform/chatNotifications'
 import { playChatCueSound } from '../platform/chatSound'
-import { DESKTOP_SIDEBAR_LAYOUT_MS, DESKTOP_SIDEBAR_LAYOUT_EASE, DESKTOP_FRAME_TITLEBAR_HEIGHT, DESKTOP_TITLEBAR_HEIGHT, DESKTOP_Z_TITLE, SIDEBAR_DEFAULT_WIDTH, WORKSPACE_CHAT_MIN_WIDTH, WORKSPACE_CHAT_RIGHT_MIN_WIDTH } from '../desktop/constants'
+import {
+  DESKTOP_SIDEBAR_LAYOUT_MS,
+  DESKTOP_SIDEBAR_LAYOUT_EASE,
+  DESKTOP_FRAME_TITLEBAR_HEIGHT,
+  DESKTOP_TITLEBAR_HEIGHT,
+  DESKTOP_TOOL_ICON_SIZE,
+  DESKTOP_Z_TITLE,
+  SIDEBAR_DEFAULT_WIDTH,
+  WORKSPACE_CHAT_MIN_WIDTH,
+  WORKSPACE_CHAT_RIGHT_MIN_WIDTH,
+} from '../desktop/constants'
 
 const useStyles = makeStyles({
   root: {
@@ -520,6 +532,11 @@ export default function ChatApp() {
   const [chatScrollEpoch, setChatScrollEpoch] = useState(0)
   const [searchOpen, setSearchOpen] = useState(false)
   const [rolePersonaOpen, setRolePersonaOpen] = useState(false)
+  const [attachmentsDrawerOpen, setAttachmentsDrawerOpen] = useState(false)
+
+  useEffect(() => {
+    setAttachmentsDrawerOpen(false)
+  }, [activeId])
   const [contextHintBanner, setContextHintBanner] = useState('')
 
   const [focusStockCode, setFocusStockCode] = useState<string | null>(null)
@@ -1395,6 +1412,20 @@ export default function ChatApp() {
       onOpenChange={setRolePersonaOpen}
     />
   )
+
+  /** Electron：始终挂到 DesktopWindowChrome titleBarTrailing，与拖拽层同级可点 */
+  const attachmentsChatTitleButton = electronChrome && view === 'chat' && !isStandaloneView && !isMobile ? (
+    <ChromeToolButton
+      label="本对话附件"
+      active={attachmentsDrawerOpen}
+      disabled={!activeId}
+      data-attachments-toggle
+      aria-controls="session-attachments-drawer"
+      onClick={() => setAttachmentsDrawerOpen(open => !open)}
+    >
+      <BoxRegular fontSize={DESKTOP_TOOL_ICON_SIZE} />
+    </ChromeToolButton>
+  ) : null
   const sidebarSessions = useMemo(() => {
     if (sidebarListTab === 'experts') return sessions.filter(s => !!s.expertId)
     if (sidebarListTab === 'chat') return sessions.filter(s => !s.expertId)
@@ -1508,6 +1539,7 @@ export default function ChatApp() {
         <DesktopWindowChrome
           title={chromeTitle}
           titleSlot={sessionTitleTools}
+          titleBarTrailing={attachmentsChatTitleButton ?? undefined}
           viewMode={chromeViewMode}
           sidebarOpen={isSettings ? settingsSidebarVisible : sidebarVisible}
           sidebarInline={isSettings
@@ -1775,6 +1807,8 @@ export default function ChatApp() {
                   onStreamError={handleStreamError}
                   resolveStreamSnapshot={resolveStreamSnapshot}
                   onClearPendingUserPrompt={clearPendingUserPrompt}
+                  attachmentsDrawerOpen={!isMobile && attachmentsDrawerOpen}
+                  onAttachmentsDrawerOpenChange={!isMobile ? setAttachmentsDrawerOpen : undefined}
                 />
               </div>
             </div>

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -28,11 +28,15 @@ import {
   ArrowMaximizeRegular,
   ArrowMinimizeRegular,
 } from './chatIcons'
+import { BoxRegular } from '@fluentui/react-icons'
 import {
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
+  DESKTOP_TOOL_ICON_SIZE,
 } from '../desktop/constants'
 import { pickWelcomeVariant } from './chatWelcomeVariants'
+import MessageOutlineRail from './MessageOutlineRail'
+import SessionAttachmentsDrawer from './SessionAttachmentsDrawer'
 
 const useStyles = makeStyles({
   root: {
@@ -68,12 +72,14 @@ const useStyles = makeStyles({
     width: '100%',
     maxWidth: opptrixTokens.chatThreadMaxWidth,
     marginInline: 'auto',
-    paddingInline: opptrixTokens.chatThreadPaddingX,
+    paddingLeft: opptrixTokens.chatThreadPaddingLeft,
+    paddingRight: opptrixTokens.chatThreadPaddingX,
     boxSizing: 'border-box',
   },
   threadColumnMobile: {
     maxWidth: 'none',
-    paddingInline: opptrixTokens.chatThreadPaddingXMobile,
+    paddingLeft: opptrixTokens.chatThreadPaddingXMobile,
+    paddingRight: opptrixTokens.chatThreadPaddingXMobile,
   },
   /** Fill the scroll viewport so empty-state welcome can sit on the Y center. */
   threadColumnEmpty: {
@@ -118,14 +124,16 @@ const useStyles = makeStyles({
     width: '100%',
     maxWidth: opptrixTokens.chatThreadMaxWidth,
     marginInline: 'auto',
-    paddingInline: opptrixTokens.chatThreadPaddingX,
+    paddingLeft: opptrixTokens.chatThreadPaddingLeft,
+    paddingRight: opptrixTokens.chatThreadPaddingX,
     paddingBottom: opptrixTokens.chatComposerBottomInset,
     boxSizing: 'border-box',
     pointerEvents: 'auto',
   },
   composerInnerMobile: {
     maxWidth: 'none',
-    paddingInline: opptrixTokens.chatThreadPaddingXMobile,
+    paddingLeft: opptrixTokens.chatThreadPaddingXMobile,
+    paddingRight: opptrixTokens.chatThreadPaddingXMobile,
     paddingBottom: `max(${opptrixTokens.chatComposerBottomInset}, env(safe-area-inset-bottom))`,
   },
   header: {
@@ -144,7 +152,7 @@ const useStyles = makeStyles({
     height: '100%',
     margin: '0 auto',
     minWidth: 0,
-    paddingLeft: opptrixTokens.chatThreadPaddingX,
+    paddingLeft: opptrixTokens.chatThreadPaddingLeft,
     paddingRight: opptrixTokens.chatThreadPaddingX,
     boxSizing: 'border-box',
     display: 'flex',
@@ -324,6 +332,9 @@ interface ChatViewProps {
   onStreamError?: (message: string) => void
   resolveStreamSnapshot?: (sessionId: string | null) => SessionStreamSnapshot | null
   onClearPendingUserPrompt?: (sessionId: string | null) => void
+  /** 本对话附件抽屉（状态由 ChatApp 持有；Electron 始终在 chrome titleBarTrailing；Web 在 headerActions） */
+  attachmentsDrawerOpen?: boolean
+  onAttachmentsDrawerOpenChange?: (open: boolean) => void
 }
 
 function ChatView({
@@ -345,6 +356,8 @@ function ChatView({
   onStreamError,
   resolveStreamSnapshot,
   onClearPendingUserPrompt,
+  attachmentsDrawerOpen = false,
+  onAttachmentsDrawerOpenChange,
 }: ChatViewProps) {
   const s = useStyles()
   const [liveTrace, setLiveTrace] = useState<ChatLiveTrace | null>(null)
@@ -570,6 +583,19 @@ function ChatView({
     ? (expertSummary ?? '')
     : welcome.subtitle
   const electronChrome = isElectron() && !isMobile
+  const showDesktopChromeExtras = !isMobile
+  const attachmentsToggle = showDesktopChromeExtras && onAttachmentsDrawerOpenChange ? (
+    <ChromeToolButton
+      label="本对话附件"
+      active={attachmentsDrawerOpen}
+      disabled={!sessionId}
+      data-attachments-toggle
+      aria-controls="session-attachments-drawer"
+      onClick={() => onAttachmentsDrawerOpenChange(!attachmentsDrawerOpen)}
+    >
+      <BoxRegular fontSize={DESKTOP_TOOL_ICON_SIZE} />
+    </ChromeToolButton>
+  ) : null
 
   const syncScrollbarHalfOffset = useCallback(() => {
     const el = chatBoxRef.current
@@ -764,8 +790,9 @@ function ChatView({
             <div className={s.headerTitleSlot}>
               {titleSlot ?? <Text className={s.title}>{title || '新对话'}</Text>}
             </div>
-            {(headerTrailing || (!rightPanelOpen && (onToggleRightPanel || onToggleChatColumn))) && (
+            {(attachmentsToggle || headerTrailing || (!rightPanelOpen && (onToggleRightPanel || onToggleChatColumn))) && (
               <div className={s.headerActions}>
+                {attachmentsToggle}
                 {headerTrailing}
                 {!rightPanelOpen && onToggleChatColumn && (
                   <ChromeToolButton
@@ -821,6 +848,24 @@ function ChatView({
             onExpandedChange={setToolbarExpanded}
           />
         )}
+
+        {showDesktopChromeExtras ? (
+          <MessageOutlineRail
+            messages={messages}
+            scrollContainerRef={chatBoxRef}
+            onJump={index => scrollToMessageStart(index, 'smooth')}
+          />
+        ) : null}
+
+        {showDesktopChromeExtras && onAttachmentsDrawerOpenChange ? (
+          <SessionAttachmentsDrawer
+            open={attachmentsDrawerOpen}
+            sessionId={sessionId}
+            composerPadBottom={threadScrollPadBottom}
+            onClose={() => onAttachmentsDrawerOpenChange(false)}
+            onOpen={(sid, attachment) => onOpenFilePreview?.(sid, attachment)}
+          />
+        ) : null}
 
         <div
           ref={chatBoxRef}

--- a/client-ui/src/chat/MessageOutlineRail.tsx
+++ b/client-ui/src/chat/MessageOutlineRail.tsx
@@ -1,0 +1,357 @@
+import {
+  useCallback, useEffect, useMemo, useRef, useState,
+  type RefObject,
+} from 'react'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import type { ChatDisplayMessage } from '../types/chat'
+import { opptrixCssVars } from '../theme/tokens'
+import { motion } from '../theme/mixins'
+import { formatFriendlyTime } from '../utils/formatFriendlyTime'
+
+export interface OutlineEntry {
+  index: number
+  role: 'assistant'
+  summary: string
+  /** ISO timestamp from ChatDisplayMessage.at; empty when missing/invalid. */
+  at: string
+}
+
+/** 仅收录助手有正文的消息；user / 空正文不进目录轨。 */
+export function buildOutlineEntries(messages: ChatDisplayMessage[]): OutlineEntry[] {
+  const out: OutlineEntry[] = []
+  for (let i = 0; i < messages.length; i += 1) {
+    const m = messages[i]
+    if (m.role !== 'assistant') continue
+    const text = m.content.trim()
+    if (!text) continue
+    out.push({
+      index: i,
+      role: 'assistant',
+      summary: text.length > 80 ? `${text.slice(0, 80)}…` : text,
+      at: typeof m.at === 'string' ? m.at : '',
+    })
+  }
+  return out
+}
+
+/** Map outline ordinal → vertical position on the rail (0–100). */
+function ordinalTopPercent(ordinal: number, count: number): number {
+  if (count <= 1) return 50
+  return (ordinal / (count - 1)) * 100
+}
+
+const useStyles = makeStyles({
+  rail: {
+    position: 'absolute',
+    left: 0,
+    top: '50%',
+    transform: 'translateY(-50%)',
+    zIndex: 4,
+    width: '22px',
+    height: 'min(56vh, 420px)',
+    boxSizing: 'border-box',
+    overflow: 'visible',
+    pointerEvents: 'auto',
+  },
+  track: {
+    position: 'relative',
+    width: '2px',
+    height: '100%',
+    marginInline: 'auto',
+    borderRadius: '1px',
+    /** Idle: solid light gray (no opacity); deepens on rail hover/focus. */
+    backgroundColor: opptrixCssVars.gray100,
+    overflow: 'visible',
+    transitionProperty: 'background-color',
+    transitionDuration: motion.fast,
+    transitionTimingFunction: motion.ease,
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '1ms',
+    },
+  },
+  trackRailHover: {
+    backgroundColor: opptrixCssVars.textSecondary,
+  },
+  trackFill: {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: '100%',
+    borderRadius: '1px',
+    backgroundColor: opptrixCssVars.gray100,
+    transitionProperty: 'height, background-color',
+    transitionDuration: motion.fast,
+    transitionTimingFunction: motion.ease,
+    pointerEvents: 'none',
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '1ms',
+    },
+  },
+  trackFillRailHover: {
+    backgroundColor: opptrixCssVars.textPrimary,
+  },
+  item: {
+    position: 'absolute',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '24px',
+    height: '24px',
+    padding: 0,
+    border: 'none',
+    background: 'transparent',
+    cursor: 'pointer',
+    outline: 'none',
+    zIndex: 1,
+    transitionProperty: 'width, height',
+    transitionDuration: motion.fast,
+    transitionTimingFunction: motion.ease,
+    ':focus-visible > span:first-child': {
+      outline: `2px solid ${opptrixCssVars.textPrimary}`,
+      outlineOffset: '2px',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '1ms',
+    },
+  },
+  itemRailHover: {
+    width: '28px',
+    height: '28px',
+  },
+  dot: {
+    width: '3px',
+    height: '3px',
+    borderRadius: '50%',
+    backgroundColor: opptrixCssVars.gray100,
+    transform: 'scale(1)',
+    transitionProperty: 'transform, width, height, background-color',
+    transitionDuration: motion.fast,
+    transitionTimingFunction: motion.ease,
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '1ms',
+    },
+  },
+  /** Mild grow for non-hot dots while rail is hovered/focused. */
+  dotRailHover: {
+    width: '6px',
+    height: '6px',
+    backgroundColor: opptrixCssVars.textSecondary,
+  },
+  /** Active while rail idle — same light gray; +1px only. */
+  dotActive: {
+    width: '4px',
+    height: '4px',
+    backgroundColor: opptrixCssVars.gray100,
+    transform: 'scale(1.05)',
+  },
+  /** Active after rail hover/focus — primary + slightly larger than peers. */
+  dotActiveRailHover: {
+    width: '7px',
+    height: '7px',
+    backgroundColor: opptrixCssVars.textPrimary,
+  },
+  /** Hover/focus target — largest; wins over active/railHover. */
+  dotHot: {
+    width: '11px',
+    height: '11px',
+    transform: 'scale(1.1)',
+    backgroundColor: opptrixCssVars.textPrimary,
+  },
+  preview: {
+    position: 'absolute',
+    left: '24px',
+    top: '50%',
+    transform: 'translateY(-50%)',
+    zIndex: 6,
+    width: '220px',
+    padding: '8px 10px',
+    boxSizing: 'border-box',
+    borderRadius: '8px',
+    backgroundColor: opptrixCssVars.surface,
+    border: `1px solid ${opptrixCssVars.separator}`,
+    boxShadow: '0 8px 24px rgba(0, 0, 0, 0.12)',
+    pointerEvents: 'none',
+    textAlign: 'left',
+  },
+  previewMeta: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: '8px',
+    marginBottom: '4px',
+  },
+  previewRole: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    color: opptrixCssVars.textSecondary,
+    flexShrink: 0,
+  },
+  previewTime: {
+    fontSize: 'var(--opptrix-font-xs)',
+    fontWeight: 400,
+    color: opptrixCssVars.textTertiary,
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    minWidth: 0,
+  },
+  previewText: {
+    display: 'block',
+    fontSize: 'var(--opptrix-font-sm)',
+    lineHeight: 1.45,
+    color: opptrixCssVars.textPrimary,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  },
+})
+
+interface Props {
+  messages: ChatDisplayMessage[]
+  scrollContainerRef: RefObject<HTMLElement | null>
+  onJump: (messageIndex: number) => void
+}
+
+export default function MessageOutlineRail({
+  messages,
+  scrollContainerRef,
+  onJump,
+}: Props) {
+  const s = useStyles()
+  const railRef = useRef<HTMLDivElement>(null)
+  const entries = useMemo(() => buildOutlineEntries(messages), [messages])
+  const [activeIndex, setActiveIndex] = useState(() => entries[0]?.index ?? -1)
+  const [previewOrdinal, setPreviewOrdinal] = useState<number | null>(null)
+  const [railHovered, setRailHovered] = useState(false)
+
+  useEffect(() => {
+    if (entries.length === 0) {
+      setActiveIndex(-1)
+      return
+    }
+    if (!entries.some(e => e.index === activeIndex)) {
+      setActiveIndex(entries[0].index)
+    }
+  }, [entries, activeIndex])
+
+  const syncActiveFromScroll = useCallback(() => {
+    const container = scrollContainerRef.current
+    if (!container || entries.length === 0) return
+    const rect = container.getBoundingClientRect()
+    const pivot = rect.top + Math.min(rect.height * 0.32, 120)
+    let best = entries[0].index
+    let bestDist = Number.POSITIVE_INFINITY
+    for (const entry of entries) {
+      const el = container.querySelector(`[data-message-index="${entry.index}"]`)
+      if (!(el instanceof HTMLElement)) continue
+      const er = el.getBoundingClientRect()
+      const mid = er.top + Math.min(er.height * 0.25, 40)
+      const dist = Math.abs(mid - pivot)
+      if (dist < bestDist) {
+        bestDist = dist
+        best = entry.index
+      }
+    }
+    setActiveIndex(best)
+  }, [entries, scrollContainerRef])
+
+  useEffect(() => {
+    const container = scrollContainerRef.current
+    if (!container || entries.length === 0) return
+    syncActiveFromScroll()
+    container.addEventListener('scroll', syncActiveFromScroll, { passive: true })
+    return () => container.removeEventListener('scroll', syncActiveFromScroll)
+  }, [entries.length, scrollContainerRef, syncActiveFromScroll])
+
+  const activeOrdinal = useMemo(
+    () => entries.findIndex(e => e.index === activeIndex),
+    [entries, activeIndex],
+  )
+
+  const progressPct = useMemo(() => {
+    if (entries.length === 0 || activeOrdinal < 0) return 0
+    return ordinalTopPercent(activeOrdinal, entries.length)
+  }, [entries.length, activeOrdinal])
+
+  if (entries.length === 0) return null
+
+  /** True when pointer is over the rail or focus is within it. */
+  const engageRail = () => setRailHovered(true)
+  const disengageRailIfLeaving = (related: EventTarget | null) => {
+    if (!railRef.current?.contains(related as Node | null)) {
+      setPreviewOrdinal(null)
+      setRailHovered(false)
+    }
+  }
+
+  return (
+    <div
+      ref={railRef}
+      className={s.rail}
+      role="navigation"
+      aria-label="消息目录"
+      onMouseEnter={engageRail}
+      onMouseLeave={() => {
+        // Keep engaged while a node inside the rail still has keyboard focus.
+        if (railRef.current?.contains(document.activeElement)) return
+        setRailHovered(false)
+        setPreviewOrdinal(null)
+      }}
+      onFocus={engageRail}
+      onBlur={e => disengageRailIfLeaving(e.relatedTarget)}
+    >
+      <div className={mergeClasses(s.track, railHovered && s.trackRailHover)}>
+        <div
+          className={mergeClasses(s.trackFill, railHovered && s.trackFillRailHover)}
+          style={{ height: `${progressPct}%` }}
+          aria-hidden
+        />
+        {entries.map((entry, ordinal) => {
+          const isActive = entry.index === activeIndex
+          const isHot = previewOrdinal === ordinal
+          const topPct = ordinalTopPercent(ordinal, entries.length)
+          const timeLabel = entry.at ? formatFriendlyTime(entry.at) : ''
+          return (
+            <button
+              key={entry.index}
+              type="button"
+              className={mergeClasses(s.item, railHovered && s.itemRailHover)}
+              style={{ top: `${topPct}%` }}
+              aria-label="跳到助手的消息"
+              aria-current={isActive ? 'true' : undefined}
+              onMouseEnter={() => setPreviewOrdinal(ordinal)}
+              onMouseLeave={() => setPreviewOrdinal(null)}
+              onFocus={() => setPreviewOrdinal(ordinal)}
+              onClick={() => {
+                setActiveIndex(entry.index)
+                onJump(entry.index)
+              }}
+            >
+              <span
+                className={mergeClasses(
+                  s.dot,
+                  railHovered && !isHot && s.dotRailHover,
+                  isActive && !isHot && !railHovered && s.dotActive,
+                  isActive && !isHot && railHovered && s.dotActiveRailHover,
+                  isHot && s.dotHot,
+                )}
+              />
+              {isHot ? (
+                <span className={s.preview} role="tooltip">
+                  <span className={s.previewMeta}>
+                    <span className={s.previewRole}>助手</span>
+                    {timeLabel ? (
+                      <span className={s.previewTime}>{timeLabel}</span>
+                    ) : null}
+                  </span>
+                  <span className={s.previewText}>{entry.summary}</span>
+                </span>
+              ) : null}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/client-ui/src/chat/SessionAttachmentsDrawer.tsx
+++ b/client-ui/src/chat/SessionAttachmentsDrawer.tsx
@@ -1,0 +1,376 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { makeStyles, mergeClasses, Spinner, Text } from '@fluentui/react-components'
+import { DeleteRegular } from '@fluentui/react-icons'
+import type { ChatAttachmentMeta, MediaKind, SessionAttachmentListItem } from '../types/chat'
+import { deleteSessionAttachment, listSessionAttachments } from '../api/client'
+import { attachmentKindIcon } from './attachmentKindIcon'
+import { formatBytesShort } from './mediaCapabilities'
+import { formatFriendlyTime } from '../utils/formatFriendlyTime'
+import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+import { ghostInteractive, motion } from '../theme/mixins'
+
+const DRAWER_MOTION_MS = 240
+
+const KIND_LABEL: Record<MediaKind, string> = {
+  text: '文本',
+  image: '图片',
+  pdf: 'PDF',
+  document: '文档',
+  video: '视频',
+  audio: '音频',
+}
+
+const useStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 5,
+    width: 'min(300px, 88%)',
+    display: 'flex',
+    flexDirection: 'column',
+    boxSizing: 'border-box',
+    backgroundColor: opptrixCssVars.canvas,
+    borderLeft: `1px solid ${opptrixCssVars.separator}`,
+    /* 偏黑投影：亮/暗均靠黑透明度，避免 textPrimary color-mix 在暗色下发白光晕 */
+    boxShadow: '-12px 0 28px rgba(0, 0, 0, 0.14), -2px 0 8px rgba(0, 0, 0, 0.06)',
+    transform: 'translate3d(104%, 0, 0)',
+    opacity: 0,
+    pointerEvents: 'none',
+    transitionProperty: 'transform, opacity',
+    transitionDuration: `${DRAWER_MOTION_MS}ms`,
+    transitionTimingFunction: motion.easeOutStrong,
+    willChange: 'transform, opacity',
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '1ms',
+      transform: 'none',
+    },
+  },
+  open: {
+    transform: 'translate3d(0, 0, 0)',
+    opacity: 1,
+    pointerEvents: 'auto',
+    '@media (prefers-reduced-motion: reduce)': {
+      opacity: 1,
+    },
+  },
+  body: {
+    flex: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    padding: '12px 8px 0',
+    boxSizing: 'border-box',
+    scrollbarWidth: 'none',
+    msOverflowStyle: 'none',
+    '::-webkit-scrollbar': {
+      display: 'none',
+      width: 0,
+      height: 0,
+    },
+  },
+  loading: {
+    display: 'flex',
+    justifyContent: 'center',
+    padding: '28px 0',
+  },
+  empty: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    padding: '28px 12px',
+    textAlign: 'center',
+  },
+  emptyTitle: {
+    fontSize: 'var(--opptrix-font-base)',
+    color: opptrixCssVars.textPrimary,
+    fontWeight: 500,
+  },
+  emptyHint: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.5,
+  },
+  error: {
+    padding: '12px',
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.error,
+    lineHeight: 1.45,
+  },
+  list: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '4px',
+    width: '100%',
+    padding: '4px 4px 4px 8px',
+    boxSizing: 'border-box',
+    borderRadius: opptrixTokens.radiusMd,
+    color: opptrixCssVars.textPrimary,
+    ':hover': {
+      backgroundColor: opptrixCssVars.canvasAlt,
+    },
+  },
+  rowOpen: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    flex: '1 1 auto',
+    minWidth: 0,
+    padding: '4px 0',
+    border: 'none',
+    background: 'transparent',
+    textAlign: 'left',
+    cursor: 'pointer',
+    color: 'inherit',
+  },
+  rowIcon: {
+    flexShrink: 0,
+    display: 'inline-flex',
+    color: opptrixCssVars.textSecondary,
+  },
+  rowMain: {
+    flex: '1 1 auto',
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  rowName: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 500,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  rowMeta: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  deleteBtn: {
+    ...ghostInteractive,
+    flexShrink: 0,
+    width: '26px',
+    height: '26px',
+    minWidth: '26px',
+    minHeight: '26px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 0,
+    color: opptrixCssVars.textTertiary,
+    ':hover:not(:disabled)': {
+      color: opptrixCssVars.error,
+    },
+    ':disabled': {
+      opacity: 0.4,
+      cursor: 'not-allowed',
+    },
+  },
+})
+
+interface Props {
+  open: boolean
+  sessionId: string | null
+  composerPadBottom: number
+  onClose: () => void
+  onOpen: (sessionId: string, attachment: ChatAttachmentMeta) => void
+}
+
+export default function SessionAttachmentsDrawer({
+  open,
+  sessionId,
+  composerPadBottom,
+  onClose,
+  onOpen,
+}: Props) {
+  const s = useStyles()
+  const [mounted, setMounted] = useState(open)
+  const [visible, setVisible] = useState(false)
+  const [items, setItems] = useState<SessionAttachmentListItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const closeTimerRef = useRef<number | null>(null)
+  const openRafRef = useRef<number | null>(null)
+  const panelRef = useRef<HTMLElement | null>(null)
+
+  const refresh = useCallback(async (sid: string) => {
+    setLoading(true)
+    setError('')
+    try {
+      setItems(await listSessionAttachments(sid))
+    } catch (e) {
+      setItems([])
+      setError(e instanceof Error ? e.message : '暂时无法加载附件列表')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    const clearTimers = () => {
+      if (closeTimerRef.current != null) {
+        window.clearTimeout(closeTimerRef.current)
+        closeTimerRef.current = null
+      }
+      if (openRafRef.current != null) {
+        window.cancelAnimationFrame(openRafRef.current)
+        openRafRef.current = null
+      }
+    }
+
+    if (open) {
+      clearTimers()
+      setMounted(true)
+      openRafRef.current = requestAnimationFrame(() => {
+        openRafRef.current = requestAnimationFrame(() => {
+          openRafRef.current = null
+          setVisible(true)
+        })
+      })
+      return clearTimers
+    }
+
+    setVisible(false)
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null
+      setMounted(false)
+    }, DRAWER_MOTION_MS)
+    return clearTimers
+  }, [open])
+
+  useEffect(() => {
+    if (!open || !sessionId) return
+    void refresh(sessionId)
+  }, [open, sessionId, refresh])
+
+  useEffect(() => {
+    if (!mounted || !visible) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [mounted, visible, onClose])
+
+  // Outside click：关抽屉；排除抽屉内部与文件箱 toggle（避免先关再 toggle 又开）
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target
+      if (!(target instanceof Element)) return
+      if (target.closest('[data-attachments-toggle]')) return
+      const panel = panelRef.current
+      if (panel && panel.contains(target)) return
+      onClose()
+    }
+    document.addEventListener('pointerdown', onPointerDown, true)
+    return () => document.removeEventListener('pointerdown', onPointerDown, true)
+  }, [open, onClose])
+
+  const handleDelete = async (item: SessionAttachmentListItem) => {
+    if (!sessionId || item.referenced || deletingId) return
+    setDeletingId(item.id)
+    setError('')
+    try {
+      await deleteSessionAttachment(sessionId, item.id)
+      await refresh(sessionId)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '删除失败，请稍后重试')
+    } finally {
+      setDeletingId(null)
+    }
+  }
+
+  if (!mounted || !sessionId) return null
+
+  return (
+    <aside
+      ref={panelRef}
+      id="session-attachments-drawer"
+      className={mergeClasses(s.root, visible && s.open)}
+      role="dialog"
+      aria-modal="false"
+      aria-label="本对话附件"
+      aria-hidden={!visible}
+    >
+      <div
+        className={mergeClasses(s.body, 'opptrix-scroll-hidden')}
+        style={{ paddingBottom: `${Math.max(composerPadBottom, 16)}px` }}
+      >
+        {loading ? (
+          <div className={s.loading}>
+            <Spinner size="tiny" label="正在加载附件…" />
+          </div>
+        ) : null}
+        {!loading && error ? (
+          <Text className={s.error} block>
+            {error}
+            {' '}请稍后重试
+          </Text>
+        ) : null}
+        {!loading && !error && items.length === 0 ? (
+          <div className={s.empty}>
+            <Text className={s.emptyTitle} block>还没有附件</Text>
+            <Text className={s.emptyHint} block>
+              在输入区添加文件后，可在这里查看与管理
+            </Text>
+          </div>
+        ) : null}
+        {!loading && items.length > 0 ? (
+          <div className={s.list}>
+            {items.map(item => {
+              const kind = KIND_LABEL[item.kind] ?? '文件'
+              const metaLine = [
+                kind,
+                formatBytesShort(item.size),
+                formatFriendlyTime(item.createdAt),
+              ].filter(Boolean).join(' · ')
+              const deleteTitle = item.referenced ? '已在对话中使用' : '删除附件'
+              return (
+                <div key={item.id} className={s.row}>
+                  <button
+                    type="button"
+                    className={s.rowOpen}
+                    onClick={() => onOpen(sessionId, item)}
+                    title={`预览 ${item.name}`}
+                  >
+                    <span className={s.rowIcon}>
+                      {attachmentKindIcon(item.kind, item.name, 18)}
+                    </span>
+                    <span className={s.rowMain}>
+                      <span className={s.rowName}>{item.name}</span>
+                      <span className={s.rowMeta}>{metaLine}</span>
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className={s.deleteBtn}
+                    disabled={item.referenced || deletingId === item.id}
+                    title={deleteTitle}
+                    aria-label={deleteTitle}
+                    onClick={() => { void handleDelete(item) }}
+                  >
+                    <DeleteRegular fontSize={14} />
+                  </button>
+                </div>
+              )
+            })}
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  )
+}

--- a/client-ui/src/desktop/DesktopWindowChrome.tsx
+++ b/client-ui/src/desktop/DesktopWindowChrome.tsx
@@ -20,6 +20,7 @@ import {
   DESKTOP_NEWS_TITLE_DRAG_CLIP_WIN,
   SIDEBAR_DEFAULT_WIDTH,
   DESKTOP_TITLE_BAR_ACTIONS_WIDTH,
+  WORKSPACE_SPLITTER_WIDTH,
 } from './constants'
 import {
   PanelLeftContractRegular,
@@ -257,7 +258,10 @@ export default function DesktopWindowChrome({
   const frameChrome = frameTitlebarHeight > 0
   /** Primary frame titlebar + open sidebar: collapse |····| back/forward across the panel top. */
   const toolbarSplitInSidebar = frameChrome && sidebarInline && sidebarOpen
-  const titleBarActionsRight = desktopTitleBarActionsRight()
+  /** 右侧面板展开时：trailing 落在聊天列右缘（分割线左），与 chatTitleBar padding 对齐 */
+  const titleBarActionsRight = rightPanelOpen && titleBarTrailing && rightPanelWidth > 0
+    ? rightPanelWidth + WORKSPACE_SPLITTER_WIDTH + DESKTOP_TITLE_GAP
+    : desktopTitleBarActionsRight()
   const showTitleBarActions = !isSettings && !rightPanelOpen && Boolean(onToggleRightPanel || onToggleChatColumn)
   const titleMaxWidth = desktopTitleMaxWidth({
     titleLeft,

--- a/client-ui/src/desktop/constants.ts
+++ b/client-ui/src/desktop/constants.ts
@@ -126,8 +126,8 @@ export const DESKTOP_Z_CHROME_TOOLS = 1300
 /** Clickable session title — above chrome tools hit layer when overlapping */
 export const DESKTOP_Z_TITLE_INTERACTIVE = 1310
 
-/** Reserve for chat title-bar panel toggle buttons (2 × tool + gap) */
-export const DESKTOP_TITLE_BAR_ACTIONS_WIDTH = 60
+/** Reserve for chat title-bar trailing actions (附件 + 最大化 + 展开；3 × tool + gaps) */
+export const DESKTOP_TITLE_BAR_ACTIONS_WIDTH = 86
 
 /** Clip global title-bar drag so news status + action buttons stay clickable */
 export const DESKTOP_NEWS_TITLE_DRAG_CLIP_DARWIN = 240

--- a/client-ui/src/market/RightMarketPanel.tsx
+++ b/client-ui/src/market/RightMarketPanel.tsx
@@ -16,9 +16,11 @@ import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
 import { ghostInteractive } from '../theme/mixins'
 import ChromeToolButton from '../desktop/ChromeToolButton'
 import {
+  DESKTOP_CHROME_TOP_OFFSET,
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
   DESKTOP_TITLEBAR_HEIGHT,
+  DESKTOP_TOOL_GAP,
   DESKTOP_Z_PANEL_TITLE,
 } from '../desktop/constants'
 import {
@@ -67,6 +69,13 @@ const useStyles = makeStyles({
     height: '40px',
     zIndex: 1,
   },
+  /**
+   * Match DesktopWindowChrome tool band: top inset + center within remaining
+   * chromeBand so tabs / actions share the file-box vertical midline.
+   */
+  titleBarElectron: {
+    paddingTop: `${DESKTOP_CHROME_TOP_OFFSET}px`,
+  },
   titleBarElectronWin: {
     paddingRight: '12px',
   },
@@ -75,8 +84,11 @@ const useStyles = makeStyles({
   },
   tabsWrap: {
     flex: '0 0 auto',
+    display: 'flex',
+    alignItems: 'center',
     minWidth: 0,
     maxWidth: '100%',
+    height: '28px',
     paddingLeft: '15px',
     overflowX: 'auto',
     overflowY: 'hidden',
@@ -87,16 +99,23 @@ const useStyles = makeStyles({
   },
   tabs: {
     minHeight: 'unset',
+    height: '28px',
     flexWrap: 'nowrap',
     width: 'max-content',
-    gap: '2px',
+    gap: `${DESKTOP_TOOL_GAP}px`,
     alignItems: 'center',
   },
-  /** Text pill — same ghost / accentSoft language as ChromeToolButton (not 28×28 icon). */
+  /** Text pill — same hit height as ChromeToolButton md (28×28), ghost / accentSoft. */
   tab: {
     ...ghostInteractive,
+    boxSizing: 'border-box',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     minWidth: 'unset',
     height: '28px',
+    minHeight: '28px',
+    maxHeight: '28px',
     padding: '0 10px',
     margin: 0,
     borderRadius: opptrixTokens.radiusMd,
@@ -119,8 +138,14 @@ const useStyles = makeStyles({
     },
     ':enabled:hover::after': { display: 'none' },
     ':enabled:active::after': { display: 'none' },
-    // Content slot owns selected semibold — override to match ChromeToolButton
-    '& .fui-Tab__content': { fontWeight: 400 },
+    // Content slot — flatten Fluent line-box so visual height matches 28px tool
+    '& .fui-Tab__content': {
+      fontWeight: 400,
+      display: 'inline-flex',
+      alignItems: 'center',
+      lineHeight: 1,
+      height: '100%',
+    },
     // Suppress Fluent Tabster focus box-shadow; keep ghostInteractive focusVisibleRing
     '&[data-fui-focus-visible]': { boxShadow: 'none' },
     ':hover': {
@@ -151,7 +176,8 @@ const useStyles = makeStyles({
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
-    gap: '2px',
+    gap: `${DESKTOP_TOOL_GAP}px`,
+    height: '28px',
     WebkitAppRegion: 'no-drag',
     pointerEvents: 'auto',
   },
@@ -384,6 +410,7 @@ function RightMarketPanel({
         className={mergeClasses(
           s.titleBar,
           !electronChrome && s.titleBarWeb,
+          electronChrome && s.titleBarElectron,
           electronChrome && 'opptrix-right-panel-title-bar',
           electronChrome && (electronWin ? s.titleBarElectronWin : s.titleBarElectronMac),
         )}

--- a/client-ui/src/theme/tokens.ts
+++ b/client-ui/src/theme/tokens.ts
@@ -24,7 +24,10 @@ const layoutTokens = {
   panelWidth: '380px',
 
   chatThreadMaxWidth: '820px',
+  /** Desktop right inset; left uses chatThreadPaddingLeft for the outline rail. */
   chatThreadPaddingX: '15px',
+  /** Desktop left inset — clears the ~22px message outline rail + breathing room. */
+  chatThreadPaddingLeft: '32px',
   chatThreadPaddingXMobile: '15px',
   chatComposerPadding: '12px',
   chatComposerBottomInset: '25px',

--- a/client-ui/src/types/chat.ts
+++ b/client-ui/src/types/chat.ts
@@ -122,7 +122,12 @@ export interface ChatAttachmentMeta {
   extract?: AttachmentExtractMeta
   /** 前端乐观插入标记；服务端不会返回此字段 */
   optimistic?: boolean
+  /** 列表 API：是否已被会话 turns 引用（可选，仅 GET list 返回） */
+  referenced?: boolean
 }
+
+/** GET /api/sessions/:id/attachments 列表项（含 referenced） */
+export type SessionAttachmentListItem = ChatAttachmentMeta & { referenced: boolean }
 
 export interface ModelMediaCapabilities {
   attachment: boolean

--- a/docs/API.md
+++ b/docs/API.md
@@ -841,6 +841,7 @@ Content-Type: application/json
 | GET | `/api/sessions/:id/role-persona` | `{ rolePersona, expertId }`；旧会话空值会惰性回填并持久化 |
 | PUT | `/api/sessions/:id/role-persona` | body `{ rolePersona }` → `sanitizeExpertPersona`；成功写回并返回 `{ rolePersona, expertId }` |
 | POST | `/api/sessions/:id/attachments` | 上传附件（raw body + `Content-Type` / `X-Attachment-Mime` + `X-Attachment-Name`）；PDF 始终可走本地文本整理（不要求模型原生 `pdf` 能力）；响应 `{ attachment: ChatAttachmentMeta }`（PDF 含 `extract.status=pending`，后台异步整理） |
+| GET | `/api/sessions/:id/attachments` | 列出会话附件元数据；响应 `{ attachments: Array<ChatAttachmentMeta & { referenced: boolean }> }`（`referenced`：是否已被 turns 引用，与 DELETE 409 判定一致；按 `createdAt` 升序） |
 | GET | `/api/sessions/:id/attachments/:attachmentId` | 流式返回附件二进制（`Content-Type` 来自元数据；路径规范化防穿越） |
 | GET | `/api/sessions/:id/attachments/:attachmentId/meta` | 返回最新 `{ attachment: ChatAttachmentMeta }`（含 PDF `extract` 整理状态与可选 `documentId`，供 UI 轮询） |
 | GET | `/api/sessions/:id/attachments/:attachmentId/extract` | 返回 `{ attachment_id, name, kind, extract }` 整理摘要（`extract` 同下表，含 `documentId?`） |

--- a/docs/UI-LAYOUT.md
+++ b/docs/UI-LAYOUT.md
@@ -43,8 +43,10 @@
 - **右侧顶栏**：关注 / 组合 / 详情为文字 Tab；进入详情时显示「详情」Tab
 - **窗口标题栏**：macOS 沿用 `hiddenInset` 系统红绿灯；Windows / Linux 在窗口最顶部额外一条与左侧栏同色毛玻璃的 frame titlebar：左侧 App 图标 + 模拟原生菜单（文件 / 编辑 / 视图 / 窗口 / 帮助），右侧为 Win11 风格 caption 按钮（高满条、宽 46px；关闭 hover 红底白标，其余灰底深色标）。左侧栏分割线不向上贯穿该 frame titlebar。
 - **附件 PDF 预览**：右侧面板内嵌紧凑阅读器（翻页 / 缩放 / 适合宽度），目录默认收起，可手动展开跳页
+- **消息目录轨**（桌面）：`bodyShell` 左侧中部比例时间轴（宽约 22px；线程/composer 左侧留白 `chatThreadPaddingLeft`≈32px，避免正文压住轨）；**仅收录助手有正文的消息**（user 不进轨）；节点默认约 5px（深灰 `textSecondary`），hover/focus 当前节点放大至约 11px（`motion.fast`；active/hot 为 `textPrimary` 黑系，不用 accent）；当前进度以轨上 `textPrimary` 填充同步滚动高亮；hover/focus 节点右侧气泡预览开头（「助手」+ 友好时间 + 约 80 字）；点击跳转对应消息；不劫持滚轮。mobile 隐藏
+- **本对话附件抽屉**（桌面）：顶栏文件箱按钮切换开合（无抽屉内标题栏/关闭按钮；Escape 可关）；自右侧滑入（z-index 低于输入区）；底边留白对齐 `threadScrollPadBottom`；已引用附件不可删除。mobile 隐藏
 
-代码：`client-ui/src/chat/ChatApp.tsx`、`client-ui/src/market/RightMarketPanel.tsx`、`client-ui/src/desktop/WindowFrameTitleBar.tsx`、`client-ui/src/chat/FilePreviewPanel.tsx`、`client-ui/src/chat/PdfPreviewViewer.tsx`。
+代码：`client-ui/src/chat/ChatApp.tsx`、`client-ui/src/chat/ChatView.tsx`、`client-ui/src/chat/MessageOutlineRail.tsx`、`client-ui/src/chat/SessionAttachmentsDrawer.tsx`、`client-ui/src/market/RightMarketPanel.tsx`、`client-ui/src/desktop/WindowFrameTitleBar.tsx`、`client-ui/src/chat/FilePreviewPanel.tsx`、`client-ui/src/chat/PdfPreviewViewer.tsx`。
 
 ### 1.2 新闻中心
 


### PR DESCRIPTION
## Summary
- 聊天左侧比例消息目录（仅助手有正文），hover/focus 预览含时间，点击跳转
- 顶栏文件箱：本对话附件列表、预览与删除；展开时可点外侧收起
- 会话附件列表 API（含 `referenced`）及桌面顶栏/右侧面板对齐相关调整

## Test plan
- [ ] 桌面长对话：目录默认浅灰安静，hover/focus 加深放大并可跳转
- [ ] 文件箱开关、列表滚动、点聊天区外侧收起、Escape 关闭
- [ ] 右侧面板展开/收起时文件箱可点且不与展开按钮重叠
- [ ] `npm run check:ui` 通过


Made with [Cursor](https://cursor.com)