### PR TITLE
fix(test): 稳定 pdf-report-extract 对旧 pdf.js 的 fixture

### DIFF
--- a/tests/pdf-report-extract.test.mjs
+++ b/tests/pdf-report-extract.test.mjs
@@ -50,6 +50,91 @@ describe('formatDocumentCatalogLine', () => {
   })
 })
 
+/** 构造可被 pdf-parse 解析的极简多页文本 PDF（Helvetica）。 */
+function buildMinimalTextPdf(pageStrings) {
+  // pdf-parse@1.1.4 (bundled old pdf.js) rejects single-page fixtures even when
+  // trailer /Size >= 8; pad to two pages so objects 3–7 are real page/content pairs.
+  const pages = pageStrings.length < 2 ? [...pageStrings, ' '] : pageStrings
+  const kids = []
+  const pageObjects = []
+  const lastPageObjNum = 3 + (pages.length - 1) * 2
+  const lastContentObjNum = lastPageObjNum + 1
+  const fontObjNum = Math.max(lastContentObjNum + 1, 7)
+  for (let i = 0; i < pages.length; i++) {
+    const pageObj = 3 + i * 2
+    const contentObj = pageObj + 1
+    kids.push(`${pageObj} 0 R`)
+    const safe = String(pages[i]).replace(/[()\\]/g, ' ')
+    const stream = `BT /F1 24 Tf 50 100 Td (${safe}) Tj ET`
+    pageObjects.push({
+      num: pageObj,
+      body: `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents ${contentObj} 0 R /Resources<< /Font<< /F1 ${fontObjNum} 0 R >> >> >>`,
+    })
+    pageObjects.push({
+      num: contentObj,
+      body: `<< /Length ${Buffer.byteLength(stream, 'utf8')} >>stream\n${stream}\nendstream`,
+    })
+  }
+
+  let body = '%PDF-1.1\n'
+  const objOffsets = new Map()
+  const writeObj = (num, content) => {
+    objOffsets.set(num, Buffer.byteLength(body, 'utf8'))
+    body += `${num} 0 obj${content}endobj\n`
+  }
+  writeObj(1, '<< /Type /Catalog /Pages 2 0 R >>')
+  writeObj(2, `<< /Type /Pages /Kids [${kids.join(' ')}] /Count ${pages.length} >>`)
+  for (const obj of pageObjects) {
+    writeObj(obj.num, obj.body)
+  }
+  for (let n = lastContentObjNum + 1; n < fontObjNum; n++) {
+    writeObj(n, '<< >>')
+  }
+  writeObj(fontObjNum, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>')
+  const maxObj = fontObjNum
+  const xrefStart = Buffer.byteLength(body, 'utf8')
+  body += `xref\n0 ${maxObj + 1}\n`
+  body += '0000000000 65535 f \n'
+  for (let i = 1; i <= maxObj; i++) {
+    const off = objOffsets.get(i) ?? 0
+    body += `${String(off).padStart(10, '0')} 00000 n \n`
+  }
+  body += `trailer<< /Size ${maxObj + 1} /Root 1 0 R >>\n`
+  body += `startxref\n${xrefStart}\n%%EOF\n`
+  return Buffer.from(body, 'utf8')
+}
+
+// Run before chat-attachments vision test: pdf-parse@1.1.4 retains broken xref state after that import path.
+describe('extractPdfToMarkdown with minimal PDF', () => {
+  it('parses a tiny text PDF buffer', async () => {
+    const pdf = buildMinimalTextPdf(['Hello Opptrix'])
+    const result = await extractPdfToMarkdown(pdf)
+    assert.ok(result.pageCount >= 1)
+    assert.ok(result.markdown.includes('<!-- page:'))
+    // pdf-parse may or may not extract text from this minimal fixture; ensure no throw
+    assert.ok(typeof result.charCount === 'number')
+    assert.ok(Array.isArray(result.chunks))
+  })
+
+  it('uses pdf-parse numpages for multi-page PDF pageCount and per-page chunks', async () => {
+    const pdf = buildMinimalTextPdf(['PageAlphaUnique', 'PageBetaUnique'])
+    const parseMod = await import('pdf-parse/lib/pdf-parse.js')
+    const pdfParse = parseMod.default
+    const parsed = await pdfParse(pdf)
+    assert.equal(parsed.numpages, 2, 'fixture must be a 2-page PDF for pdf-parse')
+
+    const result = await extractPdfToMarkdown(pdf)
+    assert.equal(result.pageCount, parsed.numpages)
+    assert.ok(result.pageCount >= 2)
+    assert.ok(result.markdown.includes('<!-- page:1 -->'))
+    assert.ok(result.markdown.includes('<!-- page:2 -->'))
+    assert.equal(result.pages.length, 2)
+    const pageNums = new Set(result.chunks.map(c => c.page))
+    assert.ok(pageNums.has(1), 'chunks should include page 1')
+    assert.ok(pageNums.has(2), 'chunks should include page 2 when pagerender splits pages')
+  })
+})
+
 describe('content parts for ready PDF', () => {
   it('emits text catalog instead of file part', () => {
     const part = attachmentToContentPart('sess', {
@@ -212,84 +297,5 @@ describe('document tools pack membership', () => {
     assert.equal(packIdForTool('list_session_documents'), 'core')
     assert.equal(packIdForTool('search_document'), 'core')
     assert.equal(packIdForTool('read_document'), 'core')
-  })
-})
-
-/** 构造可被 pdf-parse 解析的极简多页文本 PDF（Helvetica）。 */
-function buildMinimalTextPdf(pageStrings) {
-  const kids = []
-  const pageObjects = []
-  const fontObjNum = 3 + pageStrings.length * 2
-  for (let i = 0; i < pageStrings.length; i++) {
-    const pageObj = 3 + i * 2
-    const contentObj = pageObj + 1
-    kids.push(`${pageObj} 0 R`)
-    const safe = String(pageStrings[i]).replace(/[()\\]/g, ' ')
-    const stream = `BT /F1 24 Tf 50 100 Td (${safe}) Tj ET`
-    pageObjects.push({
-      num: pageObj,
-      body: `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents ${contentObj} 0 R /Resources<< /Font<< /F1 ${fontObjNum} 0 R >> >> >>`,
-    })
-    pageObjects.push({
-      num: contentObj,
-      body: `<< /Length ${Buffer.byteLength(stream, 'utf8')} >>stream\n${stream}\nendstream`,
-    })
-  }
-  pageObjects.push({
-    num: fontObjNum,
-    body: '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
-  })
-
-  let body = '%PDF-1.1\n'
-  const objOffsets = new Map()
-  const writeObj = (num, content) => {
-    objOffsets.set(num, Buffer.byteLength(body, 'utf8'))
-    body += `${num} 0 obj${content}endobj\n`
-  }
-  writeObj(1, '<< /Type /Catalog /Pages 2 0 R >>')
-  writeObj(2, `<< /Type /Pages /Kids [${kids.join(' ')}] /Count ${pageStrings.length} >>`)
-  for (const obj of pageObjects) {
-    writeObj(obj.num, obj.body)
-  }
-  const xrefStart = Buffer.byteLength(body, 'utf8')
-  const maxObj = fontObjNum
-  body += `xref\n0 ${maxObj + 1}\n`
-  body += '0000000000 65535 f \n'
-  for (let i = 1; i <= maxObj; i++) {
-    const off = objOffsets.get(i) ?? 0
-    body += `${String(off).padStart(10, '0')} 00000 n \n`
-  }
-  body += `trailer<< /Size ${maxObj + 1} /Root 1 0 R >>\n`
-  body += `startxref\n${xrefStart}\n%%EOF\n`
-  return Buffer.from(body, 'utf8')
-}
-
-describe('extractPdfToMarkdown with minimal PDF', () => {
-  it('parses a tiny text PDF buffer', async () => {
-    const pdf = buildMinimalTextPdf(['Hello Opptrix'])
-    const result = await extractPdfToMarkdown(pdf)
-    assert.ok(result.pageCount >= 1)
-    assert.ok(result.markdown.includes('<!-- page:'))
-    // pdf-parse may or may not extract text from this minimal fixture; ensure no throw
-    assert.ok(typeof result.charCount === 'number')
-    assert.ok(Array.isArray(result.chunks))
-  })
-
-  it('uses pdf-parse numpages for multi-page PDF pageCount and per-page chunks', async () => {
-    const pdf = buildMinimalTextPdf(['PageAlphaUnique', 'PageBetaUnique'])
-    const parseMod = await import('pdf-parse/lib/pdf-parse.js')
-    const pdfParse = parseMod.default
-    const parsed = await pdfParse(pdf)
-    assert.equal(parsed.numpages, 2, 'fixture must be a 2-page PDF for pdf-parse')
-
-    const result = await extractPdfToMarkdown(pdf)
-    assert.equal(result.pageCount, parsed.numpages)
-    assert.ok(result.pageCount >= 2)
-    assert.ok(result.markdown.includes('<!-- page:1 -->'))
-    assert.ok(result.markdown.includes('<!-- page:2 -->'))
-    assert.equal(result.pages.length, 2)
-    const pageNums = new Set(result.chunks.map(c => c.page))
-    assert.ok(pageNums.has(1), 'chunks should include page 1')
-    assert.ok(pageNums.has(2), 'chunks should include page 2 when pagerender splits pages')
   })
 })


### PR DESCRIPTION
## Summary
- CI 长期因 `pdf-report-extract.test.mjs` 失败：`bad XRef entry`（`pdf-parse@1.1.4` 内置旧 pdf.js）
- 单页 minimal fixture 的 xref `/Size < 8` 会被拒绝；补齐为至少两页真实对象，并保证 Size≥8
- 将 PDF 抽取用例提前到 vision/`chat-attachments` 动态 import 之前，避免同进程污染

## Test plan
- [x] `node --test tests/pdf-report-extract.test.mjs`（连续两次 14/14 pass）
- [ ] CI Build & test 变绿


Made with [Cursor](https://cursor.com)