### PR TITLE
fix(desktop): OS schedule without GUI + chat debug logging

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1237,6 +1237,16 @@ function registerWindowIpc() {
     return dir
   })
 
+  ipcMain.handle('chat-debug-open-log-dir', async () => {
+    const dataRoot = String(process.env.OPPTRIX_DATA_DIR ?? '').trim()
+      || path.join(require('node:os').homedir(), '.opptrix')
+    const dir = path.join(dataRoot, 'logs', 'chat-debug')
+    await fs.mkdir(dir, { recursive: true })
+    const err = await shell.openPath(dir)
+    if (err) throw new Error(`无法打开目录：${err}`)
+    return dir
+  })
+
   /** 仅允许打开 resolveUserDataRoot()/agent-workspace 之下的目录 */
   ipcMain.handle('open-local-directory', async (_event, dirPath) => {
     const raw = String(dirPath ?? '').trim()

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -3,8 +3,14 @@ const path = require('path')
 const fs = require('fs/promises')
 const fsSync = require('node:fs')
 const { pathToFileURL } = require('node:url')
-const { spawn } = require('node:child_process')
 const { APP_NAME, APP_TITLE, VERSION } = require('./app-meta.cjs')
+const {
+  buildSidecarEnv,
+  spawnSidecarProcess,
+  waitForHealth: waitForSidecarHealth,
+  stopChild,
+  serverEntryPath,
+} = require('./os-schedule/sidecar-launch.cjs')
 const { applyAppIcon, resolveAppIconPath } = require('./icon.cjs')
 const { configureAboutPanel, installApplicationMenu, listApplicationMenuTopItems, popupApplicationMenuAt } = require('./menu.cjs')
 const { hardenWebContents, mainWindowWebPreferences } = require('./security.cjs')
@@ -205,83 +211,46 @@ function repoRoot() {
   return path.join(process.resourcesPath, 'runtime-stage')
 }
 
-function serverEntry(root) {
-  return path.join(root, 'apps/server/dist/index.js')
-}
-
-function uiDist(root) {
-  return path.join(root, 'client-ui/dist')
-}
-
 function nodeCommand() {
   return process.env.NODE_BINARY ?? process.execPath
 }
 
+/**
+ * Sidecar env — shared with headless OS tick (`sidecar-launch.cjs`) so UI reuse
+ * and cold-start use the same STOCK_RESEARCH_* / NODE_PATH layout.
+ */
 function sidecarEnv(root) {
-  const env = {
-    ...process.env,
-    SERVE_UI: '1',
-    OPPTRIX_DESKTOP: '1',
-    OPPTRIX_APP_VERSION: VERSION,
-    STOCK_RESEARCH_HOST: API_HOST,
-    STOCK_RESEARCH_PORT: API_PORT,
-    UI_DIST_PATH: uiDist(root),
-  }
-
-  if (app.isReady()) {
-    env.OPPTRIX_HTTP_USER_AGENT = session.defaultSession.getUserAgent()
-  }
-
-  if (!isDev) {
-    env.ELECTRON_RUN_AS_NODE = '1'
-    env.OPPTRIX_RUNTIME_STAGE = root
-    // Sidecar 无 Electron resourcesPath 时仍能定位安装包内置 RAG 模型（与多模态同 llms）
-    env.OPPTRIX_E5_BUNDLED_DIR = path.join(process.resourcesPath, 'llms', 'multilingual-e5-small')
-    env.OPPTRIX_RAPIDOCR_BUNDLED_DIR = path.join(
-      process.resourcesPath,
-      'llms',
-      'rapidocr-ppocrv4-mobile',
-    )
-    env.OPPTRIX_RAG_ENGINES_BUNDLED_DIR = path.join(process.resourcesPath, 'engines')
-    const { RUNTIME_DEPS_DIR } = require('./runtime-deps.cjs')
-    const fs = require('node:fs')
-    // afterPack restores deps → node_modules so ESM bare imports resolve.
-    // Prefer node_modules; keep deps fallback for older partially-migrated installs.
-    const nmDir = path.join(root, 'node_modules')
-    const depsDir = path.join(root, RUNTIME_DEPS_DIR)
-    const moduleRoot = fs.existsSync(nmDir) ? nmDir : depsDir
-    if (fs.existsSync(moduleRoot)) {
-      env.NODE_PATH = moduleRoot
+  let httpUserAgent
+  try {
+    if (app.isReady()) {
+      httpUserAgent = session.defaultSession.getUserAgent()
     }
-    const browsersPath = path.join(root, 'playwright-browsers')
-    if (fs.existsSync(browsersPath)) {
-      env.PLAYWRIGHT_BROWSERS_PATH = browsersPath
-    }
-  } else {
-    // 开发态 sidecar cwd 可能非 monorepo 根；与生产对称注入 bundled 路径
-    env.OPPTRIX_E5_BUNDLED_DIR = path.join(root, 'apps/desktop/resources/llms', 'multilingual-e5-small')
-    env.OPPTRIX_RAPIDOCR_BUNDLED_DIR = path.join(
-      root,
-      'apps/desktop/resources/llms',
-      'rapidocr-ppocrv4-mobile',
-    )
+  } catch {
+    /* ignore */
   }
-
-  return env
+  return buildSidecarEnv({
+    root,
+    host: API_HOST,
+    port: API_PORT,
+    resourcesPath: isDev ? null : process.resourcesPath,
+    version: VERSION,
+    isDev,
+    httpUserAgent,
+  })
 }
 
 function spawnSidecar() {
   const root = repoRoot()
-  const entry = serverEntry(root)
+  const entry = serverEntryPath(root)
   if (!require('node:fs').existsSync(entry)) {
     throw new Error(`Server entry not found: ${entry}\nRun: npm run build:packages`)
   }
 
-  serverProcess = spawn(nodeCommand(), [entry], {
+  serverProcess = spawnSidecarProcess({
+    execPath: nodeCommand(),
+    entry,
     cwd: root,
     env: sidecarEnv(root),
-    stdio: ['ignore', 'pipe', 'pipe'],
-    detached: false,
   })
 
   serverProcess.stdout?.on('data', (chunk) => {
@@ -298,20 +267,7 @@ function spawnSidecar() {
 }
 
 async function waitForHealth(timeoutMs = 30_000) {
-  const url = `http://${API_HOST}:${API_PORT}/api/health`
-  const started = Date.now()
-  while (Date.now() - started < timeoutMs) {
-    try {
-      const resp = await fetch(url)
-      if (resp.ok) return
-    } catch {
-      /* retry */
-    }
-    // 前 3s 快轮询（80ms），让更新 relaunch / 冷启动尽快探到 sidecar 就绪；
-    // 之后退回 250ms，避免长时间等待时空转过密。
-    await wait(Date.now() - started < 3000 ? 80 : 250)
-  }
-  throw new Error(`API sidecar not ready: ${url}`)
+  await waitForSidecarHealth(API_HOST, API_PORT, timeoutMs)
 }
 
 async function waitForAppUi(timeoutMs = 60_000) {
@@ -330,22 +286,9 @@ async function waitForAppUi(timeoutMs = 60_000) {
 }
 
 function stopSidecar() {
-  if (!serverProcess || serverProcess.killed) return
   const proc = serverProcess
   serverProcess = null
-  try {
-    proc.kill('SIGTERM')
-  } catch {
-    /* ignore */
-  }
-  setTimeout(() => {
-    if (proc.exitCode != null || proc.killed) return
-    try {
-      proc.kill('SIGKILL')
-    } catch {
-      /* ignore */
-    }
-  }, 3000)
+  stopChild(proc)
 }
 
 /**
@@ -926,7 +869,7 @@ async function bootstrapBackgroundApp() {
   await ensureSidecarReady()
   configureScheduleBridge({ host: API_HOST, port: API_PORT })
 
-  // schedule-tick 冷启动已在 continueDesktopBootstrap 走短命 worker，不会进入本路径
+  // 新 OS 任务走 HTTP-first + headless-tick；本路径仅登录项 / 前台 / --background 常驻
   await reconcileOsSchedule().catch((err) => {
     console.warn('[schedule] reconcile failed:', err instanceof Error ? err.message : err)
   })
@@ -934,7 +877,8 @@ async function bootstrapBackgroundApp() {
 }
 
 /**
- * OS 级 `--schedule-tick` 冷启动：短命 worker，不建托盘、不常驻 reconcile poll。
+ * 兼容旧 LaunchAgent / 手动 `--schedule-tick`：短命 worker，不建托盘、不常驻 reconcile poll。
+ * 新注册的 OS tick 不再指向此路径（见 headless-tick.cjs）。
  */
 async function exitAfterEphemeralScheduleTick() {
   app.isQuitting = true
@@ -955,7 +899,8 @@ async function exitAfterEphemeralScheduleTick() {
 }
 
 /**
- * 主实例冷启动跑 OS tick：ensureSidecar → tick → 可选一次 reconcile → 干净退出。
+ * 兼容旧 plist / 手动调试的 GUI 短命 tick worker：ensureSidecar → tick → 可选 reconcile → 退出。
+ * OS runner fallback 使用 headless-tick（ELECTRON_RUN_AS_NODE），不经过本函数。
  */
 async function runEphemeralScheduleTickWorker() {
   if (process.platform === 'darwin') {
@@ -1373,6 +1318,18 @@ function setupDesktopChrome() {
       void openMainWindowFromMenu()
     },
   })
+}
+
+// Defensive: hide Dock before single-instance lock so a losing
+// --background / --schedule-tick instance does not flash the Dock icon before quit.
+if (process.platform === 'darwin' && (launchArgs.background || launchArgs.scheduleTick)) {
+  try {
+    if (app.dock && typeof app.dock.hide === 'function') {
+      app.dock.hide()
+    }
+  } catch {
+    /* ignore */
+  }
 }
 
 const gotTheLock = app.requestSingleInstanceLock()

--- a/apps/desktop/electron/os-schedule/darwin.cjs
+++ b/apps/desktop/electron/os-schedule/darwin.cjs
@@ -4,6 +4,7 @@ const os = require('node:os')
 const { spawnSync } = require('node:child_process')
 const { app } = require('electron')
 const { DEFAULT_TICK_INTERVAL_SEC } = require('./types.cjs')
+const { resolveOsTickInvocation } = require('./tick-runner.cjs')
 
 const LABEL = 'org.opptrix.schedule-tick'
 
@@ -12,10 +13,28 @@ function plistPath() {
 }
 
 function resolveProgramArguments() {
-  if (app.isPackaged) {
-    return [process.execPath, '--background', '--schedule-tick']
+  /** @type {{
+   *   userDataDir: string
+   *   isPackaged: boolean
+   *   execPath: string
+   *   headlessTickPath: string
+   *   platform: 'darwin'
+   *   runtimeStage?: string
+   *   resourcesPath?: string
+   * }} */
+  const opts = {
+    userDataDir: app.getPath('userData'),
+    isPackaged: app.isPackaged,
+    execPath: process.execPath,
+    headlessTickPath: path.join(__dirname, 'headless-tick.cjs'),
+    platform: 'darwin',
   }
-  return [process.execPath, path.join(__dirname, '..', 'main.cjs'), '--background', '--schedule-tick']
+  if (app.isPackaged && typeof process.resourcesPath === 'string') {
+    opts.resourcesPath = process.resourcesPath
+    opts.runtimeStage = path.join(process.resourcesPath, 'runtime-stage')
+  }
+  const invocation = resolveOsTickInvocation(opts)
+  return invocation.programArguments
 }
 
 function buildPlist(intervalSec) {

--- a/apps/desktop/electron/os-schedule/headless-tick.cjs
+++ b/apps/desktop/electron/os-schedule/headless-tick.cjs
@@ -1,0 +1,216 @@
+/**
+ * Headless OS schedule tick — no Electron GUI / no Dock flash.
+ *
+ * Invoked by the OS tick runner when HTTP tick fails:
+ *   ELECTRON_RUN_AS_NODE=1 "$EXEC" "$HEADLESS_TICK"
+ *
+ * Flow: POST tick → if fail, spawn sidecar → health → POST tick → stop sidecar → exit.
+ * Do not require('electron').app.
+ */
+const path = require('node:path')
+const fs = require('node:fs')
+const {
+  endpointFilePath,
+  readOsScheduleEndpoint,
+  sanitizeEndpointHost,
+} = require('./tick-runner.cjs')
+const {
+  resolveResourcesPathFromExec,
+  resolvePackagedRuntimeStage,
+  serverEntryPath,
+  buildSidecarEnv,
+  spawnSidecarProcess,
+  waitForHealth,
+  stopChildAndWait,
+} = require('./sidecar-launch.cjs')
+
+/**
+ * @param {string} msg
+ */
+function logErr(msg) {
+  process.stderr.write(`[headless-tick] ${msg}\n`)
+}
+
+/**
+ * @returns {string | null}
+ */
+function resolveEndpointFile() {
+  const fromEnv = process.env.OPPTRIX_OS_SCHEDULE_ENDPOINT?.trim()
+  if (fromEnv) return fromEnv
+  // Dev / manual: allow OPPTRIX_USER_DATA_DIR
+  const userData = process.env.OPPTRIX_USER_DATA_DIR?.trim()
+  if (userData) return endpointFilePath(userData)
+  return null
+}
+
+/**
+ * @param {string} file
+ */
+function readEndpointRecord(file) {
+  if (!fs.existsSync(file)) return null
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (!raw || typeof raw !== 'object') return null
+    const host = sanitizeEndpointHost(typeof raw.host === 'string' ? raw.host : undefined)
+    const port = typeof raw.port === 'string' || typeof raw.port === 'number'
+      ? String(raw.port)
+      : '8711'
+    const execPath = typeof raw.execPath === 'string' && raw.execPath.trim()
+      ? raw.execPath.trim()
+      : process.execPath
+    const headlessTick = typeof raw.headlessTick === 'string' ? raw.headlessTick.trim() : ''
+    const runtimeStage = typeof raw.runtimeStage === 'string' ? raw.runtimeStage.trim() : ''
+    const resourcesPath = typeof raw.resourcesPath === 'string' ? raw.resourcesPath.trim() : ''
+    return { host, port, execPath, headlessTick, runtimeStage, resourcesPath }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * @param {string} host
+ * @param {string} port
+ * @param {number} [timeoutMs]
+ */
+async function postScheduleTick(host, port, timeoutMs = 3000) {
+  const url = `http://${host}:${port}/api/schedule/tick`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ trigger: 'os' }),
+      signal: controller.signal,
+    })
+    return resp.ok
+  } catch {
+    return false
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Monorepo root when running unpackaged (headless-tick lives under electron/os-schedule).
+ */
+function resolveDevRepoRoot() {
+  return path.resolve(__dirname, '../../../..')
+}
+
+/**
+ * @param {{
+ *   host: string
+ *   port: string
+ *   execPath: string
+ *   runtimeStage?: string
+ *   resourcesPath?: string
+ * }} ep
+ */
+function resolveSidecarRoot(ep) {
+  if (ep.runtimeStage && fs.existsSync(ep.runtimeStage)) {
+    return { root: ep.runtimeStage, isDev: false, resourcesPath: ep.resourcesPath || resolveResourcesPathFromExec(ep.execPath) }
+  }
+  const packaged = resolvePackagedRuntimeStage(ep.execPath, ep.resourcesPath || undefined)
+  if (packaged && fs.existsSync(packaged)) {
+    return {
+      root: packaged,
+      isDev: false,
+      resourcesPath: ep.resourcesPath || resolveResourcesPathFromExec(ep.execPath),
+    }
+  }
+  const devRoot = resolveDevRepoRoot()
+  if (fs.existsSync(serverEntryPath(devRoot))) {
+    return { root: devRoot, isDev: true, resourcesPath: null }
+  }
+  return null
+}
+
+async function run() {
+  const endpointFile = resolveEndpointFile()
+  if (!endpointFile) {
+    logErr('missing OPPTRIX_OS_SCHEDULE_ENDPOINT (and OPPTRIX_USER_DATA_DIR)')
+    process.exitCode = 1
+    return
+  }
+
+  const ep = readEndpointRecord(endpointFile) || readOsScheduleEndpoint(path.dirname(endpointFile))
+  if (!ep) {
+    logErr(`cannot read endpoint: ${endpointFile}`)
+    process.exitCode = 1
+    return
+  }
+
+  const host = sanitizeEndpointHost(ep.host)
+  const port = String(ep.port || '8711')
+
+  if (await postScheduleTick(host, port)) {
+    process.exitCode = 0
+    return
+  }
+
+  const resolved = resolveSidecarRoot({
+    host,
+    port,
+    execPath: ep.execPath || process.execPath,
+    runtimeStage: ep.runtimeStage,
+    resourcesPath: ep.resourcesPath,
+  })
+  if (!resolved) {
+    logErr('cannot resolve runtime-stage / server entry for sidecar')
+    process.exitCode = 1
+    return
+  }
+
+  const entry = serverEntryPath(resolved.root)
+  if (!fs.existsSync(entry)) {
+    logErr(`server entry not found: ${entry}`)
+    process.exitCode = 1
+    return
+  }
+
+  const execPath = ep.execPath || process.execPath
+  const env = buildSidecarEnv({
+    root: resolved.root,
+    host,
+    port,
+    resourcesPath: resolved.resourcesPath,
+    isDev: resolved.isDev,
+    version: process.env.OPPTRIX_APP_VERSION,
+  })
+
+  logErr(`spawning sidecar on ${host}:${port} (cwd=${resolved.root})`)
+  const child = spawnSidecarProcess({
+    execPath,
+    entry,
+    cwd: resolved.root,
+    env,
+  })
+
+  child.stdout?.on('data', (chunk) => {
+    process.stderr.write(`[sidecar] ${chunk}`)
+  })
+  child.stderr?.on('data', (chunk) => {
+    process.stderr.write(`[sidecar] ${chunk}`)
+  })
+
+  let ok = false
+  try {
+    await waitForHealth(host, port, 45_000)
+    ok = await postScheduleTick(host, port, 10_000)
+    if (!ok) {
+      logErr('POST /api/schedule/tick failed after sidecar ready')
+    }
+  } catch (err) {
+    logErr(err instanceof Error ? err.message : String(err))
+  } finally {
+    await stopChildAndWait(child, 4000)
+  }
+
+  process.exitCode = ok ? 0 : 1
+}
+
+run().catch((err) => {
+  logErr(err instanceof Error ? err.message : String(err))
+  process.exitCode = 1
+})

--- a/apps/desktop/electron/os-schedule/linux.cjs
+++ b/apps/desktop/electron/os-schedule/linux.cjs
@@ -4,6 +4,7 @@ const os = require('node:os')
 const { spawnSync } = require('node:child_process')
 const { app } = require('electron')
 const { DEFAULT_TICK_INTERVAL_SEC } = require('./types.cjs')
+const { resolveOsTickInvocation } = require('./tick-runner.cjs')
 
 const SERVICE_NAME = 'opptrix-schedule-tick'
 
@@ -20,11 +21,28 @@ function timerPath() {
 }
 
 function resolveExecStart() {
-  if (app.isPackaged) {
-    return `${process.execPath} --background --schedule-tick`
+  /** @type {{
+   *   userDataDir: string
+   *   isPackaged: boolean
+   *   execPath: string
+   *   headlessTickPath: string
+   *   platform: 'linux'
+   *   runtimeStage?: string
+   *   resourcesPath?: string
+   * }} */
+  const opts = {
+    userDataDir: app.getPath('userData'),
+    isPackaged: app.isPackaged,
+    execPath: process.execPath,
+    headlessTickPath: path.join(__dirname, 'headless-tick.cjs'),
+    platform: 'linux',
   }
-  const mainPath = path.join(__dirname, '..', 'main.cjs')
-  return `${process.execPath} ${mainPath} --background --schedule-tick`
+  if (app.isPackaged && typeof process.resourcesPath === 'string') {
+    opts.resourcesPath = process.resourcesPath
+    opts.runtimeStage = path.join(process.resourcesPath, 'runtime-stage')
+  }
+  const invocation = resolveOsTickInvocation(opts)
+  return invocation.execStart
 }
 
 function buildServiceUnit() {

--- a/apps/desktop/electron/os-schedule/sidecar-launch.cjs
+++ b/apps/desktop/electron/os-schedule/sidecar-launch.cjs
@@ -1,0 +1,246 @@
+/**
+ * Shared sidecar spawn helpers for Electron main and headless OS tick.
+ * Pure Node — do not require('electron') at module load.
+ */
+const path = require('node:path')
+const fs = require('node:fs')
+const { spawn } = require('node:child_process')
+
+/**
+ * Derive Electron `resources` dir from the binary path when `process.resourcesPath`
+ * is unavailable (ELECTRON_RUN_AS_NODE / headless).
+ * @param {string} execPath
+ * @returns {string | null}
+ */
+function resolveResourcesPathFromExec(execPath) {
+  if (!execPath || typeof execPath !== 'string') return null
+  const dir = path.dirname(execPath)
+  // macOS: App.app/Contents/MacOS/Opptrix → Contents/Resources
+  if (path.basename(dir) === 'MacOS') {
+    return path.resolve(dir, '..', 'Resources')
+  }
+  // Windows / Linux unpacked: <install>/Opptrix.exe + resources/
+  const sibling = path.join(dir, 'resources')
+  if (fs.existsSync(sibling)) return sibling
+  return null
+}
+
+/**
+ * Packaged sidecar root: `<resources>/runtime-stage`.
+ * @param {string} execPath
+ * @param {string} [resourcesPath]
+ * @returns {string | null}
+ */
+function resolvePackagedRuntimeStage(execPath, resourcesPath) {
+  const resources = resourcesPath || resolveResourcesPathFromExec(execPath)
+  if (!resources) return null
+  return path.join(resources, 'runtime-stage')
+}
+
+/**
+ * @param {string} root runtime-stage or monorepo root
+ */
+function serverEntryPath(root) {
+  return path.join(root, 'apps/server/dist/index.js')
+}
+
+/**
+ * @param {string} root
+ */
+function uiDistPath(root) {
+  return path.join(root, 'client-ui/dist')
+}
+
+/**
+ * @param {{
+ *   root: string
+ *   host?: string
+ *   port?: string | number
+ *   resourcesPath?: string | null
+ *   version?: string
+ *   isDev?: boolean
+ *   httpUserAgent?: string
+ *   baseEnv?: NodeJS.ProcessEnv
+ * }} opts
+ */
+function buildSidecarEnv(opts) {
+  // Force loopback — never bind/advertise non-local hosts for OS tick / desktop sidecar.
+  const rawHost = typeof opts.host === 'string' ? opts.host.trim() : ''
+  const host = rawHost === '127.0.0.1' || rawHost === 'localhost' ? '127.0.0.1' : '127.0.0.1'
+  const port = String(opts.port != null && String(opts.port).trim() !== '' ? opts.port : '8711')
+  const root = opts.root
+  const isDev = Boolean(opts.isDev)
+  const base = opts.baseEnv ?? process.env
+  /** @type {NodeJS.ProcessEnv} */
+  const env = {
+    ...base,
+    SERVE_UI: '1',
+    OPPTRIX_DESKTOP: '1',
+    STOCK_RESEARCH_HOST: host,
+    STOCK_RESEARCH_PORT: port,
+    UI_DIST_PATH: uiDistPath(root),
+  }
+
+  if (opts.version) {
+    env.OPPTRIX_APP_VERSION = opts.version
+  }
+  if (opts.httpUserAgent) {
+    env.OPPTRIX_HTTP_USER_AGENT = opts.httpUserAgent
+  }
+
+  if (!isDev) {
+    env.ELECTRON_RUN_AS_NODE = '1'
+    env.OPPTRIX_RUNTIME_STAGE = root
+    const resourcesPath = opts.resourcesPath || null
+    if (resourcesPath) {
+      env.OPPTRIX_E5_BUNDLED_DIR = path.join(resourcesPath, 'llms', 'multilingual-e5-small')
+      env.OPPTRIX_RAPIDOCR_BUNDLED_DIR = path.join(
+        resourcesPath,
+        'llms',
+        'rapidocr-ppocrv4-mobile',
+      )
+      env.OPPTRIX_RAG_ENGINES_BUNDLED_DIR = path.join(resourcesPath, 'engines')
+    }
+    let RUNTIME_DEPS_DIR = 'deps'
+    try {
+      ;({ RUNTIME_DEPS_DIR } = require('../runtime-deps.cjs'))
+    } catch {
+      /* headless / tests may lack sibling */
+    }
+    const nmDir = path.join(root, 'node_modules')
+    const depsDir = path.join(root, RUNTIME_DEPS_DIR)
+    const moduleRoot = fs.existsSync(nmDir) ? nmDir : depsDir
+    if (fs.existsSync(moduleRoot)) {
+      env.NODE_PATH = moduleRoot
+    }
+    const browsersPath = path.join(root, 'playwright-browsers')
+    if (fs.existsSync(browsersPath)) {
+      env.PLAYWRIGHT_BROWSERS_PATH = browsersPath
+    }
+  } else {
+    env.OPPTRIX_E5_BUNDLED_DIR = path.join(root, 'apps/desktop/resources/llms', 'multilingual-e5-small')
+    env.OPPTRIX_RAPIDOCR_BUNDLED_DIR = path.join(
+      root,
+      'apps/desktop/resources/llms',
+      'rapidocr-ppocrv4-mobile',
+    )
+  }
+
+  return env
+}
+
+/**
+ * @param {{
+ *   execPath: string
+ *   entry: string
+ *   cwd: string
+ *   env: NodeJS.ProcessEnv
+ * }} opts
+ * @returns {import('node:child_process').ChildProcess}
+ */
+function spawnSidecarProcess(opts) {
+  return spawn(opts.execPath, [opts.entry], {
+    cwd: opts.cwd,
+    env: opts.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: false,
+  })
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * @param {string} host
+ * @param {string | number} port
+ * @param {number} [timeoutMs]
+ */
+async function waitForHealth(host, port, timeoutMs = 30_000) {
+  const url = `http://${host}:${port}/api/health`
+  const started = Date.now()
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const resp = await fetch(url)
+      if (resp.ok) return
+    } catch {
+      /* retry */
+    }
+    // Fast poll first 3s (cold start / relaunch), then back off.
+    await sleep(Date.now() - started < 3000 ? 80 : 250)
+  }
+  throw new Error(`API sidecar not ready: ${url}`)
+}
+
+/**
+ * SIGTERM then SIGKILL — does not wait for exit.
+ * @param {import('node:child_process').ChildProcess | null | undefined} proc
+ * @param {{ killGraceMs?: number }} [opts]
+ */
+function stopChild(proc, opts = {}) {
+  if (!proc || proc.killed || proc.exitCode != null) return
+  const graceMs = opts.killGraceMs ?? 3000
+  try {
+    proc.kill('SIGTERM')
+  } catch {
+    /* ignore */
+  }
+  setTimeout(() => {
+    if (proc.exitCode != null || proc.killed) return
+    try {
+      proc.kill('SIGKILL')
+    } catch {
+      /* ignore */
+    }
+  }, graceMs)
+}
+
+/**
+ * Stop and wait for exit (or timeout).
+ * @param {import('node:child_process').ChildProcess | null | undefined} proc
+ * @param {number} [timeoutMs]
+ * @returns {Promise<void>}
+ */
+function stopChildAndWait(proc, timeoutMs = 2500) {
+  return new Promise((resolve) => {
+    if (!proc || proc.killed || proc.exitCode != null) {
+      resolve()
+      return
+    }
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      clearTimeout(softTimer)
+      clearTimeout(hardTimer)
+      resolve()
+    }
+    proc.once('exit', finish)
+    try {
+      proc.kill('SIGTERM')
+    } catch {
+      finish()
+      return
+    }
+    const softTimer = setTimeout(() => {
+      try {
+        if (proc.exitCode == null && !proc.killed) proc.kill('SIGKILL')
+      } catch {
+        /* ignore */
+      }
+    }, Math.min(1500, timeoutMs))
+    const hardTimer = setTimeout(finish, timeoutMs)
+  })
+}
+
+module.exports = {
+  resolveResourcesPathFromExec,
+  resolvePackagedRuntimeStage,
+  serverEntryPath,
+  uiDistPath,
+  buildSidecarEnv,
+  spawnSidecarProcess,
+  waitForHealth,
+  stopChild,
+  stopChildAndWait,
+}

--- a/apps/desktop/electron/os-schedule/tick-runner.cjs
+++ b/apps/desktop/electron/os-schedule/tick-runner.cjs
@@ -1,0 +1,374 @@
+/**
+ * OS schedule tick: HTTP-first runner + loopback endpoint file.
+ *
+ * LaunchAgent / schtasks / systemd invoke a small script that POSTs
+ * /api/schedule/tick when the sidecar is up — avoiding a full Opptrix GUI
+ * spawn (Dock / taskbar flash). Falls back to ELECTRON_RUN_AS_NODE headless-tick
+ * (spawn sidecar → tick → stop) only on failure — never `--background --schedule-tick`.
+ */
+const path = require('node:path')
+const fs = require('node:fs')
+
+const ENDPOINT_FILENAME = 'os-schedule-endpoint.json'
+const RUNNER_SH = 'os-schedule-tick-runner.sh'
+const RUNNER_CMD = 'os-schedule-tick-runner.cmd'
+
+/**
+ * Absolute path to headless-tick.cjs (works inside app.asar under ELECTRON_RUN_AS_NODE).
+ */
+function defaultHeadlessTickPath() {
+  return path.join(__dirname, 'headless-tick.cjs')
+}
+
+/**
+ * @param {string} userDataDir
+ */
+function endpointFilePath(userDataDir) {
+  return path.join(userDataDir, ENDPOINT_FILENAME)
+}
+
+/**
+ * @param {string} userDataDir
+ * @param {NodeJS.Platform} [platform]
+ */
+function runnerScriptPath(userDataDir, platform = process.platform) {
+  return path.join(userDataDir, platform === 'win32' ? RUNNER_CMD : RUNNER_SH)
+}
+
+/**
+ * Force loopback only — never write non-local hosts into the endpoint file.
+ * @param {string | undefined} host
+ */
+function sanitizeEndpointHost(host) {
+  const h = typeof host === 'string' ? host.trim() : ''
+  if (h === '127.0.0.1' || h === 'localhost') return '127.0.0.1'
+  return '127.0.0.1'
+}
+
+/**
+ * @param {string | undefined} value
+ * @returns {string | undefined}
+ */
+function optionalAbsPath(value) {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+/**
+ * @param {string} userDataDir
+ * @param {{
+ *   host?: string
+ *   port?: string | number
+ *   execPath?: string
+ *   headlessTick?: string
+ *   runtimeStage?: string
+ *   resourcesPath?: string
+ * }} opts
+ * @returns {{
+ *   host: string
+ *   port: string
+ *   execPath?: string
+ *   headlessTick?: string
+ *   runtimeStage?: string
+ *   resourcesPath?: string
+ * }}
+ */
+function writeOsScheduleEndpoint(userDataDir, opts = {}) {
+  fs.mkdirSync(userDataDir, { recursive: true })
+  /** @type {Record<string, string>} */
+  const payload = {
+    host: sanitizeEndpointHost(opts.host),
+    port: String(opts.port != null && String(opts.port).trim() !== '' ? opts.port : '8711'),
+  }
+  const execPath = optionalAbsPath(opts.execPath)
+  const headlessTick = optionalAbsPath(opts.headlessTick)
+  const runtimeStage = optionalAbsPath(opts.runtimeStage)
+  const resourcesPath = optionalAbsPath(opts.resourcesPath)
+  if (execPath) payload.execPath = execPath
+  if (headlessTick) payload.headlessTick = headlessTick
+  if (runtimeStage) payload.runtimeStage = runtimeStage
+  if (resourcesPath) payload.resourcesPath = resourcesPath
+  fs.writeFileSync(endpointFilePath(userDataDir), `${JSON.stringify(payload)}\n`, 'utf8')
+  return payload
+}
+
+/**
+ * @param {string} userDataDir
+ * @returns {{
+ *   host: string
+ *   port: string
+ *   execPath?: string
+ *   headlessTick?: string
+ *   runtimeStage?: string
+ *   resourcesPath?: string
+ * } | null}
+ */
+function readOsScheduleEndpoint(userDataDir) {
+  const file = endpointFilePath(userDataDir)
+  if (!fs.existsSync(file)) return null
+  try {
+    const raw = JSON.parse(fs.readFileSync(file, 'utf8'))
+    if (!raw || typeof raw !== 'object') return null
+    const host = sanitizeEndpointHost(typeof raw.host === 'string' ? raw.host : undefined)
+    const port = typeof raw.port === 'string' || typeof raw.port === 'number'
+      ? String(raw.port)
+      : '8711'
+    /** @type {{
+     *   host: string
+     *   port: string
+     *   execPath?: string
+     *   headlessTick?: string
+     *   runtimeStage?: string
+     *   resourcesPath?: string
+     * }} */
+    const out = { host, port }
+    const execPath = optionalAbsPath(typeof raw.execPath === 'string' ? raw.execPath : undefined)
+    const headlessTick = optionalAbsPath(typeof raw.headlessTick === 'string' ? raw.headlessTick : undefined)
+    const runtimeStage = optionalAbsPath(typeof raw.runtimeStage === 'string' ? raw.runtimeStage : undefined)
+    const resourcesPath = optionalAbsPath(typeof raw.resourcesPath === 'string' ? raw.resourcesPath : undefined)
+    if (execPath) out.execPath = execPath
+    if (headlessTick) out.headlessTick = headlessTick
+    if (runtimeStage) out.runtimeStage = runtimeStage
+    if (resourcesPath) out.resourcesPath = resourcesPath
+    return out
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Headless cold-start argv: ELECTRON_RUN_AS_NODE=1 $execPath $headlessTick
+ * (env is set by the runner script; argv is only the binary + script).
+ *
+ * @param {{ execPath: string; headlessTickPath?: string }} opts
+ * @returns {string[]}
+ */
+function resolveHeadlessTickArgv(opts) {
+  return [opts.execPath, opts.headlessTickPath || defaultHeadlessTickPath()]
+}
+
+/**
+ * @deprecated Prefer resolveHeadlessTickArgv — kept for callers/tests naming.
+ * @param {{
+ *   isPackaged?: boolean
+ *   execPath: string
+ *   mainCjsPath?: string
+ *   headlessTickPath?: string
+ * }} opts
+ * @returns {string[]}
+ */
+function resolveColdStartArgv(opts) {
+  return resolveHeadlessTickArgv({
+    execPath: opts.execPath,
+    headlessTickPath: opts.headlessTickPath,
+  })
+}
+
+/**
+ * @param {string} value
+ */
+function shellSingleQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`
+}
+
+/**
+ * @param {string[]} argv
+ */
+function bashExecLine(argv) {
+  return argv.map(shellSingleQuote).join(' ')
+}
+
+/**
+ * @param {string} value
+ */
+function cmdQuote(value) {
+  return `"${String(value).replace(/"/g, '\\"')}"`
+}
+
+/**
+ * @param {{ endpointFile: string; coldStartArgv: string[] }} opts
+ * coldStartArgv = [execPath, headlessTickPath]
+ */
+function buildBashRunnerScript(opts) {
+  const endpointQuoted = shellSingleQuote(opts.endpointFile)
+  const execQuoted = shellSingleQuote(opts.coldStartArgv[0] || '')
+  const headlessQuoted = shellSingleQuote(opts.coldStartArgv[1] || '')
+  return `#!/bin/bash
+# Opptrix OS schedule tick — HTTP-first; headless ELECTRON_RUN_AS_NODE sidecar if down.
+ENDPOINT_FILE=${endpointQuoted}
+HOST='127.0.0.1'
+PORT='8711'
+EXEC=${execQuoted}
+HEADLESS_TICK=${headlessQuoted}
+if [[ -f "$ENDPOINT_FILE" ]]; then
+  _h=$(sed -n 's/.*"host"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$ENDPOINT_FILE" | head -n 1)
+  _p=$(sed -n 's/.*"port"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$ENDPOINT_FILE" | head -n 1)
+  _e=$(sed -n 's/.*"execPath"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$ENDPOINT_FILE" | head -n 1)
+  _t=$(sed -n 's/.*"headlessTick"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$ENDPOINT_FILE" | head -n 1)
+  [[ -n "$_h" ]] && HOST="$_h"
+  [[ -n "$_p" ]] && PORT="$_p"
+  [[ -n "$_e" ]] && EXEC="$_e"
+  [[ -n "$_t" ]] && HEADLESS_TICK="$_t"
+fi
+case "$HOST" in
+  127.0.0.1|localhost) ;;
+  *) HOST='127.0.0.1' ;;
+esac
+if command -v curl >/dev/null 2>&1; then
+  if curl -fsS --connect-timeout 1 --max-time 3 \\
+    -X POST "http://\${HOST}:\${PORT}/api/schedule/tick" \\
+    -H 'Content-Type: application/json' \\
+    -d '{"trigger":"os"}' \\
+    >/dev/null 2>&1; then
+    exit 0
+  fi
+fi
+export ELECTRON_RUN_AS_NODE=1
+export OPPTRIX_OS_SCHEDULE_ENDPOINT="$ENDPOINT_FILE"
+exec "$EXEC" "$HEADLESS_TICK"
+`
+}
+
+/**
+ * @param {{ endpointFile: string; coldStartArgv: string[] }} opts
+ */
+function buildCmdRunnerScript(opts) {
+  const endpoint = opts.endpointFile.replace(/"/g, '')
+  const execPath = String(opts.coldStartArgv[0] || '').replace(/"/g, '')
+  const headlessTick = String(opts.coldStartArgv[1] || '').replace(/"/g, '')
+  return `@echo off
+setlocal EnableExtensions
+set "ENDPOINT_FILE=${endpoint}"
+set "HOST=127.0.0.1"
+set "PORT=8711"
+set "EXEC=${execPath}"
+set "HEADLESS_TICK=${headlessTick}"
+if exist "%ENDPOINT_FILE%" (
+  for /f "usebackq delims=" %%A in (\`powershell -NoProfile -Command "(Get-Content -Raw -LiteralPath $env:ENDPOINT_FILE | ConvertFrom-Json).host"\`) do set "HOST=%%A"
+  for /f "usebackq delims=" %%A in (\`powershell -NoProfile -Command "(Get-Content -Raw -LiteralPath $env:ENDPOINT_FILE | ConvertFrom-Json).port"\`) do set "PORT=%%A"
+  for /f "usebackq delims=" %%A in (\`powershell -NoProfile -Command "(Get-Content -Raw -LiteralPath $env:ENDPOINT_FILE | ConvertFrom-Json).execPath"\`) do if not "%%A"=="" set "EXEC=%%A"
+  for /f "usebackq delims=" %%A in (\`powershell -NoProfile -Command "(Get-Content -Raw -LiteralPath $env:ENDPOINT_FILE | ConvertFrom-Json).headlessTick"\`) do if not "%%A"=="" set "HEADLESS_TICK=%%A"
+)
+if /I not "%HOST%"=="127.0.0.1" if /I not "%HOST%"=="localhost" set "HOST=127.0.0.1"
+curl.exe -fsS --connect-timeout 1 --max-time 3 -X POST "http://%HOST%:%PORT%/api/schedule/tick" -H "Content-Type: application/json" -d "{\\"trigger\\":\\"os\\"}" >nul 2>&1
+if %ERRORLEVEL% EQU 0 exit /b 0
+set ELECTRON_RUN_AS_NODE=1
+set "OPPTRIX_OS_SCHEDULE_ENDPOINT=%ENDPOINT_FILE%"
+"%EXEC%" "%HEADLESS_TICK%"
+exit /b %ERRORLEVEL%
+`
+}
+
+/**
+ * Write (or refresh) the OS tick runner script under userData; chmod +x on Unix.
+ *
+ * @param {{
+ *   userDataDir: string
+ *   isPackaged?: boolean
+ *   execPath: string
+ *   mainCjsPath?: string
+ *   headlessTickPath?: string
+ *   runtimeStage?: string
+ *   resourcesPath?: string
+ *   platform?: NodeJS.Platform
+ *   defaultPort?: string | number
+ * }} opts
+ * @returns {{ scriptPath: string; endpointFile: string; coldStartArgv: string[] }}
+ */
+function ensureOsScheduleTickRunner(opts) {
+  const platform = opts.platform ?? process.platform
+  const userDataDir = opts.userDataDir
+  fs.mkdirSync(userDataDir, { recursive: true })
+
+  const headlessTickPath = opts.headlessTickPath || defaultHeadlessTickPath()
+  const existing = readOsScheduleEndpoint(userDataDir)
+  writeOsScheduleEndpoint(userDataDir, {
+    host: existing?.host ?? '127.0.0.1',
+    port: existing?.port ?? opts.defaultPort ?? '8711',
+    execPath: opts.execPath,
+    headlessTick: headlessTickPath,
+    runtimeStage: opts.runtimeStage ?? existing?.runtimeStage,
+    resourcesPath: opts.resourcesPath ?? existing?.resourcesPath,
+  })
+
+  const coldStartArgv = resolveHeadlessTickArgv({
+    execPath: opts.execPath,
+    headlessTickPath,
+  })
+  const endpointFile = endpointFilePath(userDataDir)
+  const scriptPath = runnerScriptPath(userDataDir, platform)
+
+  if (platform === 'win32') {
+    fs.writeFileSync(
+      scriptPath,
+      buildCmdRunnerScript({ endpointFile, coldStartArgv }),
+      'utf8',
+    )
+  } else {
+    fs.writeFileSync(
+      scriptPath,
+      buildBashRunnerScript({ endpointFile, coldStartArgv }),
+      { encoding: 'utf8', mode: 0o755 },
+    )
+    try {
+      fs.chmodSync(scriptPath, 0o755)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return { scriptPath, endpointFile, coldStartArgv }
+}
+
+/**
+ * ProgramArguments / ExecStart / schtasks /TR for the OS tick registration.
+ * @param {{
+ *   userDataDir: string
+ *   isPackaged?: boolean
+ *   execPath: string
+ *   mainCjsPath?: string
+ *   headlessTickPath?: string
+ *   runtimeStage?: string
+ *   resourcesPath?: string
+ *   platform?: NodeJS.Platform
+ * }} opts
+ * @returns {{ programArguments: string[]; scriptPath: string; execStart: string; taskRun: string }}
+ */
+function resolveOsTickInvocation(opts) {
+  const platform = opts.platform ?? process.platform
+  const ensured = ensureOsScheduleTickRunner({ ...opts, platform })
+  if (platform === 'win32') {
+    return {
+      programArguments: [ensured.scriptPath],
+      scriptPath: ensured.scriptPath,
+      execStart: cmdQuote(ensured.scriptPath),
+      taskRun: cmdQuote(ensured.scriptPath),
+    }
+  }
+  return {
+    programArguments: ['/bin/bash', ensured.scriptPath],
+    scriptPath: ensured.scriptPath,
+    execStart: `/bin/bash ${shellSingleQuote(ensured.scriptPath)}`,
+    taskRun: `/bin/bash ${shellSingleQuote(ensured.scriptPath)}`,
+  }
+}
+
+module.exports = {
+  ENDPOINT_FILENAME,
+  RUNNER_SH,
+  RUNNER_CMD,
+  defaultHeadlessTickPath,
+  endpointFilePath,
+  runnerScriptPath,
+  sanitizeEndpointHost,
+  writeOsScheduleEndpoint,
+  readOsScheduleEndpoint,
+  resolveHeadlessTickArgv,
+  resolveColdStartArgv,
+  shellSingleQuote,
+  buildBashRunnerScript,
+  buildCmdRunnerScript,
+  ensureOsScheduleTickRunner,
+  resolveOsTickInvocation,
+}

--- a/apps/desktop/electron/os-schedule/win32.cjs
+++ b/apps/desktop/electron/os-schedule/win32.cjs
@@ -2,19 +2,33 @@ const path = require('node:path')
 const { spawnSync } = require('node:child_process')
 const { app } = require('electron')
 const { DEFAULT_TICK_INTERVAL_SEC } = require('./types.cjs')
+const { resolveOsTickInvocation } = require('./tick-runner.cjs')
 
 const TASK_NAME = 'OpptrixScheduleTick'
 
-function quoteCmd(value) {
-  return `"${String(value).replace(/"/g, '\\"')}"`
-}
-
 function resolveCommandLine() {
-  if (app.isPackaged) {
-    return `${quoteCmd(process.execPath)} --background --schedule-tick`
+  /** @type {{
+   *   userDataDir: string
+   *   isPackaged: boolean
+   *   execPath: string
+   *   headlessTickPath: string
+   *   platform: 'win32'
+   *   runtimeStage?: string
+   *   resourcesPath?: string
+   * }} */
+  const opts = {
+    userDataDir: app.getPath('userData'),
+    isPackaged: app.isPackaged,
+    execPath: process.execPath,
+    headlessTickPath: path.join(__dirname, 'headless-tick.cjs'),
+    platform: 'win32',
   }
-  const mainPath = path.join(__dirname, '..', 'main.cjs')
-  return `${quoteCmd(process.execPath)} ${quoteCmd(mainPath)} --background --schedule-tick`
+  if (app.isPackaged && typeof process.resourcesPath === 'string') {
+    opts.resourcesPath = process.resourcesPath
+    opts.runtimeStage = path.join(process.resourcesPath, 'runtime-stage')
+  }
+  const invocation = resolveOsTickInvocation(opts)
+  return invocation.taskRun
 }
 
 function schtasks(args) {
@@ -83,7 +97,7 @@ const win32Adapter = {
         ok: false,
         status: 'error',
         error: err instanceof Error ? err.message : String(err),
-    }
+      }
     }
   },
 

--- a/apps/desktop/electron/preload.cjs
+++ b/apps/desktop/electron/preload.cjs
@@ -34,6 +34,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   translationGetModels: () => ipcRenderer.invoke('translation-get-models'),
   translationGetDownloadDir: () => ipcRenderer.invoke('translation-get-download-dir'),
   translationOpenDownloadDir: () => ipcRenderer.invoke('translation-open-download-dir'),
+  chatDebugOpenLogDir: () => ipcRenderer.invoke('chat-debug-open-log-dir'),
   /** Open a directory under agent-workspace in the system file manager */
   openLocalDirectory: (dirPath) => ipcRenderer.invoke('open-local-directory', dirPath),
   translationStartDownload: (modelId) => ipcRenderer.invoke('translation-start-download', modelId),

--- a/apps/desktop/electron/schedule-bridge.cjs
+++ b/apps/desktop/electron/schedule-bridge.cjs
@@ -1,6 +1,11 @@
+const path = require('node:path')
 const { app } = require('electron')
 const { getOsScheduleAdapter } = require('./os-schedule/index.cjs')
 const { DEFAULT_TICK_INTERVAL_SEC } = require('./os-schedule/types.cjs')
+const {
+  writeOsScheduleEndpoint,
+  defaultHeadlessTickPath,
+} = require('./os-schedule/tick-runner.cjs')
 
 /** @type {string} */
 let apiHost = '127.0.0.1'
@@ -8,11 +13,43 @@ let apiHost = '127.0.0.1'
 let apiPort = '8711'
 
 /**
+ * Persist loopback host/port + headless cold-start paths for the OS tick runner (no secrets).
+ * Same endpoint JSON is reused by UI `resolveApiPort(allowReuse:true)` via host/port.
+ */
+function persistOsScheduleEndpoint() {
+  try {
+    if (typeof app?.getPath !== 'function') return
+    /** @type {{
+     *   host: string
+     *   port: string | number
+     *   execPath: string
+     *   headlessTick: string
+     *   runtimeStage?: string
+     *   resourcesPath?: string
+     * }} */
+    const opts = {
+      host: apiHost,
+      port: apiPort,
+      execPath: process.execPath,
+      headlessTick: defaultHeadlessTickPath(),
+    }
+    if (app.isPackaged && typeof process.resourcesPath === 'string') {
+      opts.resourcesPath = process.resourcesPath
+      opts.runtimeStage = path.join(process.resourcesPath, 'runtime-stage')
+    }
+    writeOsScheduleEndpoint(app.getPath('userData'), opts)
+  } catch {
+    /* non-electron / tests */
+  }
+}
+
+/**
  * @param {{ host?: string; port?: string | number }} opts
  */
 function configureScheduleBridge(opts = {}) {
   if (opts.host) apiHost = opts.host
   if (opts.port != null) apiPort = String(opts.port)
+  persistOsScheduleEndpoint()
 }
 
 function apiBase() {

--- a/apps/desktop/scripts/after-pack-adhoc.cjs
+++ b/apps/desktop/scripts/after-pack-adhoc.cjs
@@ -1,8 +1,9 @@
 /**
  * electron-builder afterPack hook.
  *
- * 0) On macOS, replace the Icon Composer stub `Resources/icon.icns` with the full
- *    `build/icons/icon.icns` (notification center / CFBundleIconFile readers).
+ * 0) On macOS: restore full `build/icons/icon.icns` over bundle stub, then strip
+ *    `CFBundleIconName` so Notification Center falls back to `CFBundleIconFile`
+ *    (Icon Composer Assets.car otherwise wins over the restored icns).
  * 1) Always restore sidecar `deps/` → `node_modules/` inside the packed app.
  *    Staging renames to `deps/` so createFilter does not drop the tree (exact
  *    relative path `node_modules` is skipped). Packaged Node ESM cannot resolve
@@ -35,16 +36,18 @@ function runtimeStageRoots(context) {
 }
 
 /**
- * Icon Composer (`build.mac.icon` = `.icon`) ships Assets.car + a stub icns.
- * Notification Center still reads CFBundleIconFile → Resources/icon.icns.
- * Overwrite that stub with the full icns from prepare-icons before codesign.
+ * Icon Composer (`build.mac.icon` = `.icon`) ships Assets.car + stub icns and sets
+ * both CFBundleIconFile and CFBundleIconName. macOS Notification Center prefers
+ * the Asset Catalog (CFBundleIconName → Assets.car) over icon.icns — so restoring
+ * icns alone leaves NC on the Composer/stub art. Strip IconName after restore so
+ * readers fall back to CFBundleIconFile → Resources/icon.icns (prepare-icons).
  */
 function restoreMacBundleIcns(context) {
   if (context.electronPlatformName !== 'darwin') return
 
   const productFilename = context.packager.appInfo.productFilename
   const appPath = path.join(context.appOutDir, `${productFilename}.app`)
-  const src = path.join(__dirname, '..', 'build', 'icons', 'icon.icns')
+  const src = path.join(__dirname, '..', 'build/icons/icon.icns')
   const dest = path.join(appPath, 'Contents', 'Resources', 'icon.icns')
 
   if (!fs.existsSync(src)) {
@@ -60,6 +63,34 @@ function restoreMacBundleIcns(context) {
 
   fs.copyFileSync(src, dest)
   console.log(`afterPack: restored full mac icon.icns → ${dest}`)
+  stripMacBundleIconName(appPath)
+}
+
+/** Remove CFBundleIconName so NC uses restored icon.icns (keeps Assets.car on disk). */
+function stripMacBundleIconName(appPath) {
+  const plist = path.join(appPath, 'Contents', 'Info.plist')
+  if (!fs.existsSync(plist)) {
+    throw new Error(`afterPack: missing Info.plist at ${plist}`)
+  }
+
+  let hasIconName = false
+  try {
+    execFileSync('plutil', ['-extract', 'CFBundleIconName', 'raw', '-o', '-', plist], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    hasIconName = true
+  } catch {
+    // Key absent — nothing to strip.
+  }
+
+  if (!hasIconName) {
+    console.log('afterPack: CFBundleIconName already absent')
+    return
+  }
+
+  execFileSync('plutil', ['-remove', 'CFBundleIconName', plist], { stdio: 'inherit' })
+  console.log(`afterPack: stripped CFBundleIconName from ${plist}`)
 }
 
 /** Rename staged deps → node_modules so ESM bare imports resolve in production. */
@@ -130,3 +161,6 @@ exports.default = async function afterPack(context) {
   restoreSidecarNodeModules(context)
   adhocSignMac(context)
 }
+
+// Exported for lightweight plist-strip smoke tests (not used by electron-builder).
+exports.stripMacBundleIconName = stripMacBundleIconName

--- a/apps/desktop/scripts/audit-desktop-pack.mjs
+++ b/apps/desktop/scripts/audit-desktop-pack.mjs
@@ -415,6 +415,13 @@ console.log('audit-desktop-pack: start')
     fail('afterPack must restore full build/icons/icon.icns over mac bundle stub')
   } else ok('afterPack restores full mac icon.icns for notification center')
 
+  if (
+    !afterPackSrc.includes('CFBundleIconName')
+    || !afterPackSrc.includes('stripMacBundleIconName')
+  ) {
+    fail('afterPack must strip CFBundleIconName so NC falls back to restored icon.icns')
+  } else ok('afterPack strips CFBundleIconName (Asset Catalog) for notification center')
+
   if (exists('build/icons/icon.icns')) {
     const icnsSize = fs.statSync(path.join(DESKTOP_ROOT, 'build/icons/icon.icns')).size
     if (icnsSize < 100_000) {

--- a/client-ui/src/pages/settings/AboutSettingsSection.tsx
+++ b/client-ui/src/pages/settings/AboutSettingsSection.tsx
@@ -12,7 +12,7 @@ import {
   WarningRegular,
 } from '@fluentui/react-icons'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
-import { getHealth } from '../../api/client'
+import { getHealth, getUserPreference, setUserPreference } from '../../api/client'
 import { useAppUpdate } from '../../hooks/useAppUpdate'
 import { isElectron, type NotificationPermissionState } from '../../platform/detect'
 import { openExternalUrl } from '../../platform/openUrl'
@@ -36,6 +36,14 @@ import {
   SettingsGroup,
   SettingsRow,
 } from './SettingsPrimitives'
+
+/** 与 packages/shared chat-debug-settings 对齐；client-ui 不从 shared 主入口导入 */
+const CHAT_DEBUG_LOGGING_KEY = 'chat_debug_logging'
+
+function parseChatDebugEnabled(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  return (value as { enabled?: unknown }).enabled === true
+}
 
 const useStyles = makeStyles({
   root: {
@@ -170,6 +178,8 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
   const [versionLabel, setVersionLabel] = useState<string | null>(null)
   const [checkedOnce, setCheckedOnce] = useState(false)
   const [notifyPermission, setNotifyPermission] = useState<NotificationPermissionState | null>(null)
+  const [chatDebugEnabled, setChatDebugEnabled] = useState(false)
+  const [chatDebugLoading, setChatDebugLoading] = useState(true)
 
   useEffect(() => {
     if (isElectron()) {
@@ -184,6 +194,21 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
     void getHealth()
       .then(health => setVersionLabel(health.version ? `v${health.version}` : null))
       .catch(() => setVersionLabel(null))
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    void getUserPreference<{ enabled?: boolean }>(CHAT_DEBUG_LOGGING_KEY)
+      .then(resp => {
+        if (!cancelled) setChatDebugEnabled(parseChatDebugEnabled(resp.value))
+      })
+      .catch(() => {
+        if (!cancelled) setChatDebugEnabled(false)
+      })
+      .finally(() => {
+        if (!cancelled) setChatDebugLoading(false)
+      })
+    return () => { cancelled = true }
   }, [])
 
   const handleCheckUpdate = useCallback(() => {
@@ -203,6 +228,18 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
     void window.electronAPI?.notificationRequestPermission?.()
       .then(perm => setNotifyPermission(perm))
       .catch(() => {})
+  }, [])
+
+  const handleChatDebugChange = useCallback((_: unknown, data: { checked: boolean | 'mixed' }) => {
+    const next = Boolean(data.checked)
+    setChatDebugEnabled(next)
+    void setUserPreference(CHAT_DEBUG_LOGGING_KEY, { enabled: next }).catch(() => {
+      setChatDebugEnabled(!next)
+    })
+  }, [])
+
+  const handleOpenChatDebugDir = useCallback(() => {
+    void window.electronAPI?.chatDebugOpenLogDir?.().catch(() => {})
   }, [])
 
   const versionDesc = versionLabel ?? '读取版本中…'
@@ -359,6 +396,37 @@ export default function AboutSettingsSection({ contentFlush = false }: AboutSett
           </SettingsGroup>
         </div>
       )}
+
+      <div className={s.sectionBlock}>
+        <Text className={s.sectionLabel} block>对话调试日志</Text>
+        <SettingsGroup>
+          <SettingsRow
+            title="对话调试日志"
+            desc="开启后，将把对话过程写入本机日志，便于排查无回复或中断；默认关闭"
+            control={(
+              <Switch
+                checked={chatDebugEnabled}
+                disabled={chatDebugLoading}
+                onChange={handleChatDebugChange}
+                aria-label="对话调试日志"
+              />
+            )}
+            last={!isElectron()}
+          />
+          {isElectron() ? (
+            <SettingsRow
+              title="日志文件夹"
+              desc="在系统文件管理器中打开本机日志目录"
+              control={(
+                <OpptrixButton variant="secondary" onClick={handleOpenChatDebugDir}>
+                  打开日志文件夹
+                </OpptrixButton>
+              )}
+              last
+            />
+          ) : null}
+        </SettingsGroup>
+      </div>
 
       <div className={s.sectionBlock}>
         <Text className={s.sectionLabel} block>法律与官网</Text>

--- a/client-ui/src/pages/settings/settingsSearchIndex.ts
+++ b/client-ui/src/pages/settings/settingsSearchIndex.ts
@@ -38,6 +38,7 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   { section: 'about', title: '关于', desc: '产品说明、版本更新、法律条款与帮助反馈', keywords: ['关于 Opptrix', 'Opptrix'] },
   { section: 'about', title: '应用更新', desc: '检查更新与重启安装', keywords: ['版本', '升级', '热更新'] },
   { section: 'about', title: '检查更新', keywords: ['更新', 'upgrade'] },
+  { section: 'about', title: '对话调试日志', desc: '将对话过程写入本机日志，便于排查无回复或中断', keywords: ['调试', '日志', '无回复', '中断'] },
   { section: 'about', title: '官方网站', desc: 'Opptrix 官网', keywords: ['官网', 'opptrix.org', '网站'] },
   { section: 'about', title: '用户协议', keywords: ['条款', 'legal', 'agreement'] },
   { section: 'about', title: '隐私政策', keywords: ['privacy', '隐私'] },

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -41,6 +41,8 @@ declare global {
       translationGetModels?: () => Promise<TranslationModelsResult>
       translationGetDownloadDir?: () => Promise<string>
       translationOpenDownloadDir?: () => Promise<string>
+      /** 打开 ~/.opptrix/logs/chat-debug 目录 */
+      chatDebugOpenLogDir?: () => Promise<string>
       /** Open a path under agent-workspace in the system file manager (validated in main) */
       openLocalDirectory?: (dirPath: string) => Promise<string>
       translationStartDownload?: (modelId: string) => Promise<{ filePath: string; filename: string }>

--- a/docs/API.md
+++ b/docs/API.md
@@ -532,7 +532,7 @@ Shell 运行时出站确认（`sandboxAskCallback` / `confirmation.kind === "net
 
 定时执行智能体提示词或受控脚本。持久化于用户 SQLite（`packages/user-store` 的 `schedule` 命名空间）；调度引擎为 `@opptrix/schedule` 的 `ScheduleService`。Sidecar 启动时注册 `registerScheduleRoutes` 并调用 `scheduleService.start()`（进程内每 **20s** 扫描到期任务，`trigger: 'timer'`）。
 
-桌面端另有一套 **OS 级通用 tick**（用户级、无需 root），经 `POST /api/schedule/tick` 触发（`trigger: 'os'`）；详见 [DESKTOP.md · 计划任务与后台常驻](./DESKTOP.md#计划任务与后台常驻)。
+桌面端另有一套 **OS 级通用 tick**（用户级、无需 root），经 `POST /api/schedule/tick` 触发（`trigger: 'os'`）。冷启动路径为 **HTTP-first → `ELECTRON_RUN_AS_NODE` headless sidecar**（不拉起 Opptrix GUI）；详见 [DESKTOP.md · 计划任务与后台常驻](./DESKTOP.md#计划任务与后台常驻)。
 
 | 方法 | 路径 | 说明 |
 |------|------|------|

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -73,7 +73,7 @@ The release app loads `http://127.0.0.1:8711` (UI + API same origin).
 
 ## 计划任务与后台常驻
 
-桌面端计划任务采用 **双轨调度**：Sidecar 内 `ScheduleService.start()` 每 **20s** 进程内扫描（`trigger: 'timer'`）；另注册 **OS 级通用 tick**（默认间隔 **60s**，用户级、**不要求 root**），在关窗或仅后台常驻时仍能唤醒 sidecar 执行 `POST /api/schedule/tick`（`trigger: 'os'`）。两路均经乐观 claim 幂等，避免重复跑同一到期任务。
+桌面端计划任务采用 **双轨调度**：Sidecar 内 `ScheduleService.start()` 每 **20s** 进程内扫描（`trigger: 'timer'`）；另注册 **OS 级通用 tick**（默认间隔 **60s**，用户级、**不要求 root**）。OS tick 优先经 userData 内 **HTTP-first runner** 对已运行 sidecar 发 `POST /api/schedule/tick`（`trigger: 'os'`）；仅当 sidecar 未起时才 fallback **`ELECTRON_RUN_AS_NODE` headless-tick**（无界面拉起 sidecar → tick → 停掉本次 sidecar），**不再** GUI 冷启动 `--background --schedule-tick`。两路均经乐观 claim 幂等，避免重复跑同一到期任务。
 
 ### 关窗 = 托盘常驻（生产包）
 
@@ -144,26 +144,30 @@ Electron 官方建议 Windows 用 **多尺寸 `.ico`**（至少含上表 small �
 | 参数 | 含义 |
 |------|------|
 | `--background` | 无 splash/主窗启动；macOS 隐藏 Dock；仍 spawn sidecar 并 reconcile OS 调度 |
-| `--schedule-tick` | 本次启动为 OS tick 唤醒：短命 worker（`runEphemeralScheduleTickWorker`）在 sidecar ready 后 `POST /api/schedule/tick`，然后退出（常与 `--background` 合用；不建托盘、不常驻） |
+| `--schedule-tick` | **兼容**旧 LaunchAgent / 手动调试：短命 Electron worker（`runEphemeralScheduleTickWorker`）在 sidecar ready 后 `POST /api/schedule/tick`，然后退出（常与 `--background` 合用；不建托盘、不常驻）。**新注册的 OS 任务不再指向此路径** |
 
-OS 适配器写入的系统任务均带 `--background --schedule-tick`：
+OS 适配器注册的系统任务执行 **HTTP-first tick runner**（写在 Electron `userData`，如 `os-schedule-tick-runner.sh` / `.cmd`），**不再**把 Opptrix GUI 本体当作 StartInterval / schtasks / systemd 的主程序：
+
+1. 读取 `userData/os-schedule-endpoint.json`（`host` 强制 `127.0.0.1`、`port`，以及冷启动用的 `execPath` + `headlessTick`；可选 `runtimeStage` / `resourcesPath`；由 `configureScheduleBridge` / ensure runner 写入，**无密钥**）
+2. 短超时 `POST http://127.0.0.1:$PORT/api/schedule/tick`（`{"trigger":"os"}`）→ **成功则 exit 0**（应用已运行时不拉起新进程，避免 Dock / 任务栏闪烁；UI 侧 `resolveApiPort(allowReuse:true)` 可 reuse 同一 endpoint 上的健康 sidecar）
+3. 失败（sidecar 未起）再 fallback：`ELECTRON_RUN_AS_NODE=1 "$execPath" "$headlessTick"`（`os-schedule/headless-tick.cjs`：再试 POST → 必要时 spawn sidecar → health → POST tick → **停掉本次 sidecar** → exit）。**禁止** fallback 到 `Opptrix --background --schedule-tick`
 
 | 平台 | 机制 | 标识 |
 |------|------|------|
-| **macOS** | 用户 LaunchAgent `~/Library/LaunchAgents/org.opptrix.schedule-tick.plist`，`StartInterval` ≥ 30s | `launchctl` gui 域 |
-| **Windows** | 用户计划任务 `schtasks`，按分钟重复 | 任务名 `OpptrixScheduleTick` |
-| **Linux** | 用户 systemd timer `~/.config/systemd/user/opptrix-schedule-tick.timer` | `systemctl --user` |
+| **macOS** | 用户 LaunchAgent `~/Library/LaunchAgents/org.opptrix.schedule-tick.plist`，`ProgramArguments` = `/bin/bash` + tick runner，`StartInterval` ≥ 30s | `launchctl` gui 域 |
+| **Windows** | 用户计划任务 `schtasks`，`/TR` 指向 tick runner `.cmd`，按分钟重复 | 任务名 `OpptrixScheduleTick` |
+| **Linux** | 用户 systemd timer；`.service` 的 `ExecStart` = `/bin/bash` + tick runner | `systemctl --user` |
 
-实现：`apps/desktop/electron/os-schedule/{darwin,win32,linux}.cjs`；入口 `os-schedule/index.cjs`。Windows NSIS 安装器（`nsis/installer.nsh`）会在安装前移除 `OpptrixScheduleTick` 并结束运行中的 Opptrix，避免旧版定时拉起阻塞覆盖安装。
+实现：`apps/desktop/electron/os-schedule/{tick-runner,headless-tick,sidecar-launch}.cjs` + `{darwin,win32,linux}.cjs`；入口 `os-schedule/index.cjs`。Windows NSIS 安装器（`nsis/installer.nsh`）会在安装前移除 `OpptrixScheduleTick` 并结束运行中的 Opptrix，避免旧版定时拉起阻塞覆盖安装。
 
-单实例锁：若已有实例运行，带 `--schedule-tick` 的第二次启动只触发 `handleScheduleTickFromOs()`（经已有 sidecar），不重复开主窗（除非未带 `--background`）。
+单实例锁：若已有实例运行，带 `--schedule-tick` 的第二次启动（仅兼容旧 plist / 手动调试）只触发 `handleScheduleTickFromOs()`（经已有 sidecar），不重复开主窗（除非未带 `--background`）。macOS 在 `requestSingleInstanceLock` 之前对 `--background` / `--schedule-tick` 尽早 `app.dock.hide()`，进一步降低秒退时的 Dock 闪烁。
 
 ### `schedule-bridge.cjs` 与 reconcile
 
-主进程通过 bridge 调用 sidecar REST（`configureScheduleBridge({ host, port })`）：
+主进程通过 bridge 调用 sidecar REST（`configureScheduleBridge({ host, port })` 同时写入 `os-schedule-endpoint.json`）：
 
 1. `GET /api/schedule/os/reconcile` — 是否应注册 OS tick（`register_tick` = `master_enabled`）、`autostart`、`interval_sec`
-2. `getOsScheduleAdapter().ensureTickRegistration` / `removeTickRegistration` — 写系统级任务
+2. `getOsScheduleAdapter().ensureTickRegistration` / `removeTickRegistration` — 生成/刷新 tick runner 并写系统级任务
 3. `app.setLoginItemSettings({ openAtLogin, args: ['--background'] })` — macOS/Windows 登录项（`autostart`）
 4. `PATCH /api/schedule/settings` — 回写 `os_tick_status` / `os_tick_error`
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -133,7 +133,7 @@ Electron 官方建议 Windows 用 **多尺寸 `.ico`**（至少含上表 small �
 3. **合成 `.icns`（macOS 应用图标，不是托盘）**  
    - 托盘用 `trayTemplate*.png` 即可，**不需要** `.icns`；  
    - Dock / DMG 应用图标：PNG → `iconutil`（`prepare-icons.mjs` 在 macOS 上会生成 `build/icons/icon.icns`），或 Icon Slate 等插件。  
-   - mac App 使用 Icon Composer（`build.mac.icon` → `icon.icon`）；afterPack 再用完整 `build/icons/icon.icns` 覆盖 bundle 内 `Resources/icon.icns`，供通知中心等读取。
+   - mac App 使用 Icon Composer（`build.mac.icon` → `icon.icon`）；afterPack 用完整 `build/icons/icon.icns` 覆盖 bundle 内 `Resources/icon.icns`，并去掉 Info.plist 的 `CFBundleIconName`（否则通知中心优先读 Assets.car，仍显示 Composer 旧图）。
 
 > 「hdi」一般指 **`.icns`**（Apple icon 容器）。托盘请继续交 PNG Template；`.icns` 只用于 App / DMG 图标。
 
@@ -285,7 +285,7 @@ Renderer：若展示返回失败且权限为 `denied`，聊天页温和提示一
 | 平台 | 注意 |
 |------|------|
 | **Windows** | `configureNotificationIdentity(appId)` → `app.setAppUserModelId`（`package.json` `build.appId`），否则通知可能不归到本应用；toast 图标经 `Notification.icon` 指向 `prepare-icons` 产出的 `icon.ico` / logo PNG |
-| **macOS** | 需系统「通知」权限；启动时刷新权限状态；用户在系统设置中拒绝则无法展示，应用内会引导去开启；`Notification.icon` 无效，依赖 bundle `Resources/icon.icns`（afterPack 覆盖完整 icns） |
+| **macOS** | 需系统「通知」权限；启动时刷新权限状态；用户在系统设置中拒绝则无法展示，应用内会引导去开启；`Notification.icon` 无效，依赖 bundle `Resources/icon.icns`（afterPack 覆盖完整 icns，并移除 `CFBundleIconName` 以免走 Assets.car） |
 | **Linux** | 依赖桌面环境对 Electron `Notification` 的支持（`Notification.isSupported()`）；部分环境可能静默失败。toast 图标经 `Notification.icon` 指向 `build/icons/linux/*.png` 或 logo PNG；桌面入口图标仍用 `build.linux.icon` |
 
 单元测试：`tests/chat-notifications.test.mjs`（注意力、离开标记、builder、sanitize、macOS 权限映射）。

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -254,6 +254,7 @@ opptrix://chat?session={encodeURIComponent(sessionId)}
 | `notification-show` | `showLocalNotification(payload)` | 校验后展示；点击走 `onNotificationClick`；权限为 denied 时返回 `false` |
 | `window-is-focused` | `windowIsFocused()` | 主窗口是否 focused（注意力判断） |
 | `open-local-directory` | `openLocalDirectory(dirPath)` | 用系统文件管理器打开目录；路径须在 `resolveUserDataRoot()/agent-workspace` 之下，不存在则递归创建后再打开 |
+| `chat-debug-open-log-dir` | `chatDebugOpenLogDir()` | 打开（必要时先创建）`~/.opptrix/logs/chat-debug`；设置 → 关于「对话调试日志」写入按会话拆分的 JSONL |
 
 协议事件仍为 `opptrix-protocol`（`onProtocolOpen`），与通知点击深链共用。
 

--- a/packages/agent/src/chat-debug-log.ts
+++ b/packages/agent/src/chat-debug-log.ts
@@ -1,0 +1,173 @@
+/**
+ * 对话调试日志 — 可选 JSONL 落盘，便于排查无回复与断流。
+ * enabled=false 时早退；禁止写入 API Key / Authorization。
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import {
+  CHAT_DEBUG_LOGGING_KEY,
+  parseChatDebugLoggingSettings,
+  resolveUserDataRoot,
+} from '@opptrix/shared'
+import { getUserDataStore } from '@opptrix/user-store'
+
+const PREF_NS = 'preference'
+const MAX_FIELD_CHARS = 4096
+const ENABLED_CACHE_TTL_MS = 5_000
+/** 每 N 个 data 行采 1 个样本（含首条） */
+export const CHAT_DEBUG_SSE_SAMPLE_EVERY_N = 10
+/** 单轮最多保留的 SSE 样本数 */
+export const CHAT_DEBUG_SSE_MAX_SAMPLES = 20
+
+let cachedEnabled: { value: boolean; at: number } | null = null
+
+export function truncateForChatDebug(value: string, maxChars = MAX_FIELD_CHARS): string {
+  if (typeof value !== 'string') return ''
+  if (value.length <= maxChars) return value
+  return `${value.slice(0, maxChars)}…[+${value.length - maxChars}]`
+}
+
+export function resetChatDebugLogCacheForTests(): void {
+  cachedEnabled = null
+}
+
+export function isChatDebugLoggingEnabled(): boolean {
+  const now = Date.now()
+  if (cachedEnabled && now - cachedEnabled.at < ENABLED_CACHE_TTL_MS) {
+    return cachedEnabled.value
+  }
+  let enabled = false
+  try {
+    const raw = getUserDataStore().getDocument(PREF_NS, CHAT_DEBUG_LOGGING_KEY)
+    enabled = parseChatDebugLoggingSettings(raw).enabled
+  } catch {
+    enabled = false
+  }
+  cachedEnabled = { value: enabled, at: now }
+  return enabled
+}
+
+export function resolveChatDebugLogDir(): string {
+  return path.join(resolveUserDataRoot(), 'logs', 'chat-debug')
+}
+
+function safeSessionFileName(sessionId: string): string {
+  const cleaned = sessionId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 128)
+  return cleaned || 'unknown'
+}
+
+export function resolveChatDebugLogPath(sessionId: string): string {
+  return path.join(resolveChatDebugLogDir(), `${safeSessionFileName(sessionId)}.jsonl`)
+}
+
+function appendJsonl(sessionId: string, event: Record<string, unknown>): void {
+  if (!sessionId || !isChatDebugLoggingEnabled()) return
+  try {
+    const dir = resolveChatDebugLogDir()
+    fs.mkdirSync(dir, { recursive: true })
+    const line = JSON.stringify({
+      ts: new Date().toISOString(),
+      sessionId,
+      ...event,
+    })
+    fs.appendFileSync(resolveChatDebugLogPath(sessionId), `${line}\n`, 'utf8')
+  } catch {
+    // 日志失败不影响对话主路径
+  }
+}
+
+export function logChatDebugRoundStart(
+  sessionId: string,
+  payload: { round: number; model: string },
+): void {
+  appendJsonl(sessionId, {
+    event: 'round_start',
+    round: payload.round,
+    model: payload.model,
+  })
+}
+
+export function logChatDebugSseChunkSample(
+  sessionId: string,
+  payload: { sampleIndex: number; truncatedPayload: string; contentLenSoFar: number },
+): void {
+  appendJsonl(sessionId, {
+    event: 'sse_chunk_sample',
+    sampleIndex: payload.sampleIndex,
+    truncatedPayload: truncateForChatDebug(payload.truncatedPayload),
+    contentLenSoFar: payload.contentLenSoFar,
+  })
+}
+
+export function logChatDebugRoundEnd(
+  sessionId: string,
+  payload: {
+    finishReason: string
+    contentLen: number
+    toolCallNames?: string[]
+    usage?: { promptTokens?: number; completionTokens?: number; totalTokens?: number }
+  },
+): void {
+  appendJsonl(sessionId, {
+    event: 'round_end',
+    finishReason: payload.finishReason,
+    contentLen: payload.contentLen,
+    ...(payload.toolCallNames?.length ? { toolCallNames: payload.toolCallNames } : {}),
+    ...(payload.usage ? { usage: payload.usage } : {}),
+  })
+}
+
+export function logChatDebugEmptyReply(
+  sessionId: string,
+  payload?: { round?: number },
+): void {
+  appendJsonl(sessionId, {
+    event: 'empty_reply',
+    ...(payload?.round != null ? { round: payload.round } : {}),
+  })
+}
+
+export function logChatDebugAbort(
+  sessionId: string,
+  payload?: { reason?: string },
+): void {
+  appendJsonl(sessionId, {
+    event: 'abort',
+    ...(payload?.reason ? { reason: payload.reason } : {}),
+  })
+}
+
+export function logChatDebugHttpError(
+  sessionId: string,
+  payload: { status: number; bodyTruncated: string },
+): void {
+  appendJsonl(sessionId, {
+    event: 'http_error',
+    status: payload.status,
+    bodyTruncated: truncateForChatDebug(payload.bodyTruncated),
+  })
+}
+
+/** SSE 采样器：enabled=false 时 next() 几乎零开销 */
+export function createSseChunkSampler(sessionId: string | undefined): {
+  onDataPayload: (payload: string, contentLenSoFar: number) => void
+} {
+  if (!sessionId || !isChatDebugLoggingEnabled()) {
+    return { onDataPayload: () => {} }
+  }
+  let chunkIndex = 0
+  let sampleIndex = 0
+  return {
+    onDataPayload(payload: string, contentLenSoFar: number) {
+      chunkIndex += 1
+      if (sampleIndex >= CHAT_DEBUG_SSE_MAX_SAMPLES) return
+      if (chunkIndex !== 1 && chunkIndex % CHAT_DEBUG_SSE_SAMPLE_EVERY_N !== 0) return
+      logChatDebugSseChunkSample(sessionId, {
+        sampleIndex,
+        truncatedPayload: payload,
+        contentLenSoFar,
+      })
+      sampleIndex += 1
+    },
+  }
+}

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -33,6 +33,12 @@ import {
 } from './mcp/tool-route-plan.js'
 import { buildSessionClockPlaybook, parseNamespacedMcpTool } from '@opptrix/shared'
 import {
+  logChatDebugAbort,
+  logChatDebugEmptyReply,
+  logChatDebugRoundEnd,
+  logChatDebugRoundStart,
+} from './chat-debug-log.js'
+import {
   applySessionLanAskChoice,
   getWorkspaceService,
 } from '@opptrix/agent-workspace'
@@ -1037,6 +1043,7 @@ export class AgentEngine {
     }
 
     const finalizeCancelled = (partialTools: string[], partialSteps: ChatToolStep[]): ChatResult => {
+      logChatDebugAbort(sessionId, { reason: 'cancelled' })
       this.userPromptBridge.cancelSession(sessionId)
       record!.messages = record!.messages.slice(0, messagesBeforeAssistant)
       if (record!.turns) {
@@ -1094,6 +1101,8 @@ export class AgentEngine {
         ?? activeModel?.replace(/^[^:]+:/, '')
         ?? 'default'
       const providerId = providerIdFromModelRef(activeModel)
+
+      logChatDebugRoundStart(sessionId, { round: round + 1, model: activeModel || modelId })
 
       let overflowRetried = false
       let lastRoundEstimatedTokens: number | undefined
@@ -1191,14 +1200,28 @@ export class AgentEngine {
         throwIfAborted(signal)
       }
 
+      const turnContentText = chatMessageContentToText(turn.message.content)
+      logChatDebugRoundEnd(sessionId, {
+        finishReason: turn.finishReason,
+        contentLen: turnContentText.length,
+        toolCallNames: turn.message.tool_calls?.map(tc => tc.function.name).filter(Boolean),
+        usage: turn.usage
+          ? {
+              promptTokens: turn.usage.promptTokens,
+              completionTokens: turn.usage.completionTokens,
+              totalTokens: turn.usage.totalTokens,
+            }
+          : undefined,
+      })
+
       if (turn.finishReason === 'error') {
         if (turn.error === 'cancelled' || signal?.aborted) {
           return finalizeCancelled(toolsUsed, toolSteps)
         }
-        const overflow = turn.contextOverflow || isContextOverflowError(turn.error, chatMessageContentToText(turn.message.content))
+        const overflow = turn.contextOverflow || isContextOverflowError(turn.error, turnContentText)
         const reply = overflow
           ? '对话内容过多，整理后仍无法继续。请新开对话，或换用更大上下文窗口的模型。'
-          : (chatMessageContentToText(turn.message.content) || turn.error || '请求失败')
+          : (turnContentText || turn.error || '请求失败')
         pushAssistant(reply, toolsUsed, toolSteps, chatUsage.usage.totalTokens > 0 ? chatUsage.usage : undefined, chatUsage.estimated)
         emit({
           type: 'error',
@@ -1209,7 +1232,7 @@ export class AgentEngine {
       }
 
       if (turn.finishReason === 'tool_calls' && turn.message.tool_calls?.length) {
-        const thinkingSnippet = chatMessageContentToText(turn.message.content).trim()
+        const thinkingSnippet = turnContentText.trim()
         if (thinkingSnippet) {
           emit({
             type: 'thinking',
@@ -1223,7 +1246,7 @@ export class AgentEngine {
 
         record.messages.push({
           role: 'assistant',
-          content: chatMessageContentToText(turn.message.content) || null,
+          content: turnContentText || null,
           tool_calls: turn.message.tool_calls,
         })
         this.sessions.save(record)
@@ -1337,7 +1360,12 @@ export class AgentEngine {
         continue
       }
 
-      const reply = chatMessageContentToText(turn.message.content).trim() || '（无回复内容）'
+      const replyRaw = turnContentText.trim()
+      const isEmptyReply = !replyRaw || replyRaw === '（无回复内容）'
+      const reply = replyRaw || '（无回复内容）'
+      if (isEmptyReply) {
+        logChatDebugEmptyReply(sessionId, { round: round + 1 })
+      }
       const outputAttachments = turn.outputAttachments
       emit({
         type: 'reply',

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -6,6 +6,12 @@ import {
   sanitizeMessagesForModelMedia,
 } from '../content-parts.js'
 import { resolveModelMediaCapabilitiesAsync } from './models-dev-context.js'
+import {
+  createSseChunkSampler,
+  logChatDebugAbort,
+  logChatDebugHttpError,
+  truncateForChatDebug,
+} from '../chat-debug-log.js'
 
 export interface LlmConfig {
   provider: string
@@ -235,6 +241,7 @@ async function consumeChatCompletionSse(
   let usage: TokenUsage | undefined
   let sawToolCalls = false
   const toolCallsByIndex = new Map<number, ToolCall>()
+  const sseSampler = createSseChunkSampler(opts?.sessionId)
 
   const mergeToolCallDelta = (delta: {
     index?: number
@@ -272,6 +279,8 @@ async function consumeChatCompletionSse(
         const payload = line.slice(5).trim()
         if (!payload) continue
         if (payload === '[DONE]') continue
+
+        sseSampler.onDataPayload(payload, content.length)
 
         let parsed: {
           usage?: unknown
@@ -428,6 +437,21 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       return turnFromAssistantMessage(raw, usage, opts?.sessionId)
     }
 
+    const noteHttpError = (status: number, bodyText: string) => {
+      if (opts?.sessionId) {
+        logChatDebugHttpError(opts.sessionId, {
+          status,
+          bodyTruncated: truncateForChatDebug(bodyText),
+        })
+      }
+    }
+
+    const noteAbort = () => {
+      if (opts?.sessionId) {
+        logChatDebugAbort(opts.sessionId, { reason: 'cancelled' })
+      }
+    }
+
     try {
       if (opts?.onDelta) {
         let streamConsumeStarted = false
@@ -439,16 +463,21 @@ export class OpenAiCompatibleProvider implements LlmProvider {
             if (streamResp.status === 400 || streamResp.status === 422) {
               const fallback = await post(false)
               if (!fallback.ok) {
-                return httpErrorTurn(fallback.status, (await fallback.text()).slice(0, 300))
+                const fbText = (await fallback.text()).slice(0, 300)
+                noteHttpError(fallback.status, fbText)
+                return httpErrorTurn(fallback.status, fbText)
               }
               return await parseJsonTurn(fallback)
             }
+            noteHttpError(streamResp.status, text)
             return httpErrorTurn(streamResp.status, text)
           }
           if (!streamResp.body) {
             const fallback = await post(false)
             if (!fallback.ok) {
-              return httpErrorTurn(fallback.status, (await fallback.text()).slice(0, 300))
+              const fbText = (await fallback.text()).slice(0, 300)
+              noteHttpError(fallback.status, fbText)
+              return httpErrorTurn(fallback.status, fbText)
             }
             return await parseJsonTurn(fallback)
           }
@@ -456,6 +485,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
           return await consumeChatCompletionSse(streamResp, opts)
         } catch (streamErr) {
           if (signal?.aborted) {
+            noteAbort()
             const msg = '已取消'
             return { message: { role: 'assistant', content: msg }, finishReason: 'error', error: 'cancelled' }
           }
@@ -463,7 +493,9 @@ export class OpenAiCompatibleProvider implements LlmProvider {
           if (!streamConsumeStarted) {
             const fallback = await post(false)
             if (!fallback.ok) {
-              return httpErrorTurn(fallback.status, (await fallback.text()).slice(0, 300))
+              const fbText = (await fallback.text()).slice(0, 300)
+              noteHttpError(fallback.status, fbText)
+              return httpErrorTurn(fallback.status, fbText)
             }
             return await parseJsonTurn(fallback)
           }
@@ -473,11 +505,14 @@ export class OpenAiCompatibleProvider implements LlmProvider {
 
       const resp = await post(false)
       if (!resp.ok) {
-        return httpErrorTurn(resp.status, (await resp.text()).slice(0, 300))
+        const text = (await resp.text()).slice(0, 300)
+        noteHttpError(resp.status, text)
+        return httpErrorTurn(resp.status, text)
       }
       return await parseJsonTurn(resp)
     } catch (e) {
       if (signal?.aborted) {
+        noteAbort()
         const msg = '已取消'
         return { message: { role: 'assistant', content: msg }, finishReason: 'error', error: 'cancelled' }
       }

--- a/packages/shared/src/chat-debug-settings.ts
+++ b/packages/shared/src/chat-debug-settings.ts
@@ -1,0 +1,21 @@
+/** Preference key：对话调试日志开关（user-store `preference` / `chat_debug_logging`） */
+export const CHAT_DEBUG_LOGGING_KEY = 'chat_debug_logging'
+
+export interface ChatDebugLoggingSettings {
+  enabled: boolean
+}
+
+export const DEFAULT_CHAT_DEBUG_LOGGING: ChatDebugLoggingSettings = {
+  enabled: false,
+}
+
+export function parseChatDebugLoggingSettings(
+  raw: unknown,
+): ChatDebugLoggingSettings {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_CHAT_DEBUG_LOGGING }
+  }
+  return {
+    enabled: (raw as { enabled?: unknown }).enabled === true,
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -30,6 +30,7 @@ export * from './provider-priority-order.js'
 export * from './free-provider-throttle.js'
 export * from './mcp-servers.js'
 export * from './onboarding.js'
+export * from './chat-debug-settings.js'
 export {
   initOutboundNetwork,
   getOutboundNetworkStatus,

--- a/tests/chat-debug-log.test.mjs
+++ b/tests/chat-debug-log.test.mjs
@@ -1,0 +1,79 @@
+/**
+ * 对话调试日志 — truncate / parse / 默认关闭 / 落盘
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  CHAT_DEBUG_LOGGING_KEY,
+  DEFAULT_CHAT_DEBUG_LOGGING,
+  parseChatDebugLoggingSettings,
+} from '../packages/shared/dist/chat-debug-settings.js'
+import { getUserDataStore } from '../packages/user-store/dist/index.js'
+import {
+  isChatDebugLoggingEnabled,
+  logChatDebugRoundStart,
+  resetChatDebugLogCacheForTests,
+  resolveChatDebugLogPath,
+  truncateForChatDebug,
+} from '../packages/agent/dist/chat-debug-log.js'
+
+function withTempStore(fn) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-chat-debug-'))
+  const prev = process.env.OPPTRIX_DATA_DIR
+  process.env.OPPTRIX_DATA_DIR = tmp
+  getUserDataStore().close()
+  resetChatDebugLogCacheForTests()
+  return fn(tmp).finally(() => {
+    resetChatDebugLogCacheForTests()
+    getUserDataStore().close()
+    fs.rmSync(tmp, { recursive: true, force: true })
+    if (prev == null) delete process.env.OPPTRIX_DATA_DIR
+    else process.env.OPPTRIX_DATA_DIR = prev
+  })
+}
+
+test('parseChatDebugLoggingSettings defaults to disabled', () => {
+  assert.deepEqual(parseChatDebugLoggingSettings(null), DEFAULT_CHAT_DEBUG_LOGGING)
+  assert.deepEqual(parseChatDebugLoggingSettings(undefined), { enabled: false })
+  assert.deepEqual(parseChatDebugLoggingSettings({}), { enabled: false })
+  assert.deepEqual(parseChatDebugLoggingSettings({ enabled: false }), { enabled: false })
+  assert.deepEqual(parseChatDebugLoggingSettings({ enabled: true }), { enabled: true })
+  assert.deepEqual(parseChatDebugLoggingSettings({ enabled: 'yes' }), { enabled: false })
+  assert.equal(CHAT_DEBUG_LOGGING_KEY, 'chat_debug_logging')
+})
+
+test('truncateForChatDebug caps long strings', () => {
+  assert.equal(truncateForChatDebug('short'), 'short')
+  const long = 'x'.repeat(5000)
+  const out = truncateForChatDebug(long, 4096)
+  assert.ok(out.startsWith('x'.repeat(4096)))
+  assert.match(out, /\…\[\+\d+\]$/)
+  assert.ok(out.length < long.length)
+})
+
+test('isChatDebugLoggingEnabled defaults false and writes only when enabled', async () => {
+  await withTempStore(async () => {
+    assert.equal(isChatDebugLoggingEnabled(), false)
+    logChatDebugRoundStart('sess-a', { round: 1, model: 'test:model' })
+    assert.equal(fs.existsSync(resolveChatDebugLogPath('sess-a')), false)
+
+    getUserDataStore().setDocument('preference', CHAT_DEBUG_LOGGING_KEY, { enabled: true })
+    resetChatDebugLogCacheForTests()
+    assert.equal(isChatDebugLoggingEnabled(), true)
+
+    logChatDebugRoundStart('sess-a', { round: 1, model: 'test:model' })
+    const logPath = resolveChatDebugLogPath('sess-a')
+    assert.equal(fs.existsSync(logPath), true)
+    const line = fs.readFileSync(logPath, 'utf8').trim()
+    const parsed = JSON.parse(line)
+    assert.equal(parsed.event, 'round_start')
+    assert.equal(parsed.sessionId, 'sess-a')
+    assert.equal(parsed.model, 'test:model')
+    assert.equal(parsed.round, 1)
+    assert.ok(!JSON.stringify(parsed).toLowerCase().includes('authorization'))
+    assert.ok(!Object.keys(parsed).some(k => /api.?key|token|authorization/i.test(k)))
+  })
+})

--- a/tests/os-schedule-tick-runner.test.mjs
+++ b/tests/os-schedule-tick-runner.test.mjs
@@ -1,0 +1,249 @@
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const {
+  ENDPOINT_FILENAME,
+  RUNNER_SH,
+  RUNNER_CMD,
+  endpointFilePath,
+  runnerScriptPath,
+  sanitizeEndpointHost,
+  writeOsScheduleEndpoint,
+  readOsScheduleEndpoint,
+  resolveColdStartArgv,
+  resolveHeadlessTickArgv,
+  defaultHeadlessTickPath,
+  buildBashRunnerScript,
+  buildCmdRunnerScript,
+  ensureOsScheduleTickRunner,
+  resolveOsTickInvocation,
+} = require('../apps/desktop/electron/os-schedule/tick-runner.cjs')
+const {
+  resolveResourcesPathFromExec,
+  resolvePackagedRuntimeStage,
+  buildSidecarEnv,
+  serverEntryPath,
+} = require('../apps/desktop/electron/os-schedule/sidecar-launch.cjs')
+
+const HEADLESS = defaultHeadlessTickPath()
+
+describe('os-schedule tick-runner', () => {
+  /** @type {string} */
+  let tmpDir
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-tick-runner-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('sanitizeEndpointHost forces loopback', () => {
+    assert.equal(sanitizeEndpointHost('127.0.0.1'), '127.0.0.1')
+    assert.equal(sanitizeEndpointHost('localhost'), '127.0.0.1')
+    assert.equal(sanitizeEndpointHost('evil.example'), '127.0.0.1')
+    assert.equal(sanitizeEndpointHost(''), '127.0.0.1')
+  })
+
+  it('writeOsScheduleEndpoint writes host/port/execPath/headlessTick (no secrets)', () => {
+    const execPath = '/Applications/Opptrix.app/Contents/MacOS/Opptrix'
+    const written = writeOsScheduleEndpoint(tmpDir, {
+      host: '0.0.0.0',
+      port: 8712,
+      execPath,
+      headlessTick: HEADLESS,
+    })
+    assert.equal(written.host, '127.0.0.1')
+    assert.equal(written.port, '8712')
+    assert.equal(written.execPath, execPath)
+    assert.equal(written.headlessTick, HEADLESS)
+
+    const file = endpointFilePath(tmpDir)
+    assert.equal(path.basename(file), ENDPOINT_FILENAME)
+    const raw = fs.readFileSync(file, 'utf8')
+    assert.ok(!/token|secret|key|password/i.test(raw))
+    assert.deepEqual(JSON.parse(raw), {
+      host: '127.0.0.1',
+      port: '8712',
+      execPath,
+      headlessTick: HEADLESS,
+    })
+    assert.deepEqual(readOsScheduleEndpoint(tmpDir), {
+      host: '127.0.0.1',
+      port: '8712',
+      execPath,
+      headlessTick: HEADLESS,
+    })
+  })
+
+  it('resolveHeadlessTickArgv is ELECTRON_RUN_AS_NODE pair (no --schedule-tick)', () => {
+    const packaged = resolveHeadlessTickArgv({
+      execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      headlessTickPath: HEADLESS,
+    })
+    assert.deepEqual(packaged, [
+      '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      HEADLESS,
+    ])
+    assert.ok(!packaged.includes('--schedule-tick'))
+    assert.ok(!packaged.includes('--background'))
+
+    // resolveColdStartArgv aliases to headless argv
+    assert.deepEqual(
+      resolveColdStartArgv({
+        isPackaged: true,
+        execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+        mainCjsPath: '/ignored/main.cjs',
+        headlessTickPath: HEADLESS,
+      }),
+      packaged,
+    )
+  })
+
+  it('bash runner is HTTP-first then ELECTRON_RUN_AS_NODE headless-tick', () => {
+    const endpoint = path.join(tmpDir, ENDPOINT_FILENAME)
+    const execPath = '/Applications/Opptrix.app/Contents/MacOS/Opptrix'
+    const script = buildBashRunnerScript({
+      endpointFile: endpoint,
+      coldStartArgv: [execPath, HEADLESS],
+    })
+    assert.match(script, /^#!\/bin\/bash/)
+    assert.match(script, /\bcurl\b/)
+    assert.match(script, /\/api\/schedule\/tick/)
+    assert.match(script, /\{"trigger":"os"\}/)
+    assert.match(script, /export ELECTRON_RUN_AS_NODE=1/)
+    assert.match(script, /export OPPTRIX_OS_SCHEDULE_ENDPOINT=/)
+    assert.match(script, /exec "\$EXEC" "\$HEADLESS_TICK"/)
+    assert.doesNotMatch(script, /--schedule-tick/)
+    assert.doesNotMatch(script, /--background/)
+    assert.ok(script.includes(HEADLESS) || script.includes('HEADLESS_TICK'))
+    assert.ok(script.indexOf('curl') < script.indexOf('export ELECTRON_RUN_AS_NODE'))
+    assert.ok(script.indexOf('export ELECTRON_RUN_AS_NODE') < script.indexOf('exec "$EXEC"'))
+  })
+
+  it('cmd runner is HTTP-first then ELECTRON_RUN_AS_NODE headless-tick', () => {
+    const endpoint = path.join(tmpDir, ENDPOINT_FILENAME)
+    const script = buildCmdRunnerScript({
+      endpointFile: endpoint,
+      coldStartArgv: ['C:\\Opptrix\\Opptrix.exe', 'C:\\Opptrix\\headless-tick.cjs'],
+    })
+    assert.match(script, /curl\.exe .*\/api\/schedule\/tick/)
+    assert.match(script, /set ELECTRON_RUN_AS_NODE=1/)
+    assert.match(script, /OPPTRIX_OS_SCHEDULE_ENDPOINT/)
+    assert.match(script, /"%EXEC%" "%HEADLESS_TICK%"/)
+    assert.doesNotMatch(script, /--schedule-tick/)
+    assert.doesNotMatch(script, /--background/)
+    assert.ok(script.indexOf('curl.exe') < script.indexOf('ELECTRON_RUN_AS_NODE'))
+  })
+
+  it('ensureOsScheduleTickRunner writes endpoint + headless fallback (no GUI flags)', () => {
+    const result = ensureOsScheduleTickRunner({
+      userDataDir: tmpDir,
+      isPackaged: true,
+      execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      headlessTickPath: HEADLESS,
+      platform: 'darwin',
+      defaultPort: '8711',
+    })
+    assert.equal(result.scriptPath, runnerScriptPath(tmpDir, 'darwin'))
+    assert.equal(path.basename(result.scriptPath), RUNNER_SH)
+    assert.ok(fs.existsSync(result.scriptPath))
+    assert.ok(fs.existsSync(result.endpointFile))
+    const ep = readOsScheduleEndpoint(tmpDir)
+    assert.equal(ep?.execPath, '/Applications/Opptrix.app/Contents/MacOS/Opptrix')
+    assert.equal(ep?.headlessTick, HEADLESS)
+    const body = fs.readFileSync(result.scriptPath, 'utf8')
+    assert.match(body, /\/api\/schedule\/tick/)
+    assert.match(body, /ELECTRON_RUN_AS_NODE=1/)
+    assert.doesNotMatch(body, /--schedule-tick/)
+    const mode = fs.statSync(result.scriptPath).mode & 0o111
+    assert.ok(mode !== 0, 'runner should be executable')
+  })
+
+  it('ensureOsScheduleTickRunner writes .cmd on win32', () => {
+    const result = ensureOsScheduleTickRunner({
+      userDataDir: tmpDir,
+      isPackaged: true,
+      execPath: 'C:\\Opptrix\\Opptrix.exe',
+      headlessTickPath: 'C:\\Opptrix\\headless-tick.cjs',
+      platform: 'win32',
+    })
+    assert.equal(path.basename(result.scriptPath), RUNNER_CMD)
+    assert.ok(fs.existsSync(result.scriptPath))
+    const body = fs.readFileSync(result.scriptPath, 'utf8')
+    assert.match(body, /curl\.exe/)
+    assert.match(body, /ELECTRON_RUN_AS_NODE=1/)
+    assert.doesNotMatch(body, /--schedule-tick/)
+  })
+
+  it('resolveOsTickInvocation uses bash+runner on darwin/linux and cmd on win32', () => {
+    const darwin = resolveOsTickInvocation({
+      userDataDir: tmpDir,
+      isPackaged: true,
+      execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      headlessTickPath: HEADLESS,
+      platform: 'darwin',
+    })
+    assert.deepEqual(darwin.programArguments, ['/bin/bash', darwin.scriptPath])
+    assert.ok(!darwin.programArguments.some((a) => a.includes('Opptrix.app/Contents/MacOS')))
+
+    const linux = resolveOsTickInvocation({
+      userDataDir: tmpDir,
+      isPackaged: false,
+      execPath: '/usr/bin/electron',
+      headlessTickPath: HEADLESS,
+      platform: 'linux',
+    })
+    assert.match(linux.execStart, /^\/bin\/bash /)
+    assert.ok(linux.execStart.includes(linux.scriptPath))
+
+    const win = resolveOsTickInvocation({
+      userDataDir: tmpDir,
+      isPackaged: true,
+      execPath: 'C:\\Opptrix\\Opptrix.exe',
+      headlessTickPath: 'C:\\Opptrix\\headless-tick.cjs',
+      platform: 'win32',
+    })
+    assert.equal(win.programArguments.length, 1)
+    assert.equal(win.programArguments[0], win.scriptPath)
+    assert.match(win.taskRun, /\.cmd"/)
+  })
+})
+
+describe('os-schedule sidecar-launch helpers', () => {
+  it('resolveResourcesPathFromExec / resolvePackagedRuntimeStage for macOS app bundle', () => {
+    const exec = '/Applications/Opptrix.app/Contents/MacOS/Opptrix'
+    const resources = resolveResourcesPathFromExec(exec)
+    assert.equal(resources, '/Applications/Opptrix.app/Contents/Resources')
+    assert.equal(
+      resolvePackagedRuntimeStage(exec),
+      '/Applications/Opptrix.app/Contents/Resources/runtime-stage',
+    )
+  })
+
+  it('buildSidecarEnv packaged forces loopback host + ELECTRON_RUN_AS_NODE', () => {
+    const root = '/tmp/fake-runtime-stage'
+    const env = buildSidecarEnv({
+      root,
+      host: '0.0.0.0',
+      port: 8712,
+      resourcesPath: '/tmp/fake-resources',
+      isDev: false,
+      version: '0.0.0-test',
+      baseEnv: {},
+    })
+    assert.equal(env.STOCK_RESEARCH_HOST, '127.0.0.1')
+    assert.equal(env.STOCK_RESEARCH_PORT, '8712')
+    assert.equal(env.ELECTRON_RUN_AS_NODE, '1')
+    assert.equal(env.OPPTRIX_RUNTIME_STAGE, root)
+    assert.equal(env.OPPTRIX_APP_VERSION, '0.0.0-test')
+    assert.equal(env.UI_DIST_PATH, path.join(root, 'client-ui/dist'))
+    assert.equal(serverEntryPath(root), path.join(root, 'apps/server/dist/index.js'))
+  })
+})


### PR DESCRIPTION
## Summary
- Run OS schedule ticks via HTTP-first / headless sidecar instead of launching GUI Electron (fixes Dock flash when Opptrix is already open).
- After packing macOS apps, strip `CFBundleIconName` so Notification Center uses the restored brand `icon.icns`.
- Add optional chat debug logging (Settings → About) that writes truncated SSE samples and empty_reply markers under `~/.opptrix/logs/chat-debug`.

## Test plan
- [x] `node --test tests/os-schedule-tick-runner.test.mjs`
- [x] `node --test --test-force-exit tests/chat-debug-log.test.mjs`
- [x] `npm run check:ui` (About settings)
- [ ] Install build with OS tick fix → LaunchAgent ProgramArguments no longer point at Opptrix GUI
- [ ] Enable chat debug → reproduce empty reply → confirm jsonl samples


Made with [Cursor](https://cursor.com)