### PR TITLE
feat(settings): card-style data source config shared with onboarding

### DIFF
--- a/client-ui/src/onboarding/OnboardingDataList.tsx
+++ b/client-ui/src/onboarding/OnboardingDataList.tsx
@@ -1,10 +1,10 @@
 import { Text } from '@fluentui/react-components'
 import type { ProviderCatalogResponse } from '../types/provider'
 import {
-  ProviderCatalogListPanel,
   ProviderCatalogLoading,
   useProviderCatalog,
 } from '../pages/settings/ProviderSettingsCatalog'
+import { DataProvidersCardsPanel } from '../pages/settings/DataProvidersCardsPanel'
 import { opptrixCssVars } from '../theme/tokens'
 import { TONGHUASHUN_PROVIDER_ID } from './OnboardingFuyaoPanel'
 
@@ -38,11 +38,10 @@ export function OnboardingDataList() {
   }
 
   return (
-    <ProviderCatalogListPanel
+    <DataProvidersCardsPanel
       catalog={catalogWithoutTonghuashun(catalog)}
       onSaved={() => { void refresh() }}
-      showInstalled={false}
-      panelHeight="min(40vh, 320px)"
+      showAdvancedOrder={false}
     />
   )
 }

--- a/client-ui/src/pages/settings/DataProvidersCardsPanel.tsx
+++ b/client-ui/src/pages/settings/DataProvidersCardsPanel.tsx
@@ -1,0 +1,321 @@
+import { useState } from 'react'
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Text,
+  makeStyles,
+  mergeClasses,
+} from '@fluentui/react-components'
+import {
+  ChevronDownRegular,
+  ChevronUpRegular,
+} from '@fluentui/react-icons'
+import type { ProviderCatalogResponse, PublicProviderRuntime } from '../../types/provider'
+import { saveProviderConfig } from '../../api/client'
+import { ProviderSettingsForm, isExpandableSettingsField } from './ProviderSettingsForm'
+import {
+  ProviderOrderList,
+  providerConfigStatus,
+} from './ProviderSettingsCatalog'
+import { useSettingsToast } from './SettingsToast'
+import OpptrixButton from '../../components/opptrix/OpptrixButton'
+import { opptrixCssVars } from '../../theme/tokens'
+import {
+  SettingsEmptyState,
+  SettingsGroup,
+  SettingsListPanel,
+  SettingsListScroll,
+  SettingsRow,
+} from './SettingsPrimitives'
+
+type CardStatus = 'available' | 'needs_config' | 'disabled'
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+  },
+  rowActions: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    gap: '8px',
+    flexWrap: 'wrap',
+  },
+  configDialogSurface: {
+    maxWidth: '440px',
+    width: 'min(440px, calc(100vw - 32px))',
+  },
+  configDialogBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '12px',
+    padding: '4px 0 0',
+  },
+  configDialogIntro: {
+    fontSize: 'var(--opptrix-font-md)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.5,
+  },
+  advancedBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  advancedHint: {
+    fontSize: 'var(--opptrix-font-md)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.45,
+    padding: '0 2px',
+  },
+  orderPanel: {
+    maxHeight: '280px',
+  },
+})
+
+function resolveCardStatus(provider: PublicProviderRuntime): CardStatus {
+  if (provider.enabled) return 'available'
+  if (!provider.canEnable) return 'needs_config'
+  const config = providerConfigStatus(provider)
+  if (config === 'none' || config === 'partial') return 'needs_config'
+  return 'disabled'
+}
+
+function statusDesc(provider: PublicProviderRuntime): string {
+  const status = resolveCardStatus(provider)
+  const subtitle = provider.subtitle?.trim()
+  if (status === 'available') {
+    return subtitle ? `可用 · ${subtitle}` : '可用'
+  }
+  if (status === 'needs_config') {
+    return subtitle ? `待配置 · ${subtitle}` : '待配置 · 完成连接后即可启用'
+  }
+  return subtitle ? `已关闭 · ${subtitle}` : '已关闭'
+}
+
+function DataProviderRow({
+  provider,
+  onSaved,
+  last,
+}: {
+  provider: PublicProviderRuntime
+  onSaved: () => void
+  last: boolean
+}) {
+  const s = useStyles()
+  const toast = useSettingsToast()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const hasSettings = provider.settingsFields.some(isExpandableSettingsField)
+  const status = resolveCardStatus(provider)
+
+  const openConfig = () => {
+    if (hasSettings) setDialogOpen(true)
+  }
+
+  const setEnabled = async (checked: boolean) => {
+    if (checked && !provider.canEnable) {
+      if (hasSettings) {
+        setDialogOpen(true)
+        return
+      }
+      toast.showError('请先完成必填配置后再启用')
+      return
+    }
+    setBusy(true)
+    try {
+      await saveProviderConfig(provider.providerId, { enabled: checked })
+      toast.showSuccess(checked ? '已启用' : '已停用')
+      onSaved()
+    } catch (e) {
+      toast.showError(e instanceof Error ? e.message : '更新失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const primary = (() => {
+    if (status === 'needs_config') {
+      return (
+        <OpptrixButton
+          variant="primary"
+          size="small"
+          disabled={busy || !hasSettings}
+          onClick={openConfig}
+        >
+          去配置
+        </OpptrixButton>
+      )
+    }
+    if (status === 'available') {
+      return (
+        <OpptrixButton
+          variant="secondary"
+          size="small"
+          disabled={busy}
+          onClick={() => { void setEnabled(false) }}
+        >
+          停用
+        </OpptrixButton>
+      )
+    }
+    return (
+      <OpptrixButton
+        variant="primary"
+        size="small"
+        disabled={busy}
+        onClick={() => { void setEnabled(true) }}
+      >
+        启用
+      </OpptrixButton>
+    )
+  })()
+
+  return (
+    <>
+      <SettingsRow
+        title={provider.title}
+        desc={statusDesc(provider)}
+        last={last}
+        control={(
+          <div className={s.rowActions}>
+            {hasSettings && status !== 'needs_config' && (
+              <OpptrixButton variant="ghost" size="small" disabled={busy} onClick={openConfig}>
+                配置
+              </OpptrixButton>
+            )}
+            {primary}
+          </div>
+        )}
+      />
+
+      {hasSettings && (
+        <Dialog
+          open={dialogOpen}
+          modalType="modal"
+          onOpenChange={(_, data) => {
+            if (!data.open) setDialogOpen(false)
+          }}
+        >
+          <DialogSurface
+            className={mergeClasses('opptrix-glass-dialog-surface', s.configDialogSurface)}
+          >
+            <DialogBody>
+              <DialogTitle>{provider.title}</DialogTitle>
+              <DialogContent className={s.configDialogBody}>
+                {provider.subtitle?.trim() && (
+                  <Text className={s.configDialogIntro} block>
+                    {provider.subtitle.trim()}
+                  </Text>
+                )}
+                <ProviderSettingsForm
+                  provider={provider}
+                  onSaved={() => {
+                    onSaved()
+                  }}
+                />
+              </DialogContent>
+            </DialogBody>
+          </DialogSurface>
+        </Dialog>
+      )}
+    </>
+  )
+}
+
+export function DataProvidersCardsPanel({
+  catalog,
+  onSaved,
+  onOrderSaved,
+  showAdvancedOrder = false,
+}: {
+  catalog: ProviderCatalogResponse
+  onSaved: () => void
+  onOrderSaved?: (catalog: ProviderCatalogResponse) => void
+  /** 设置页：展示可折叠的行情回退顺序；onboarding 关闭 */
+  showAdvancedOrder?: boolean
+}) {
+  const s = useStyles()
+  const [advancedOpen, setAdvancedOpen] = useState(false)
+
+  const allProviders = catalog.providers?.length
+    ? catalog.providers
+    : catalog.groups.flatMap(g => g.providers)
+
+  if (!allProviders.length) {
+    return (
+      <SettingsGroup>
+        <SettingsEmptyState
+          title="还没有可接入的数据源"
+          desc="稍后再试，或检查网络后刷新页面"
+        />
+      </SettingsGroup>
+    )
+  }
+
+  const canShowOrder = showAdvancedOrder && !!onOrderSaved
+
+  return (
+    <div className={s.root}>
+      <SettingsGroup>
+        {allProviders.map((provider, index) => (
+          <DataProviderRow
+            key={provider.providerId}
+            provider={provider}
+            onSaved={onSaved}
+            last={index === allProviders.length - 1}
+          />
+        ))}
+      </SettingsGroup>
+
+      {canShowOrder && (
+        <>
+          <SettingsGroup>
+            <SettingsRow
+              title="高级：行情回退顺序"
+              desc={advancedOpen
+                ? '拖拽调整优先顺序；越靠前越优先'
+                : '仅已启用且配置完成的数据源会参与回退'}
+              last
+              control={(
+                <OpptrixButton
+                  variant="ghost"
+                  size="small"
+                  aria-expanded={advancedOpen}
+                  icon={advancedOpen
+                    ? <ChevronUpRegular fontSize={14} />
+                    : <ChevronDownRegular fontSize={14} />}
+                  onClick={() => setAdvancedOpen(v => !v)}
+                >
+                  {advancedOpen ? '收起' : '展开'}
+                </OpptrixButton>
+              )}
+            />
+          </SettingsGroup>
+
+          {advancedOpen && (
+            <div className={s.advancedBody}>
+              <Text className={s.advancedHint} block>
+                拖拽调整优先顺序；越靠前越优先。仅已启用且配置完成的数据源会参与回退。
+              </Text>
+              <SettingsListPanel className={s.orderPanel} height="280px">
+                <SettingsListScroll>
+                  <ProviderOrderList
+                    providers={allProviders}
+                    onSaved={onSaved}
+                    onOrderSaved={onOrderSaved}
+                  />
+                </SettingsListScroll>
+              </SettingsListPanel>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/client-ui/src/pages/settings/DataProvidersSettingsSection.tsx
+++ b/client-ui/src/pages/settings/DataProvidersSettingsSection.tsx
@@ -1,9 +1,9 @@
 import { Text, makeStyles } from '@fluentui/react-components'
 import {
-  ProviderCatalogListPanel,
   ProviderCatalogLoading,
   useProviderCatalog,
 } from './ProviderSettingsCatalog'
+import { DataProvidersCardsPanel } from './DataProvidersCardsPanel'
 import { opptrixCssVars } from '../../theme/tokens'
 
 const useStyles = makeStyles({
@@ -28,7 +28,7 @@ export default function DataProvidersSettingsSection() {
     return (
       <div className={s.root}>
         <Text className={s.tabHint} block>
-          点击数据源或「配置」编辑连接，打开开关启用。拖拽列表调整行情回退顺序；越靠前越优先，仅已启用且配置完成的源会参与回退。
+          选择并启用数据源，开始查看行情。需要填写连接信息的，先完成配置再启用。
         </Text>
         <ProviderCatalogLoading />
       </div>
@@ -36,19 +36,19 @@ export default function DataProvidersSettingsSection() {
   }
 
   if (!catalog) {
-    return <Text block>无法加载数据源配置</Text>
+    return <Text block>暂时无法加载数据源，请稍后重试</Text>
   }
 
   return (
     <div className={s.root}>
       <Text className={s.tabHint} block>
-        点击数据源或「配置」编辑连接，打开开关启用。拖拽列表调整行情回退顺序；越靠前越优先，仅已启用且配置完成的源会参与回退。
+        选择并启用数据源，开始查看行情。需要填写连接信息的，先完成配置再启用。高级选项可调整行情回退顺序。
       </Text>
-      <ProviderCatalogListPanel
+      <DataProvidersCardsPanel
         catalog={catalog}
         onSaved={() => { void refresh() }}
         onOrderSaved={setCatalog}
-        showInstalled={false}
+        showAdvancedOrder
       />
     </div>
   )

--- a/client-ui/src/pages/settings/ProviderSettingsCatalog.tsx
+++ b/client-ui/src/pages/settings/ProviderSettingsCatalog.tsx
@@ -437,7 +437,7 @@ export function useProviderCatalog() {
   return { catalog, loading, refresh, setCatalog }
 }
 
-function providerConfigStatus(provider: PublicProviderRuntime): 'configured' | 'partial' | 'none' | 'n/a' {
+export function providerConfigStatus(provider: PublicProviderRuntime): 'configured' | 'partial' | 'none' | 'n/a' {
   const requiredSecrets = provider.settingsFields.filter(f => f.type === 'secret' && f.required)
   if (requiredSecrets.length) {
     const configured = requiredSecrets.filter(f => provider.secretsConfigured[f.key]).length
@@ -470,10 +470,10 @@ function providerOrderStatusMeta(provider: PublicProviderRuntime): string {
     return parts.join(' · ')
   }
   if (provider.requiresApiKey) {
-    parts.push('请完成配置并打开开关')
+    parts.push('请完成配置并启用')
     return parts.join(' · ')
   }
-  parts.push('请打开开关后生效')
+  parts.push('请启用后生效')
   return parts.join(' · ')
 }
 
@@ -588,10 +588,8 @@ function InstalledProvidersSection({ onChanged }: { onChanged: () => void }) {
     <div className={s.sectionBlock}>
       <div className={s.listPanel} style={{ height: 'auto', maxHeight: items.length ? '220px' : 'none' }}>
         <div className={s.listHeader}>
-          <Text className={s.listHeaderMeta} block>
-            {providersDir
-              ? `扩展数据源：将插件文件夹放入 ${providersDir}，保存后会自动扫描（约 1 秒内）`
-              : '扩展数据源：将插件文件夹放入用户数据目录下的 providers 文件夹'}
+          <Text className={s.listHeaderMeta} block title={providersDir || undefined}>
+            可将扩展文件夹放入本机扩展目录，保存后约 1 秒内自动出现
           </Text>
           <OpptrixButton variant="ghost" disabled={scanning} onClick={() => { void handleRescan() }}>
             {scanning ? '扫描中…' : '重新扫描'}
@@ -639,6 +637,8 @@ function ProviderListRow({
   onSaved,
   settingsMode = 'full',
   sortable = false,
+  /** 排序行默认不显示启用开关，避免高级区变成开关墙；密列表保持默认 true */
+  showEnabledToggle,
   saving = false,
   onDragHandlePointerDown,
   onMoveUp,
@@ -652,6 +652,7 @@ function ProviderListRow({
   onSaved: () => void
   settingsMode?: 'full' | 'toggle-only'
   sortable?: boolean
+  showEnabledToggle?: boolean
   saving?: boolean
   onDragHandlePointerDown?: (e: ReactPointerEvent<HTMLSpanElement>) => void
   onMoveUp?: () => void
@@ -667,6 +668,7 @@ function ProviderListRow({
   const [toggling, setToggling] = useState(false)
 
   const hasSettings = settingsMode === 'full' && provider.settingsFields.some(isExpandableSettingsField)
+  const enabledToggleVisible = showEnabledToggle ?? !sortable
   const statusMeta = sortable
     ? providerOrderStatusMeta(provider)
     : providerStatusMeta(provider, marketLabel)
@@ -770,12 +772,14 @@ function ProviderListRow({
                 />
               </div>
             )}
-            <Switch
-              checked={provider.enabled}
-              disabled={toggling}
-              onChange={(_, d) => { void handleToggleEnabled(!!d.checked) }}
-              aria-label={`${provider.enabled ? '停用' : '启用'} ${provider.title}`}
-            />
+            {enabledToggleVisible && (
+              <Switch
+                checked={provider.enabled}
+                disabled={toggling}
+                onChange={(_, d) => { void handleToggleEnabled(!!d.checked) }}
+                aria-label={`${provider.enabled ? '停用' : '启用'} ${provider.title}`}
+              />
+            )}
           </div>
         </div>
       </div>
@@ -897,7 +901,7 @@ function reorderList<T>(items: T[], from: number, to: number): T[] {
   return next
 }
 
-function ProviderOrderList({
+export function ProviderOrderList({
   providers,
   onSaved,
   onOrderSaved,
@@ -1036,7 +1040,9 @@ function ProviderOrderList({
               provider={provider}
               marketLabel=""
               onSaved={onSaved}
+              settingsMode="toggle-only"
               sortable
+              showEnabledToggle={false}
               saving={saving}
               dragging={draggingIndex === index}
               onDragHandlePointerDown={(e) => { onHandlePointerDown(index, e) }}


### PR DESCRIPTION
## Summary
- Replace the dense data-source list with SettingsGroup rows (enable / configure / disable) aligned to existing settings UI primitives
- Move fallback order into an advanced section; share the same panel with onboarding (tonghuashun still filtered there)
- Drop the extended-provider scan panel from the settings data path for now

## Test plan
- [ ] Settings → Data: cards show status in description; primary actions work; config dialog still saves
- [ ] Advanced: expand fallback order, reorder persists; no installed-extension panel
- [ ] Onboarding data step: same card UI, no advanced order, tonghuashun hidden
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)