### PR TITLE
fix(ci): assert RAG engines env in sidecar-launch

### DIFF
--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -317,7 +317,7 @@ Hybrid RAG 使用的 **multilingual-e5-small** 权重默认打进桌面安装包
 | OCR 模型 Stage | `apps/desktop/scripts/stage-rapidocr.mjs` → `resources/llms/rapidocr-ppocrv4-mobile/`（PP-OCRv4 mobile ONNX） |
 | engines Stage | `apps/desktop/scripts/stage-rag-engines.mjs` → `resources/engines/<platform>-<arch>/MANIFEST.json`（仅写 MANIFEST / 兼容 prebuild+audit；**不再**下载 pdfplumber / rapidocr Python wheels）。CI / release 步骤名：`Stage RAG engines MANIFEST (Node OCR)` |
 | 打包 | `extraResources`：`resources/llms` → `llms`；`resources/engines` → `engines`（兼容旧探测） |
-| 运行时 | Node ONNX OCR；`OPPTRIX_RAG_ENGINES_BUNDLED_DIR` 仍可由 `main.cjs` 注入 |
+| 运行时 | Node ONNX OCR；`OPPTRIX_RAG_ENGINES_BUNDLED_DIR` 由 `sidecar-launch.cjs`（`buildSidecarEnv`）注入 |
 | 首启 | 后台 `ensureBundledRagRuntime()`：启用 embedding；OCR 模型齐全则深度整理可用 |
 
 禁止默认路径纳入 PyMuPDF（AGPL）。研报入库支持 `.pdf` / `.txt` / `.md` / `.docx` / `.pptx` / 图片；`.pptx` 按幻灯片分 chunk。

--- a/tests/rag-engines-bundled.test.mjs
+++ b/tests/rag-engines-bundled.test.mjs
@@ -66,17 +66,17 @@ describe('rag engines bundled paths', () => {
     assert.doesNotMatch(src, /downloadWheel/)
   })
 
-  it('prebuild and main inject engines', () => {
+  it('prebuild and sidecar-launch inject engines', () => {
     const prebuild = fs.readFileSync(
       path.join(ROOT, 'apps/desktop/scripts/prebuild.mjs'),
       'utf8',
     )
     assert.match(prebuild, /stage-rag-engines\.mjs/)
-    const main = fs.readFileSync(
-      path.join(ROOT, 'apps/desktop/electron/main.cjs'),
+    const sidecarLaunch = fs.readFileSync(
+      path.join(ROOT, 'apps/desktop/electron/os-schedule/sidecar-launch.cjs'),
       'utf8',
     )
-    assert.match(main, /OPPTRIX_RAG_ENGINES_BUNDLED_DIR/)
+    assert.match(sidecarLaunch, /OPPTRIX_RAG_ENGINES_BUNDLED_DIR/)
   })
 
   it('ensureBundledRagRuntime enables embedding; layout stays retired', async () => {


### PR DESCRIPTION
## Summary
- Update `rag-engines-bundled` test to assert `OPPTRIX_RAG_ENGINES_BUNDLED_DIR` in `sidecar-launch.cjs` (injection left `main.cjs`).
- Align `docs/DESKTOP.md` runtime note with the same path.

## Test plan
- [x] `node --test tests/rag-engines-bundled.test.mjs` (4/4)
- [ ] CI Build & test green after merge


Made with [Cursor](https://cursor.com)