### PR TITLE
fix(pdf): Node 24 下以 Uint8Array 调用 pdf-parse

### DIFF
--- a/packages/a-stock-layer/src/providers/sinafinance/api/pdf-parse.d.ts
+++ b/packages/a-stock-layer/src/providers/sinafinance/api/pdf-parse.d.ts
@@ -4,5 +4,5 @@ declare module 'pdf-parse/lib/pdf-parse.js' {
     numpages?: number
   }
 
-  export default function pdfParse(data: Buffer): Promise<PdfParseResult>
+  export default function pdfParse(data: Uint8Array): Promise<PdfParseResult>
 }

--- a/packages/a-stock-layer/src/providers/sinafinance/api/pdf-text.ts
+++ b/packages/a-stock-layer/src/providers/sinafinance/api/pdf-text.ts
@@ -2,10 +2,16 @@
  * 从 PDF 二进制提取纯文本（用于新浪公告附件）。
  * 使用 pdf-parse 子路径，避免主入口在 import 时读取测试文件。
  */
+
+/** Node 24 + pdf-parse 1.1.4: Buffer 会触发 bad XRef；纯 Uint8Array 正常。 */
+function toPdfParseInput(data: Uint8Array | Buffer): Uint8Array {
+  return new Uint8Array(data)
+}
+
 export async function extractPdfPlainText(data: Uint8Array | Buffer): Promise<string> {
   const mod = await import('pdf-parse/lib/pdf-parse.js')
-  const pdfParse = mod.default as (buf: Buffer) => Promise<{ text?: string }>
-  const result = await pdfParse(Buffer.from(data))
+  const pdfParse = mod.default as (buf: Uint8Array) => Promise<{ text?: string }>
+  const result = await pdfParse(toPdfParseInput(data))
   return String(result.text ?? '')
     .replace(/\r\n/g, '\n')
     .replace(/\n{3,}/g, '\n\n')

--- a/packages/agent/src/pdf-extract.ts
+++ b/packages/agent/src/pdf-extract.ts
@@ -164,6 +164,11 @@ function buildChunks(pages: PdfExtractPage[]): PdfExtractChunk[] {
   return chunks
 }
 
+/** Node 24 + pdf-parse 1.1.4: Buffer 会触发 bad XRef；纯 Uint8Array 正常。 */
+function toPdfParseInput(data: Buffer | Uint8Array): Uint8Array {
+  return new Uint8Array(data)
+}
+
 function toPdfExtractPages(pageTexts: string[]): PdfExtractPage[] {
   return pageTexts.map((pageText, idx) => {
     const normalized = pageText.replace(/\r\n/g, '\n').replace(/\n{3,}/g, '\n\n').trim()
@@ -183,7 +188,7 @@ export async function extractPdfToMarkdown(data: Buffer | Uint8Array): Promise<P
     'pdf-parse/lib/pdf-parse.js' as string
   ) as {
     default: (
-      buf: Buffer,
+      buf: Uint8Array,
       options?: {
         pagerender?: (pageData: {
           getTextContent: (opts: {
@@ -198,7 +203,7 @@ export async function extractPdfToMarkdown(data: Buffer | Uint8Array): Promise<P
 
   // 优先用 pagerender 按真实页收集正文（默认实现把各页用 \n\n 拼成整文，splitPages 常拆不出多页）
   const collectedPageTexts: string[] = []
-  const result = await pdfParse(Buffer.from(data), {
+  const result = await pdfParse(toPdfParseInput(data), {
     pagerender: async pageData => {
       const pageText = await renderPdfPageText(pageData)
       collectedPageTexts.push(pageText)

--- a/tests/pdf-report-extract.test.mjs
+++ b/tests/pdf-report-extract.test.mjs
@@ -120,7 +120,7 @@ describe('extractPdfToMarkdown with minimal PDF', () => {
     const pdf = buildMinimalTextPdf(['PageAlphaUnique', 'PageBetaUnique'])
     const parseMod = await import('pdf-parse/lib/pdf-parse.js')
     const pdfParse = parseMod.default
-    const parsed = await pdfParse(pdf)
+    const parsed = await pdfParse(new Uint8Array(pdf))
     assert.equal(parsed.numpages, 2, 'fixture must be a 2-page PDF for pdf-parse')
 
     const result = await extractPdfToMarkdown(pdf)


### PR DESCRIPTION
## Summary
- CI（Node 24）上 `pdf-report-extract` 仍失败：`bad XRef entry`
- 根因：`pdf-parse@1.1.4` 旧 pdf.js 在 Node 24 不能正确吃 `Buffer`；`new Uint8Array(...)` 正常
- 生产路径（agent `extractPdfToMarkdown`、sinafinance `extractPdfPlainText`）统一转纯 `Uint8Array`

## Test plan
- [x] Node 24：`node --test tests/pdf-report-extract.test.mjs` 14/14
- [x] Node 22：同上 14/14
- [ ] CI Build & test 变绿


Made with [Cursor](https://cursor.com)