### PR TITLE
fix(onboarding): align data-source steps with settings provider UI

### DIFF
--- a/client-ui/src/onboarding/OnboardingDataList.tsx
+++ b/client-ui/src/onboarding/OnboardingDataList.tsx
@@ -1,250 +1,32 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Switch, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
-import { ChevronDownRegular, ChevronRightRegular } from '@fluentui/react-icons'
-import type { ProviderCatalogResponse, PublicProviderRuntime } from '../types/provider'
-import { getProviderCatalog, saveProviderConfig } from '../api/client'
-import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
-import { SettingsListPanelSkeleton } from '../pages/settings/SettingsListPanelSkeleton'
-import { ProviderSettingsForm, isExpandableSettingsField } from '../pages/settings/ProviderSettingsForm'
-import { useSettingsToast } from '../pages/settings/SettingsToast'
+import { Text } from '@fluentui/react-components'
+import type { ProviderCatalogResponse } from '../types/provider'
+import {
+  ProviderCatalogListPanel,
+  ProviderCatalogLoading,
+  useProviderCatalog,
+} from '../pages/settings/ProviderSettingsCatalog'
+import { opptrixCssVars } from '../theme/tokens'
+import { TONGHUASHUN_PROVIDER_ID } from './OnboardingFuyaoPanel'
 
