### PR TITLE
fix(desktop): Linux autostart XDG 测试在 CI 下稳定

### DIFF
--- a/apps/desktop/electron/os-schedule/linux-autostart.cjs
+++ b/apps/desktop/electron/os-schedule/linux-autostart.cjs
@@ -15,11 +15,16 @@ const BACKGROUND_ARG = '--background'
  * @returns {string}
  */
 function resolveAutostartDir(opts = {}) {
-  const fromEnv =
-    typeof opts.configHome === 'string' && opts.configHome.trim()
-      ? opts.configHome.trim()
-      : String(process.env.XDG_CONFIG_HOME ?? '').trim()
-  if (fromEnv) return path.join(fromEnv, 'autostart')
+  // Explicit configHome (including '') bypasses process.env — tests / callers can
+  // force the ~/.config fallback without inheriting the runner's XDG_CONFIG_HOME.
+  if (Object.prototype.hasOwnProperty.call(opts ?? {}, 'configHome')) {
+    const explicit =
+      typeof opts.configHome === 'string' ? opts.configHome.trim() : ''
+    if (explicit) return path.join(explicit, 'autostart')
+  } else {
+    const fromEnv = String(process.env.XDG_CONFIG_HOME ?? '').trim()
+    if (fromEnv) return path.join(fromEnv, 'autostart')
+  }
   const home =
     typeof opts.homedir === 'string' && opts.homedir
       ? opts.homedir

--- a/tests/linux-autostart.test.mjs
+++ b/tests/linux-autostart.test.mjs
@@ -22,13 +22,20 @@ describe('linux-autostart XDG helpers', () => {
   /** @type {string} */
   let tmpConfig
 
+  /** @type {string | undefined} */
+  let prevXdgConfigHome
+
   beforeEach(() => {
     tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-xdg-home-'))
     tmpConfig = path.join(tmpHome, 'config')
     fs.mkdirSync(tmpConfig, { recursive: true })
+    prevXdgConfigHome = process.env.XDG_CONFIG_HOME
+    delete process.env.XDG_CONFIG_HOME
   })
 
   afterEach(() => {
+    if (prevXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME
+    else process.env.XDG_CONFIG_HOME = prevXdgConfigHome
     fs.rmSync(tmpHome, { recursive: true, force: true })
   })
 
@@ -40,9 +47,18 @@ describe('linux-autostart XDG helpers', () => {
   })
 
   it('falls back to ~/.config/autostart', () => {
+    process.env.XDG_CONFIG_HOME = path.join(tmpHome, 'env-config')
     assert.equal(
       resolveAutostartDir({ homedir: tmpHome, configHome: '' }),
       path.join(tmpHome, '.config', 'autostart'),
+    )
+  })
+
+  it('uses process.env.XDG_CONFIG_HOME when configHome omitted', () => {
+    process.env.XDG_CONFIG_HOME = tmpConfig
+    assert.equal(
+      resolveAutostartDir({ homedir: tmpHome }),
+      path.join(tmpConfig, 'autostart'),
     )
   })
 


### PR DESCRIPTION
## Summary
- `resolveAutostartDir`：显式传入 `configHome`（含空串）时不再回落到 `process.env.XDG_CONFIG_HOME`
- 补强 `linux-autostart` 单测，覆盖 CI 常见 XDG 环境

## Test plan
- [x] `node --test tests/linux-autostart.test.mjs`
- [ ] CI Build & test 绿


Made with [Cursor](https://cursor.com)