### PR TITLE
fix(chat): 选模型后关闭面板并收紧编辑气泡高度

### DIFF
--- a/client-ui/src/chat/ChatMessageItem.tsx
+++ b/client-ui/src/chat/ChatMessageItem.tsx
@@ -17,10 +17,10 @@ import { fadeInUp } from '../theme/mixins'
 import { copyTextToClipboard } from '../platform/clipboard'
 import { formatFriendlyTime } from '../utils/formatFriendlyTime'
 
-/** 用户气泡编辑区约 5 行可见高度（超出滚动） */
+/** 用户气泡编辑区约 3 行可见高度（超出滚动） */
 const USER_BUBBLE_LINE_HEIGHT = 1.65
 const USER_BUBBLE_FONT_PX = 16
-const USER_BUBBLE_MAX_HEIGHT = Math.round(USER_BUBBLE_FONT_PX * USER_BUBBLE_LINE_HEIGHT * 5)
+const USER_BUBBLE_MAX_HEIGHT = Math.round(USER_BUBBLE_FONT_PX * USER_BUBBLE_LINE_HEIGHT * 3)
 
 const useStyles = makeStyles({
   entry: {
@@ -414,7 +414,7 @@ function ChatMessageItem({
                 onChange={e => setDraft(e.target.value)}
                 onKeyDown={handleEditKeyDown}
                 onClick={e => e.stopPropagation()}
-                rows={5}
+                rows={3}
                 aria-label="编辑消息"
               />
               <div className={s.editActions} onClick={e => e.stopPropagation()}>

--- a/client-ui/src/chat/ModelSelector.tsx
+++ b/client-ui/src/chat/ModelSelector.tsx
@@ -366,7 +366,7 @@ export default function ModelSelector({
                 active={activeRef === model.ref}
                 onClick={() => {
                   onChange(model.ref)
-                  if (!showParams) setOpen(false)
+                  setOpen(false)
                 }}
               >
                 <span className={s.modelName}>{model.model}</span>


### PR DESCRIPTION
## Summary
- 聊天区选择模型后立即收起菜单，避免二次点击关闭
- 用户消息编辑气泡默认高度由约 5 行改为约 3 行

## Test plan
- [ ] 打开模型菜单选中一项后面板自动关闭
- [ ] 再次打开仍可调整温度等参数
- [ ] 点击用户气泡进入编辑，输入区约为 3 行高


Made with [Cursor](https://cursor.com)