-const useStyles = makeStyles({
-  root: {
-    width: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    borderRadius: opptrixTokens.radiusMd,
-    border: `1px solid ${opptrixCssVars.border}`,
-    backgroundColor: opptrixCssVars.surface,
-    overflow: 'hidden',
-  },
-  head: {
-    padding: '10px 14px',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    fontSize: 'var(--opptrix-font-md)',
-    color: opptrixCssVars.textTertiary,
-    lineHeight: 1.45,
-  },
-  scroll: {
-    maxHeight: 'min(40vh, 300px)',
-    overflowY: 'auto',
-  },
-  row: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '8px',
-    padding: '10px 14px',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': {
-      borderBottom: 'none',
-    },
-  },
-  rowExpanded: {
-    paddingBottom: '12px',
-  },
-  rowTop: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: '12px',
-    width: '100%',
-  },
-  rowMain: {
-    flex: 1,
-    minWidth: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '6px',
-  },
-  rowMainTop: {
-    display: 'flex',
-    alignItems: 'baseline',
-    flexWrap: 'wrap',
-    gap: '4px 8px',
-  },
-  rowTitle: {
-    fontSize: 'var(--opptrix-font-base)',
-    fontWeight: 600,
-    color: opptrixCssVars.textPrimary,
-    lineHeight: 1.35,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  rowMeta: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
-    lineHeight: 1.4,
-  },
-  enabled: {
-    color: opptrixCssVars.accent,
-    fontWeight: 500,
-  },
-  expandToggle: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: '4px',
-    padding: 0,
-    border: 'none',
-    background: 'none',
-    cursor: 'pointer',
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.accent,
-    lineHeight: 1.35,
-    ':hover': {
-      textDecoration: 'underline',
-    },
-  },
-  credentialExpand: {
-    width: '100%',
-    maxWidth: '100%',
-    boxSizing: 'border-box',
-    overflow: 'hidden',
-    paddingLeft: '2px',
-  },
-})
-
-function onboardingProviderStatus(provider: PublicProviderRuntime, marketLabel: string): string {
-  const parts: string[] = [marketLabel]
-  if (provider.enabled) {
-    parts.push('已启用')
-    return parts.join(' · ')
+/** Hide tonghuashun in data step — configured separately in the fuyao step. */
+function catalogWithoutTonghuashun(catalog: ProviderCatalogResponse): ProviderCatalogResponse {
+  const keep = (id: string) => id !== TONGHUASHUN_PROVIDER_ID
+  return {
+    groups: catalog.groups
+      .map(g => ({
+        ...g,
+        providers: g.providers.filter(p => keep(p.providerId)),
+      }))
+      .filter(g => g.providers.length > 0),
+    providers: (catalog.providers ?? []).filter(p => keep(p.providerId)),
   }
-
-  const requiredSecrets = provider.settingsFields.filter(f => f.type === 'secret' && f.required)
-  if (requiredSecrets.length) {
-    const configured = requiredSecrets.filter(f => provider.secretsConfigured[f.key]).length
-    if (configured === requiredSecrets.length) {
-      parts.push('密钥已填写，可启用')
-    } else {
-      parts.push('需填写数据密钥')
-    }
-    return parts.join(' · ')
-  }
-
-  if (provider.settingsFields.some(f => f.type === 'secret')) {
-    const anySecret = provider.settingsFields.some(
-      f => f.type === 'secret' && provider.secretsConfigured[f.key],
-    )
-    parts.push(anySecret ? '密钥已填写，可启用' : '需填写数据密钥')
-    return parts.join(' · ')
-  }
-
-  if (!provider.canEnable) {
-    parts.push('需完成配置后可启用')
-    return parts.join(' · ')
-  }
-
-  parts.push('未启用')
-  return parts.join(' · ')
-}
-
-function ProviderRow({
-  provider,
-  marketLabel,
-  onSaved,
-}: {
-  provider: PublicProviderRuntime
-  marketLabel: string
-  onSaved: () => void
-}) {
-  const s = useStyles()
-  const toast = useSettingsToast()
-  const hasSettings = provider.settingsFields.some(isExpandableSettingsField)
-  const needsConfig = !provider.canEnable && hasSettings
-  const [expanded, setExpanded] = useState(needsConfig)
-  const [toggling, setToggling] = useState(false)
-
-  useEffect(() => {
-    if (needsConfig) setExpanded(true)
-  }, [needsConfig])
-
-  const handleToggle = async (checked: boolean) => {
-    if (checked && !provider.canEnable) {
-      toast.showError('请先填写必填项后再启用')
-      if (hasSettings) setExpanded(true)
-      return
-    }
-    setToggling(true)
-    try {
-      await saveProviderConfig(provider.providerId, { enabled: checked })
-      toast.showSuccess(checked ? '已启用' : '已停用')
-      onSaved()
-    } catch (e) {
-      toast.showError(e instanceof Error ? e.message : '更新失败')
-    } finally {
-      setToggling(false)
-    }
-  }
-
-  const status = onboardingProviderStatus(provider, marketLabel)
-  const expandLabel = provider.requiresApiKey || provider.settingsFields.some(f => f.type === 'secret')
-    ? (expanded ? '收起' : '填写密钥')
-    : (expanded ? '收起' : '展开配置')
-
-  return (
-    <div className={mergeClasses(s.row, expanded && hasSettings && s.rowExpanded)}>
-      <div className={s.rowTop}>
-        <div className={s.rowMain}>
-          <div className={s.rowMainTop}>
-            <Text className={s.rowTitle} block title={provider.title}>{provider.title}</Text>
-            <Text className={mergeClasses(s.rowMeta, provider.enabled && s.enabled)} block>
-              {status}
-            </Text>
-            {hasSettings && (
-              <button
-                type="button"
-                className={mergeClasses(s.expandToggle, 'opptrix-focusable')}
-                aria-expanded={expanded}
-                onClick={() => setExpanded(v => !v)}
-              >
-                {expanded
-                  ? <ChevronDownRegular fontSize={11} />
-                  : <ChevronRightRegular fontSize={11} />}
-                <span>{expandLabel}</span>
-              </button>
-            )}
-          </div>
-          {expanded && hasSettings && (
-            <div className={s.credentialExpand}>
-              <ProviderSettingsForm provider={provider} onSaved={onSaved} />
-            </div>
-          )}
-        </div>
-        <Switch
-          checked={provider.enabled}
-          disabled={toggling || (!provider.enabled && !provider.canEnable)}
-          onChange={(_, d) => { void handleToggle(!!d.checked) }}
-          aria-label={`${provider.enabled ? '停用' : '启用'} ${provider.title}`}
-        />
-      </div>
-    </div>
-  )
 }
 
 export function OnboardingDataList() {
-  const s = useStyles()
-  const [catalog, setCatalog] = useState<ProviderCatalogResponse | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  const refresh = useCallback(async () => {
-    setLoading(true)
-    try {
-      const data = await getProviderCatalog()
-      setCatalog(data)
-    } catch {
-      setCatalog(null)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    void refresh()
-  }, [refresh])
+  const { catalog, loading, refresh } = useProviderCatalog()
 
   if (loading && !catalog) {
-    return <SettingsListPanelSkeleton />
+    return <ProviderCatalogLoading />
   }
 
   if (!catalog) {
@@ -255,28 +37,12 @@ export function OnboardingDataList() {
     )
   }
 
-  const rows = catalog.groups.flatMap(g =>
-    g.providers.map(p => ({ provider: p, marketLabel: g.label })),
-  )
-  const enabledCount = rows.filter(r => r.provider.enabled).length
-
   return (
-    <div className={s.root}>
-      <Text className={s.head} block>
-        {enabledCount > 0
-          ? `已启用 ${enabledCount} / ${rows.length} 个来源`
-          : `${rows.length} 个来源可供选择`}
-      </Text>
-      <div className={mergeClasses(s.scroll, 'opptrix-scroll')}>
-        {rows.map(({ provider, marketLabel }) => (
-          <ProviderRow
-            key={provider.providerId}
-            provider={provider}
-            marketLabel={marketLabel}
-            onSaved={() => { void refresh() }}
-          />
-        ))}
-      </div>
-    </div>
+    <ProviderCatalogListPanel
+      catalog={catalogWithoutTonghuashun(catalog)}
+      onSaved={() => { void refresh() }}
+      showInstalled={false}
+      panelHeight="min(40vh, 320px)"
+    />
   )
 }

--- a/client-ui/src/onboarding/OnboardingFuyaoPanel.tsx
+++ b/client-ui/src/onboarding/OnboardingFuyaoPanel.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Input, Spinner, Text, makeStyles } from '@fluentui/react-components'
+import { Spinner, Text, makeStyles } from '@fluentui/react-components'
 import { CheckmarkCircleRegular } from '@fluentui/react-icons'
-import { getProviderCatalog, saveProviderConfig, testProviderConfig } from '../api/client'
+import { getProviderCatalog } from '../api/client'
 import type { PublicProviderRuntime } from '../types/provider'
-import OpptrixField from '../components/opptrix/OpptrixField'
+import { ProviderSettingsForm } from '../pages/settings/ProviderSettingsForm'
 import { openExternalUrl } from '../platform/openUrl'
 import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
 import { ONBOARDING_COPY } from './manifest'
@@ -69,11 +69,6 @@ const useStyles = makeStyles({
     alignSelf: 'flex-start',
     fontSize: 'var(--opptrix-font-md)',
   },
-  error: {
-    fontSize: 'var(--opptrix-font-md)',
-    color: opptrixCssVars.error,
-    lineHeight: 1.45,
-  },
   loading: {
     display: 'flex',
     alignItems: 'center',
@@ -83,15 +78,34 @@ const useStyles = makeStyles({
   },
 })
 
+/** True when all required secret fields from settingsFields are configured. */
 export function isTonghuashunConfigured(provider: PublicProviderRuntime | null | undefined): boolean {
   if (!provider) return false
-  return provider.secretsConfigured.apiKey === true
+  const requiredSecrets = provider.settingsFields.filter(f => f.type === 'secret' && f.required)
+  if (requiredSecrets.length > 0) {
+    return requiredSecrets.every(f => provider.secretsConfigured[f.key] === true)
+  }
+  const secrets = provider.settingsFields.filter(f => f.type === 'secret')
+  if (secrets.length > 0) {
+    return secrets.every(f => provider.secretsConfigured[f.key] === true)
+  }
+  return provider.canEnable
+}
+
+function firstSecretPreview(provider: PublicProviderRuntime | null | undefined): string | undefined {
+  if (!provider?.secretPreviews) return undefined
+  const secretField = provider.settingsFields.find(f => f.type === 'secret')
+  if (!secretField) return undefined
+  const preview = provider.secretPreviews[secretField.key]
+  return preview?.trim() ? preview : undefined
 }
 
 function findTonghuashunProvider(
-  groups: { providers: PublicProviderRuntime[] }[],
+  catalog: { groups: { providers: PublicProviderRuntime[] }[]; providers?: PublicProviderRuntime[] },
 ): PublicProviderRuntime | null {
-  for (const group of groups) {
+  const fromFlat = catalog.providers?.find(p => p.providerId === TONGHUASHUN_PROVIDER_ID)
+  if (fromFlat) return fromFlat
+  for (const group of catalog.groups) {
     const hit = group.providers.find(p => p.providerId === TONGHUASHUN_PROVIDER_ID)
     if (hit) return hit
   }
@@ -105,6 +119,7 @@ export function OnboardingFuyaoReadyPanel({
 }) {
   const s = useStyles()
   const shell = useOnboardingShellStyles()
+  const preview = firstSecretPreview(provider)
 
   return (
     <>
@@ -120,9 +135,9 @@ export function OnboardingFuyaoReadyPanel({
             ? ONBOARDING_COPY.fuyao.readyEnabled
             : ONBOARDING_COPY.fuyao.readyDisabled}
         </Text>
-        {provider?.secretPreviews?.apiKey && (
+        {preview && (
           <Text className={s.hint} block>
-            当前密钥：{provider.secretPreviews.apiKey}
+            当前密钥：{preview}
           </Text>
         )}
       </div>
@@ -142,51 +157,46 @@ export function OnboardingFuyaoPanel({
   const s = useStyles()
   const shell = useOnboardingShellStyles()
   const [loading, setLoading] = useState(true)
-  const [apiKey, setApiKey] = useState('')
-  const [advancing, setAdvancing] = useState(false)
-  const [error, setError] = useState('')
+  const [provider, setProvider] = useState<PublicProviderRuntime | null>(null)
 
   const advanceImplRef = useRef<() => Promise<void>>(async () => {})
 
-  const runAdvance = useCallback(async () => {
-    const key = apiKey.trim()
-    if (!key) {
-      setError(ONBOARDING_COPY.fuyao.emptyKeyError)
-      return
-    }
-    setAdvancing(true)
-    setError('')
+  const refresh = useCallback(async () => {
     try {
-      const test = await testProviderConfig(TONGHUASHUN_PROVIDER_ID, { apiKey: key })
-      if (!test.data?.ok) {
-        setError(test.data?.message ?? ONBOARDING_COPY.fuyao.testFailedError)
-        return
-      }
-      await saveProviderConfig(TONGHUASHUN_PROVIDER_ID, {
-        enabled: true,
-        extra: { apiKey: key },
-      })
-      onConfigured()
-      onComplete()
-    } catch (e) {
-      setError(e instanceof Error ? e.message : '连接失败，请稍后重试')
+      const data = await getProviderCatalog()
+      const hit = findTonghuashunProvider(data)
+      setProvider(hit)
+      return hit
+    } catch {
+      setProvider(null)
+      return null
     } finally {
-      setAdvancing(false)
+      setLoading(false)
     }
-  }, [apiKey, onComplete, onConfigured])
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  const configured = isTonghuashunConfigured(provider)
+
+  const runAdvance = useCallback(async () => {
+    if (!isTonghuashunConfigured(provider)) return
+    onConfigured()
+    onComplete()
+  }, [provider, onComplete, onConfigured])
 
   advanceImplRef.current = runAdvance
 
-  const canAdvance = apiKey.trim().length > 0 && !advancing
-
   const reportNav = useCallback(() => {
     onNavChange({
-      canAdvance,
-      advancing,
-      advanceLabel: advancing ? '验证中…' : '继续',
+      canAdvance: configured,
+      advancing: false,
+      advanceLabel: '继续',
       advance: () => advanceImplRef.current(),
     })
-  }, [advancing, canAdvance, onNavChange])
+  }, [configured, onNavChange])
 
   useEffect(() => {
     reportNav()
@@ -194,23 +204,11 @@ export function OnboardingFuyaoPanel({
 
   useEffect(() => () => { onNavChange(null) }, [onNavChange])
 
-  useEffect(() => {
-    let cancelled = false
-    setLoading(true)
-    void getProviderCatalog()
-      .then(data => {
-        if (cancelled) return
-        const provider = findTonghuashunProvider(data.groups)
-        if (provider?.values.apiKey && typeof provider.values.apiKey === 'string') {
-          setApiKey(String(provider.values.apiKey))
-        }
-      })
-      .catch(() => { /* keep empty */ })
-      .finally(() => {
-        if (!cancelled) setLoading(false)
-      })
-    return () => { cancelled = true }
-  }, [])
+  const handleSaved = useCallback(() => {
+    void refresh().then((next) => {
+      if (isTonghuashunConfigured(next)) onConfigured()
+    })
+  }, [refresh, onConfigured])
 
   if (loading) {
     return (
@@ -218,6 +216,17 @@ export function OnboardingFuyaoPanel({
         <Spinner size="tiny" />
         <Text>正在读取数据源配置…</Text>
       </div>
+    )
+  }
+
+  if (!provider) {
+    return (
+      <>
+        <Text className={shell.sectionTitle} block>{ONBOARDING_COPY.fuyao.title}</Text>
+        <Text className={shell.sectionLead} block>
+          暂时无法加载历史行情配置，请稍后在设置中继续完成。
+        </Text>
+      </>
     )
   }
 
@@ -238,25 +247,7 @@ export function OnboardingFuyaoPanel({
         >
           {ONBOARDING_COPY.fuyao.apiPortalLinkLabel}
         </OnboardingTextLink>
-        <OpptrixField
-          label={ONBOARDING_COPY.fuyao.apiFieldLabel}
-          hint={ONBOARDING_COPY.fuyao.apiFieldHint}
-        >
-          <Input
-            appearance="filled-darker"
-            size="medium"
-            type="password"
-            value={apiKey}
-            placeholder={ONBOARDING_COPY.fuyao.apiPlaceholder}
-            onChange={(_, d) => {
-              setApiKey(d.value ?? '')
-              if (error) setError('')
-            }}
-          />
-        </OpptrixField>
-        {error && (
-          <Text className={s.error} block role="alert">{error}</Text>
-        )}
+        <ProviderSettingsForm provider={provider} onSaved={handleSaved} />
       </div>
     </>
   )

--- a/client-ui/src/onboarding/OnboardingWizard.tsx
+++ b/client-ui/src/onboarding/OnboardingWizard.tsx
@@ -329,11 +329,13 @@ export default function OnboardingWizard({
       )
     } else {
       body = (
-        <OnboardingFuyaoPanel
-          onConfigured={() => { void refreshFuyaoStatus() }}
-          onComplete={goNext}
-          onNavChange={setFuyaoNav}
-        />
+        <SettingsToastProvider>
+          <OnboardingFuyaoPanel
+            onConfigured={() => { void refreshFuyaoStatus() }}
+            onComplete={goNext}
+            onNavChange={setFuyaoNav}
+          />
+        </SettingsToastProvider>
       )
       footerSecondary = (
         <OpptrixButton variant="ghost" onClick={skipFuyao}>


### PR DESCRIPTION
## Summary
- Onboarding data step reuses settings ProviderCatalogListPanel / catalog hook.
- Fuyao step uses ProviderSettingsForm (settingsFields); optional test; same saveProviderConfig path.
- Hide tonghuashun in data list to avoid duplicating the fuyao step.

## Test plan
- [ ] `npm run check:ui`
- [ ] Configure a provider in onboarding data → appears in 设置 → 数据源
- [ ] Configure fuyao in onboarding → tonghuashun matches settings


Made with [Cursor](https://cursor.com)