### PR TITLE
feat: CN ETF portfolio trades + trade drawer width fix

### DIFF
--- a/client-ui/src/market/FollowStockDialog.tsx
+++ b/client-ui/src/market/FollowStockDialog.tsx
@@ -66,7 +66,9 @@ const useStyles = makeStyles({
   },
   drawer: {
     width: '100%',
-    maxWidth: `${DRAWER_MAX_WIDTH}px`,
+    minWidth: 0,
+    maxWidth: `min(100%, ${DRAWER_MAX_WIDTH}px)`,
+    boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
     maxHeight: 'min(78%, 520px)',
@@ -137,7 +139,10 @@ const useStyles = makeStyles({
   },
   drawerBody: {
     flex: 1,
+    minWidth: 0,
     minHeight: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
     overflow: 'hidden',
     display: 'flex',
     flexDirection: 'column',
@@ -145,7 +150,10 @@ const useStyles = makeStyles({
   },
   contentStack: {
     flex: 1,
+    minWidth: 0,
     minHeight: 0,
+    maxWidth: '100%',
+    boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
     gap: '8px',
@@ -192,16 +200,21 @@ const useStyles = makeStyles({
     letterSpacing: '0.04em',
   },
   tabRow: {
-    display: 'inline-flex',
+    display: 'flex',
+    width: '100%',
+    maxWidth: '100%',
+    minWidth: 0,
+    boxSizing: 'border-box',
     gap: '2px',
     padding: '2px',
     borderRadius: opptrixTokens.radiusXl,
     backgroundColor: 'rgba(29, 29, 31, 0.06)',
-    width: 'fit-content',
     flexShrink: 0,
   },
   tabBtn: {...ghostInteractive,
 
+    flex: '1 1 0',
+    minWidth: 0,
     border: 'none',
     backgroundColor: 'transparent',
     color: opptrixCssVars.textSecondary,
@@ -212,6 +225,8 @@ const useStyles = makeStyles({
     borderRadius: opptrixTokens.radiusFull,
     cursor: 'pointer',
     whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
 ':hover': {
       backgroundColor: 'rgba(29, 29, 31, 0.08)',
       color: opptrixCssVars.textPrimary,
@@ -246,15 +261,28 @@ const useStyles = makeStyles({
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
     gap: '6px',
+    width: '100%',
+    minWidth: 0,
+    boxSizing: 'border-box',
+  },
+  tradeFullRow: {
+    gridColumn: '1 / -1',
+    minWidth: 0,
+    width: '100%',
+    boxSizing: 'border-box',
   },
   tradeSideRow: {
     gridColumn: '1 / -1',
     display: 'flex',
+    alignItems: 'stretch',
+    width: '100%',
+    minWidth: 0,
     gap: '4px',
   },
   sideBtn: {...ghostInteractive,
 
-    flex: 1,
+    flex: '1 1 0',
+    minWidth: 0,
     minHeight: '26px',
     borderRadius: opptrixTokens.radiusFull,
     border: 'none',
@@ -275,11 +303,13 @@ const useStyles = makeStyles({
     color: MARKET_DOWN,
   },
   glassInput: {
+    minWidth: 0,
     backgroundColor: 'rgba(29, 29, 31, 0.06)',
     borderRadius: opptrixTokens.radiusMd,
   },
   feeHint: {
     gridColumn: '1 / -1',
+    minWidth: 0,
     fontSize: 'var(--opptrix-font-xs)',
     color: opptrixCssVars.textTertiary,
     lineHeight: 1.35,
@@ -691,11 +721,13 @@ export default function FollowStockDialog({
                     value={tradeForm.price}
                     onChange={(_, data) => setTradeForm(prev => ({ ...prev, price: data.value }))}
                   />
-                  <TradeDateField
-                    className={s.glassInput}
-                    value={tradeForm.date}
-                    onChange={date => setTradeForm(prev => ({ ...prev, date }))}
-                  />
+                  <div className={s.tradeFullRow}>
+                    <TradeDateField
+                      className={s.glassInput}
+                      value={tradeForm.date}
+                      onChange={date => setTradeForm(prev => ({ ...prev, date }))}
+                    />
+                  </div>
                   {previewFees && tradeForm.shares && tradeForm.price && (
                     <Text className={s.feeHint}>
                       预估成交额 {formatCompactNumberForMarket(stockRef?.market, estimateTradeAmount(Number(tradeForm.shares), Number(tradeForm.price)))}
@@ -704,7 +736,9 @@ export default function FollowStockDialog({
                     </Text>
                   )}
                   <OpptrixButton
+                    className={s.tradeFullRow}
                     variant="primary"
+                    block
                     disabled={submitting || !tradeForm.shares || !tradeForm.price}
                     onClick={() => void handleSubmitTrade()}
                   >

--- a/client-ui/src/market/PortfolioTab.tsx
+++ b/client-ui/src/market/PortfolioTab.tsx
@@ -269,7 +269,7 @@ export default function PortfolioTab({ active = true, selectedCode, onSelect }: 
           <SidebarListEmpty
             icon={<BriefcaseRegular />}
             title="还没有持仓记录"
-            hint="在个股详情里录入买卖后，会在这里汇总市值与盈亏"
+            hint="在个股或 ETF 详情里录入买卖后，会在这里汇总市值与盈亏"
           />
         ) : (
           holdings.map((h, index) => {
@@ -280,11 +280,13 @@ export default function PortfolioTab({ active = true, selectedCode, onSelect }: 
               || portfolioHoldingsKey(selectedCode, h.market) === displayCode
               || (() => {
                 const parsed = parseInstrumentInput(selectedCode)
-                return parsed ? instrumentKey(parsed) === instrumentKey({
-                  market: (h.market ?? 'CN') as import('../types/instrument').Market,
-                  assetClass: 'EQUITY',
-                  symbol: h.code,
-                }) : false
+                if (!parsed) return false
+                const market = (h.market ?? 'CN') as import('../types/instrument').Market
+                // CN 用 parseInstrumentInput 推断真实 assetClass（ETF/INDEX/EQUITY）；非 CN 仍为 EQUITY
+                const holdingRef = market === 'CN'
+                  ? parseInstrumentInput(h.code)
+                  : { market, assetClass: 'EQUITY' as const, symbol: h.code }
+                return instrumentKey(parsed) === instrumentKey(holdingRef)
               })()
             )
             const sharesLabel = formatShares(h.shares)

--- a/client-ui/src/market/capabilities.ts
+++ b/client-ui/src/market/capabilities.ts
@@ -14,7 +14,7 @@ const CN_INDEX: ApplicationCapability[] = [
 ]
 
 const CN_ETF: ApplicationCapability[] = [
-  'quote', 'batch_quote', 'snapshot', 'chart_daily', 'scorecard', 'discover_mine',
+  'quote', 'batch_quote', 'snapshot', 'chart_daily', 'scorecard', 'discover_mine', 'portfolio_pnl',
 ]
 
 const US_EQUITY: ApplicationCapability[] = [

--- a/packages/shared/src/instrument-capabilities.ts
+++ b/packages/shared/src/instrument-capabilities.ts
@@ -40,7 +40,7 @@ const CN_INDEX: ApplicationCapability[] = [
 ]
 
 const CN_ETF: ApplicationCapability[] = [
-  'quote', 'batch_quote', 'snapshot', 'chart_daily', 'scorecard', 'discover_mine',
+  'quote', 'batch_quote', 'snapshot', 'chart_daily', 'scorecard', 'discover_mine', 'portfolio_pnl',
 ]
 
 const US_EQUITY: ApplicationCapability[] = [

--- a/tests/multi-market-architecture.test.mjs
+++ b/tests/multi-market-architecture.test.mjs
@@ -208,6 +208,18 @@ test('gateInstrumentEvaluation — CN equity supported, US technical bundle', ()
   assert.equal(hasApplicationCapability({ market: 'HK', assetClass: 'EQUITY', symbol: '00700' }, 'discover_mine'), true)
 })
 
+test('hasApplicationCapability — CN ETF portfolio_pnl enabled', () => {
+  assert.equal(
+    hasApplicationCapability({ market: 'CN', assetClass: 'ETF', symbol: '510300' }, 'portfolio_pnl'),
+    true,
+  )
+  // 个股路径仍开放，避免回归
+  assert.equal(
+    hasApplicationCapability({ market: 'CN', assetClass: 'EQUITY', symbol: '600519' }, 'portfolio_pnl'),
+    true,
+  )
+})
+
 test('gateInstrumentAnalytics — US strategy_signal supported', () => {
   assert.equal(
     gateInstrumentAnalytics({ market: 'US', assetClass: 'EQUITY', symbol: 'AAPL' }, 'strategy_signal').status,

--- a/tests/portfolio-instrument.test.mjs
+++ b/tests/portfolio-instrument.test.mjs
@@ -11,6 +11,12 @@ test('portfolioInstrumentRef — CN six-digit, HK five-digit, US ticker', () => 
   const cn = portfolioInstrumentRef('600519', 'CN')
   assert.equal(cn.market, 'CN')
   assert.equal(cn.symbol, '600519')
+  assert.equal(cn.assetClass, 'EQUITY')
+
+  const cnEtf = portfolioInstrumentRef('510300', 'CN')
+  assert.equal(cnEtf.market, 'CN')
+  assert.equal(cnEtf.symbol, '510300')
+  assert.equal(cnEtf.assetClass, 'ETF')
 
   const hk = portfolioInstrumentRef('700', 'HK')
   assert.equal(hk.market, 'HK')


### PR DESCRIPTION
## Summary
- 为 A 股 ETF 打开 `portfolio_pnl` 能力闸门，持仓录入/组合列表与个股对齐
- 修正组合列表选中比对的 `assetClass`（不再写死 EQUITY）
- 修复「录入交易」抽屉中 Tabs、日期与提交按钮超出右侧栏宽度的布局问题

## Test plan
- [ ] A 股 ETF 详情可「管理持仓」并录入买卖，不再提示暂不支持
- [ ] 组合列表出现该 ETF，现价/盈亏可刷新；个股路径无回归
- [ ] 窄右侧栏下 Tabs、买入/卖出、日期、「添加记录」不横向溢出
- [ ] `npm run check:ui`；`node --test` portfolio-instrument + multi-market 相关用例


Made with [Cursor](https://cursor.com)