### PR TITLE
refactor(schedule): 托盘进程内计划任务并隐藏 Dock

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -445,6 +445,24 @@ function isMainWindowUiHealthy(win) {
   }
 }
 
+/** Restore Dock (mac) / taskbar entry before show (paired with close-to-tray hide). */
+function restoreWindowTaskbarVisibility(win) {
+  if (process.platform === 'darwin') {
+    try {
+      if (app.dock && typeof app.dock.show === 'function') app.dock.show()
+    } catch {
+      /* ignore */
+    }
+  }
+  if (!win || win.isDestroyed()) return
+  if (typeof win.setSkipTaskbar !== 'function') return
+  try {
+    win.setSkipTaskbar(false)
+  } catch {
+    /* ignore */
+  }
+}
+
 /**
  * 托盘 / 菜单 / focus：健康窗则 restore+show；坏窗则重载；无窗则 bootstrap。
  */
@@ -452,6 +470,7 @@ async function ensureMainWindowVisible() {
   const win = getMainWindow()
   if (win) {
     if (isMainWindowUiHealthy(win)) {
+      restoreWindowTaskbarVisibility(win)
       if (win.isMinimized()) win.restore()
       win.show()
       win.focus()
@@ -460,6 +479,7 @@ async function ensureMainWindowVisible() {
     try {
       await loadAppInMainWindow(win, { enforceMinSplash: false })
       if (!win.isDestroyed()) {
+        restoreWindowTaskbarVisibility(win)
         if (win.isMinimized()) win.restore()
         win.show()
         win.focus()
@@ -869,7 +889,7 @@ async function bootstrapBackgroundApp() {
   await ensureSidecarReady()
   configureScheduleBridge({ host: API_HOST, port: API_PORT })
 
-  // 新 OS 任务走 HTTP-first + headless-tick；本路径仅登录项 / 前台 / --background 常驻
+  // 登录项 / 前台 / --background 常驻：sidecar + 进程内 timer；reconcile 仅注销遗留 OS tick
   await reconcileOsSchedule().catch((err) => {
     console.warn('[schedule] reconcile failed:', err instanceof Error ? err.message : err)
   })

--- a/apps/desktop/electron/os-schedule/sidecar-launch.cjs
+++ b/apps/desktop/electron/os-schedule/sidecar-launch.cjs
@@ -139,11 +139,14 @@ function buildSidecarEnv(opts) {
  * @returns {import('node:child_process').ChildProcess}
  */
 function spawnSidecarProcess(opts) {
+  // windowsHide: 避免 Win 上弹出控制台；Node/Electron-as-Node 均支持。
   return spawn(opts.execPath, [opts.entry], {
     cwd: opts.cwd,
     env: opts.env,
     stdio: ['ignore', 'pipe', 'pipe'],
     detached: false,
+    windowsHide: true,
+    shell: false,
   })
 }
 

--- a/apps/desktop/electron/os-schedule/tick-runner.cjs
+++ b/apps/desktop/electron/os-schedule/tick-runner.cjs
@@ -5,6 +5,9 @@
  * /api/schedule/tick when the sidecar is up — avoiding a full Opptrix GUI
  * spawn (Dock / taskbar flash). Falls back to ELECTRON_RUN_AS_NODE headless-tick
  * (spawn sidecar → tick → stop) only on failure — never `--background --schedule-tick`.
+ *
+ * Cold-start EXEC is OpptrixSchedule (renamed Electron copy beside the product
+ * binary), not Opptrix productName — so crash UI / process list stay distinct.
  */
 const path = require('node:path')
 const fs = require('node:fs')
@@ -12,12 +15,147 @@ const fs = require('node:fs')
 const ENDPOINT_FILENAME = 'os-schedule-endpoint.json'
 const RUNNER_SH = 'os-schedule-tick-runner.sh'
 const RUNNER_CMD = 'os-schedule-tick-runner.cmd'
+/** Cold-start identity distinct from Opptrix productName (crash UI / process list). */
+const HELPER_BASENAME_UNIX = 'OpptrixSchedule'
+const HELPER_BASENAME_WIN = 'OpptrixSchedule.exe'
 
 /**
  * Absolute path to headless-tick.cjs (works inside app.asar under ELECTRON_RUN_AS_NODE).
  */
 function defaultHeadlessTickPath() {
   return path.join(__dirname, 'headless-tick.cjs')
+}
+
+/**
+ * @param {NodeJS.Platform} [platform]
+ */
+function scheduleHelperFileName(platform = process.platform) {
+  return platform === 'win32' ? HELPER_BASENAME_WIN : HELPER_BASENAME_UNIX
+}
+
+/**
+ * Helper must sit beside the Electron binary so @executable_path / adjacent DLLs resolve.
+ * @param {string} sourceExecPath Absolute path to Opptrix / Electron binary
+ * @param {NodeJS.Platform} [platform]
+ */
+function resolveScheduleHelperPath(sourceExecPath, platform = process.platform) {
+  return path.join(path.dirname(sourceExecPath), scheduleHelperFileName(platform))
+}
+
+/**
+ * True when basename is OpptrixSchedule(.exe) — not the main product binary name.
+ * @param {string} execPath
+ * @param {NodeJS.Platform} [platform]
+ */
+function isScheduleHelperPath(execPath, platform = process.platform) {
+  if (typeof execPath !== 'string' || !execPath.trim()) return false
+  return path.basename(execPath.trim()) === scheduleHelperFileName(platform)
+}
+
+/**
+ * Ensure a renamed Electron copy (OpptrixSchedule) exists next to sourceExecPath.
+ * Prefer hardlink (same dir / frameworks); fallback copyFileSync. Never silently
+ * rewrite cold-start EXEC to the main Opptrix product binary name.
+ *
+ * @param {{
+ *   sourceExecPath: string
+ *   platform?: NodeJS.Platform
+ * }} opts
+ * @returns {{ helperPath: string; created: boolean; refreshed: boolean }}
+ */
+function ensureOsScheduleHelperExec(opts) {
+  const platform = opts.platform ?? process.platform
+  const sourceExecPath = optionalAbsPath(opts.sourceExecPath)
+  if (!sourceExecPath || !path.isAbsolute(sourceExecPath)) {
+    throw new Error('schedule helper: sourceExecPath must be an absolute path')
+  }
+  if (!fs.existsSync(sourceExecPath)) {
+    throw new Error(`schedule helper: source missing: ${sourceExecPath}`)
+  }
+  // Refuse to treat an already-named helper as the copy source (would clobber itself).
+  if (isScheduleHelperPath(sourceExecPath, platform)) {
+    return { helperPath: sourceExecPath, created: false, refreshed: false }
+  }
+
+  const helperPath = resolveScheduleHelperPath(sourceExecPath, platform)
+  if (path.resolve(helperPath) === path.resolve(sourceExecPath)) {
+    throw new Error('schedule helper: helper path collides with source')
+  }
+
+  let needWrite = !fs.existsSync(helperPath)
+  if (!needWrite) {
+    try {
+      const src = fs.statSync(sourceExecPath)
+      const dst = fs.statSync(helperPath)
+      needWrite = src.size !== dst.size || src.mtimeMs > dst.mtimeMs + 1000
+    } catch {
+      needWrite = true
+    }
+  }
+
+  let created = false
+  let refreshed = false
+  if (needWrite) {
+    const existed = fs.existsSync(helperPath)
+    try {
+      try {
+        if (existed) fs.unlinkSync(helperPath)
+      } catch {
+        /* Windows may lock running helper — try overwrite via temp */
+      }
+      let linked = false
+      try {
+        fs.linkSync(sourceExecPath, helperPath)
+        linked = true
+      } catch {
+        /* hardlink unsupported (permissions / FS) — copy */
+      }
+      if (!linked) {
+        const tmp = `${helperPath}.tmp-${process.pid}`
+        try {
+          fs.copyFileSync(sourceExecPath, tmp)
+          fs.renameSync(tmp, helperPath)
+        } catch (copyErr) {
+          try {
+            if (fs.existsSync(tmp)) fs.unlinkSync(tmp)
+          } catch {
+            /* ignore */
+          }
+          throw copyErr
+        }
+      }
+      if (platform !== 'win32') {
+        try {
+          fs.chmodSync(helperPath, 0o755)
+        } catch {
+          /* ignore */
+        }
+      }
+      created = !existed
+      refreshed = existed
+    } catch (err) {
+      if (fs.existsSync(helperPath) && isScheduleHelperPath(helperPath, platform)) {
+        // Keep existing helper; surface refresh failure for diagnostics without
+        // falling back to Opptrix productName.
+        console.error(
+          '[os-schedule] helper refresh failed, keeping existing OpptrixSchedule:',
+          err instanceof Error ? err.message : String(err),
+        )
+      } else {
+        throw new Error(
+          `schedule helper: cannot create OpptrixSchedule beside ${sourceExecPath}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        )
+      }
+    }
+  }
+
+  if (!fs.existsSync(helperPath) || !isScheduleHelperPath(helperPath, platform)) {
+    throw new Error(`schedule helper: OpptrixSchedule not available at ${helperPath}`)
+  }
+
+  return { helperPath, created, refreshed }
 }
 
 /**
@@ -135,6 +273,47 @@ function readOsScheduleEndpoint(userDataDir) {
   } catch {
     return null
   }
+}
+
+/**
+ * Remove legacy OS tick runner scripts and strip cold-start fields from endpoint.
+ * Idempotent; host/port retained for UI sidecar reuse.
+ * @param {string} userDataDir
+ * @returns {{ removedRunners: string[]; endpointStripped: boolean }}
+ */
+function purgeLegacyOsTickArtifacts(userDataDir) {
+  /** @type {string[]} */
+  const removedRunners = []
+  for (const name of [RUNNER_SH, RUNNER_CMD]) {
+    const p = path.join(userDataDir, name)
+    try {
+      if (fs.existsSync(p)) {
+        fs.unlinkSync(p)
+        removedRunners.push(name)
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  let endpointStripped = false
+  try {
+    const existing = readOsScheduleEndpoint(userDataDir)
+    if (
+      existing
+      && (existing.execPath || existing.headlessTick || existing.runtimeStage || existing.resourcesPath)
+    ) {
+      writeOsScheduleEndpoint(userDataDir, {
+        host: existing.host,
+        port: existing.port,
+      })
+      endpointStripped = true
+    }
+  } catch {
+    /* best-effort */
+  }
+
+  return { removedRunners, endpointStripped }
 }
 
 /**
@@ -262,6 +441,8 @@ exit /b %ERRORLEVEL%
 
 /**
  * Write (or refresh) the OS tick runner script under userData; chmod +x on Unix.
+ * Cold-start EXEC is OpptrixSchedule helper (renamed Electron copy beside source),
+ * not the Opptrix productName binary.
  *
  * @param {{
  *   userDataDir: string
@@ -274,26 +455,42 @@ exit /b %ERRORLEVEL%
  *   platform?: NodeJS.Platform
  *   defaultPort?: string | number
  * }} opts
- * @returns {{ scriptPath: string; endpointFile: string; coldStartArgv: string[] }}
+ * @returns {{
+ *   scriptPath: string
+ *   endpointFile: string
+ *   coldStartArgv: string[]
+ *   helperPath: string
+ *   sourceExecPath: string
+ * }}
  */
 function ensureOsScheduleTickRunner(opts) {
   const platform = opts.platform ?? process.platform
   const userDataDir = opts.userDataDir
   fs.mkdirSync(userDataDir, { recursive: true })
 
+  const sourceExecPath = optionalAbsPath(opts.execPath)
+  if (!sourceExecPath) {
+    throw new Error('ensureOsScheduleTickRunner: execPath (Electron source) is required')
+  }
+
+  const { helperPath } = ensureOsScheduleHelperExec({
+    sourceExecPath,
+    platform,
+  })
+
   const headlessTickPath = opts.headlessTickPath || defaultHeadlessTickPath()
   const existing = readOsScheduleEndpoint(userDataDir)
   writeOsScheduleEndpoint(userDataDir, {
     host: existing?.host ?? '127.0.0.1',
     port: existing?.port ?? opts.defaultPort ?? '8711',
-    execPath: opts.execPath,
+    execPath: helperPath,
     headlessTick: headlessTickPath,
     runtimeStage: opts.runtimeStage ?? existing?.runtimeStage,
     resourcesPath: opts.resourcesPath ?? existing?.resourcesPath,
   })
 
   const coldStartArgv = resolveHeadlessTickArgv({
-    execPath: opts.execPath,
+    execPath: helperPath,
     headlessTickPath,
   })
   const endpointFile = endpointFilePath(userDataDir)
@@ -318,7 +515,7 @@ function ensureOsScheduleTickRunner(opts) {
     }
   }
 
-  return { scriptPath, endpointFile, coldStartArgv }
+  return { scriptPath, endpointFile, coldStartArgv, helperPath, sourceExecPath }
 }
 
 /**
@@ -358,12 +555,19 @@ module.exports = {
   ENDPOINT_FILENAME,
   RUNNER_SH,
   RUNNER_CMD,
+  HELPER_BASENAME_UNIX,
+  HELPER_BASENAME_WIN,
   defaultHeadlessTickPath,
   endpointFilePath,
   runnerScriptPath,
+  scheduleHelperFileName,
+  resolveScheduleHelperPath,
+  isScheduleHelperPath,
+  ensureOsScheduleHelperExec,
   sanitizeEndpointHost,
   writeOsScheduleEndpoint,
   readOsScheduleEndpoint,
+  purgeLegacyOsTickArtifacts,
   resolveHeadlessTickArgv,
   resolveColdStartArgv,
   shellSingleQuote,

--- a/apps/desktop/electron/schedule-bridge.cjs
+++ b/apps/desktop/electron/schedule-bridge.cjs
@@ -1,10 +1,9 @@
 const path = require('node:path')
 const { app } = require('electron')
 const { getOsScheduleAdapter } = require('./os-schedule/index.cjs')
-const { DEFAULT_TICK_INTERVAL_SEC } = require('./os-schedule/types.cjs')
 const {
   writeOsScheduleEndpoint,
-  defaultHeadlessTickPath,
+  purgeLegacyOsTickArtifacts,
 } = require('./os-schedule/tick-runner.cjs')
 
 /** @type {string} */
@@ -13,29 +12,16 @@ let apiHost = '127.0.0.1'
 let apiPort = '8711'
 
 /**
- * Persist loopback host/port + headless cold-start paths for the OS tick runner (no secrets).
- * Same endpoint JSON is reused by UI `resolveApiPort(allowReuse:true)` via host/port.
+ * Persist loopback host/port for UI `resolveApiPort(allowReuse:true)`.
+ * No longer writes OpptrixSchedule / headless-tick cold-start paths (OS tick abolished).
  */
 function persistOsScheduleEndpoint() {
   try {
     if (typeof app?.getPath !== 'function') return
-    /** @type {{
-     *   host: string
-     *   port: string | number
-     *   execPath: string
-     *   headlessTick: string
-     *   runtimeStage?: string
-     *   resourcesPath?: string
-     * }} */
+    /** @type {{ host: string; port: string | number }} */
     const opts = {
       host: apiHost,
       port: apiPort,
-      execPath: process.execPath,
-      headlessTick: defaultHeadlessTickPath(),
-    }
-    if (app.isPackaged && typeof process.resourcesPath === 'string') {
-      opts.resourcesPath = process.resourcesPath
-      opts.runtimeStage = path.join(process.resourcesPath, 'runtime-stage')
     }
     writeOsScheduleEndpoint(app.getPath('userData'), opts)
   } catch {
@@ -132,6 +118,12 @@ function probeAutostart() {
   return { enabled: current.openAtLogin, platform: process.platform }
 }
 
+/**
+ * Reconcile desktop schedule side-effects:
+ * - Always remove legacy OS tick (LaunchAgent / schtasks / systemd) — never ensure
+ * - Purge userData runner scripts + cold-start endpoint fields
+ * - Sync login-item autostart when hint.autostart is boolean
+ */
 async function reconcileOsSchedule(opts = {}) {
   const isDesktop = process.type === 'browser'
   if (!isDesktop) {
@@ -142,22 +134,25 @@ async function reconcileOsSchedule(opts = {}) {
   try {
     hint = opts.hint ?? await fetchOsReconcileHint()
   } catch (err) {
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : String(err),
-    }
+    // Sidecar may be down; still attempt OS tick purge for upgrade cleanup
+    hint = { register_tick: false, autostart: undefined }
+    console.warn(
+      '[schedule-bridge] reconcile hint failed, still removing OS tick:',
+      err instanceof Error ? err.message : String(err),
+    )
   }
 
   const adapter = getOsScheduleAdapter()
-  const shouldRegister = Boolean(hint.register_tick)
-  let tickResult
+  // Product decision: never register OS tick (ignore hint.register_tick)
+  const tickResult = await adapter.removeTickRegistration()
 
-  if (shouldRegister) {
-    tickResult = await adapter.ensureTickRegistration({
-      intervalSec: hint.interval_sec ?? DEFAULT_TICK_INTERVAL_SEC,
-    })
-  } else {
-    tickResult = await adapter.removeTickRegistration()
+  let purge = { removedRunners: [], endpointStripped: false }
+  try {
+    if (typeof app?.getPath === 'function') {
+      purge = purgeLegacyOsTickArtifacts(app.getPath('userData'))
+    }
+  } catch {
+    /* best-effort */
   }
 
   let autostartResult = null
@@ -165,10 +160,11 @@ async function reconcileOsSchedule(opts = {}) {
     autostartResult = ensureAutostart(hint.autostart)
   }
 
-  const nextStatus = tickResult.status ?? (tickResult.ok ? 'synced' : 'error')
+  const nextStatus = tickResult.status ?? (tickResult.ok ? 'n/a' : 'error')
   try {
     await patchScheduleSettings({
-      os_tick_status: nextStatus,
+      run_when_closed: false,
+      os_tick_status: nextStatus === 'synced' ? 'n/a' : nextStatus,
       os_tick_error: tickResult.error ?? null,
     })
   } catch {
@@ -177,22 +173,29 @@ async function reconcileOsSchedule(opts = {}) {
 
   return {
     ok: tickResult.ok && (autostartResult == null || autostartResult.ok !== false),
-    register_tick: shouldRegister,
+    register_tick: false,
     tick: tickResult,
     autostart: autostartResult,
+    purge,
     probe: await adapter.probeTickRegistration().catch(() => null),
   }
 }
 
 /**
- * 更新安装前暂停 OS 级 tick，避免 launchd/schtasks/systemd 在替换 .app 期间
- * 再拉起第二实例，导致 ShipIt「App Still Running」或空壳进程。
- * 不改动登录项；安装成功或恢复 UI 后由 reconcileOsSchedule 重新注册。
+ * 更新安装前暂停遗留 OS 级 tick，避免 launchd/schtasks/systemd 在替换 .app 期间
+ * 再拉起第二实例。不改动登录项；安装后仍只 remove，永不重新 ensure。
  */
 async function pauseOsScheduleForUpdateInstall() {
   const adapter = getOsScheduleAdapter()
   try {
     const tickResult = await adapter.removeTickRegistration()
+    try {
+      if (typeof app?.getPath === 'function') {
+        purgeLegacyOsTickArtifacts(app.getPath('userData'))
+      }
+    } catch {
+      /* best-effort */
+    }
     return { ok: tickResult.ok !== false, tick: tickResult }
   } catch (err) {
     return {

--- a/apps/desktop/electron/tray.cjs
+++ b/apps/desktop/electron/tray.cjs
@@ -1,6 +1,6 @@
 const fs = require('node:fs')
 const path = require('node:path')
-const { Menu, Tray } = require('electron')
+const { Menu, Tray, app } = require('electron')
 const { loadAppIconImage } = require('./icon.cjs')
 const { APP_NAME } = require('./app-meta.cjs')
 
@@ -59,6 +59,25 @@ function resolveTrayIcon() {
   return resized
 }
 
+/** Hide Dock (mac) / taskbar entry (win/linux) after close-to-tray hide. */
+function hideAppFromDockAndTaskbar(win) {
+  if (process.platform === 'darwin') {
+    try {
+      if (app.dock && typeof app.dock.hide === 'function') app.dock.hide()
+    } catch {
+      /* ignore */
+    }
+    return
+  }
+  if (win && !win.isDestroyed() && typeof win.setSkipTaskbar === 'function') {
+    try {
+      win.setSkipTaskbar(true)
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 function attachCloseToTray(win, { enabled, shouldQuit }) {
   if (!enabled) return
 
@@ -66,6 +85,7 @@ function attachCloseToTray(win, { enabled, shouldQuit }) {
     if (shouldQuit()) return
     event.preventDefault()
     win.hide()
+    hideAppFromDockAndTaskbar(win)
     if (process.platform === 'darwin' && win.isFullScreen()) {
       win.setFullScreen(false)
     }

--- a/apps/desktop/scripts/after-pack-adhoc.cjs
+++ b/apps/desktop/scripts/after-pack-adhoc.cjs
@@ -8,7 +8,8 @@
  *    Staging renames to `deps/` so createFilter does not drop the tree (exact
  *    relative path `node_modules` is skipped). Packaged Node ESM cannot resolve
  *    bare imports via NODE_PATH — only classic `node_modules` parent walks work.
- * 2) Optional ad-hoc mac codesign when OPPTRIX_MAC_UNSIGNED=1.
+ * 2) OpptrixSchedule helper generation retired (in-process schedule only).
+ * 3) Optional ad-hoc mac codesign when OPPTRIX_MAC_UNSIGNED=1.
  */
 const { execFileSync } = require('node:child_process')
 const fs = require('node:fs')
@@ -33,6 +34,15 @@ function runtimeStageRoots(context) {
     return [path.join(context.appOutDir, `${appName}.app`, 'Contents', 'Resources', 'runtime-stage')]
   }
   return [path.join(context.appOutDir, 'resources', 'runtime-stage')]
+}
+
+/**
+ * OS schedule Helper (OpptrixSchedule) is retired — in-process timer only.
+ * Kept as no-op so afterPack callers stay stable.
+ * @param {{ electronPlatformName: string; appOutDir: string; packager: { appInfo: { productFilename: string } } }} _context
+ */
+function ensurePackagedScheduleHelper(_context) {
+  // no-op: do not generate OpptrixSchedule helper for OS tick cold-start
 }
 
 /**
@@ -159,8 +169,10 @@ function adhocSignMac(context) {
 exports.default = async function afterPack(context) {
   restoreMacBundleIcns(context)
   restoreSidecarNodeModules(context)
+  ensurePackagedScheduleHelper(context)
   adhocSignMac(context)
 }
 
 // Exported for lightweight plist-strip smoke tests (not used by electron-builder).
 exports.stripMacBundleIconName = stripMacBundleIconName
+exports.ensurePackagedScheduleHelper = ensurePackagedScheduleHelper

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -123,7 +123,10 @@ const workspaceService = getWorkspaceService()
 scheduleService.setExecutor(createJobExecutor({
   agent: {
     createSession: opts => agent.createSession(opts),
-    chat: (sessionId, message) => agent.chat(sessionId, message),
+    chat: (sessionId, message, modelRef, opts) =>
+      agent.chat(sessionId, message, modelRef, {
+        unattended: opts?.unattended === true,
+      }),
     llmConfigured: agent.llmConfigured,
   },
   shell: {

--- a/apps/server/src/schedule-routes.ts
+++ b/apps/server/src/schedule-routes.ts
@@ -62,20 +62,30 @@ export function registerScheduleRoutes(
         os = resyncOsRegistration(scheduleService)
       }
 
-      const { resync_os: _resync, ...patch } = body
+      // run_when_closed 已废除 OS 注册：忽略客户端写入，始终保持 false
+      const { resync_os: _resync, run_when_closed: _ignoredRwc, ...rest } = body
+      const patch: Partial<ScheduleSettings> = {
+        ...rest,
+        run_when_closed: false,
+      }
       const current = scheduleService.getSettings()
-      const needsOsPending = (
+      // 仅 autostart / master 变更时标记 pending，供桌面 reconcile 同步登录项并强制 remove OS tick
+      const needsReconcilePending = (
         patch.master_enabled !== undefined && patch.master_enabled !== current.master_enabled
       ) || (
         patch.autostart !== undefined && patch.autostart !== current.autostart
       )
-      const nextPatch = needsOsPending && !body.resync_os
+      const nextPatch = needsReconcilePending && !body.resync_os
         ? { ...patch, os_tick_status: 'pending' as const, os_tick_error: null }
         : patch
 
       const settings = Object.keys(nextPatch).length > 0
         ? scheduleService.patchSettings(nextPatch)
-        : scheduleService.getSettings()
+        : scheduleService.patchSettings({ run_when_closed: false })
+
+      if (body.resync_os !== true) {
+        os = computeOsHealth(settings, scheduleService.listJobs())
+      }
 
       return { settings, os }
     },
@@ -149,6 +159,7 @@ export function registerScheduleRoutes(
     const recentFailures = summarizeRecentFailures(scheduleService)
     return {
       master_enabled: settings.master_enabled,
+      run_when_closed: settings.run_when_closed,
       allow_shell_scripts: settings.allow_shell_scripts,
       autostart: settings.autostart,
       os,
@@ -161,12 +172,13 @@ export function registerScheduleRoutes(
 
   app.get('/api/schedule/os/reconcile', async () => {
     const settings = scheduleService.getSettings()
-    const isDesktop = process.env.OPPTRIX_DESKTOP === '1'
+    // OS 级 tick 已废除：永远不注册；桌面侧每次 reconcile 仍须 removeTickRegistration
     return {
-      register_tick: settings.master_enabled,
+      register_tick: false,
+      run_when_closed: false,
       autostart: settings.autostart,
       interval_sec: 60,
-      os_tick_status: settings.os_tick_status ?? (isDesktop ? 'pending' : 'n/a'),
+      os_tick_status: settings.os_tick_status ?? 'n/a',
       os_tick_error: settings.os_tick_error ?? null,
       desktop_required: true,
     }

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -2397,6 +2397,8 @@ export type ScheduleOsStatus = 'synced' | 'pending' | 'error' | 'n/a'
 
 export interface ScheduleSettings {
   master_enabled: boolean
+  /** 兼容字段：始终 false，不再注册系统定时 */
+  run_when_closed: boolean
   autostart: boolean
   allow_shell_scripts: boolean
   os_tick_status?: ScheduleOsStatus
@@ -2448,6 +2450,7 @@ export const scheduleApi = {
   getStatus: () =>
     jsonFetch<{
       master_enabled: boolean
+      run_when_closed: boolean
       allow_shell_scripts: boolean
       autostart: boolean
       os: ScheduleOsHealth

--- a/client-ui/src/pages/settings/ScheduleSettingsSection.tsx
+++ b/client-ui/src/pages/settings/ScheduleSettingsSection.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Spinner, Switch, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import {
-  ArrowSyncRegular,
   CalendarClockRegular,
   CheckmarkCircleRegular,
   DismissCircleRegular,
@@ -16,7 +15,6 @@ import {
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import { opptrixCssVars } from '../../theme/tokens'
 import {
-  SettingsAddBar,
   SettingsEmptyState,
   SettingsGroup,
   SettingsListPanel,
@@ -96,14 +94,14 @@ function lastStatusLabel(status: string | null): string {
   }
 }
 
-function osStatusBadge(os: ScheduleOsHealth | null, s: ReturnType<typeof useStyles>) {
+function scheduleHealthBadge(os: ScheduleOsHealth | null, s: ReturnType<typeof useStyles>) {
   if (!os) return null
   switch (os.status) {
-    case 'synced':
+    case 'error':
       return (
-        <span className={mergeClasses(s.statusBadge, s.statusReady)}>
-          <CheckmarkCircleRegular fontSize={14} />
-          已同步
+        <span className={mergeClasses(s.statusBadge, s.statusError)}>
+          <DismissCircleRegular fontSize={14} />
+          需关注
         </span>
       )
     case 'pending':
@@ -112,17 +110,17 @@ function osStatusBadge(os: ScheduleOsHealth | null, s: ReturnType<typeof useStyl
           同步中
         </span>
       )
-    case 'error':
+    case 'synced':
       return (
-        <span className={mergeClasses(s.statusBadge, s.statusError)}>
-          <DismissCircleRegular fontSize={14} />
-          同步失败
+        <span className={mergeClasses(s.statusBadge, s.statusReady)}>
+          <CheckmarkCircleRegular fontSize={14} />
+          就绪
         </span>
       )
     default:
       return (
         <span className={s.statusBadge}>
-          应用内定时
+          托盘内执行
         </span>
       )
   }
@@ -132,7 +130,6 @@ export default function ScheduleSettingsSection() {
   const s = useStyles()
   const toast = useSettingsToast()
   const [loading, setLoading] = useState(true)
-  const [syncing, setSyncing] = useState(false)
   const [settings, setSettings] = useState<ScheduleSettings | null>(null)
   const [jobs, setJobs] = useState<ScheduledJob[]>([])
   const [os, setOs] = useState<ScheduleOsHealth | null>(null)
@@ -164,6 +161,13 @@ export default function ScheduleSettingsSection() {
       const resp = await scheduleApi.patchSettings(patch)
       setSettings(resp.settings)
       if (resp.os) setOs(resp.os)
+      const needsReconcile = (
+        patch.master_enabled !== undefined
+        || patch.autostart !== undefined
+      )
+      if (needsReconcile) {
+        void window.electronAPI?.scheduleOsReconcile?.().catch(() => {})
+      }
       toast.showSuccess('已保存')
     } catch (e) {
       toast.showError(e instanceof Error ? e.message : '保存失败，请稍后重试')
@@ -180,21 +184,6 @@ export default function ScheduleSettingsSection() {
       toast.showError(e instanceof Error ? e.message : '暂时无法更新任务')
     }
   }, [toast])
-
-  const handleResync = useCallback(async () => {
-    setSyncing(true)
-    try {
-      const resp = await scheduleApi.patchSettings({ resync_os: true })
-      setSettings(resp.settings)
-      if (resp.os) setOs(resp.os)
-      toast.showSuccess('已重新注册系统定时')
-      await load()
-    } catch (e) {
-      toast.showError(e instanceof Error ? e.message : '重新注册失败，请稍后重试')
-    } finally {
-      setSyncing(false)
-    }
-  }, [load, toast])
 
   if (loading) {
     return <Spinner size="tiny" label="正在加载计划任务…" />
@@ -220,7 +209,7 @@ export default function ScheduleSettingsSection() {
         <SettingsGroup>
           <SettingsRow
             title="计划任务"
-            desc="关闭后，所有任务都不会自动执行"
+            desc="关闭后所有任务都不会自动执行。最小化到托盘时仍会按计划执行；从托盘完全退出后不会执行"
             control={(
               <Switch
                 checked={settings.master_enabled}
@@ -248,12 +237,15 @@ export default function ScheduleSettingsSection() {
         <SettingsSectionLabel>后台常驻</SettingsSectionLabel>
         <SettingsGroup>
           <SettingsRow
-            title="随应用启动"
-            desc={settings.autostart ? '应用启动后会尝试注册系统定时' : '当前由应用内定时扫描执行'}
+            title="登录时在托盘启动"
+            desc="开机后静默进入托盘，便于计划任务在后台继续执行；完全退出应用后仍不会执行"
             control={(
-              <Text style={{ fontSize: 'var(--opptrix-font-sm)', color: opptrixCssVars.textTertiary }}>
-                {settings.autostart ? '已开启' : '未开启'}
-              </Text>
+              <Switch
+                checked={settings.autostart}
+                disabled={!settings.master_enabled}
+                onChange={(_, data) => { void patchSettings({ autostart: Boolean(data.checked) }) }}
+                aria-label="登录时在托盘启动"
+              />
             )}
             last
           />
@@ -261,32 +253,15 @@ export default function ScheduleSettingsSection() {
       </div>
 
       <div className={s.sectionBlock}>
-        <SettingsSectionLabel>系统定时</SettingsSectionLabel>
+        <SettingsSectionLabel>运行说明</SettingsSectionLabel>
         <SettingsListPanel>
-          <SettingsAddBar
-            meta={os?.message ?? '正在获取同步状态…'}
-            actions={(
-              <OpptrixButton
-                variant="ghost"
-                size="small"
-                icon={<ArrowSyncRegular fontSize={14} />}
-                disabled={syncing}
-                onClick={() => { void handleResync() }}
-              >
-                {syncing ? '注册中…' : '重新注册'}
-              </OpptrixButton>
-            )}
-          />
           <SettingsListRow
-            title="同步状态"
+            title={os?.message ?? '应用运行或驻留托盘时按计划执行'}
             meta={summary
               ? `共 ${summary.total} 个任务，${summary.enabled} 个启用`
               : '暂无任务摘要'}
-            trailing={osStatusBadge(os, s)}
+            trailing={scheduleHealthBadge(os, s)}
           />
-          {os?.error && (
-            <SettingsListRow title={os.error} />
-          )}
         </SettingsListPanel>
       </div>
 

--- a/client-ui/src/platform/detect.ts
+++ b/client-ui/src/platform/detect.ts
@@ -70,6 +70,9 @@ declare global {
       setThemeSource?: (source: 'system' | 'light' | 'dark') => void
       shellInstallWindowsSandbox?: () => Promise<{ ok: boolean; cancelled?: boolean; message?: string }>
       shellInstallLinuxSandbox?: () => Promise<{ ok: boolean; cancelled?: boolean; message?: string }>
+      /** 同步登录项并注销遗留 OS 计划任务 */
+      scheduleOsReconcile?: () => Promise<unknown>
+      scheduleEnsureAutostart?: (enabled: boolean) => Promise<unknown>
     }
     showDirectoryPicker?: (options?: { mode?: 'read' | 'readwrite' }) => Promise<FileSystemDirectoryHandle>
     showSaveFilePicker?: (options?: {

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -101,7 +101,7 @@ Opptrix/
 │   ├── research-hub/ · search-hub/
 │   ├── news-feed/ · article-enrichment/
 │   ├── local-inference/
-│   ├── schedule/            # 计划任务服务（应用内 timer + 桌面 OS tick）
+│   ├── schedule/            # 计划任务服务（sidecar 进程内 timer；托盘存活时执行）
 │   ├── user-store/          # SQLite 用户数据
 │   ├── agent/               # LLM + 127 MCP 工具 + Tool Pack 路由
 │   ├── agent-workspace/     # Agent 工作区：文件/Shell/Python/密钥保险箱
@@ -184,7 +184,7 @@ Opptrix/
     - **确认纪律（与 MCP 安装同类）**：`delete_news_source`、`import_news_sources`、`delete_news_group` **须先 `ask_user`，再以相同参数 + `confirmed=true` 重试**；未 confirmed 只返回摘要、不落库。删订阅不可恢复；删分组仅把组内订阅改为未分组，不删订阅本身。导入入参：`schema_version=1` + `subscriptions`，或仅 `subscriptions` 数组（已存在 url 跳过）
     - Hub feature 映射：`news_center_status` / `news_groups_list` / `news_sources_list` / `news_articles_list` / `news_article_detail` / `news_source_add|delete|validate` / `news_sources_import` / `news_group_create|update|delete` / `news_source_move_group`（见 [API.md](./API.md) Hub Features）
   - **网页浏览（`browser` pack）**：`browser_navigate` / `browser_snapshot` / `browser_click` / `browser_type` / `browser_screenshot` / `browser_close`（Playwright 完整 Chromium，headless，无需单独 headless-shell；开发环境 `npm install` 会自动安装 Chromium，可用 `OPPTRIX_SKIP_PLAYWRIGHT_BROWSER=1` 跳过；桌面安装包已内置）
-  - **计划任务（`automation` pack）**：实现 `packages/agent/src/mcp/schedule-tools.ts`，底层 `@opptrix/schedule` / user-store；REST 见 [API.md · 计划任务](./API.md#计划任务--schedule)；桌面 OS tick 见 [DESKTOP.md · 计划任务与后台常驻](./DESKTOP.md#计划任务与后台常驻)
+  - **计划任务（`automation` pack）**：实现 `packages/agent/src/mcp/schedule-tools.ts`，底层 `@opptrix/schedule` / user-store；REST 见 [API.md · 计划任务](./API.md#计划任务--schedule)；桌面调度（进程内 timer；reconcile 仅注销遗留 OS 注册）见 [DESKTOP.md · 计划任务与后台常驻](./DESKTOP.md#计划任务与后台常驻)
     - **工具**：`list_scheduled_jobs` / `get_scheduled_job` / `create_scheduled_job` / `update_scheduled_job` / `enable_scheduled_job` / `disable_scheduled_job` / `delete_scheduled_job` / `run_scheduled_job_now` / `list_scheduled_job_runs`
     - **激活**：非 always-on；关键词播种（`tool-pack-resolver.ts`：`计划任务|定时任务|定时分析|自动执行` 等）或 `activate_tool_pack({ pack_ids: ["automation"] })`
     - **何时用**：用户要**定时重复**跑智能体分析、提醒或受控脚本；一次性命令仍用 `shell_run`，勿用计划任务代替
@@ -196,10 +196,11 @@ Opptrix/
       - `enabled`（可选，默认 true）
     - **安全与纪律**：
       - `kind=shell_script` **须**用户在设置中开启 `allow_shell_scripts`（`PATCH /api/schedule/settings`）；未开启时 create/update 返回错误，Agent 应引导用户先开开关，**禁止**用 `shell_run` 绕过定时登记
+      - **无人值守执行**：`agent_prompt` 后台跑时 `chat({ unattended: true })` — 剔除 `ask_user` / `request_secret`，禁止 `waitForAnswer` 挂起；工作区覆盖/删除确认自动放行，保险箱密钥立即取消不可用；若仍命中 `ask_user` 则立即返回失败结果让模型继续
       - `delete_scheduled_job` **须** `ask_user` 后以 `confirmed=true` 重试；未确认只返回 `needs_confirmation`
       - `run_scheduled_job_now` 写入执行记录（`trigger: 'agent'`）；同一任务勿连续多次触发
       - `list_scheduled_job_runs`：`job_id` 必填，`limit` 默认 20、最大 50
-    - **与调度关系**：Sidecar 进程内 timer（20s）在应用运行时常驻扫描；桌面 **OS tick**（60s 用户级）在关窗/后台时兜底——Agent 只读写任务定义，不负责触发 OS 注册（由桌面 `reconcileOsSchedule` 完成）
+    - **与调度关系**：Sidecar 进程内 timer（20s）在应用运行或托盘常驻时扫描并执行；**完全退出应用后不执行**。不再注册系统级 OS tick——Agent 只读写任务定义，不负责 OS 注册（桌面 `reconcileOsSchedule` 仅注销遗留任务）
   - **工作区与文件（`workspace` pack）**：实现 `@opptrix/agent-workspace` + `packages/agent/src/mcp/workspace-tools.ts`
     - **工具**：`workspace_list` / `workspace_read` / `workspace_write` / `workspace_mkdir` / `workspace_delete` / `download_file` / `http_fetch` / `request_folder_access` / `list_workspace_grants` / `resolve_workspace_path_uri` / `shell_platform_status` / `shell_run` / `shell_install` / `python_env_status` / `ensure_python` / `list_local_data_apis` / `get_local_data_catalog` / `prepare_fuyao_dump` / `request_session_lan_access` / `request_secret` / `list_vault_secrets` / `grant_session_secret` / `revoke_session_secret` / `delete_vault_secret`
     - **消息内文件引用**：聊天 Markdown 展示工作区图片/音视频/文件时，使用协议 `opptrix-ws://{root_id}/{相对路径}`（例：`opptrix-ws://shared/charts/a.png`）。可先调 `resolve_workspace_path_uri({ root_id, path })` 得到规范 `uri` 与 `exists` / `kind_hint`（合法且已授权即返回 uri，不返回本机绝对路径）。UI 将 URI 解析为 `GET /api/sessions/:id/workspace/file` 流。**禁止**消息中写 `file://` 或绝对路径。
@@ -390,7 +391,7 @@ npm run serve               # 生产预览
 |------|----------|
 | 新增 Hub feature | `packages/research-hub/src/hub.ts` |
 | 新增 REST 端点 | `apps/server/src/index.ts`（计划任务：`apps/server/src/schedule-routes.ts`） |
-| 计划任务 / 调度引擎 | `packages/schedule/` + `packages/user-store/src/schedule.ts`；Agent 工具：`packages/agent/src/mcp/schedule-tools.ts`；桌面 OS tick：`apps/desktop/electron/schedule-bridge.cjs`、`os-schedule/` |
+| 计划任务 / 调度引擎 | `packages/schedule/` + `packages/user-store/src/schedule.ts`；Agent 工具：`packages/agent/src/mcp/schedule-tools.ts`；桌面 reconcile（仅注销遗留）：`apps/desktop/electron/schedule-bridge.cjs`、`os-schedule/` |
 | 新增 Agent/MCP 工具 | `packages/agent/src/tools.ts` + `tool-meta.ts` + `packages/shared/src/tool-packs.ts`（挂 pack）+ `tool-route-plan.ts`（意图精排）；遵循 `.cursor/rules/mcp-tool-pack-routing.mdc` |
 | 工作区 / http_fetch / 文件夹授权 | `packages/agent-workspace/` + `packages/agent/src/mcp/workspace-tools.ts`；grant REST：`apps/server/src/index.ts`（`/api/sessions/:id/workspace/grants`） |
 | 调整聊天工具包播种 | `packages/agent/src/mcp/tool-pack-resolver.ts` |

--- a/docs/API.md
+++ b/docs/API.md
@@ -534,33 +534,34 @@ Shell 运行时出站确认（`sandboxAskCallback` / `confirmation.kind === "net
 
 定时执行智能体提示词或受控脚本。持久化于用户 SQLite（`packages/user-store` 的 `schedule` 命名空间）；调度引擎为 `@opptrix/schedule` 的 `ScheduleService`。Sidecar 启动时注册 `registerScheduleRoutes` 并调用 `scheduleService.start()`（进程内每 **20s** 扫描到期任务，`trigger: 'timer'`）。
 
-桌面端另有一套 **OS 级通用 tick**（用户级、无需 root），经 `POST /api/schedule/tick` 触发（`trigger: 'os'`）。冷启动路径为 **HTTP-first → `ELECTRON_RUN_AS_NODE` headless sidecar**（不拉起 Opptrix GUI）；详见 [DESKTOP.md · 计划任务与后台常驻](./DESKTOP.md#计划任务与后台常驻)。
+计划任务仅在 **应用运行或托盘常驻** 时由进程内 timer 执行；完全退出后不执行。桌面 `reconcile` **只**注销遗留 OS 注册（LaunchAgent / schtasks / systemd），**不再**注册系统级 tick。`POST /api/schedule/tick`（`trigger: 'os'`）仅兼容旧 runner；详见 [DESKTOP.md · 计划任务与后台常驻](./DESKTOP.md#计划任务与后台常驻)。
 
 | 方法 | 路径 | 说明 |
 |------|------|------|
 | GET | `/api/schedule/settings` | 读取全局设置 |
-| PATCH | `/api/schedule/settings` | 更新设置；可选 `resync_os: true` 触发 OS tick 重新注册 |
+| PATCH | `/api/schedule/settings` | 更新设置；可选 `resync_os: true` 清理遗留 OS 状态字段 |
 | GET | `/api/schedule/jobs` | 列出全部任务 |
 | GET | `/api/schedule/jobs/:id` | 单条任务详情 |
 | POST | `/api/schedule/jobs` | 创建任务 |
 | PATCH | `/api/schedule/jobs/:id` | 更新任务 |
 | DELETE | `/api/schedule/jobs/:id` | 删除任务 |
 | POST | `/api/schedule/jobs/:id/run` | 立即执行一次（`trigger: 'manual'`） |
-| POST | `/api/schedule/tick` | 扫描并执行到期任务（**仅本机**；`trigger: 'os'`） |
+| POST | `/api/schedule/tick` | 扫描并执行到期任务（**仅本机**；兼容旧 OS runner，`trigger: 'os'`） |
 | GET | `/api/schedule/status` | 汇总状态、启用任务数、最近失败 |
-| GET | `/api/schedule/os/reconcile` | 桌面 reconcile 提示（是否注册 OS tick、间隔等） |
+| GET | `/api/schedule/os/reconcile` | 桌面 reconcile 提示（`register_tick` 恒为 false） |
 
 **`ScheduleSettings`（GET/PATCH `/api/schedule/settings`）**
 
 | 字段 | 类型 | 默认 | 说明 |
 |------|------|------|------|
 | `master_enabled` | boolean | `true` | 总开关；为 `false` 时 `tick` 跳过所有到期任务 |
-| `autostart` | boolean | `false` | 桌面：登录项 `--background` 后台常驻 + 启用 OS tick 注册 |
+| `run_when_closed` | boolean | `false` | **兼容字段**：始终 `false`；PATCH 忽略写入；不再注册系统 crontab |
+| `autostart` | boolean | `false` | 桌面：登录项 `--background` 托盘常驻 |
 | `allow_shell_scripts` | boolean | `false` | 为 `false` 时禁止创建/改为 `shell_script` 任务 |
-| `os_tick_status` | `'synced' \| 'pending' \| 'error' \| 'n/a'` | `'n/a'` | OS 级 tick 注册状态（桌面写入） |
-| `os_tick_error` | string \| null | `null` | OS 注册失败原因 |
+| `os_tick_status` | `'synced' \| 'pending' \| 'error' \| 'n/a'` | `'n/a'` | 遗留字段；新版本通常为 `n/a` |
+| `os_tick_error` | string \| null | `null` | 遗留 OS 注销失败原因（少见） |
 
-PATCH 时若变更 `master_enabled` 或 `autostart` 且未带 `resync_os`，响应会将 `os_tick_status` 置为 `pending`。`resync_os: true` 时额外调用 `resyncOsRegistration` 并返回 `os` 健康摘要。
+PATCH 时若变更 `master_enabled` 或 `autostart` 且未带 `resync_os`，可将 `os_tick_status` 置为 `pending` 以提示桌面 reconcile（强制 remove）。`resync_os: true` 时清理任务级 `os_*` 字段并返回健康摘要。计划任务仅在 **应用运行或托盘常驻** 时由进程内 timer 执行；完全退出后不执行。
 
 **任务类型**
 
@@ -591,16 +592,17 @@ PATCH 时若变更 `master_enabled` 或 `autostart` 且未带 `resync_os`，响�
 - 仅允许来源 IP 为 `127.0.0.1` / `::1` / `::ffff:127.0.0.1`；否则 **403** `{ "error": "仅允许本机调用" }`
 - 成功：`{ "result": { "due": string[], "ran": string[], "skipped": string[] } }`
 - `master_enabled=false` 时返回空数组（不执行）
-- 通过乐观 claim（推进 `next_run_at` + running lease）保证幂等，避免 OS tick 与进程内 timer 重复执行同一到期窗口
+- 通过乐观 claim（推进 `next_run_at` + running lease）保证幂等，避免并发 tick 重复执行同一到期窗口
 
 **GET `/api/schedule/status` 响应（节选）**
 
 ```json
 {
   "master_enabled": true,
+  "run_when_closed": false,
   "allow_shell_scripts": false,
   "autostart": true,
-  "os": { "status": "synced", "message": "…", "error": null, "autostart": true },
+  "os": { "status": "n/a", "message": "…", "error": null, "autostart": true },
   "jobs": { "total": 2, "enabled": 1, "disabled": 1, "next_due": "2026-07-28T08:00:00.000Z" },
   "enabled_jobs": 1,
   "recent_failures": [],
@@ -610,7 +612,7 @@ PATCH 时若变更 `master_enabled` 或 `autostart` 且未带 `resync_os`，响�
 
 **GET `/api/schedule/os/reconcile`**
 
-供 Electron `schedule-bridge.cjs` 读取：`register_tick`（= `master_enabled`）、`autostart`、`interval_sec`（固定 **60**）、`os_tick_status`、`desktop_required: true`。
+供 Electron `schedule-bridge.cjs` 读取：`register_tick` **恒为 `false`**（不再注册系统 crontab）、`run_when_closed: false`、`autostart`、`interval_sec`（保留字段，固定 **60**）、`os_tick_status`、`desktop_required: true`。桌面侧每次 reconcile 仍调用 `removeTickRegistration` 清理旧版遗留。
 
 **错误**
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -73,20 +73,22 @@ The release app loads `http://127.0.0.1:8711` (UI + API same origin).
 
 ## 计划任务与后台常驻
 
-桌面端计划任务采用 **双轨调度**：Sidecar 内 `ScheduleService.start()` 每 **20s** 进程内扫描（`trigger: 'timer'`）；另注册 **OS 级通用 tick**（默认间隔 **60s**，用户级、**不要求 root**）。OS tick 优先经 userData 内 **HTTP-first runner** 对已运行 sidecar 发 `POST /api/schedule/tick`（`trigger: 'os'`）；仅当 sidecar 未起时才 fallback **`ELECTRON_RUN_AS_NODE` headless-tick**（无界面拉起 sidecar → tick → 停掉本次 sidecar），**不再** GUI 冷启动 `--background --schedule-tick`。两路均经乐观 claim 幂等，避免重复跑同一到期任务。
+桌面端计划任务为 **仅进程内执行**：Sidecar 内 `ScheduleService.start()` 每 **20s** 扫描到期任务（`trigger: 'timer'`）。**不再**注册 LaunchAgent / Windows schtasks / Linux systemd timer；升级启动时 `reconcileOsSchedule` **强制** `removeTickRegistration` 并清理旧 runner 脚本。
+
+关窗到托盘时 sidecar 与 timer 继续运行；从托盘 **完全退出** 后计划任务 **不会** 执行。登录项 `autostart`（`--background`）可保留，与已废除的 OS tick 无关。
 
 ### 关窗 = 托盘常驻（生产包）
 
-打包应用（`app.isPackaged`）启用系统托盘（`tray.cjs`）。用户点关闭主窗口时 **不退出进程**（`attachCloseToTray` → `preventDefault` + `hide`）；sidecar 与进程内 20s timer 继续运行。托盘菜单含计划任务状态摘要（`fetchScheduleStatus`）与「显示 Opptrix」。真正退出须选托盘/菜单 **退出**（`app.isQuitting = true` 后允许窗口关闭并 `stopSidecar`）。
+打包应用（`app.isPackaged`）启用系统托盘（`tray.cjs`）。用户点关闭主窗口时 **不退出进程**（`attachCloseToTray` → `preventDefault` + `hide`，并隐藏 macOS Dock / Windows·Linux 任务栏图标，仅保留系统托盘）；从托盘「显示」时 `revealAppFromTray` / `ensureMainWindowVisible` 恢复 Dock 与任务栏。sidecar 与进程内 20s timer 继续运行。托盘菜单含计划任务状态摘要（`fetchScheduleStatus`）与「显示 Opptrix」。真正退出须选托盘/菜单 **退出**（`app.isQuitting = true` 后允许窗口关闭并 `stopSidecar`）。
 
 **更新安装防护（兼容托盘 / 计划任务）**：
 
-1. 安装前：`isUpdating` + `isQuitting` → 停 reconcile 轮询 → **暂停 OS tick**（launchd / 任务计划 / systemd-user；Linux 会 `stop` oneshot + `disable --now` timer）→ 销毁托盘 → 等待 sidecar 退出 → 销毁窗口（卸掉关窗进托盘）→ **`killResidualAppProcessesForUpdate`**（`kill-app-for-update.cjs`）：三端按 **.app bundle / 安装目录 / AppImage·deb 路径** 强杀残留 PID（Helper、孤儿实例、sidecar 孙进程等），**始终排除当前主进程 `process.pid`**；Linux 另用 `/proc/*/exe`+cmdline 双通道并 **settle 后再扫一轮**（与 macOS/Windows 对等），再交给 `quitAndInstall`  
-2. 安装中：`second-instance`（含 `--schedule-tick`）一律忽略，避免第二实例拖住进程  
-3. OS tick 唤醒（`--schedule-tick`）**不**自动 `quitAndInstall`，等下次正常打开再装  
-4. `quitAndInstall` 后约 3s 仍未退出 → 强制 `app.exit`（防 macOS 安装器因应用仍在运行而卡住 / Linux AppImage 占锁）；约 12s 仍存活 → 清安装态、提示用户强制退出后重开即可继续安装，并重建托盘/主窗口，再 `reconcileOsSchedule` 恢复 OS tick  
+1. 安装前：`isUpdating` + `isQuitting` → 停 reconcile 轮询 → **移除遗留 OS tick**（若仍有 launchd / 任务计划 / systemd-user）→ 销毁托盘 → 等待 sidecar 退出 → 销毁窗口（卸掉关窗进托盘）→ **`killResidualAppProcessesForUpdate`**（`kill-app-for-update.cjs`）：三端按 **.app bundle / 安装目录 / AppImage·deb 路径** 强杀残留 PID（Helper、孤儿实例、sidecar 孙进程等），**始终排除当前主进程 `process.pid`**；Linux 另用 `/proc/*/exe`+cmdline 双通道并 **settle 后再扫一轮**（与 macOS/Windows 对等），再交给 `quitAndInstall`  
+2. 安装中：`second-instance`（含旧版 `--schedule-tick`）一律忽略，避免第二实例拖住进程  
+3. 遗留 OS tick 唤醒（`--schedule-tick`）**不**自动 `quitAndInstall`，等下次正常打开再装  
+4. `quitAndInstall` 后约 3s 仍未退出 → 强制 `app.exit`（防 macOS 安装器因应用仍在运行而卡住 / Linux AppImage 占锁）；约 12s 仍存活 → 清安装态、提示用户强制退出后重开即可继续安装，并重建托盘/主窗口，再 `reconcileOsSchedule`（仅 remove + 登录项）  
 5. Windows 另有 NSIS（`nsis/installer.nsh`）在写文件前删 `OpptrixScheduleTick` 并 `taskkill` / 按 `$INSTDIR` 路径强杀；Electron 侧强杀是安装器唤起前的补强，语义对齐但不无差别先杀本进程  
-6. Linux 用户退出 / 短命 tick 结束时与 Windows 一样有短超时 `app.exit` 兜底，避免 AppImage 幽灵进程占住下一版安装  
+6. Linux 用户退出时与 Windows 一样有短超时 `app.exit` 兜底，避免 AppImage 幽灵进程占住下一版安装  
 
 
 托盘图标源文件在仓库 `icons/tray/`，经 `prepare-icons.mjs` 同步到 `apps/desktop/build/icons/tray/`（已纳入 `electron-builder` `files`）。
@@ -143,42 +145,34 @@ Electron 官方建议 Windows 用 **多尺寸 `.ico`**（至少含上表 small �
 
 | 参数 | 含义 |
 |------|------|
-| `--background` | 无 splash/主窗启动；macOS 隐藏 Dock；仍 spawn sidecar 并 reconcile OS 调度 |
-| `--schedule-tick` | **兼容**旧 LaunchAgent / 手动调试：短命 Electron worker（`runEphemeralScheduleTickWorker`）在 sidecar ready 后 `POST /api/schedule/tick`，然后退出（常与 `--background` 合用；不建托盘、不常驻）。**新注册的 OS 任务不再指向此路径** |
+| `--background` | 无 splash/主窗启动；macOS 隐藏 Dock；仍 spawn sidecar；进程内 timer 工作；reconcile 仅 remove 遗留 OS tick + 同步登录项 |
+| `--schedule-tick` | **兼容**旧 LaunchAgent：短命 worker 在 sidecar ready 后 `POST /api/schedule/tick` 后退出；**新版本不再注册**此类 OS 任务 |
 
-OS 适配器注册的系统任务执行 **HTTP-first tick runner**（写在 Electron `userData`，如 `os-schedule-tick-runner.sh` / `.cmd`），**不再**把 Opptrix GUI 本体当作 StartInterval / schtasks / systemd 的主程序：
+**已废除**：系统级 OS tick（LaunchAgent / schtasks / systemd timer）、OpptrixSchedule Helper 冷启、headless-tick 作为主路径。适配器仍保留 `removeTickRegistration` / `probeTickRegistration`，供升级清理。`userData` 内旧 `os-schedule-tick-runner.*` 与 endpoint 冷启字段在 reconcile 时清除；`os-schedule-endpoint.json` 仅保留 loopback `host`/`port` 供 UI 复用 sidecar。
 
-1. 读取 `userData/os-schedule-endpoint.json`（`host` 强制 `127.0.0.1`、`port`，以及冷启动用的 `execPath` + `headlessTick`；可选 `runtimeStage` / `resourcesPath`；由 `configureScheduleBridge` / ensure runner 写入，**无密钥**）
-2. 短超时 `POST http://127.0.0.1:$PORT/api/schedule/tick`（`{"trigger":"os"}`）→ **成功则 exit 0**（应用已运行时不拉起新进程，避免 Dock / 任务栏闪烁；UI 侧 `resolveApiPort(allowReuse:true)` 可 reuse 同一 endpoint 上的健康 sidecar）
-3. 失败（sidecar 未起）再 fallback：`ELECTRON_RUN_AS_NODE=1 "$execPath" "$headlessTick"`（`os-schedule/headless-tick.cjs`：再试 POST → 必要时 spawn sidecar → health → POST tick → **停掉本次 sidecar** → exit）。**禁止** fallback 到 `Opptrix --background --schedule-tick`
+Windows NSIS（`nsis/installer.nsh`）仍会在安装前移除 `OpptrixScheduleTick`，避免旧版定时拉起阻塞覆盖安装。
 
-| 平台 | 机制 | 标识 |
-|------|------|------|
-| **macOS** | 用户 LaunchAgent `~/Library/LaunchAgents/org.opptrix.schedule-tick.plist`，`ProgramArguments` = `/bin/bash` + tick runner，`StartInterval` ≥ 30s | `launchctl` gui 域 |
-| **Windows** | 用户计划任务 `schtasks`，`/TR` 指向 tick runner `.cmd`，按分钟重复 | 任务名 `OpptrixScheduleTick` |
-| **Linux** | 用户 systemd timer；`.service` 的 `ExecStart` = `/bin/bash` + tick runner | `systemctl --user` |
-
-实现：`apps/desktop/electron/os-schedule/{tick-runner,headless-tick,sidecar-launch}.cjs` + `{darwin,win32,linux}.cjs`；入口 `os-schedule/index.cjs`。Windows NSIS 安装器（`nsis/installer.nsh`）会在安装前移除 `OpptrixScheduleTick` 并结束运行中的 Opptrix，避免旧版定时拉起阻塞覆盖安装。
-
-单实例锁：若已有实例运行，带 `--schedule-tick` 的第二次启动（仅兼容旧 plist / 手动调试）只触发 `handleScheduleTickFromOs()`（经已有 sidecar），不重复开主窗（除非未带 `--background`）。macOS 在 `requestSingleInstanceLock` 之前对 `--background` / `--schedule-tick` 尽早 `app.dock.hide()`，进一步降低秒退时的 Dock 闪烁。
+单实例锁：若已有实例运行，带 `--schedule-tick` 的第二次启动（仅兼容旧 plist）只触发 `handleScheduleTickFromOs()`，不重复开主窗（除非未带 `--background`）。
 
 ### `schedule-bridge.cjs` 与 reconcile
 
-主进程通过 bridge 调用 sidecar REST（`configureScheduleBridge({ host, port })` 同时写入 `os-schedule-endpoint.json`）：
+主进程通过 bridge 调用 sidecar REST（`configureScheduleBridge({ host, port })` 写入 endpoint 的 host/port）：
 
-1. `GET /api/schedule/os/reconcile` — 是否应注册 OS tick（`register_tick` = `master_enabled`）、`autostart`、`interval_sec`
-2. `getOsScheduleAdapter().ensureTickRegistration` / `removeTickRegistration` — 生成/刷新 tick runner 并写系统级任务
-3. `app.setLoginItemSettings({ openAtLogin, args: ['--background'] })` — macOS/Windows 登录项（`autostart`）
-4. `PATCH /api/schedule/settings` — 回写 `os_tick_status` / `os_tick_error`
+1. `GET /api/schedule/os/reconcile` — `register_tick` **恒为 false**；读取 `autostart`
+2. `getOsScheduleAdapter().removeTickRegistration()` — **每次**启动/轮询强制注销遗留 OS 任务（永不 `ensureTickRegistration`）
+3. `purgeLegacyOsTickArtifacts` — 删除旧 runner 脚本、剥离 endpoint 冷启字段
+4. `app.setLoginItemSettings({ openAtLogin, args: ['--background'] })` — macOS/Windows 登录项（`autostart`）
+5. `PATCH /api/schedule/settings` — 回写 `os_tick_status`（通常 `n/a`）
 
-前台与 `--background` 启动后均 `reconcileOsSchedule()`，并每 **30s** 轮询 reconcile（`startScheduleReconcilePoll`）。用户 PATCH settings 且 `resync_os: true` 时 sidecar 也会触发 `resyncOsRegistration`。
+前台与 `--background` 启动后均 `reconcileOsSchedule()`，并每 **30s** 轮询（幂等 remove）。
 
 ### 设置字段（与 API 一致）
 
 | 字段 | 桌面行为 |
 |------|----------|
-| `master_enabled` | 为 false 时不注册 OS tick、tick 跳过执行 |
-| `autostart` | 登录项 `--background` + 参与 OS 健康计算（`computeOsHealth`） |
+| `master_enabled` | 为 false 时 tick 跳过执行 |
+| `run_when_closed` | **兼容字段**，始终 false；API 忽略写入；UI 已隐藏 |
+| `autostart` | 登录项 `--background` 托盘常驻 |
 | `allow_shell_scripts` | 与 Agent/REST 一致；脚本类任务门禁 |
 
 REST 与 Agent 工具详见 [API.md · 计划任务](./API.md#计划任务--schedule)、[AGENT-GUIDE.md §4.2 · automation pack](./AGENT-GUIDE.md#42-agent-与-mcp)。

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -154,6 +154,11 @@ export interface ChatProgressOptions {
   onProgress?: (event: ChatProgressEvent) => void
   /** AbortSignal，用于用户取消聊天请求 */
   signal?: AbortSignal
+  /**
+   * 无人值守（计划任务 / 后台 Agent）：剔除 ask_user / request_secret，
+   * 禁止 waitForAnswer 挂起；工作区覆盖/删除确认自动放行，密钥类立即取消。
+   */
+  unattended?: boolean
 }
 
 // ── 工具中文标签映射 ──

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -75,6 +75,14 @@ import {
   type UserPromptOption,
   UserPromptCancelledError,
 } from './user-prompt.js'
+import {
+  UNATTENDED_ASK_USER_RESULT,
+  UNATTENDED_SECRET_RESULT,
+  appendUnattendedTurnTail,
+  filterOpenAiToolsForUnattended,
+  filterToolNamesForUnattended,
+  pickUnattendedConfirmIds,
+} from './unattended.js'
 import { SessionStore, sessionToMeta, type SessionRecord, type SessionContextRef, type CreateSessionOptions, type ReasoningEffort } from './sessions.js'
 import { getExpertCatalogService } from './experts/catalog-service.js'
 import {
@@ -314,16 +322,23 @@ export class AgentEngine {
     this.expertPacksSeeded.add(seedKey)
   }
 
-  private async rebuildRoundTools(activeNames: readonly string[]) {
-    const broker = await this.createRoundBroker(activeNames)
+  private async rebuildRoundTools(activeNames: readonly string[], unattended = false) {
+    const names = unattended ? filterToolNamesForUnattended(activeNames) : activeNames
+    const broker = await this.createRoundBroker(names)
     const rawTools = await broker.openAiTools()
     const preferred = this.lastRoutePlan?.preferredTools ?? []
     // 远程 MCP 工具整体优先于本地兜底工具；preferred 排序仅在各自分组内生效。
-    const openAiTools = orderToolsByPreference(rawTools, preferred, { remoteFirst: true })
+    let openAiTools = orderToolsByPreference(rawTools, preferred, { remoteFirst: true })
+    if (unattended) openAiTools = filterOpenAiToolsForUnattended(openAiTools)
     return { broker, openAiTools }
   }
 
-  private bindWorkspaceBridge(sessionId: string, emit: (event: ChatProgressEvent) => void, signal?: AbortSignal): number {
+  private bindWorkspaceBridge(
+    sessionId: string,
+    emit: (event: ChatProgressEvent) => void,
+    signal?: AbortSignal,
+    unattended = false,
+  ): number {
     const bridge: WorkspaceToolBridge = {
       sessionId,
       signal,
@@ -335,6 +350,8 @@ export class AgentEngine {
         root_id: string
         path: string
       }) => {
+        // Unattended schedule jobs: auto-allow like scheduleShellConfirm (never waitForAnswer)
+        if (unattended) return pickUnattendedConfirmIds(payload.options)
         const promptId = createUserPromptId()
         emit({
           type: 'user_prompt',
@@ -349,6 +366,15 @@ export class AgentEngine {
         return { selected_ids: answer.selected_ids }
       },
       askUser: async (payload) => {
+        if (unattended) {
+          return {
+            kind: 'option' as const,
+            selected_ids: [] as string[],
+            selected_labels: [] as string[],
+            cancelled: true,
+            custom_text: UNATTENDED_ASK_USER_RESULT.error,
+          }
+        }
         const promptId = createUserPromptId()
         emit({
           type: 'user_prompt',
@@ -364,6 +390,18 @@ export class AgentEngine {
         return this.userPromptBridge.waitForAnswer(sessionId, promptId, signal)
       },
       askSecret: async (payload) => {
+        if (unattended) {
+          return {
+            kind: 'secret' as const,
+            selected_ids: [] as string[],
+            selected_labels: [] as string[],
+            name: payload.name,
+            saved: false,
+            session_granted: false,
+            cancelled: true,
+            custom_text: UNATTENDED_SECRET_RESULT.error,
+          }
+        }
         const promptId = createUserPromptId()
         emit({
           type: 'user_prompt',
@@ -1047,6 +1085,7 @@ export class AgentEngine {
     }
 
     const signal = progress?.signal
+    const unattended = progress?.unattended === true
 
     const toolsUsed: string[] = []
     const toolSteps: ChatToolStep[] = []
@@ -1159,17 +1198,19 @@ export class AgentEngine {
     this.seedExpertDefaultPacks(sessionId, record)
     const packBridgeGen = this.bindPackBridge(sessionId)
     const skillBridgeGen = this.bindSkillBridge(sessionId)
-    const workspaceBridgeGen = this.bindWorkspaceBridge(sessionId, emit, signal)
+    const workspaceBridgeGen = this.bindWorkspaceBridge(sessionId, emit, signal, unattended)
     this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
     let activeNames = toolNamesForPacks(this.lastRoundPackIds)
-    let { broker, openAiTools } = await this.rebuildRoundTools(activeNames)
+    if (unattended) activeNames = filterToolNamesForUnattended(activeNames)
+    let { broker, openAiTools } = await this.rebuildRoundTools(activeNames, unattended)
 
     try {
     for (let round = 0; round < MAX_SAFETY_ROUNDS; round++) {
       throwIfAborted(signal)
       // 稳定 system（无时钟/选型卡）；动态内容经 turn-tail 追加，利于前缀缓存
       const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
-      const turnTail = this.buildRoundTurnTail(sessionId, activeNames)
+      let turnTail = this.buildRoundTurnTail(sessionId, activeNames)
+      if (unattended) turnTail = appendUnattendedTurnTail(turnTail)
       const contextMessages = contextRefToChatMessages(record.contextRef)
       const resolvedModel = this.registry.resolve(activeModel)
       const modelId = resolvedModel?.model
@@ -1439,24 +1480,29 @@ export class AgentEngine {
           let result: unknown
           try {
             if (fn === 'ask_user') {
-              const parsed = parseAskUserArgs(args)
-              if (parsed.error || !parsed.payload) {
-                result = { error: parsed.error ?? 'ask_user 参数无效' }
+              if (unattended) {
+                // Defense: never emit user_prompt / waitForAnswer in background jobs
+                result = { ...UNATTENDED_ASK_USER_RESULT }
               } else {
-                const promptId = createUserPromptId()
-                const answerPromise = this.userPromptBridge.waitForAnswer(sessionId, promptId, signal)
-                emit({
-                  type: 'user_prompt',
-                  prompt: { id: promptId, ...parsed.payload },
-                })
-                const answer = await answerPromise
-                const resultPayload: Record<string, unknown> = { ok: true, ...answer }
-                if (answer.selected_ids.includes('allow_lan_session')) {
-                  applySessionLanAskChoice(sessionId, answer.selected_ids)
-                  resultPayload.lan_granted = true
-                  resultPayload.lan_note = '本对话已允许局域网；具体域名仍可能需出站确认'
+                const parsed = parseAskUserArgs(args)
+                if (parsed.error || !parsed.payload) {
+                  result = { error: parsed.error ?? 'ask_user 参数无效' }
+                } else {
+                  const promptId = createUserPromptId()
+                  const answerPromise = this.userPromptBridge.waitForAnswer(sessionId, promptId, signal)
+                  emit({
+                    type: 'user_prompt',
+                    prompt: { id: promptId, ...parsed.payload },
+                  })
+                  const answer = await answerPromise
+                  const resultPayload: Record<string, unknown> = { ok: true, ...answer }
+                  if (answer.selected_ids.includes('allow_lan_session')) {
+                    applySessionLanAskChoice(sessionId, answer.selected_ids)
+                    resultPayload.lan_granted = true
+                    resultPayload.lan_note = '本对话已允许局域网；具体域名仍可能需出站确认'
+                  }
+                  result = resultPayload
                 }
-                result = resultPayload
               }
             } else if (!activeSet.has(fn) && !parseNamespacedMcpTool(fn)) {
               result = { error: unloadedToolHint(fn) }
@@ -1515,7 +1561,8 @@ export class AgentEngine {
           await broker.close()
           this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
           activeNames = toolNamesForPacks(this.lastRoundPackIds)
-          ;({ broker, openAiTools } = await this.rebuildRoundTools(activeNames))
+          if (unattended) activeNames = filterToolNamesForUnattended(activeNames)
+          ;({ broker, openAiTools } = await this.rebuildRoundTools(activeNames, unattended))
         }
         continue
       }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -31,6 +31,17 @@ export {
   parseAskUserArgs,
 } from './user-prompt.js'
 export {
+  UNATTENDED_ASK_USER_RESULT,
+  UNATTENDED_BLOCKED_TOOL_NAMES,
+  UNATTENDED_SECRET_RESULT,
+  UNATTENDED_TURN_TAIL_NOTE,
+  appendUnattendedTurnTail,
+  filterOpenAiToolsForUnattended,
+  filterToolNamesForUnattended,
+  isUnattendedBlockedTool,
+  pickUnattendedConfirmIds,
+} from './unattended.js'
+export {
   type AgentAppContext,
   type PublicAppSettings,
   createDefaultAppContext,

--- a/packages/agent/src/unattended.ts
+++ b/packages/agent/src/unattended.ts
@@ -1,0 +1,82 @@
+/**
+ * Unattended (background / scheduled) chat helpers.
+ * Strips interactive tools and provides immediate fail results so JobRunner never hangs on waitForAnswer.
+ */
+
+/** Tools that require a live user — never expose in unattended tool lists */
+export const UNATTENDED_BLOCKED_TOOL_NAMES = Object.freeze([
+  'ask_user',
+  'request_secret',
+] as const)
+
+export type UnattendedBlockedToolName = (typeof UNATTENDED_BLOCKED_TOOL_NAMES)[number]
+
+const BLOCKED = new Set<string>(UNATTENDED_BLOCKED_TOOL_NAMES)
+
+export function isUnattendedBlockedTool(name: string): boolean {
+  return BLOCKED.has(name)
+}
+
+export function filterToolNamesForUnattended(names: readonly string[]): string[] {
+  return names.filter(n => !BLOCKED.has(n))
+}
+
+/** OpenAI tools shape (minimal for filtering by function.name) */
+export function filterOpenAiToolsForUnattended<T extends { function?: { name?: string } }>(
+  tools: readonly T[],
+): T[] {
+  return tools.filter(t => {
+    const name = t.function?.name
+    return typeof name !== 'string' || !BLOCKED.has(name)
+  })
+}
+
+/** Immediate tool result when ask_user is still invoked under unattended */
+export const UNATTENDED_ASK_USER_RESULT = Object.freeze({
+  ok: false as const,
+  unattended: true as const,
+  error: '无人值守模式不可向用户提问；请自行推断或跳过并在答复中说明',
+})
+
+/** Immediate secret / vault result — never auto-fill secrets */
+export const UNATTENDED_SECRET_RESULT = Object.freeze({
+  ok: false as const,
+  unattended: true as const,
+  cancelled: true as const,
+  error: '无人值守模式无法录入或确认保险箱密钥；请跳过需密钥的步骤并说明',
+})
+
+/** Appended to turn-tail so the model knows not to ask the user */
+export const UNATTENDED_TURN_TAIL_NOTE = [
+  '【无人值守模式】',
+  '本轮为后台计划任务，无法向用户提问或等待确认。',
+  '禁止调用 ask_user / request_secret；勿索要密码或密钥。',
+  '请根据已有信息自行推断；缺关键信息则跳过该步并在答复中说明原因。',
+].join('')
+
+export function appendUnattendedTurnTail(turnTail: string): string {
+  const base = turnTail.trim()
+  return base ? `${base}\n\n${UNATTENDED_TURN_TAIL_NOTE}` : UNATTENDED_TURN_TAIL_NOTE
+}
+
+/** Same preference order as scheduleShellConfirm — auto-allow overwrite/delete in unattended */
+const CONFIRM_PREFER_IDS = [
+  'allow_session',
+  'sticky',
+  'allow_host_session',
+  'allow_once',
+  'once',
+  'allow_host_once',
+] as const
+
+export function pickUnattendedConfirmIds(
+  options: ReadonlyArray<{ id: string }>,
+): { selected_ids: string[] } {
+  for (const id of CONFIRM_PREFER_IDS) {
+    const hit = options.find(o => o.id === id)
+    if (hit) return { selected_ids: [hit.id] }
+  }
+  const fallback = options.find(o => o.id !== 'cancel')
+  if (fallback) return { selected_ids: [fallback.id] }
+  return { selected_ids: ['cancel'] }
+}

--- a/packages/schedule/src/os-sync.ts
+++ b/packages/schedule/src/os-sync.ts
@@ -15,56 +15,30 @@ function enabledJobCount(jobs: ScheduledJob[]): number {
   return jobs.filter(j => j.enabled).length
 }
 
-/** 根据 autostart 与任务 os_status 汇总系统定时健康状态（不含 launchd/cron 细节）。 */
+/**
+ * 进程内调度健康摘要。OS 级 tick 已废除；关闭到托盘仍执行，完全退出则不执行。
+ * `run_when_closed` 字段保留兼容，但不影响注册（永远不注册 OS tick）。
+ */
 export function computeOsHealth(
   settings: ScheduleSettings,
-  jobs: ScheduledJob[],
+  _jobs: ScheduledJob[],
 ): ScheduleOsHealth {
-  if (!settings.autostart) {
+  if (!settings.master_enabled) {
     return {
       status: 'n/a',
-      message: '未开启后台常驻，由应用内定时扫描执行',
+      message: '计划任务已关闭，不会自动执行',
       error: null,
-      autostart: false,
-    }
-  }
-
-  const enabled = jobs.filter(j => j.enabled)
-  if (enabled.length === 0) {
-    return {
-      status: 'synced',
-      message: '系统定时已就绪，当前没有启用的任务',
-      error: settings.os_tick_error ?? null,
-      autostart: true,
-    }
-  }
-
-  const errored = enabled.filter(j => j.os_status === 'error')
-  const pending = enabled.filter(j => j.os_status === 'pending' || j.os_status === 'n/a')
-
-  if (errored.length > 0 || settings.os_tick_status === 'error') {
-    return {
-      status: 'error',
-      message: '部分任务未能同步到系统定时，请重新注册',
-      error: settings.os_tick_error ?? null,
-      autostart: true,
-    }
-  }
-
-  if (pending.length > 0 || settings.os_tick_status === 'pending') {
-    return {
-      status: 'pending',
-      message: '正在等待系统定时同步完成',
-      error: settings.os_tick_error ?? null,
-      autostart: true,
+      autostart: settings.autostart,
     }
   }
 
   return {
-    status: 'synced',
-    message: '系统定时已与全部启用任务同步',
-    error: settings.os_tick_error ?? null,
-    autostart: true,
+    status: 'n/a',
+    message: settings.autostart
+      ? '登录后可在托盘常驻并按计划执行；完全退出应用后不会执行'
+      : '应用运行或驻留托盘时按计划执行；完全退出后不会执行',
+    error: null,
+    autostart: settings.autostart,
   }
 }
 
@@ -77,25 +51,26 @@ export interface OsSyncActions {
   ): ScheduledJob | null
 }
 
-/** 重新向系统定时注册全部启用任务（桌面 autostart 开启时）。 */
+/**
+ * 清理遗留 OS 注册状态（不再向系统注册 tick）。
+ * 将全局与任务级 os_* 字段置为 n/a / null。
+ */
 export function resyncOsRegistration(actions: OsSyncActions): ScheduleOsHealth {
-  const settings = actions.patchSettings({ os_tick_status: 'pending', os_tick_error: null })
   const jobs = actions.listJobs()
-
-  if (!settings.autostart) {
-    actions.patchSettings({ os_tick_status: 'n/a', os_tick_error: null })
-    return computeOsHealth(actions.patchSettings({}), jobs)
-  }
-
   try {
     for (const job of jobs) {
-      if (!job.enabled) continue
-      actions.updateJob(job.id, {
-        os_status: 'synced',
-        os_registration_id: job.os_registration_id ?? job.id,
-      })
+      if (job.os_status !== 'n/a' || job.os_registration_id != null) {
+        actions.updateJob(job.id, {
+          os_status: 'n/a',
+          os_registration_id: null,
+        })
+      }
     }
-    const next = actions.patchSettings({ os_tick_status: 'synced', os_tick_error: null })
+    const next = actions.patchSettings({
+      run_when_closed: false,
+      os_tick_status: 'n/a',
+      os_tick_error: null,
+    })
     return computeOsHealth(next, actions.listJobs())
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e)

--- a/packages/schedule/src/runner.ts
+++ b/packages/schedule/src/runner.ts
@@ -15,6 +15,7 @@ export interface JobRunnerAgent {
     sessionId: string,
     message: string,
     modelRef?: string,
+    opts?: { unattended?: boolean },
   ): Promise<{ reply: string; sessionId: string }>
   llmConfigured?: boolean
 }
@@ -175,7 +176,7 @@ export class JobRunner {
     }
 
     const model = job.payload.model?.trim() || undefined
-    const chat = await this.deps.agent.chat(sessionId, prompt, model)
+    const chat = await this.deps.agent.chat(sessionId, prompt, model, { unattended: true })
     sessionId = chat.sessionId
 
     if (job.payload.session_id !== sessionId) {

--- a/packages/user-store/src/schedule.ts
+++ b/packages/user-store/src/schedule.ts
@@ -45,6 +45,12 @@ export type SchedulePayload = AgentPromptPayload | ShellScriptPayload
 
 export interface ScheduleSettings {
   master_enabled: boolean
+  /**
+   * 兼容旧版「关闭后仍注册 OS tick」开关；产品已废除系统 crontab，
+   * 默认 false，API 忽略写入，仅进程内（托盘/前台）执行。
+   */
+  run_when_closed: boolean
+  /** 登录项以 `--background` 托盘常驻（与 OS tick 无关） */
   autostart: boolean
   allow_shell_scripts: boolean
   os_tick_status?: ScheduleOsStatus
@@ -53,6 +59,7 @@ export interface ScheduleSettings {
 
 export const DEFAULT_SCHEDULE_SETTINGS: ScheduleSettings = {
   master_enabled: true,
+  run_when_closed: false,
   autostart: false,
   allow_shell_scripts: false,
   os_tick_status: 'n/a',
@@ -249,6 +256,8 @@ export class ScheduleRepository {
     return {
       ...DEFAULT_SCHEDULE_SETTINGS,
       ...raw,
+      // OS tick 已废除：始终 false（兼容旧库中 true）
+      run_when_closed: false,
       os_tick_error: raw?.os_tick_error ?? null,
     }
   }
@@ -257,6 +266,7 @@ export class ScheduleRepository {
     const next: ScheduleSettings = {
       ...this.getSettings(),
       ...patch,
+      run_when_closed: false,
     }
     this.setDocument(SETTINGS_NS, SETTINGS_ID, next)
     return next

--- a/tests/agent-ask-user.test.mjs
+++ b/tests/agent-ask-user.test.mjs
@@ -194,3 +194,54 @@ test('UserPromptBridge rejects on session cancel', async () => {
   bridge.cancelSession(sessionId)
   await assert.rejects(answerPromise, UserPromptCancelledError)
 })
+
+test('unattended helpers strip ask_user / request_secret and never hang', async () => {
+  const {
+    filterToolNamesForUnattended,
+    filterOpenAiToolsForUnattended,
+    isUnattendedBlockedTool,
+    UNATTENDED_ASK_USER_RESULT,
+    UNATTENDED_SECRET_RESULT,
+    appendUnattendedTurnTail,
+    pickUnattendedConfirmIds,
+  } = await import('../packages/agent/dist/unattended.js')
+
+  assert.equal(isUnattendedBlockedTool('ask_user'), true)
+  assert.equal(isUnattendedBlockedTool('request_secret'), true)
+  assert.equal(isUnattendedBlockedTool('shell_run'), false)
+
+  assert.deepEqual(
+    filterToolNamesForUnattended(['ask_user', 'shell_run', 'request_secret', 'search_instruments']),
+    ['shell_run', 'search_instruments'],
+  )
+
+  const tools = [
+    { type: 'function', function: { name: 'ask_user', description: '', parameters: { type: 'object', properties: {} } } },
+    { type: 'function', function: { name: 'shell_run', description: '', parameters: { type: 'object', properties: {} } } },
+    { type: 'function', function: { name: 'request_secret', description: '', parameters: { type: 'object', properties: {} } } },
+  ]
+  assert.deepEqual(
+    filterOpenAiToolsForUnattended(tools).map(t => t.function.name),
+    ['shell_run'],
+  )
+
+  assert.equal(UNATTENDED_ASK_USER_RESULT.ok, false)
+  assert.equal(UNATTENDED_ASK_USER_RESULT.unattended, true)
+  assert.match(UNATTENDED_ASK_USER_RESULT.error, /无人值守/)
+
+  assert.equal(UNATTENDED_SECRET_RESULT.cancelled, true)
+  assert.equal(UNATTENDED_SECRET_RESULT.unattended, true)
+
+  const tail = appendUnattendedTurnTail('【本轮动态说明】')
+  assert.match(tail, /无人值守/)
+  assert.match(tail, /ask_user/)
+
+  assert.deepEqual(
+    pickUnattendedConfirmIds([
+      { id: 'cancel' },
+      { id: 'allow_once' },
+      { id: 'allow_session' },
+    ]),
+    { selected_ids: ['allow_session'] },
+  )
+})

--- a/tests/os-schedule-tick-runner.test.mjs
+++ b/tests/os-schedule-tick-runner.test.mjs
@@ -10,6 +10,8 @@ const {
   ENDPOINT_FILENAME,
   RUNNER_SH,
   RUNNER_CMD,
+  HELPER_BASENAME_UNIX,
+  HELPER_BASENAME_WIN,
   endpointFilePath,
   runnerScriptPath,
   sanitizeEndpointHost,
@@ -18,6 +20,10 @@ const {
   resolveColdStartArgv,
   resolveHeadlessTickArgv,
   defaultHeadlessTickPath,
+  scheduleHelperFileName,
+  resolveScheduleHelperPath,
+  isScheduleHelperPath,
+  ensureOsScheduleHelperExec,
   buildBashRunnerScript,
   buildCmdRunnerScript,
   ensureOsScheduleTickRunner,
@@ -31,6 +37,17 @@ const {
 } = require('../apps/desktop/electron/os-schedule/sidecar-launch.cjs')
 
 const HEADLESS = defaultHeadlessTickPath()
+
+/**
+ * Fake Electron binary for helper copy/link tests (writable tmp).
+ * @param {string} dir
+ * @param {string} [name]
+ */
+function fakeSourceExec(dir, name = 'Opptrix') {
+  const p = path.join(dir, name)
+  fs.writeFileSync(p, '#!/bin/sh\necho fake-electron\n', { mode: 0o755 })
+  return p
+}
 
 describe('os-schedule tick-runner', () => {
   /** @type {string} */
@@ -52,7 +69,7 @@ describe('os-schedule tick-runner', () => {
   })
 
   it('writeOsScheduleEndpoint writes host/port/execPath/headlessTick (no secrets)', () => {
-    const execPath = '/Applications/Opptrix.app/Contents/MacOS/Opptrix'
+    const execPath = '/Applications/Opptrix.app/Contents/MacOS/OpptrixSchedule'
     const written = writeOsScheduleEndpoint(tmpDir, {
       host: '0.0.0.0',
       port: 8712,
@@ -83,22 +100,21 @@ describe('os-schedule tick-runner', () => {
   })
 
   it('resolveHeadlessTickArgv is ELECTRON_RUN_AS_NODE pair (no --schedule-tick)', () => {
+    const helper = '/Applications/Opptrix.app/Contents/MacOS/OpptrixSchedule'
     const packaged = resolveHeadlessTickArgv({
-      execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      execPath: helper,
       headlessTickPath: HEADLESS,
     })
-    assert.deepEqual(packaged, [
-      '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
-      HEADLESS,
-    ])
+    assert.deepEqual(packaged, [helper, HEADLESS])
     assert.ok(!packaged.includes('--schedule-tick'))
     assert.ok(!packaged.includes('--background'))
+    assert.ok(isScheduleHelperPath(packaged[0], 'darwin'))
 
     // resolveColdStartArgv aliases to headless argv
     assert.deepEqual(
       resolveColdStartArgv({
         isPackaged: true,
-        execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+        execPath: helper,
         mainCjsPath: '/ignored/main.cjs',
         headlessTickPath: HEADLESS,
       }),
@@ -106,9 +122,28 @@ describe('os-schedule tick-runner', () => {
     )
   })
 
+  it('ensureOsScheduleHelperExec creates OpptrixSchedule beside source (not productName)', () => {
+    const source = fakeSourceExec(tmpDir, 'Opptrix')
+    const { helperPath, created } = ensureOsScheduleHelperExec({
+      sourceExecPath: source,
+      platform: 'darwin',
+    })
+    assert.equal(path.basename(helperPath), HELPER_BASENAME_UNIX)
+    assert.equal(helperPath, resolveScheduleHelperPath(source, 'darwin'))
+    assert.ok(created)
+    assert.ok(fs.existsSync(helperPath))
+    assert.ok(isScheduleHelperPath(helperPath, 'darwin'))
+    assert.notEqual(path.basename(helperPath), 'Opptrix')
+
+    // idempotent refresh when already present
+    const again = ensureOsScheduleHelperExec({ sourceExecPath: source, platform: 'darwin' })
+    assert.equal(again.helperPath, helperPath)
+    assert.equal(again.created, false)
+  })
+
   it('bash runner is HTTP-first then ELECTRON_RUN_AS_NODE headless-tick', () => {
     const endpoint = path.join(tmpDir, ENDPOINT_FILENAME)
-    const execPath = '/Applications/Opptrix.app/Contents/MacOS/Opptrix'
+    const execPath = '/Applications/Opptrix.app/Contents/MacOS/OpptrixSchedule'
     const script = buildBashRunnerScript({
       endpointFile: endpoint,
       coldStartArgv: [execPath, HEADLESS],
@@ -123,6 +158,7 @@ describe('os-schedule tick-runner', () => {
     assert.doesNotMatch(script, /--schedule-tick/)
     assert.doesNotMatch(script, /--background/)
     assert.ok(script.includes(HEADLESS) || script.includes('HEADLESS_TICK'))
+    assert.ok(script.includes('OpptrixSchedule'))
     assert.ok(script.indexOf('curl') < script.indexOf('export ELECTRON_RUN_AS_NODE'))
     assert.ok(script.indexOf('export ELECTRON_RUN_AS_NODE') < script.indexOf('exec "$EXEC"'))
   })
@@ -131,7 +167,7 @@ describe('os-schedule tick-runner', () => {
     const endpoint = path.join(tmpDir, ENDPOINT_FILENAME)
     const script = buildCmdRunnerScript({
       endpointFile: endpoint,
-      coldStartArgv: ['C:\\Opptrix\\Opptrix.exe', 'C:\\Opptrix\\headless-tick.cjs'],
+      coldStartArgv: ['C:\\Opptrix\\OpptrixSchedule.exe', 'C:\\Opptrix\\headless-tick.cjs'],
     })
     assert.match(script, /curl\.exe .*\/api\/schedule\/tick/)
     assert.match(script, /set ELECTRON_RUN_AS_NODE=1/)
@@ -139,14 +175,18 @@ describe('os-schedule tick-runner', () => {
     assert.match(script, /"%EXEC%" "%HEADLESS_TICK%"/)
     assert.doesNotMatch(script, /--schedule-tick/)
     assert.doesNotMatch(script, /--background/)
+    assert.ok(script.includes('OpptrixSchedule.exe'))
     assert.ok(script.indexOf('curl.exe') < script.indexOf('ELECTRON_RUN_AS_NODE'))
   })
 
-  it('ensureOsScheduleTickRunner writes endpoint + headless fallback (no GUI flags)', () => {
+  it('ensureOsScheduleTickRunner writes helper EXEC + headless fallback (no GUI flags)', () => {
+    const binDir = path.join(tmpDir, 'MacOS')
+    fs.mkdirSync(binDir, { recursive: true })
+    const source = fakeSourceExec(binDir, 'Opptrix')
     const result = ensureOsScheduleTickRunner({
       userDataDir: tmpDir,
       isPackaged: true,
-      execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      execPath: source,
       headlessTickPath: HEADLESS,
       platform: 'darwin',
       defaultPort: '8711',
@@ -155,59 +195,83 @@ describe('os-schedule tick-runner', () => {
     assert.equal(path.basename(result.scriptPath), RUNNER_SH)
     assert.ok(fs.existsSync(result.scriptPath))
     assert.ok(fs.existsSync(result.endpointFile))
+    assert.equal(path.basename(result.helperPath), HELPER_BASENAME_UNIX)
+    assert.ok(isScheduleHelperPath(result.coldStartArgv[0], 'darwin'))
+    assert.notEqual(path.basename(result.coldStartArgv[0]), 'Opptrix')
     const ep = readOsScheduleEndpoint(tmpDir)
-    assert.equal(ep?.execPath, '/Applications/Opptrix.app/Contents/MacOS/Opptrix')
+    assert.equal(ep?.execPath, result.helperPath)
+    assert.equal(path.basename(ep?.execPath ?? ''), HELPER_BASENAME_UNIX)
     assert.equal(ep?.headlessTick, HEADLESS)
     const body = fs.readFileSync(result.scriptPath, 'utf8')
     assert.match(body, /\/api\/schedule\/tick/)
     assert.match(body, /ELECTRON_RUN_AS_NODE=1/)
+    assert.match(body, /OpptrixSchedule/)
     assert.doesNotMatch(body, /--schedule-tick/)
     const mode = fs.statSync(result.scriptPath).mode & 0o111
     assert.ok(mode !== 0, 'runner should be executable')
   })
 
-  it('ensureOsScheduleTickRunner writes .cmd on win32', () => {
+  it('ensureOsScheduleTickRunner writes .cmd on win32 with OpptrixSchedule.exe', () => {
+    const binDir = path.join(tmpDir, 'winbin')
+    fs.mkdirSync(binDir, { recursive: true })
+    const source = fakeSourceExec(binDir, 'Opptrix.exe')
     const result = ensureOsScheduleTickRunner({
       userDataDir: tmpDir,
       isPackaged: true,
-      execPath: 'C:\\Opptrix\\Opptrix.exe',
-      headlessTickPath: 'C:\\Opptrix\\headless-tick.cjs',
+      execPath: source,
+      headlessTickPath: path.join(tmpDir, 'headless-tick.cjs'),
       platform: 'win32',
     })
     assert.equal(path.basename(result.scriptPath), RUNNER_CMD)
     assert.ok(fs.existsSync(result.scriptPath))
+    assert.equal(path.basename(result.helperPath), HELPER_BASENAME_WIN)
+    assert.equal(scheduleHelperFileName('win32'), HELPER_BASENAME_WIN)
     const body = fs.readFileSync(result.scriptPath, 'utf8')
     assert.match(body, /curl\.exe/)
     assert.match(body, /ELECTRON_RUN_AS_NODE=1/)
+    assert.match(body, /OpptrixSchedule\.exe/)
     assert.doesNotMatch(body, /--schedule-tick/)
+    const ep = readOsScheduleEndpoint(tmpDir)
+    assert.equal(path.basename(ep?.execPath ?? ''), HELPER_BASENAME_WIN)
   })
 
   it('resolveOsTickInvocation uses bash+runner on darwin/linux and cmd on win32', () => {
+    const darwinBin = path.join(tmpDir, 'darwin-bin')
+    fs.mkdirSync(darwinBin, { recursive: true })
+    const darwinSource = fakeSourceExec(darwinBin, 'Opptrix')
     const darwin = resolveOsTickInvocation({
       userDataDir: tmpDir,
       isPackaged: true,
-      execPath: '/Applications/Opptrix.app/Contents/MacOS/Opptrix',
+      execPath: darwinSource,
       headlessTickPath: HEADLESS,
       platform: 'darwin',
     })
     assert.deepEqual(darwin.programArguments, ['/bin/bash', darwin.scriptPath])
     assert.ok(!darwin.programArguments.some((a) => a.includes('Opptrix.app/Contents/MacOS')))
 
+    const linuxBin = path.join(tmpDir, 'linux-bin')
+    fs.mkdirSync(linuxBin, { recursive: true })
+    const linuxSource = fakeSourceExec(linuxBin, 'electron')
     const linux = resolveOsTickInvocation({
-      userDataDir: tmpDir,
+      userDataDir: path.join(tmpDir, 'linux-ud'),
       isPackaged: false,
-      execPath: '/usr/bin/electron',
+      execPath: linuxSource,
       headlessTickPath: HEADLESS,
       platform: 'linux',
     })
     assert.match(linux.execStart, /^\/bin\/bash /)
     assert.ok(linux.execStart.includes(linux.scriptPath))
+    const linuxEp = readOsScheduleEndpoint(path.join(tmpDir, 'linux-ud'))
+    assert.equal(path.basename(linuxEp?.execPath ?? ''), HELPER_BASENAME_UNIX)
 
+    const winBin = path.join(tmpDir, 'win-bin')
+    fs.mkdirSync(winBin, { recursive: true })
+    const winSource = fakeSourceExec(winBin, 'Opptrix.exe')
     const win = resolveOsTickInvocation({
-      userDataDir: tmpDir,
+      userDataDir: path.join(tmpDir, 'win-ud'),
       isPackaged: true,
-      execPath: 'C:\\Opptrix\\Opptrix.exe',
-      headlessTickPath: 'C:\\Opptrix\\headless-tick.cjs',
+      execPath: winSource,
+      headlessTickPath: path.join(tmpDir, 'headless-tick.cjs'),
       platform: 'win32',
     })
     assert.equal(win.programArguments.length, 1)
@@ -225,6 +289,9 @@ describe('os-schedule sidecar-launch helpers', () => {
       resolvePackagedRuntimeStage(exec),
       '/Applications/Opptrix.app/Contents/Resources/runtime-stage',
     )
+    // Helper sibling still resolves Resources via MacOS parent
+    const helper = '/Applications/Opptrix.app/Contents/MacOS/OpptrixSchedule'
+    assert.equal(resolveResourcesPathFromExec(helper), resources)
   })
 
   it('buildSidecarEnv packaged forces loopback host + ELECTRON_RUN_AS_NODE', () => {

--- a/tests/schedule-os-sync-inprocess.test.mjs
+++ b/tests/schedule-os-sync-inprocess.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * Schedule OS sync — in-process only; register_tick forever false semantics
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+
+async function withStore(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-os-sync-'))
+  const prev = process.env.OPPTRIX_DATA_DIR
+  process.env.OPPTRIX_DATA_DIR = dir
+  const { UserDataStore } = await import('../packages/user-store/dist/index.js')
+  const {
+    ScheduleService,
+    computeOsHealth,
+    resyncOsRegistration,
+  } = await import('../packages/schedule/dist/index.js')
+  try { UserDataStore.getInstance().close() } catch { /* */ }
+  const store = UserDataStore.getInstance()
+  try {
+    await fn({ store, ScheduleService, computeOsHealth, resyncOsRegistration })
+  } finally {
+    store.close()
+    if (prev == null) delete process.env.OPPTRIX_DATA_DIR
+    else process.env.OPPTRIX_DATA_DIR = prev
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+test('run_when_closed coerced false even if patched true', async () => {
+  await withStore(async ({ store }) => {
+    const next = store.schedule.patchSettings({ run_when_closed: true, master_enabled: true })
+    assert.equal(next.run_when_closed, false)
+    assert.equal(store.schedule.getSettings().run_when_closed, false)
+  })
+})
+
+test('computeOsHealth never wants OS tick; tray messaging', async () => {
+  await withStore(async ({ store, computeOsHealth }) => {
+    store.schedule.patchSettings({ master_enabled: true, autostart: false })
+    const health = computeOsHealth(store.schedule.getSettings(), [])
+    assert.equal(health.status, 'n/a')
+    assert.match(health.message, /托盘|运行/)
+    assert.doesNotMatch(health.message, /关闭应用后仍/)
+  })
+})
+
+test('resyncOsRegistration clears job os fields', async () => {
+  await withStore(async ({ store, ScheduleService, resyncOsRegistration }) => {
+    const svc = new ScheduleService(store, async () => ({ summary: 'ok' }))
+    const job = svc.createJob({
+      title: 't',
+      kind: 'agent_prompt',
+      schedule_kind: 'interval',
+      schedule: { every_sec: 60 },
+      payload: { prompt: 'hi' },
+      enabled: true,
+      os_status: 'synced',
+      os_registration_id: 'legacy-id',
+    })
+    assert.equal(job.os_status, 'synced')
+    const health = resyncOsRegistration(svc)
+    assert.equal(health.status, 'n/a')
+    const updated = svc.getJob(job.id)
+    assert.ok(updated)
+    assert.equal(updated.os_status, 'n/a')
+    assert.equal(updated.os_registration_id, null)
+    assert.equal(svc.getSettings().run_when_closed, false)
+  })
+})
+
+test('purgeLegacyOsTickArtifacts removes runners and strips cold-start', async () => {
+  const { purgeLegacyOsTickArtifacts, writeOsScheduleEndpoint, RUNNER_SH, ENDPOINT_FILENAME } =
+    await import('../apps/desktop/electron/os-schedule/tick-runner.cjs')
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-purge-tick-'))
+  try {
+    const runner = path.join(dir, RUNNER_SH)
+    fs.writeFileSync(runner, '#!/bin/bash\n', 'utf8')
+    writeOsScheduleEndpoint(dir, {
+      host: '127.0.0.1',
+      port: 8711,
+      execPath: '/Applications/Opptrix.app/Contents/MacOS/OpptrixSchedule',
+      headlessTick: '/tmp/headless-tick.cjs',
+    })
+    const result = purgeLegacyOsTickArtifacts(dir)
+    assert.ok(result.removedRunners.includes(RUNNER_SH))
+    assert.equal(result.endpointStripped, true)
+    assert.equal(fs.existsSync(runner), false)
+    const endpoint = JSON.parse(fs.readFileSync(path.join(dir, ENDPOINT_FILENAME), 'utf8'))
+    assert.equal(endpoint.host, '127.0.0.1')
+    assert.equal(endpoint.port, '8711')
+    assert.equal(endpoint.execPath, undefined)
+    assert.equal(endpoint.headlessTick, undefined)
+    // idempotent
+    const again = purgeLegacyOsTickArtifacts(dir)
+    assert.deepEqual(again.removedRunners, [])
+    assert.equal(again.endpointStripped, false)
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/tests/schedule-unattended-agent.test.mjs
+++ b/tests/schedule-unattended-agent.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { JobRunner } from '../packages/schedule/dist/runner.js'
+
+test('JobRunner agent_prompt passes unattended: true to chat', async () => {
+  /** @type {{ sessionId: string, message: string, modelRef?: string, opts?: { unattended?: boolean } }[]} */
+  const chatCalls = []
+
+  const runner = new JobRunner({
+    agent: {
+      llmConfigured: true,
+      createSession: async () => ({ id: 'sess-sched-1' }),
+      chat: async (sessionId, message, modelRef, opts) => {
+        chatCalls.push({ sessionId, message, modelRef, opts })
+        return { reply: '后台完成', sessionId }
+      },
+    },
+    shell: {
+      run: async () => ({ ok: true, exit_code: 0, stdout: '', stderr: '' }),
+    },
+    getSettings: () => ({
+      master_enabled: true,
+      allow_shell_scripts: false,
+      notify_on_complete: false,
+      notify_on_error: true,
+    }),
+  })
+
+  const job = {
+    id: 'job-1',
+    title: '收盘分析',
+    enabled: true,
+    kind: 'agent_prompt',
+    schedule_kind: 'once',
+    schedule: { run_at: new Date().toISOString() },
+    payload: { prompt: '总结今日大盘' },
+    os_registration_id: null,
+    os_status: 'n/a',
+    next_run_at: null,
+    last_run_at: null,
+    last_status: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  }
+  const run = {
+    id: 'run-1',
+    job_id: job.id,
+    started_at: new Date().toISOString(),
+    finished_at: null,
+    status: 'running',
+    trigger: 'manual',
+    summary: null,
+    error: null,
+    session_id: null,
+  }
+
+  const result = await runner.execute(job, run)
+  assert.equal(result.summary, '后台完成')
+  assert.equal(chatCalls.length, 1)
+  assert.equal(chatCalls[0].opts?.unattended, true)
+  assert.equal(chatCalls[0].message, '总结今日大盘')
+})


### PR DESCRIPTION
## Summary
- 计划任务改为仅在 Opptrix 进程内（含托盘）执行；废除 OS crontab 注册，升级启动时强制注销遗留 LaunchAgent/schtasks/systemd
- 计划任务 Agent 无人值守：跳过 ask_user / 密钥挂起，避免后台卡死
- 关窗到托盘时隐藏 macOS Dock / Windows·Linux 任务栏，仅保留托盘；唤起时恢复

## Test plan
- [ ] build:packages / check:ui
- [ ] schedule 相关测试绿
- [ ] 托盘常驻可跑计划任务；完全退出不跑；旧 OS 任务被注销
- [ ] 关窗后 Dock/任务栏隐藏，托盘可唤起


Made with [Cursor](https://cursor.com)