### PR TITLE
perf(desktop): listen-first boot, parallel splash, sidecar health reuse

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -82,10 +82,10 @@ let API_PORT = process.env.STOCK_RESEARCH_PORT ?? '8711'
 let WEB_DEV_PORT = process.env.WEB_PORT ?? '5173'
 /** @type {'use' | 'reuse' | 'bump'} */
 let apiPortMode = process.env.OPPTRIX_API_PORT_MODE ?? 'use'
-const MIN_SPLASH_MS = 2200
-  const SPLASH_HTML = path.join(__dirname, 'splash.html')
-  const SPLASH_CANVAS = '#FCFCFC'
-  const APP_ID = require('../package.json').build?.appId
+const MIN_SPLASH_MS = 1000
+const SPLASH_HTML = path.join(__dirname, 'splash.html')
+const SPLASH_CANVAS = '#FCFCFC'
+const APP_ID = require('../package.json').build?.appId
 
 app.setName(APP_NAME)
 /** @type {boolean} */
@@ -981,8 +981,11 @@ function showSplashInMainWindow(win) {
   })
 }
 
-async function loadAppInMainWindow(win, { enforceMinSplash = true } = {}) {
-  await ensureSidecarReady()
+async function loadAppInMainWindow(win, { enforceMinSplash = true, sidecarAlreadyReady = false } = {}) {
+  // bootstrapApp 已并行 ensureSidecarReady 时跳过，避免重复 spawn
+  if (!sidecarAlreadyReady) {
+    await ensureSidecarReady()
+  }
   await waitForAppUi()
   if (enforceMinSplash) await waitForSplashMinimum()
 
@@ -1052,7 +1055,15 @@ async function ensureSidecarReady() {
     await waitForHealth()
     return
   }
-  if (!serverProcess) spawnSidecar()
+  // Spawn 前先 probe：托盘二次唤起 / second-instance 等场景下健康窗可 reuse，避免双开
+  if (!serverProcess) {
+    const healthy = await probeSidecarHealth(2500)
+    if (healthy) {
+      apiPortMode = 'reuse'
+      return
+    }
+    spawnSidecar()
+  }
   await waitForHealth()
 }
 
@@ -1060,8 +1071,11 @@ async function bootstrapApp({ withSplash = true } = {}) {
   const win = await createMainWindow()
 
   if (withSplash) {
-    await showSplashInMainWindow(win)
-    await loadAppInMainWindow(win, { enforceMinSplash: true })
+    // splash ∥ 尽早 ensureSidecarReady（冷启 spawn 与 splash 重叠；reuse 仅短 probe/wait）
+    const splashPromise = showSplashInMainWindow(win)
+    const sidecarPromise = ensureSidecarReady()
+    await Promise.all([splashPromise, sidecarPromise])
+    await loadAppInMainWindow(win, { enforceMinSplash: true, sidecarAlreadyReady: true })
     return
   }
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1635,6 +1635,7 @@ async function listenWithStaleCleanup(): Promise<void> {
 }
 
 async function bootstrap() {
+  // ── phaseA：listen 前只做网络 + 路由/静态/404，使 /api/health 与 GET / 尽早可通
   await initOutboundNetwork()
   console.log('  Outbound network → IPv4-first, v6 fallback on connect failure')
 
@@ -1654,6 +1655,29 @@ async function bootstrap() {
   registerSessionAttachmentRoutes(app, agent)
   ensureMediaTranscriptBridge()
   await registerSpeechRoutes(app)
+
+  serveUi = shouldServeUi()
+  if (serveUi) {
+    serveUi = await registerStaticUi(app)
+  }
+
+  app.setNotFoundHandler(async (req, reply) => {
+    if (serveUi && !isApiPath(req.url)) {
+      return reply.sendFile('index.html', resolveUiDist())
+    }
+    return reply.code(404).send({ error: 'not found' })
+  })
+
+  await listenWithStaleCleanup()
+  console.log(`\n  Opptrix API → http://${HOST}:${PORT}/api/health`)
+  if (serveUi) {
+    console.log(`  Desktop UI → http://${HOST}:${PORT}\n`)
+  } else {
+    console.log(`  Web UI → npm run dev → http://127.0.0.1:5173\n`)
+  }
+
+  // ── phaseB：listen 之后再跑调度/预热等非路由重活。
+  // Fastify 5：listen 后路由树锁定，禁止再 app.register / app.get|post|… 注册新路由。
   startNewsFeedScheduler()
   startEnrichmentScheduler(90_000, resolveProjectRoot())
   startRetentionMaintenance({
@@ -1684,25 +1708,6 @@ async function bootstrap() {
       console.warn(`[boot] prune orphan chat-attachments / session-state failed: ${msg}`)
     }
   })
-  serveUi = shouldServeUi()
-  if (serveUi) {
-    serveUi = await registerStaticUi(app)
-  }
-
-  app.setNotFoundHandler(async (req, reply) => {
-    if (serveUi && !isApiPath(req.url)) {
-      return reply.sendFile('index.html', resolveUiDist())
-    }
-    return reply.code(404).send({ error: 'not found' })
-  })
-
-  await listenWithStaleCleanup()
-  console.log(`\n  Opptrix API → http://${HOST}:${PORT}/api/health`)
-  if (serveUi) {
-    console.log(`  Desktop UI → http://${HOST}:${PORT}\n`)
-  } else {
-    console.log(`  Web UI → npm run dev → http://127.0.0.1:5173\n`)
-  }
 
   // 桌面/有内置资源时后台探测磁盘 runtime（不载入 E5）；OCR 尽量就绪（失败不崩）
   void import('@opptrix/doc-library')

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -39,6 +39,8 @@ npm run dev:desktop
 
 This builds workspace packages, starts the API sidecar + Vite HMR, and opens the Electron window. The main window first shows an in-window startup screen, then navigates to the app UI when the dev server is ready.
 
+**启动加速**：sidecar 在 `listen` 后才启动调度/预热（health 与静态 UI 先通）；打包启动时 splash 与 sidecar spawn 并行，最短 splash 约 1s；若本机端口 health 已通则 `reuse` 不重复 spawn（托盘/二次唤起同理）。
+
 ### 主窗口尺寸
 
 - **默认大小**：约 **1115×635**（按主显示器 work area 约 70%×75% 再封顶），最小宽高与 UI 一致（宽 ≥ `DESKTOP_CHAT_MIN_WIDTH` / 510px，高 ≥ 600）。

--- a/tests/desktop-startup-accel.test.mjs
+++ b/tests/desktop-startup-accel.test.mjs
@@ -1,0 +1,109 @@
+/**
+ * 桌面启动加速 P0–P2：源码契约（phase 拆分、splash∥spawn、reuse probe）。
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const serverIndex = fs.readFileSync(
+  path.join(here, '../apps/server/src/index.ts'),
+  'utf8',
+)
+const mainCjs = fs.readFileSync(
+  path.join(here, '../apps/desktop/electron/main.cjs'),
+  'utf8',
+)
+
+function sliceBootstrap(src) {
+  const start = src.indexOf('async function bootstrap()')
+  assert.ok(start >= 0, 'bootstrap() missing')
+  const end = src.indexOf('\nlet shuttingDown', start)
+  assert.ok(end > start, 'bootstrap body end marker missing')
+  return src.slice(start, end)
+}
+
+describe('server bootstrap phaseA / phaseB', () => {
+  const boot = sliceBootstrap(serverIndex)
+
+  it('registers routes and listens before schedulers (phaseA → listen → phaseB)', () => {
+    const listenAt = boot.indexOf('await listenWithStaleCleanup()')
+    assert.ok(listenAt >= 0)
+
+    const phaseAMarkers = [
+      'await initOutboundNetwork()',
+      'await registerNewsRoutes(app)',
+      'registerStaticUi',
+      'setNotFoundHandler',
+    ]
+    for (const m of phaseAMarkers) {
+      const at = boot.indexOf(m)
+      assert.ok(at >= 0, `phaseA missing: ${m}`)
+      assert.ok(at < listenAt, `${m} must be before listen`)
+    }
+
+    const phaseBMarkers = [
+      'startNewsFeedScheduler()',
+      'startEnrichmentScheduler(',
+      'startRetentionMaintenance(',
+      'scheduleService.start()',
+      'maybeBootstrapTranslationModel',
+      'pruneOrphanChatAttachments',
+      'ensureBundledRagRuntime',
+    ]
+    for (const m of phaseBMarkers) {
+      const at = boot.indexOf(m)
+      assert.ok(at >= 0, `phaseB missing: ${m}`)
+      assert.ok(at > listenAt, `${m} must be after listen`)
+    }
+  })
+
+  it('documents Fastify 5 lock: no new routes after listen', () => {
+    assert.match(boot, /Fastify 5/)
+    assert.match(boot, /禁止再 app\.register/)
+    const afterListen = boot.slice(boot.indexOf('await listenWithStaleCleanup()'))
+    assert.doesNotMatch(afterListen, /await register\w+Routes\(app\)/)
+    assert.doesNotMatch(afterListen, /app\.register\(/)
+    assert.doesNotMatch(afterListen, /app\.(get|post|put|delete|patch)\(/)
+  })
+})
+
+describe('desktop splash ∥ sidecar + reuse probe', () => {
+  it('MIN_SPLASH_MS is 1000 (800–1200)', () => {
+    const m = mainCjs.match(/const MIN_SPLASH_MS\s*=\s*(\d+)/)
+    assert.ok(m, 'MIN_SPLASH_MS missing')
+    const ms = Number(m[1])
+    assert.equal(ms, 1000)
+    assert.ok(ms >= 800 && ms <= 1200)
+  })
+
+  it('bootstrapApp runs splash and ensureSidecarReady in parallel', () => {
+    const start = mainCjs.indexOf('async function bootstrapApp')
+    assert.ok(start >= 0)
+    const end = mainCjs.indexOf('async function handleScheduleTickFromOs', start)
+    const body = mainCjs.slice(start, end)
+    assert.match(body, /Promise\.all\(\[splashPromise,\s*sidecarPromise\]\)/)
+    assert.match(body, /sidecarAlreadyReady:\s*true/)
+  })
+
+  it('loadAppInMainWindow skips ensure when sidecarAlreadyReady', () => {
+    const start = mainCjs.indexOf('async function loadAppInMainWindow')
+    const end = mainCjs.indexOf('async function ensureSidecarReady', start)
+    const body = mainCjs.slice(start, end)
+    assert.match(body, /sidecarAlreadyReady/)
+    assert.match(body, /if\s*\(\s*!sidecarAlreadyReady\s*\)/)
+  })
+
+  it('ensureSidecarReady probes health before spawn and sets reuse', () => {
+    const start = mainCjs.indexOf('async function ensureSidecarReady')
+    const end = mainCjs.indexOf('async function bootstrapApp', start)
+    const body = mainCjs.slice(start, end)
+    const probeAt = body.indexOf('probeSidecarHealth')
+    const spawnAt = body.indexOf('spawnSidecar()')
+    assert.ok(probeAt >= 0, 'probeSidecarHealth required before spawn')
+    assert.ok(spawnAt > probeAt, 'probe must precede spawn')
+    assert.match(body, /apiPortMode\s*=\s*['"]reuse['"]/)
+  })
+})


### PR DESCRIPTION
## Summary
- Server bootstrap phaseA listens after routes/static; phaseB starts news/enrichment/retention/schedule after bind.
- Desktop overlaps splash with sidecar ready; `MIN_SPLASH_MS` is 1s.
- Probe health before spawn and reuse a live sidecar (tray / second open).

## Test plan
- [x] `npm run build -w @opptrix/server`
- [x] `node --test tests/desktop-startup-accel.test.mjs`
- [ ] Smoke cold start: splash overlaps API bring-up; first paint sooner than before
- [ ] Smoke: quit to tray then reopen — no second sidecar when health already ok


Made with [Cursor](https://cursor.com)