### PR TITLE
fix: chat scrollbar + Windows description

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@opptrix/desktop",
   "version": "1.3.2",
   "private": true,
-  "description": "Opptrix 桌面端：Electron 壳 + 本地投研 API，支持自动更新与离线数据",
+  "description": "Opptrix 投研工作台",
   "homepage": "https://www.opptrix.org",
   "author": {
     "name": "Opptrix contributors",
@@ -205,7 +205,7 @@
       "icon": "build/icons/linux",
       "category": "Office;Finance",
       "synopsis": "面向个人投资者的多市场投研助手",
-      "description": "Opptrix 桌面端：自然语言提问即可查看行情、新闻与研报摘要，数据默认保存在本机。",
+      "description": "Opptrix 投研工作台",
       "artifactName": "${productName}-${version}-Linux.${ext}",
       "executableName": "opptrix",
       "desktop": {

--- a/client-ui/src/chat/ChatProcessTrace.tsx
+++ b/client-ui/src/chat/ChatProcessTrace.tsx
@@ -623,17 +623,17 @@ function StepRow({ step, live = false, defaultExpanded = false }: StepRowProps) 
       {expandable && expanded && (
         <div className={s.stepBody}>
           {step.thinking && (
-            <Text className={s.detailBlock} block>
+            <Text className={mergeClasses(s.detailBlock, 'opptrix-scroll')} block>
               {`【分析思路】\n${step.thinking}`}
             </Text>
           )}
           {step.resultDetail && (
-            <Text className={s.detailBlock} block>
+            <Text className={mergeClasses(s.detailBlock, 'opptrix-scroll')} block>
               {step.resultDetail}
             </Text>
           )}
           {!step.resultDetail && step.resultPreview && (
-            <Text className={s.detailBlock} block>
+            <Text className={mergeClasses(s.detailBlock, 'opptrix-scroll')} block>
               {step.resultPreview}
             </Text>
           )}

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -2526,6 +2526,10 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
   }
 }
 
+.opptrix-scroll {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(60, 60, 67, 0.12) transparent;
+}
 .opptrix-scroll::-webkit-scrollbar {
   width: 5px;
 }


### PR DESCRIPTION
## Summary
- 聊天步骤展开区补齐 `opptrix-scroll`，避免非 Mac 出现系统默认粗滚动条
- 桌面包 `description` 改为「Opptrix 投研工作台」，避免 Windows 快捷方式/安装包说明过长

## Test plan
- [ ] 非 Mac：展开聊天步骤详情，滚动条为细样式
- [ ] 重新打 Windows 包后，快捷方式悬停说明为「Opptrix 投研工作台」
- [x] `npm run check:ui`（scrollbar 改动）
- [x] `npm run verify:release-metadata-policy -w @opptrix/desktop`


Made with [Cursor](https://cursor.com)