### PR TITLE
feat(agent): enhance research agent loop for parallel gather and verify

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,7 +16,7 @@ import {
 import { closeMarketDuckRuntime, getMarketDataService } from '@opptrix/market-data-store'
 import { registerStaticUi, shouldServeUi, isApiPath, resolveUiDist } from './static-ui.js'
 import { cancelDiscoverJob, deleteDiscoverJob, getDiscoverJob, listDiscoverJobs, startDiscoverCustomJob, startDiscoverJob } from './discover-jobs.js'
-import { cancelSessionChat, clearSessionChat, registerSessionChat } from './session-chat-runs.js'
+import { cancelSessionChat, clearSessionChat, hasActiveSessionChat, registerSessionChat } from './session-chat-runs.js'
 import {
   deleteCustomDiscoverStrategy,
   listCustomDiscoverStrategies,
@@ -1304,8 +1304,27 @@ app.post<{ Params: { id: string } }>('/api/sessions/:id/chat/cancel', async (req
   const cancelled = cancelSessionChat(req.params.id)
   if (!cancelled) return reply.code(404).send({ error: 'no active chat' })
   agent.userPromptBridge.cancelSession(req.params.id)
+  agent.steerBridge.clear(req.params.id)
   return { cancelled: true }
 })
+
+app.post<{ Params: { id: string }; Body: { message?: string } }>(
+  '/api/sessions/:id/chat/steer',
+  async (req, reply) => {
+    const message = typeof req.body?.message === 'string' ? req.body.message.trim() : ''
+    if (!message) {
+      return reply.code(200).send({ ok: false, reason: 'empty' })
+    }
+    if (!hasActiveSessionChat(req.params.id)) {
+      return reply.code(200).send({ ok: false, reason: 'no_active_chat' })
+    }
+    const result = agent.enqueueSteer(req.params.id, message)
+    if (!result.ok) {
+      return reply.code(200).send({ ok: false, reason: result.reason })
+    }
+    return { ok: true }
+  },
+)
 
 app.post<{
   Params: { id: string }

--- a/apps/server/src/session-chat-runs.ts
+++ b/apps/server/src/session-chat-runs.ts
@@ -15,6 +15,10 @@ export function cancelSessionChat(sessionId: string): boolean {
   return true
 }
 
+export function hasActiveSessionChat(sessionId: string): boolean {
+  return running.has(sessionId)
+}
+
 export function clearSessionChat(sessionId: string, ac: AbortController) {
   if (running.get(sessionId) === ac) running.delete(sessionId)
 }

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1712,6 +1712,18 @@ export async function cancelSessionChat(sessionId: string) {
   })
 }
 
+/** 生成中补充说明（soft steer，不取消当前回复） */
+export async function steerSessionChat(sessionId: string, message: string) {
+  return jsonFetch<{ ok: boolean; reason?: 'no_active_chat' | 'empty' }>(
+    `/sessions/${sessionId}/chat/steer`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message }),
+    },
+  )
+}
+
 export async function submitUserPromptResponse(
   sessionId: string,
   promptId: string,

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -35,7 +35,7 @@ import WorkspaceSplitDivider from './WorkspaceSplitDivider'
 import {
   listSessions, createSession, getSession, getSessionContextUsage, deleteSession, forkSession, truncateSession, clearSessionContext,
   setSessionContext, ephemeralAsk,
-  streamSessionChat, cancelSessionChat, getHealth, listAvailableModels, setSessionModel, setSessionLlmParams,
+  streamSessionChat, cancelSessionChat, steerSessionChat, getHealth, listAvailableModels, setSessionModel, setSessionLlmParams,
   archiveSession,
   listArchivedSessions, createSessionArchiveFolder, renameSessionArchiveFolder, deleteSessionArchiveFolder,
   clearSessionArchiveFolder, renameSession, listWorkspaceGrants,
@@ -1130,6 +1130,22 @@ export default function ChatApp() {
     }
 
     if (streamingSessionIdsRef.current.has(sessionId)) {
+      // 生成中：纯文本走 soft steer；带附件仍排队等本轮结束后发送
+      if (!ids.length && msg) {
+        try {
+          const result = await steerSessionChat(sessionId, msg)
+          if (!result.ok) {
+            if (result.reason === 'no_active_chat') {
+              setError('当前没有进行中的回复，请直接发送新问题')
+            } else {
+              setError('补充说明未能送出，请稍后重试')
+            }
+          }
+        } catch (e) {
+          setError(e instanceof Error ? e.message : '补充说明未能送出')
+        }
+        return
+      }
       const result = enqueueQueuedPrompt(sessionId, {
         text: msg,
         attachmentIds: ids,

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -798,8 +798,9 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
 
   const hasSendPayload = hasContent || attachmentIds.length > 0
   const canEnqueueOrSend = hasSendPayload && !userPrompt && !uploading
-  const canSend = canEnqueueOrSend && !loading
-  /** 仅 ask_user / 上传中锁定编辑；执行中仍可输入以加入排队 */
+  /** 生成中也可发送纯文字作为补充说明（soft steer） */
+  const canSend = canEnqueueOrSend && (!loading || (hasContent && attachmentIds.length === 0))
+  /** 仅 ask_user / 上传中锁定编辑；执行中仍可输入以补充或排队 */
   const composerLocked = Boolean(userPrompt) || uploading
   const showWelcomeStarters = starters.length > 0 && isEmpty && !alwaysShowStarters
   const showExpertStarterBar = alwaysShowStarters && starters.length > 0
@@ -849,10 +850,10 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
   const speechListening = speechBusy
   const speechListeningPhase = speechPhase !== 'idle' ? speechPhase : null
 
-  /** 右侧操作可并存：loading 仅 stop；非 loading 时 speechAvailable 常显 mic，canSend 另显 send */
+  /** 右侧：loading 时 stop + 可发补充；非 loading 时 mic / send */
   const showStop = loading
   const showMic = !loading && speechAvailable
-  const showSend = !loading && canSend
+  const showSend = canSend
   /** 空态仅麦 → primary 实心底；与发送并排 → ghost 透明图标 */
   const micSolo = showMic && !showSend && !speechListening
   const micBesideSend = showMic && showSend && !speechListening
@@ -1113,7 +1114,7 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
                 aria-label="输入问题，@ 选择股票，/ 引用技能"
                 data-placeholder={
                   loading
-                    ? (isMobile ? '继续输入，将加入排队…' : '继续输入，发送后加入排队…')
+                    ? (isMobile ? '继续输入，可补充说明…' : '继续输入，发送后作为补充说明…')
                     : (isMobile
                       ? '输入问题，@ 股票，/ 技能…'
                       : '输入问题，@ 选择股票，/ 引用技能，Enter 发送…')
@@ -1205,7 +1206,7 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
                     icon={<ArrowUpRegular fontSize={14} />}
                     disabled={!canSend}
                     onClick={() => handleSubmitMessage()}
-                    aria-label="发送"
+                    aria-label={loading ? '补充说明' : '发送'}
                   />
                 )}
               </div>

--- a/client-ui/src/chat/sessionStreamRuntime.ts
+++ b/client-ui/src/chat/sessionStreamRuntime.ts
@@ -193,6 +193,16 @@ export function applyChatProgressEvent(
         }),
       }
     }
+    case 'steer_applied':
+      // 生成中补充说明：轻量提示，避免完全不可见（不打断工具/思考时间线）
+      return {
+        ...snapshot,
+        liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
+          phaseLabel: '已收到补充说明',
+          thinkingSnippet: snapshot.liveTrace?.thinkingSnippet,
+          thinkingSegments: snapshot.liveTrace?.thinkingSegments,
+        }),
+      }
     case 'done':
     case 'error':
       return {

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -69,6 +69,7 @@ export type ChatProgressEvent =
   | { type: 'tool_start'; step: ChatToolStep }
   | { type: 'tool_done'; step: ChatToolStep }
   | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
+  | { type: 'steer_applied'; message: string }
   | { type: 'reply'; content?: string; estimatedTokens?: number }
   | {
     type: 'done'

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -166,6 +166,11 @@ Opptrix/
     - 单测：`tests/external-mcp-failover.test.mjs`
   - **分层精排**：`resolveToolRoutePlan` 将用户意图映射为首选工具顺序与研究档位（L1 事实快答 / L2 结构化解读 / L3 深度备忘录），注入「本轮工具选型卡」与证据纪律/输出骨架，并把首选工具排到 tools schema 前列
   - **投研完备性闭环（`buildResearchCompletenessLoop`，仅 L2/L3 注入）**：出报告前强制「缺口自检 → 针对性补齐（换源重试 / activate_tool_pack / 远程重试降级项）→ 重新纳入分析 → 收敛输出」；同一缺口最多补 1 轮，取不到则如实标注缺口。L1 事实快答不注入，避免过度拉数
+  - **投研 Agent Loop 增强**（`packages/agent/src/loop/`，engine 仅编排）：
+    1. **只读同轮并行**：连续只读工具可 `Promise.all`；`ask_user` / workspace 写删 / shell / secret / schedule 变更 / `activate_*` / MCP 变更 / browser 会话态 / 外部 `serverId__tool` **必须串行**；tool 消息写回仍按原 `tool_calls` 顺序；每 call 各自 `runInToolSession`
+    2. **Checklist + 反空转**：会话内存 checklist（`update_research_checklist`，meta pack）；Skill 激活写入占位步骤；turn-tail 注入未完成项。同 fingerprint（工具名+规范化 args）成功重复 ≥3 或失败 ≥2 → 短路返回 `spin_guard`；连续多轮无新指纹且无 checklist 进展 → 强制收口提示。`deleteSession` / 归档旁路清理
+    3. **证据核对 + 分段 `tool_choice`**：`LlmChatOpts.toolChoice` 可配置，上游 400/422 对该字段 fallback（改 `auto` 或省略）。有效档位（`expert.defaultResearchTier ?? route.researchTier`，与 system 一致）为 L3 或已激活 skill，且本 turn 用过 ≥1 业务工具时，纯文本终答前追加核对轮（`tool_choice:'none'` + 核对说明）；L1/无 skill 不强制。SSE thinking 文案：「正在核对关键依据…」
+    4. **Soft steer**：`POST /api/sessions/:id/chat/steer`；仅有进行中 chat 时接受；不 abort；下一 `runLlmRound` 前写入可见 user「（补充）…」；cancel 清 pending；无人值守忽略
   - 默认角色为**投研研究员**：事实与推断分层、标注时效、工具失败不编造、L3 声明数据缺口；配合 MCP 取证后按档位写结论
   - **消息正文插图（无需 pack，日常默认）**：L2/L3 有对比/趋势/占比/强弱矩阵等定量数据时，助手回复 Markdown 可用 ` ```chart ` / ` ```opptrix-chart ` 围栏（内容为 JSON，非 TSX）直接渲染 `@opptrix/canvas` 的 `Chart`（与画布同源），无需授权、无需 `artifacts`。「画个图」用围栏，勿误当成完整报告；**禁止**用 `opptrix_run` + Python（matplotlib/seaborn/plotly 等）出图再当聊天插图（用户明确要求导出图像文件到工作区时除外）。多折线/分组柱须 `data[].series`；单折线勿用每点不同 `color` 冒充多指标；类目密时建议 `showValues:false`、`showTooltip:true`。见 `buildResearchEpistemicPlaybook`。
   - **画布与脑图（`artifacts` pack）**：实现 `packages/agent/src/canvas-tools.ts`；非 always-on，意图播种（可视化报告/画布/脑图/思维导图）或 `activate_tool_pack({ pack_ids: ["artifacts"] })`

--- a/docs/API.md
+++ b/docs/API.md
@@ -951,6 +951,9 @@ Content-Type: application/json
 | DELETE | `/api/sessions/:id/attachments/:attachmentId` | 删除未入 turns 引用的附件；已引用 → 409 |
 | POST | `/api/sessions/:id/chat/stream` | SSE 聊天；body `{ message, model?, attachments?: string[] }`（`attachments` 为已上传附件 id 列表） |
 | POST | `/api/sessions/:id/chat` | 同步聊天；body 同上 |
+| POST | `/api/sessions/:id/chat/cancel` | 取消进行中的聊天；无活动流 → 404；同时清空 pending `ask_user` 与 soft steer |
+| POST | `/api/sessions/:id/chat/steer` | Soft steer：生成中注入补充说明，**不** abort；body `{ message: string }` → `{ ok: true }` 或 `{ ok: false, reason: 'no_active_chat' \| 'empty' }`；下一 LLM 轮前以用户消息「（补充）…」写入会话；SSE 可发 `steer_applied` |
+| POST | `/api/sessions/:id/chat/user-prompt` | 回填 `ask_user` / 密钥问答；见下 |
 | POST | `/api/sessions/:id/fork` | 从助手气泡分叉新会话；body `{ message_index }`（display turn 索引，须为 assistant）→ `{ session, messages, contextRef }`；无效索引/角色 → 404 |
 | POST | `/api/sessions/:id/truncate` | 编辑重发前截断：从指定 **user** display turn 起删除该条及之后（同步 `turns` / `messages`，清空 `sessionMemory`）；body `{ message_index: number }`（整数 ≥0）→ `{ session, messages, contextRef }`；非 user 锚点或无效 → 404；校验失败 → 400 |
 | GET | `/api/speech/status` | 本机语音识别就绪状态：`{ ready, engine, modelName, modelsDir, language?, promptEnabled? }` |

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -115,6 +115,7 @@ export type ChatProgressEvent =
   | { type: 'tool_start'; step: ChatToolStep }
   | { type: 'tool_done'; step: ChatToolStep }
   | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
+  | { type: 'steer_applied'; message: string }
   | { type: 'reply'; content?: string; estimatedTokens?: number }
   | {
     type: 'done'

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -41,6 +41,28 @@ import {
   parseNamespacedMcpTool,
 } from '@opptrix/shared'
 import {
+  buildChecklistTurnTail,
+  buildSpinGuardTurnTail,
+  beginSpinRound,
+  checkSpinGuard,
+  clearResearchChecklistSession,
+  clearSpinGuardSession,
+  formatSteerUserMessage,
+  getChecklistProgressEpoch,
+  isBusinessToolName,
+  noteRoundProgress,
+  partitionToolCallsForExecution,
+  recordSpinOutcome,
+  resolveGatherToolChoice,
+  resolveVerifyToolChoice,
+  roundHadNewFingerprint,
+  seedChecklistOnSkillActivate,
+  resolveEffectiveResearchTier,
+  shouldEnterVerifyPhase,
+  SteerBridge,
+  VERIFY_TURN_TAIL,
+} from './loop/index.js'
+import {
   logChatDebugAbort,
   logChatDebugEmptyReply,
   logChatDebugRoundEnd,
@@ -197,6 +219,7 @@ export class AgentEngine {
   private lastRoutePlan: ToolRoutePlan | null = null
   private readonly expertPacksSeeded = new Set<string>()
   readonly userPromptBridge = new UserPromptBridge()
+  readonly steerBridge = new SteerBridge()
   private readonly workspaceService = getWorkspaceService()
   /** 会话上下文用量估算缓存（内存；切会话命中则不再 rebuildRoundTools） */
   private readonly contextUsageCache = new Map<string, SessionContextUsage>()
@@ -298,24 +321,57 @@ export class AgentEngine {
       roleLabel: expert?.title ?? null,
       activePacks: this.lastRoundPackIds,
       activeToolNames: activeNames,
-      researchTier: expert?.defaultResearchTier ?? plan.researchTier,
+      researchTier: resolveEffectiveResearchTier(expert?.defaultResearchTier, plan.researchTier),
       dataSourcingPolicy: this.buildDataSourcingPolicy(plan),
       agentSkillCatalog: buildSkillCatalogPrompt(),
       activatedAgentSkills: buildActivatedSkillsPrompt(activatedSkills),
     })
   }
 
-  /** 本轮动态尾注：会话时钟 + 选型卡（append 到 modelView，不进稳定 system） */
+  /** 与 system 档位一致：专家默认优先于路由 */
+  private resolveSessionResearchTier(sessionId: string) {
+    const record = this.sessions.get(sessionId)
+    const expert = record?.expertId
+      ? getExpertCatalogService().getDefinitionSync(record.expertId)
+      : null
+    const plan = this.lastRoutePlan ?? resolveToolRoutePlan({
+      message: this.lastChatSeedMessage,
+      contextRef: record?.contextRef ?? null,
+    })
+    return resolveEffectiveResearchTier(expert?.defaultResearchTier, plan.researchTier)
+  }
+
+  /** 本轮动态尾注：会话时钟 + 选型卡 + checklist/反空转（append 到 modelView，不进稳定 system） */
   private buildRoundTurnTail(sessionId: string, activeNames: readonly string[]) {
     const record = this.sessions.get(sessionId)
     const plan = this.lastRoutePlan ?? resolveToolRoutePlan({
       message: this.lastChatSeedMessage,
       contextRef: record?.contextRef ?? null,
     })
-    return buildTurnTailPrompt({
+    const base = buildTurnTailPrompt({
       sessionClock: buildSessionClockPlaybook(getCurrentTime()),
       routePlaybook: buildRoundRoutePlaybook(plan, activeNames),
     })
+    const extras = [
+      buildChecklistTurnTail(sessionId),
+      buildSpinGuardTurnTail(sessionId),
+    ].filter(Boolean)
+    if (!extras.length) return base
+    return [base, ...extras].filter(Boolean).join('\n\n')
+  }
+
+  private clearLoopSessionState(sessionId: string) {
+    clearResearchChecklistSession(sessionId)
+    clearSpinGuardSession(sessionId)
+    this.steerBridge.clear(sessionId)
+  }
+
+  /** Soft steer：仅由 API 在有进行中 chat 时调用；写入 pending，下一 LLM 轮前注入 */
+  enqueueSteer(sessionId: string, message: string): { ok: true } | { ok: false; reason: 'empty' } {
+    const text = message.trim()
+    if (!text) return { ok: false, reason: 'empty' }
+    this.steerBridge.enqueue(sessionId, text)
+    return { ok: true }
   }
 
   /** 旧会话 rolePersona 为空时惰性回填并持久化 */
@@ -503,6 +559,9 @@ export class AgentEngine {
           valid,
           { resolveDeps: (n) => resolveSkillDependencies(n) },
         )
+        if (activated.length) {
+          seedChecklistOnSkillActivate(sessionId, activated)
+        }
         const allSkipped = [...skipped, ...skippedUnknown]
         this.invalidateContextUsage(sessionId)
         const hintParts = [allSkipped.length
@@ -801,6 +860,7 @@ export class AgentEngine {
       this.toolPackSessions.clear(id)
       this.agentSkillSessions.clear(id)
       this.clearExpertPacksSeeded(id)
+      this.clearLoopSessionState(id)
     }
     return record
   }
@@ -839,6 +899,7 @@ export class AgentEngine {
 
   deleteSession(id: string) {
     this.userPromptBridge.cancelSession(id)
+    this.clearLoopSessionState(id)
     this.toolPackSessions.clear(id)
     this.agentSkillSessions.clear(id)
     this.clearExpertPacksSeeded(id)
@@ -876,6 +937,7 @@ export class AgentEngine {
   /** 截断会话至指定 user display turn 之前（编辑重发前调用） */
   truncateSession(sessionId: string, messageIndex: number) {
     this.userPromptBridge.cancelSession(sessionId)
+    this.steerBridge.clear(sessionId)
     const updated = this.sessions.truncateFromDisplayIndex(sessionId, messageIndex)
     this.invalidateContextUsage(sessionId)
     return updated
@@ -1196,6 +1258,7 @@ export class AgentEngine {
     const finalizeCancelled = (partialTools: string[], partialSteps: ChatToolStep[]): ChatResult => {
       logChatDebugAbort(sessionId, { reason: 'cancelled' })
       this.userPromptBridge.cancelSession(sessionId)
+      this.steerBridge.clear(sessionId)
       record!.messages = record!.messages.slice(0, messagesBeforeAssistant)
       if (record!.turns) {
         record!.turns = record!.turns.slice(0, turnsBeforeAssistant + 1)
@@ -1243,11 +1306,41 @@ export class AgentEngine {
     let { broker, openAiTools } = await this.rebuildRoundTools(activeNames, unattended)
 
     try {
+    let businessToolsUsed = 0
+    let alreadyVerified = false
+    let checklistNoneTried = false
+    let forceToolChoice: import('./llm/provider.js').LlmToolChoice | undefined
+    let ephemeralTurnTailExtra = ''
+
     for (let round = 0; round < MAX_SAFETY_ROUNDS; round++) {
       throwIfAborted(signal)
+
+      // Soft steer：下一 LLM 轮前注入可见 user 消息（unattended 忽略并清空）
+      if (unattended) {
+        this.steerBridge.clear(sessionId)
+      } else {
+        const steers = this.steerBridge.consume(sessionId)
+        for (const raw of steers) {
+          const content = formatSteerUserMessage(raw)
+          record.messages.push({ role: 'user', content })
+          if (!record.turns) record.turns = []
+          record.turns.push({
+            role: 'user',
+            content,
+            at: new Date().toISOString(),
+          })
+          emit({ type: 'steer_applied', message: content })
+        }
+        if (steers.length) this.sessions.save(record)
+      }
+
       // 稳定 system（无时钟/选型卡）；动态内容经 turn-tail 追加，利于前缀缓存
       const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
       let turnTail = this.buildRoundTurnTail(sessionId, activeNames)
+      if (ephemeralTurnTailExtra) {
+        turnTail = [turnTail, ephemeralTurnTailExtra].filter(Boolean).join('\n\n')
+        ephemeralTurnTailExtra = ''
+      }
       if (unattended) turnTail = appendUnattendedTurnTail(turnTail)
       const contextMessages = contextRefToChatMessages(record.contextRef)
       const resolvedModel = this.registry.resolve(activeModel)
@@ -1266,6 +1359,16 @@ export class AgentEngine {
 
       let overflowRetried = false
       let lastRoundEstimatedTokens: number | undefined
+      const roundToolChoice = forceToolChoice
+        ?? resolveGatherToolChoice(sessionId, {
+          preferNoneAfterChecklistDone: true,
+          checklistNoneAlreadyTried: checklistNoneTried,
+        })
+      if (roundToolChoice === 'none' && !forceToolChoice) {
+        checklistNoneTried = true
+      }
+      forceToolChoice = undefined
+
       const runLlmRound = async (aggressive: boolean) => {
         const budgeted = await this.applyContextBudget(record, {
           modelId,
@@ -1303,6 +1406,7 @@ export class AgentEngine {
           temperature: record.llmParams?.temperature,
           maxTokens: record.llmParams?.maxTokens,
           reasoningEffort: record.llmParams?.reasoningEffort,
+          toolChoice: roundToolChoice,
           onDelta: (delta) => {
             // hasToolCalls：只停 token 进度，勿 return，以免同包/后续 reasoning 被丢掉
             if (delta.hasToolCalls) {
@@ -1492,16 +1596,24 @@ export class AgentEngine {
 
         let refreshTools = false
         const activeSet = new Set(activeNames)
+        const fingerprintsBefore = beginSpinRound(sessionId)
+        const checklistEpochBefore = getChecklistProgressEpoch(sessionId)
 
-        for (const tc of turn.message.tool_calls) {
-          throwIfAborted(signal)
+        type PreparedCall = {
+          tc: (typeof turn.message.tool_calls)[number]
+          fn: string
+          args: Record<string, unknown>
+          runningStep: ChatToolStep
+        }
+
+        const prepareToolCall = (tc: (typeof turn.message.tool_calls)[number]): PreparedCall => {
           const fn = tc.function.name
           toolsUsed.push(fn)
+          if (isBusinessToolName(fn)) businessToolsUsed += 1
           let args: Record<string, unknown> = {}
           try {
             args = JSON.parse(tc.function.arguments || '{}') as Record<string, unknown>
           } catch { /* empty */ }
-
           const runningStep: ChatToolStep = {
             id: tc.id,
             tool: fn,
@@ -1514,12 +1626,19 @@ export class AgentEngine {
           }
           toolSteps.push(runningStep)
           emit({ type: 'tool_start', step: runningStep })
+          return { tc, fn, args, runningStep }
+        }
 
+        const runPreparedToolCall = async (prepared: PreparedCall) => {
+          throwIfAborted(signal)
+          const { tc, fn, args, runningStep } = prepared
           let result: unknown
           try {
-            if (fn === 'ask_user') {
+            const blocked = checkSpinGuard(sessionId, fn, args)
+            if (blocked) {
+              result = blocked
+            } else if (fn === 'ask_user') {
               if (unattended) {
-                // Defense: never emit user_prompt / waitForAnswer in background jobs
                 result = { ...UNATTENDED_ASK_USER_RESULT }
               } else {
                 const parsed = parseAskUserArgs(args)
@@ -1570,6 +1689,8 @@ export class AgentEngine {
             result = { error: e instanceof Error ? e.message : String(e) }
           }
 
+          recordSpinOutcome(sessionId, fn, args, result)
+
           if (result && typeof result === 'object' && !Array.isArray(result)) {
             const att = (result as Record<string, unknown>).attachment
             if (
@@ -1583,9 +1704,29 @@ export class AgentEngine {
           }
 
           const doneStep = enrichStepFromResult(runningStep, result)
-          toolSteps[toolSteps.length - 1] = doneStep
+          const stepIdx = toolSteps.findIndex(s => s.id === tc.id)
+          if (stepIdx >= 0) toolSteps[stepIdx] = doneStep
           emit({ type: 'tool_done', step: doneStep })
+          return { tc, fn, result }
+        }
 
+        const batches = partitionToolCallsForExecution(turn.message.tool_calls)
+        const orderedResults: Array<{ tc: (typeof turn.message.tool_calls)[number]; fn: string; result: unknown }> = []
+
+        for (const batch of batches) {
+          if (batch.mode === 'parallel' && batch.calls.length > 1) {
+            const prepared = batch.calls.map(prepareToolCall)
+            const settled = await Promise.all(prepared.map(p => runPreparedToolCall(p)))
+            orderedResults.push(...settled)
+          } else {
+            for (const tc of batch.calls) {
+              const prepared = prepareToolCall(tc)
+              orderedResults.push(await runPreparedToolCall(prepared))
+            }
+          }
+        }
+
+        for (const { tc, fn, result } of orderedResults) {
           record.messages.push({
             role: 'tool',
             tool_call_id: tc.id,
@@ -1595,6 +1736,13 @@ export class AgentEngine {
         }
         this.sessions.save(record)
 
+        const hadNewFp = roundHadNewFingerprint(sessionId, fingerprintsBefore)
+        const checklistProgressed = getChecklistProgressEpoch(sessionId) !== checklistEpochBefore
+        noteRoundProgress(sessionId, {
+          hadNewFingerprint: hadNewFp,
+          checklistProgressed,
+        })
+
         if (refreshTools) {
           await broker.close()
           this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
@@ -1602,6 +1750,34 @@ export class AgentEngine {
           if (unattended) activeNames = filterToolNamesForUnattended(activeNames)
           ;({ broker, openAiTools } = await this.rebuildRoundTools(activeNames, unattended))
         }
+        continue
+      }
+
+      // F3：有效档位 L3 / 已激活 skill 且本 turn 用过业务工具 → 成稿前证据核对一轮（tool_choice:none）
+      if (
+        shouldEnterVerifyPhase({
+          researchTier: this.resolveSessionResearchTier(sessionId),
+          hasActivatedSkill: this.agentSkillSessions.getActivated(sessionId).length > 0,
+          businessToolsUsed,
+          alreadyVerified,
+          unattended,
+        })
+      ) {
+        alreadyVerified = true
+        forceToolChoice = resolveVerifyToolChoice()
+        ephemeralTurnTailExtra = VERIFY_TURN_TAIL
+        emit({
+          type: 'thinking',
+          round: round + 1,
+          label: '正在核对关键依据…',
+        })
+        // 将刚产生的终答草稿保留在 messages，供核对轮对照；不 pushAssistant
+        record.messages.push({
+          role: 'assistant',
+          content: turnContentText || null,
+          reasoningContent: turn.reasoningContent ?? '',
+        })
+        this.sessions.save(record)
         continue
       }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -31,6 +31,35 @@ export {
   parseAskUserArgs,
 } from './user-prompt.js'
 export {
+  SteerBridge,
+  formatSteerUserMessage,
+  isSerialTool,
+  SERIAL_TOOL_NAMES,
+  partitionToolCallsForExecution,
+  fingerprintToolCall,
+  checkSpinGuard,
+  recordSpinOutcome,
+  buildSpinGuardTurnTail,
+  clearSpinGuardSession,
+  resetSpinGuardForTests,
+  SPIN_GUARD_LIMITS,
+  updateResearchChecklist,
+  buildChecklistTurnTail,
+  clearResearchChecklistSession,
+  resetResearchChecklistForTests,
+  seedChecklistOnSkillActivate,
+  getResearchChecklist,
+  resolveEffectiveResearchTier,
+  shouldEnterVerifyPhase,
+  resolveGatherToolChoice,
+  resolveVerifyToolChoice,
+  VERIFY_TURN_TAIL,
+  type ResearchChecklistItem,
+  type ToolCallLike,
+  type ToolExecutionBatch,
+  type SpinGuardBlock,
+} from './loop/index.js'
+export {
   UNATTENDED_ASK_USER_RESULT,
   UNATTENDED_BLOCKED_TOOL_NAMES,
   UNATTENDED_SECRET_RESULT,
@@ -327,9 +356,12 @@ export {
   autoOutputBudget,
   looksLikeReasoningModel,
   resolveRequestMaxTokens,
+  resolveBodyToolChoice,
   type LlmConfig,
   type LlmTurn,
   type LlmChatDelta,
+  type LlmChatOpts,
+  type LlmToolChoice,
 } from './llm/provider.js'
 export { initOutboundNetwork, type OutboundConnectFamily, type OutboundNetworkStatus } from './llm/outbound-network.js'
 

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -117,6 +117,13 @@ export type LlmChatDelta = {
   hasToolCalls?: boolean
 }
 
+/** OpenAI-compatible tool_choice；上游不支持时 provider 会降级为 auto / 省略 */
+export type LlmToolChoice =
+  | 'none'
+  | 'auto'
+  | 'required'
+  | { type: 'function'; function: { name: string } }
+
 export interface LlmChatOpts {
   sessionId?: string
   /** 传入时走 SSE 流式；文本增量与 tool_calls 发现会回调 */
@@ -127,6 +134,25 @@ export interface LlmChatOpts {
   maxTokens?: number
   /** 有值时写入 body.reasoning_effort */
   reasoningEffort?: 'low' | 'medium' | 'high'
+  /**
+   * 有 tools 时写入 body.tool_choice；默认 auto。
+   * 上游 400/422 时对该字段 fallback（改 auto 或去掉），勿整轮失败。
+   */
+  toolChoice?: LlmToolChoice
+}
+
+/** 供测试与 buildBody 共用：有 tools 时解析 tool_choice 字段 */
+export function resolveBodyToolChoice(
+  toolsLength: number,
+  toolChoice?: LlmToolChoice,
+): LlmToolChoice | undefined {
+  if (toolsLength <= 0) return undefined
+  return toolChoice ?? 'auto'
+}
+
+function toolChoiceNeedsFallback(toolChoice: LlmToolChoice | undefined): boolean {
+  if (toolChoice == null || toolChoice === 'auto') return false
+  return true
 }
 
 export interface LlmProvider {
@@ -524,6 +550,14 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       ...opts,
       maxTokens: requestedMaxTokens,
     }
+    let toolChoiceFallback: 'auto' | 'omit' | null = null
+    const effectiveToolChoice = (): LlmToolChoice | undefined => {
+      const resolved = resolveBodyToolChoice(tools?.length ?? 0, opts?.toolChoice)
+      if (toolChoiceFallback === 'omit') return undefined
+      if (toolChoiceFallback === 'auto') return 'auto'
+      return resolved
+    }
+
     const buildBody = (stream: boolean): Record<string, unknown> => {
       const body: Record<string, unknown> = {
         model: this.cfg.model,
@@ -541,7 +575,8 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       }
       if (tools?.length) {
         body.tools = tools
-        body.tool_choice = 'auto'
+        const tc = effectiveToolChoice()
+        if (tc !== undefined) body.tool_choice = tc
       }
       if (stream) body.stream = true
       return body
@@ -561,6 +596,30 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       body: JSON.stringify(buildBody(stream)),
       signal: requestSignal,
     })
+
+    /** 上游拒收 tool_choice 时：先改 auto，再省略该字段后重试 */
+    const postWithToolChoiceFallback = async (stream: boolean): Promise<Response> => {
+      const resp = await post(stream)
+      if (resp.ok) return resp
+      if (resp.status !== 400 && resp.status !== 422) return resp
+      if (!tools?.length || !toolChoiceNeedsFallback(opts?.toolChoice)) return resp
+      if (toolChoiceFallback == null) {
+        await resp.text().catch(() => '')
+        toolChoiceFallback = 'auto'
+        const retryAuto = await post(stream)
+        if (retryAuto.ok) return retryAuto
+        if (retryAuto.status !== 400 && retryAuto.status !== 422) return retryAuto
+        await retryAuto.text().catch(() => '')
+        toolChoiceFallback = 'omit'
+        return post(stream)
+      }
+      if (toolChoiceFallback === 'auto') {
+        await resp.text().catch(() => '')
+        toolChoiceFallback = 'omit'
+        return post(stream)
+      }
+      return resp
+    }
 
     const parseJsonTurn = async (resp: Response): Promise<LlmTurn> => {
       const data = await resp.json() as {
@@ -611,12 +670,12 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       if (opts?.onDelta) {
         let streamConsumeStarted = false
         try {
-          const streamResp = await post(true)
+          const streamResp = await postWithToolChoiceFallback(true)
           if (!streamResp.ok) {
             const text = (await streamResp.text()).slice(0, 300)
-            // 部分上游不支持 stream：回退非流式
+            // 部分上游不支持 stream：回退非流式（保留已生效的 tool_choice fallback）
             if (streamResp.status === 400 || streamResp.status === 422) {
-              const fallback = await post(false)
+              const fallback = await postWithToolChoiceFallback(false)
               if (!fallback.ok) {
                 const fbText = (await fallback.text()).slice(0, 300)
                 noteHttpError(fallback.status, fbText)
@@ -628,7 +687,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
             return httpErrorTurn(streamResp.status, text)
           }
           if (!streamResp.body) {
-            const fallback = await post(false)
+            const fallback = await postWithToolChoiceFallback(false)
             if (!fallback.ok) {
               const fbText = (await fallback.text()).slice(0, 300)
               noteHttpError(fallback.status, fbText)
@@ -646,7 +705,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
           }
           // 尚未开始读流时回退非流式；中途失败不再重放整轮
           if (!streamConsumeStarted) {
-            const fallback = await post(false)
+            const fallback = await postWithToolChoiceFallback(false)
             if (!fallback.ok) {
               const fbText = (await fallback.text()).slice(0, 300)
               noteHttpError(fallback.status, fbText)
@@ -658,7 +717,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
         }
       }
 
-      const resp = await post(false)
+      const resp = await postWithToolChoiceFallback(false)
       if (!resp.ok) {
         const text = (await resp.text()).slice(0, 300)
         noteHttpError(resp.status, text)

--- a/packages/agent/src/loop/index.ts
+++ b/packages/agent/src/loop/index.ts
@@ -1,0 +1,50 @@
+export {
+  SERIAL_TOOL_NAMES,
+  isSerialTool,
+  partitionToolCallsForExecution,
+  type ToolCallLike,
+  type ToolExecutionBatch,
+} from './tool-parallel.js'
+
+export {
+  fingerprintToolCall,
+  checkSpinGuard,
+  recordSpinOutcome,
+  noteRoundProgress,
+  beginSpinRound,
+  roundHadNewFingerprint,
+  buildSpinGuardTurnTail,
+  clearSpinGuardSession,
+  resetSpinGuardForTests,
+  SPIN_GUARD_LIMITS,
+  type SpinGuardBlock,
+} from './spin-guard.js'
+
+export {
+  getResearchChecklist,
+  hasPendingChecklistItems,
+  isChecklistAllDone,
+  getChecklistProgressEpoch,
+  updateResearchChecklist,
+  seedChecklistOnSkillActivate,
+  buildChecklistTurnTail,
+  clearResearchChecklistSession,
+  resetResearchChecklistForTests,
+  type ResearchChecklistItem,
+  type ResearchChecklistStatus,
+} from './research-checklist.js'
+
+export {
+  SteerBridge,
+  formatSteerUserMessage,
+} from './steer-bridge.js'
+
+export {
+  resolveEffectiveResearchTier,
+  shouldEnterVerifyPhase,
+  isBusinessToolName,
+  resolveGatherToolChoice,
+  resolveVerifyToolChoice,
+  VERIFY_TURN_TAIL,
+  type LoopPhase,
+} from './verify-phase.js'

--- a/packages/agent/src/loop/research-checklist.ts
+++ b/packages/agent/src/loop/research-checklist.ts
@@ -1,0 +1,154 @@
+export type ResearchChecklistStatus = 'pending' | 'done' | 'skipped'
+
+export type ResearchChecklistItem = {
+  id: string
+  title: string
+  status: ResearchChecklistStatus
+}
+
+type SessionChecklist = {
+  items: ResearchChecklistItem[]
+  /** 用于 spin-guard：是否相对上一快照有进展 */
+  progressEpoch: number
+}
+
+const sessions = new Map<string, SessionChecklist>()
+
+function getOrCreate(sessionId: string): SessionChecklist {
+  let state = sessions.get(sessionId)
+  if (!state) {
+    state = { items: [], progressEpoch: 0 }
+    sessions.set(sessionId, state)
+  }
+  return state
+}
+
+function normalizeStatus(raw: unknown): ResearchChecklistStatus | null {
+  if (raw === 'pending' || raw === 'done' || raw === 'skipped') return raw
+  return null
+}
+
+function normalizeItem(raw: unknown, index: number): ResearchChecklistItem | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const rec = raw as Record<string, unknown>
+  const title = typeof rec.title === 'string' ? rec.title.trim() : ''
+  if (!title) return null
+  const idRaw = typeof rec.id === 'string' ? rec.id.trim() : ''
+  const id = idRaw || `item_${index + 1}`
+  const status = normalizeStatus(rec.status) ?? 'pending'
+  return { id, title, status }
+}
+
+export function getResearchChecklist(sessionId: string): ResearchChecklistItem[] {
+  return getOrCreate(sessionId).items.map(i => ({ ...i }))
+}
+
+export function hasPendingChecklistItems(sessionId: string): boolean {
+  return getOrCreate(sessionId).items.some(i => i.status === 'pending')
+}
+
+export function isChecklistAllDone(sessionId: string): boolean {
+  const items = getOrCreate(sessionId).items
+  if (!items.length) return false
+  return items.every(i => i.status === 'done' || i.status === 'skipped')
+}
+
+export function getChecklistProgressEpoch(sessionId: string): number {
+  return getOrCreate(sessionId).progressEpoch
+}
+
+/**
+ * replace：整体替换；merge：按 id 合并（无 id 则追加）。
+ */
+export function updateResearchChecklist(
+  sessionId: string,
+  args: { mode?: string; items?: unknown },
+): {
+  ok: true
+  mode: 'replace' | 'merge'
+  items: ResearchChecklistItem[]
+  pending_count: number
+} | { error: string } {
+  const modeRaw = typeof args.mode === 'string' ? args.mode.trim().toLowerCase() : 'merge'
+  const mode = modeRaw === 'replace' ? 'replace' : modeRaw === 'merge' ? 'merge' : null
+  if (!mode) return { error: 'mode 须为 replace 或 merge' }
+  if (!Array.isArray(args.items)) return { error: 'items 须为数组' }
+
+  const incoming: ResearchChecklistItem[] = []
+  for (let i = 0; i < args.items.length; i++) {
+    const item = normalizeItem(args.items[i], i)
+    if (!item) return { error: `items[${i}] 无效：需要 title` }
+    incoming.push(item)
+  }
+
+  const state = getOrCreate(sessionId)
+  const beforePending = state.items.filter(i => i.status === 'pending').length
+  const beforeDone = state.items.filter(i => i.status === 'done' || i.status === 'skipped').length
+
+  if (mode === 'replace') {
+    state.items = incoming
+  } else {
+    const byId = new Map(state.items.map(i => [i.id, i]))
+    for (const item of incoming) {
+      byId.set(item.id, item)
+    }
+    state.items = [...byId.values()]
+  }
+
+  const afterPending = state.items.filter(i => i.status === 'pending').length
+  const afterDone = state.items.filter(i => i.status === 'done' || i.status === 'skipped').length
+  if (afterPending !== beforePending || afterDone !== beforeDone || mode === 'replace') {
+    state.progressEpoch += 1
+  }
+
+  return {
+    ok: true,
+    mode,
+    items: state.items.map(i => ({ ...i })),
+    pending_count: afterPending,
+  }
+}
+
+/** Skill 激活后写入占位步骤（解析不稳时的稳健路径）。 */
+export function seedChecklistOnSkillActivate(
+  sessionId: string,
+  skillNames: readonly string[],
+): void {
+  const names = skillNames.map(n => n.trim()).filter(Boolean)
+  if (!names.length) return
+  const state = getOrCreate(sessionId)
+  const id = 'skill_workflow'
+  const title = names.length === 1
+    ? `按已激活技能「${names[0]}」步骤推进`
+    : `按已激活技能步骤推进（${names.join('、')}）`
+  const existing = state.items.find(i => i.id === id)
+  if (existing) {
+    existing.title = title
+    if (existing.status === 'done' || existing.status === 'skipped') {
+      existing.status = 'pending'
+      state.progressEpoch += 1
+    }
+    return
+  }
+  state.items.push({ id, title, status: 'pending' })
+  state.progressEpoch += 1
+}
+
+export function buildChecklistTurnTail(sessionId: string): string {
+  const pending = getOrCreate(sessionId).items.filter(i => i.status === 'pending')
+  if (!pending.length) return ''
+  const lines = pending.map((i, idx) => `${idx + 1}. [${i.id}] ${i.title}`)
+  return [
+    '【研究步骤 — 未完成】',
+    ...lines,
+    '可用 update_research_checklist 标记完成或跳过；勿忽略未完成项直接空转。',
+  ].join('\n')
+}
+
+export function clearResearchChecklistSession(sessionId: string): void {
+  sessions.delete(sessionId)
+}
+
+export function resetResearchChecklistForTests(): void {
+  sessions.clear()
+}

--- a/packages/agent/src/loop/spin-guard.ts
+++ b/packages/agent/src/loop/spin-guard.ts
@@ -1,0 +1,207 @@
+/** 反空转：同 fingerprint 成功/失败重复达阈值则短路，并注入 turn-tail 提示。 */
+
+const SUCCESS_REPEAT_LIMIT = 3
+const FAILURE_REPEAT_LIMIT = 2
+const STALE_ROUNDS_WITHOUT_PROGRESS = 3
+const ARGS_JSON_MAX = 480
+
+export type SpinGuardBlock = {
+  error: string
+  spin_guard: true
+  hint: string
+}
+
+type FingerprintStats = {
+  success: number
+  failure: number
+}
+
+type SessionSpinState = {
+  byFingerprint: Map<string, FingerprintStats>
+  /** 本轮是否出现过新 fingerprint（工具执行后标记） */
+  seenFingerprints: Set<string>
+  /** 连续无新 fingerprint 且 checklist 无进展的轮数 */
+  staleRounds: number
+  forceCloseHint: boolean
+  lastBlockedHint: string | null
+}
+
+const sessions = new Map<string, SessionSpinState>()
+
+function getOrCreate(sessionId: string): SessionSpinState {
+  let state = sessions.get(sessionId)
+  if (!state) {
+    state = {
+      byFingerprint: new Map(),
+      seenFingerprints: new Set(),
+      staleRounds: 0,
+      forceCloseHint: false,
+      lastBlockedHint: null,
+    }
+    sessions.set(sessionId, state)
+  }
+  return state
+}
+
+/** 稳定 key 序 + 截断，避免无关字段抖动。 */
+export function fingerprintToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+): string {
+  const normalized = stableStringify(args)
+  const clipped = normalized.length > ARGS_JSON_MAX
+    ? `${normalized.slice(0, ARGS_JSON_MAX)}…`
+    : normalized
+  return `${toolName.trim()}::${clipped}`
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeys(value))
+}
+
+function sortKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value
+  if (Array.isArray(value)) return value.map(sortKeys)
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  const out: Record<string, unknown> = {}
+  for (const key of keys) {
+    out[key] = sortKeys(obj[key])
+  }
+  return out
+}
+
+function isFailureResult(result: unknown): boolean {
+  if (result == null) return true
+  if (typeof result !== 'object' || Array.isArray(result)) return false
+  const rec = result as Record<string, unknown>
+  if (typeof rec.error === 'string' && rec.error.trim()) return true
+  if (rec.ok === false) return true
+  if (rec.spin_guard === true) return true
+  return false
+}
+
+/**
+ * 若同 fingerprint 已达阈值，返回短路结果（不再打 broker）。
+ * 否则返回 null，调用方应继续执行并在完成后 `recordSpinOutcome`。
+ */
+export function checkSpinGuard(
+  sessionId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): SpinGuardBlock | null {
+  const fp = fingerprintToolCall(toolName, args)
+  const state = getOrCreate(sessionId)
+  const stats = state.byFingerprint.get(fp)
+  if (!stats) return null
+
+  if (stats.success >= SUCCESS_REPEAT_LIMIT) {
+    const hint = '同一查询已重复多次且结果无新意。请换数据源或角度，或开始整理成稿，勿继续空转。'
+    state.lastBlockedHint = hint
+    return {
+      error: '已拦截重复调用',
+      spin_guard: true,
+      hint,
+    }
+  }
+  if (stats.failure >= FAILURE_REPEAT_LIMIT) {
+    const hint = '同一操作连续失败。请更换路径、说明缺口，或开始基于已有材料成稿。'
+    state.lastBlockedHint = hint
+    return {
+      error: '已拦截重复失败调用',
+      spin_guard: true,
+      hint,
+    }
+  }
+  return null
+}
+
+export function recordSpinOutcome(
+  sessionId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  result: unknown,
+): void {
+  const fp = fingerprintToolCall(toolName, args)
+  const state = getOrCreate(sessionId)
+  const wasNew = !state.seenFingerprints.has(fp)
+  state.seenFingerprints.add(fp)
+  if (wasNew) {
+    // 新证据路径出现 → 重置空转轮计数（本轮结束时再评估）
+    state.forceCloseHint = false
+  }
+  const stats = state.byFingerprint.get(fp) ?? { success: 0, failure: 0 }
+  if (isFailureResult(result)) stats.failure += 1
+  else stats.success += 1
+  state.byFingerprint.set(fp, stats)
+}
+
+/**
+ * 每 LLM 工具轮结束后调用：若本轮无新 fingerprint 且 checklist 无进展，累计空转轮。
+ * @returns 是否应注入强制收口 turn-tail
+ */
+export function noteRoundProgress(
+  sessionId: string,
+  opts: { hadNewFingerprint: boolean; checklistProgressed: boolean },
+): boolean {
+  const state = getOrCreate(sessionId)
+  if (opts.hadNewFingerprint || opts.checklistProgressed) {
+    state.staleRounds = 0
+    state.forceCloseHint = false
+    return false
+  }
+  state.staleRounds += 1
+  if (state.staleRounds >= STALE_ROUNDS_WITHOUT_PROGRESS) {
+    state.forceCloseHint = true
+    return true
+  }
+  return state.forceCloseHint
+}
+
+/** 一轮工具执行开始前调用，用于区分「本轮新 fingerprint」。 */
+export function beginSpinRound(sessionId: string): Set<string> {
+  const state = getOrCreate(sessionId)
+  return new Set(state.seenFingerprints)
+}
+
+export function roundHadNewFingerprint(
+  sessionId: string,
+  fingerprintsBefore: ReadonlySet<string>,
+): boolean {
+  const state = getOrCreate(sessionId)
+  for (const fp of state.seenFingerprints) {
+    if (!fingerprintsBefore.has(fp)) return true
+  }
+  return false
+}
+
+export function buildSpinGuardTurnTail(sessionId: string): string {
+  const state = sessions.get(sessionId)
+  if (!state) return ''
+  const parts: string[] = []
+  if (state.lastBlockedHint) {
+    parts.push(`【路径提醒】${state.lastBlockedHint}`)
+    state.lastBlockedHint = null
+  }
+  if (state.forceCloseHint) {
+    parts.push(
+      '【收口提醒】连续多轮没有新的取证路径，也没有推进研究步骤。请基于已有材料整理结论；缺证据处如实说明缺口，不要继续重复同一查询。',
+    )
+  }
+  return parts.join('\n')
+}
+
+export function clearSpinGuardSession(sessionId: string): void {
+  sessions.delete(sessionId)
+}
+
+/** 测试钩子 */
+export function resetSpinGuardForTests(): void {
+  sessions.clear()
+}
+
+export const SPIN_GUARD_LIMITS = {
+  SUCCESS_REPEAT_LIMIT,
+  FAILURE_REPEAT_LIMIT,
+  STALE_ROUNDS_WITHOUT_PROGRESS,
+} as const

--- a/packages/agent/src/loop/steer-bridge.ts
+++ b/packages/agent/src/loop/steer-bridge.ts
@@ -1,0 +1,39 @@
+/**
+ * Soft steer — 运行中注入补充说明，不 abort。
+ * 按 session 排队；下一 runLlmRound 前 consume。
+ */
+export class SteerBridge {
+  private readonly pending = new Map<string, string[]>()
+
+  enqueue(sessionId: string, message: string): void {
+    const text = message.trim()
+    if (!text) return
+    const list = this.pending.get(sessionId) ?? []
+    list.push(text)
+    this.pending.set(sessionId, list)
+  }
+
+  /** 取出并清空该会话全部 pending */
+  consume(sessionId: string): string[] {
+    const list = this.pending.get(sessionId) ?? []
+    this.pending.delete(sessionId)
+    return list
+  }
+
+  peek(sessionId: string): readonly string[] {
+    return this.pending.get(sessionId) ?? []
+  }
+
+  clear(sessionId: string): void {
+    this.pending.delete(sessionId)
+  }
+
+  hasPending(sessionId: string): boolean {
+    return (this.pending.get(sessionId)?.length ?? 0) > 0
+  }
+}
+
+export function formatSteerUserMessage(message: string): string {
+  const text = message.trim()
+  return text.startsWith('（补充）') ? text : `（补充）${text}`
+}

--- a/packages/agent/src/loop/tool-parallel.ts
+++ b/packages/agent/src/loop/tool-parallel.ts
@@ -1,0 +1,92 @@
+import { parseNamespacedMcpTool } from '@opptrix/shared'
+
+/**
+ * 必须串行的工具（人机确认 / 写删 / shell / secret / 调度变更 / activate·MCP / browser 会话态）。
+ * 外部命名空间 MCP（serverId__tool）默认串行。
+ */
+export const SERIAL_TOOL_NAMES: ReadonlySet<string> = new Set([
+  // 人机
+  'ask_user',
+  // Workspace 写/删/侧效
+  'workspace_write',
+  'workspace_mkdir',
+  'workspace_delete',
+  'download_file',
+  'request_folder_access',
+  // Shell
+  'opptrix_run',
+  'shell_run',
+  'shell_install',
+  'ensure_python',
+  // Secret
+  'request_secret',
+  'grant_session_secret',
+  // Schedule 变更/执行
+  'create_scheduled_job',
+  'update_scheduled_job',
+  'enable_scheduled_job',
+  'disable_scheduled_job',
+  'delete_scheduled_job',
+  'run_scheduled_job_now',
+  // Activate / MCP 变更
+  'activate_tool_pack',
+  'activate_agent_skill',
+  'enable_mcp_server',
+  'disable_mcp_server',
+  'edit_mcp_server',
+  'install_mcp_server',
+  'uninstall_mcp_server',
+  'reorder_mcp_servers',
+  // 会话 checklist 写（避免并行竞态）
+  'update_research_checklist',
+  // Browser 写/会话态（含截图：共享 Playwright session）
+  'browser_navigate',
+  'browser_click',
+  'browser_type',
+  'browser_close',
+  'browser_screenshot',
+])
+
+export function isSerialTool(name: string): boolean {
+  const trimmed = name.trim()
+  if (!trimmed) return true
+  if (SERIAL_TOOL_NAMES.has(trimmed)) return true
+  if (parseNamespacedMcpTool(trimmed)) return true
+  return false
+}
+
+export type ToolCallLike = {
+  id: string
+  function: { name: string; arguments?: string }
+}
+
+export type ToolExecutionBatch<T extends ToolCallLike = ToolCallLike> =
+  | { mode: 'parallel'; calls: T[] }
+  | { mode: 'serial'; calls: T[] }
+
+/**
+ * 只读片段可并行：连续非串行工具合成 parallel batch；遇串行则单独 serial batch（保持相对顺序）。
+ */
+export function partitionToolCallsForExecution<T extends ToolCallLike>(
+  calls: readonly T[],
+): ToolExecutionBatch<T>[] {
+  const batches: ToolExecutionBatch<T>[] = []
+  let pendingParallel: T[] = []
+
+  const flushParallel = () => {
+    if (!pendingParallel.length) return
+    batches.push({ mode: 'parallel', calls: pendingParallel })
+    pendingParallel = []
+  }
+
+  for (const call of calls) {
+    if (isSerialTool(call.function.name)) {
+      flushParallel()
+      batches.push({ mode: 'serial', calls: [call] })
+    } else {
+      pendingParallel.push(call)
+    }
+  }
+  flushParallel()
+  return batches
+}

--- a/packages/agent/src/loop/verify-phase.ts
+++ b/packages/agent/src/loop/verify-phase.ts
@@ -1,0 +1,90 @@
+import type { ResearchTier } from '@opptrix/shared'
+import type { LlmToolChoice } from '../llm/provider.js'
+import { hasPendingChecklistItems, isChecklistAllDone } from './research-checklist.js'
+
+export type LoopPhase = 'gather' | 'verify'
+
+export const VERIFY_TURN_TAIL =
+  '请核对结论中的关键数字与事实是否均来自本轮工具结果；缺证据则说明缺口；不要编造。'
+
+/**
+ * 与 `buildRoundSystemPrompt` 一致：专家默认档位优先于路由档位。
+ * 避免「专家 L3 + 路由 L1」时 system 按 L3 写、verify 却跳过。
+ */
+export function resolveEffectiveResearchTier(
+  expertDefaultTier: ResearchTier | string | null | undefined,
+  planTier: ResearchTier | string | null | undefined,
+): ResearchTier | undefined {
+  const raw = expertDefaultTier ?? planTier
+  if (raw === 'L1' || raw === 'L2' || raw === 'L3') return raw
+  return undefined
+}
+
+export function shouldEnterVerifyPhase(opts: {
+  researchTier: ResearchTier | string | undefined
+  hasActivatedSkill: boolean
+  businessToolsUsed: number
+  alreadyVerified: boolean
+  unattended?: boolean
+}): boolean {
+  if (opts.alreadyVerified) return false
+  if (opts.businessToolsUsed < 1) return false
+  const tier = opts.researchTier
+  const deep = tier === 'L3' || opts.hasActivatedSkill
+  if (!deep) return false
+  // unattended：可轻量做 verify
+  return true
+}
+
+/** 业务工具：排除交互/元工具，避免误触发 verify */
+const NON_BUSINESS_TOOLS = new Set([
+  'ask_user',
+  'update_research_checklist',
+  'list_tool_packs',
+  'activate_tool_pack',
+  'list_agent_skills',
+  'activate_agent_skill',
+  'get_agent_skill',
+  'get_agent_skill_file',
+  'create_agent_skill',
+  'import_agent_skill',
+  'delete_agent_skill',
+  'list_mcp_servers',
+  'enable_mcp_server',
+  'disable_mcp_server',
+  'edit_mcp_server',
+  'install_mcp_server',
+  'uninstall_mcp_server',
+  'reorder_mcp_servers',
+  'request_secret',
+  'grant_session_secret',
+])
+
+export function isBusinessToolName(name: string): boolean {
+  const n = name.trim()
+  if (!n) return false
+  if (NON_BUSINESS_TOOLS.has(n)) return false
+  return true
+}
+
+/**
+ * gather 默认 auto；checklist 全 done 后倾向 none（若模型仍调工具则下一轮允许再 auto 一次由调用方处理）。
+ */
+export function resolveGatherToolChoice(sessionId: string, opts?: {
+  preferNoneAfterChecklistDone?: boolean
+  checklistNoneAlreadyTried?: boolean
+}): LlmToolChoice {
+  if (
+    opts?.preferNoneAfterChecklistDone
+    && isChecklistAllDone(sessionId)
+    && !hasPendingChecklistItems(sessionId)
+    && !opts.checklistNoneAlreadyTried
+  ) {
+    return 'none'
+  }
+  return 'auto'
+}
+
+export function resolveVerifyToolChoice(): LlmToolChoice {
+  return 'none'
+}

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -583,6 +583,11 @@ export const TOOL_META: Record<string, ToolMeta> = {
     usageGuide: '激活工作流技能，将完整步骤注入本会话 system；用户提到早报/收盘报告/产业链/财报速读/深度分析流程时使用。技能正文中的 `@skill:依赖` 会自动递归激活。',
     compliance: 'skill_names 为字符串数组；同会话最多 3 个；无效名或超额进入 skipped；循环依赖会被检测并跳过。',
   },
+  update_research_checklist: {
+    packId: 'meta',
+    usageGuide: '维护本轮研究步骤清单（待办/完成/跳过）；多步投研或已激活技能时用来对照进度，避免漏步。',
+    compliance: 'mode=replace|merge；items 为 { id?, title, status: pending|done|skipped }[]；merge 按 id 合并。',
+  },
   get_agent_skill: {
     packId: 'meta',
     usageGuide: '预览单个工作流技能的完整说明；确认后再 activate_agent_skill。',

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -777,6 +777,40 @@ export class ToolRegistry {
         },
       },
       {
+        name: 'update_research_checklist',
+        category: '工作流技能',
+        description: '更新本会话研究步骤清单（替换或合并）；用于多步投研对照进度',
+        parameters: S({
+          mode: {
+            type: 'string',
+            description: 'replace=整体替换；merge=按 id 合并（默认）',
+          },
+          items: {
+            type: 'array',
+            description: '步骤列表：{ id?, title, status: pending|done|skipped }',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                title: { type: 'string' },
+                status: { type: 'string', enum: ['pending', 'done', 'skipped'] },
+              },
+            },
+          },
+        }, ['items']),
+        handler: async (a: Record<string, unknown>) => {
+          const sessionId = currentToolSessionId()
+          if (!sessionId) {
+            return { error: 'update_research_checklist 需在聊天会话中调用' }
+          }
+          const { updateResearchChecklist } = await import('./loop/research-checklist.js')
+          return updateResearchChecklist(sessionId, {
+            mode: typeof a.mode === 'string' ? a.mode : undefined,
+            items: a.items,
+          })
+        },
+      },
+      {
         name: 'get_agent_skill',
         category: '工作流技能',
         description: '读取单个工作流技能的完整说明正文；也可用于预览后再 activate',

--- a/packages/shared/src/tool-packs.ts
+++ b/packages/shared/src/tool-packs.ts
@@ -157,6 +157,7 @@ export const TOOL_PACK_MEMBERSHIP: Readonly<Record<string, ToolPackId>> = {
   activate_tool_pack: 'meta',
   list_agent_skills: 'meta',
   activate_agent_skill: 'meta',
+  update_research_checklist: 'meta',
   get_agent_skill: 'meta',
   get_agent_skill_file: 'meta',
   create_agent_skill: 'meta',

--- a/tests/agent-loop-tool-choice.test.mjs
+++ b/tests/agent-loop-tool-choice.test.mjs
@@ -1,0 +1,115 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  resolveBodyToolChoice,
+} from '../packages/agent/dist/llm/provider.js'
+import {
+  shouldEnterVerifyPhase,
+  resolveEffectiveResearchTier,
+  resolveGatherToolChoice,
+  resolveVerifyToolChoice,
+  isBusinessToolName,
+} from '../packages/agent/dist/loop/verify-phase.js'
+import {
+  resetResearchChecklistForTests,
+  updateResearchChecklist,
+} from '../packages/agent/dist/loop/research-checklist.js'
+
+test('resolveBodyToolChoice defaults to auto when tools present', () => {
+  assert.equal(resolveBodyToolChoice(2), 'auto')
+  assert.equal(resolveBodyToolChoice(2, 'none'), 'none')
+  assert.equal(resolveBodyToolChoice(2, 'required'), 'required')
+  assert.deepEqual(
+    resolveBodyToolChoice(1, { type: 'function', function: { name: 'ask_user' } }),
+    { type: 'function', function: { name: 'ask_user' } },
+  )
+  assert.equal(resolveBodyToolChoice(0, 'none'), undefined)
+})
+
+test('resolveEffectiveResearchTier prefers expert default over route', () => {
+  assert.equal(resolveEffectiveResearchTier('L3', 'L1'), 'L3')
+  assert.equal(resolveEffectiveResearchTier(undefined, 'L1'), 'L1')
+  assert.equal(resolveEffectiveResearchTier(null, 'L2'), 'L2')
+  assert.equal(resolveEffectiveResearchTier('L2', undefined), 'L2')
+})
+
+test('verify phase gates: L1 without skill skips; L3 with tools enters', () => {
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: 'L1',
+    hasActivatedSkill: false,
+    businessToolsUsed: 2,
+    alreadyVerified: false,
+  }), false)
+
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: 'L3',
+    hasActivatedSkill: false,
+    businessToolsUsed: 1,
+    alreadyVerified: false,
+  }), true)
+
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: 'L1',
+    hasActivatedSkill: true,
+    businessToolsUsed: 1,
+    alreadyVerified: false,
+  }), true)
+
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: 'L3',
+    hasActivatedSkill: false,
+    businessToolsUsed: 0,
+    alreadyVerified: false,
+  }), false)
+
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: 'L3',
+    hasActivatedSkill: false,
+    businessToolsUsed: 3,
+    alreadyVerified: true,
+  }), false)
+})
+
+test('expert L3 + route L1 still enters verify via effective tier', () => {
+  const effective = resolveEffectiveResearchTier('L3', 'L1')
+  assert.equal(effective, 'L3')
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: effective,
+    hasActivatedSkill: false,
+    businessToolsUsed: 1,
+    alreadyVerified: false,
+  }), true)
+  // 仅用路由 L1 会跳过 — 对照说明为何必须用 effective
+  assert.equal(shouldEnterVerifyPhase({
+    researchTier: 'L1',
+    hasActivatedSkill: false,
+    businessToolsUsed: 1,
+    alreadyVerified: false,
+  }), false)
+})
+
+test('resolveVerifyToolChoice is none; gather prefers none after checklist done once', () => {
+  resetResearchChecklistForTests()
+  assert.equal(resolveVerifyToolChoice(), 'none')
+  assert.equal(resolveGatherToolChoice('g1'), 'auto')
+
+  updateResearchChecklist('g1', {
+    mode: 'replace',
+    items: [{ id: '1', title: 'A', status: 'done' }],
+  })
+  assert.equal(resolveGatherToolChoice('g1', {
+    preferNoneAfterChecklistDone: true,
+    checklistNoneAlreadyTried: false,
+  }), 'none')
+  assert.equal(resolveGatherToolChoice('g1', {
+    preferNoneAfterChecklistDone: true,
+    checklistNoneAlreadyTried: true,
+  }), 'auto')
+})
+
+test('isBusinessToolName excludes meta/interactive', () => {
+  assert.equal(isBusinessToolName('get_instrument_realtime'), true)
+  assert.equal(isBusinessToolName('ask_user'), false)
+  assert.equal(isBusinessToolName('activate_tool_pack'), false)
+  assert.equal(isBusinessToolName('update_research_checklist'), false)
+})

--- a/tests/agent-research-checklist.test.mjs
+++ b/tests/agent-research-checklist.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  updateResearchChecklist,
+  buildChecklistTurnTail,
+  clearResearchChecklistSession,
+  resetResearchChecklistForTests,
+  seedChecklistOnSkillActivate,
+  getResearchChecklist,
+  hasPendingChecklistItems,
+  isChecklistAllDone,
+} from '../packages/agent/dist/loop/research-checklist.js'
+
+test.beforeEach(() => {
+  resetResearchChecklistForTests()
+})
+
+test('update merge and replace', () => {
+  const sid = 'c1'
+  const merged = updateResearchChecklist(sid, {
+    mode: 'merge',
+    items: [
+      { id: 'a', title: '取行情', status: 'pending' },
+      { id: 'b', title: '读新闻', status: 'pending' },
+    ],
+  })
+  assert.equal(merged.ok, true)
+  assert.equal(merged.pending_count, 2)
+
+  const step = updateResearchChecklist(sid, {
+    mode: 'merge',
+    items: [{ id: 'a', title: '取行情', status: 'done' }],
+  })
+  assert.equal(step.ok, true)
+  assert.equal(step.pending_count, 1)
+  assert.equal(getResearchChecklist(sid).find(i => i.id === 'a')?.status, 'done')
+
+  const replaced = updateResearchChecklist(sid, {
+    mode: 'replace',
+    items: [{ title: '只剩一项', status: 'pending' }],
+  })
+  assert.equal(replaced.ok, true)
+  assert.equal(replaced.items.length, 1)
+  assert.equal(hasPendingChecklistItems(sid), true)
+})
+
+test('turn-tail includes pending items', () => {
+  const sid = 'c2'
+  updateResearchChecklist(sid, {
+    mode: 'replace',
+    items: [
+      { id: 'x', title: '核对 PE', status: 'pending' },
+      { id: 'y', title: '已完成项', status: 'done' },
+    ],
+  })
+  const tail = buildChecklistTurnTail(sid)
+  assert.match(tail, /核对 PE/)
+  assert.doesNotMatch(tail, /已完成项/)
+})
+
+test('skill seed placeholder + clear', () => {
+  const sid = 'c3'
+  seedChecklistOnSkillActivate(sid, ['morning-brief'])
+  assert.equal(hasPendingChecklistItems(sid), true)
+  assert.match(getResearchChecklist(sid)[0]?.title ?? '', /已激活技能/)
+  clearResearchChecklistSession(sid)
+  assert.equal(getResearchChecklist(sid).length, 0)
+  assert.equal(isChecklistAllDone(sid), false)
+})
+
+test('all done when every item done or skipped', () => {
+  const sid = 'c4'
+  updateResearchChecklist(sid, {
+    mode: 'replace',
+    items: [
+      { id: '1', title: 'A', status: 'done' },
+      { id: '2', title: 'B', status: 'skipped' },
+    ],
+  })
+  assert.equal(isChecklistAllDone(sid), true)
+  assert.equal(buildChecklistTurnTail(sid), '')
+})

--- a/tests/agent-spin-guard.test.mjs
+++ b/tests/agent-spin-guard.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  fingerprintToolCall,
+  checkSpinGuard,
+  recordSpinOutcome,
+  noteRoundProgress,
+  beginSpinRound,
+  roundHadNewFingerprint,
+  buildSpinGuardTurnTail,
+  resetSpinGuardForTests,
+  SPIN_GUARD_LIMITS,
+} from '../packages/agent/dist/loop/spin-guard.js'
+
+test.beforeEach(() => {
+  resetSpinGuardForTests()
+})
+
+test('fingerprint is stable under key order', () => {
+  const a = fingerprintToolCall('get_x', { b: 1, a: 2 })
+  const b = fingerprintToolCall('get_x', { a: 2, b: 1 })
+  assert.equal(a, b)
+})
+
+test('fingerprint differs for different args', () => {
+  const a = fingerprintToolCall('get_x', { code: '600519' })
+  const b = fingerprintToolCall('get_x', { code: '000001' })
+  assert.notEqual(a, b)
+})
+
+test('success repeat ≥3 blocks with spin_guard hint', () => {
+  const sid = 's1'
+  const args = { code: '600519' }
+  for (let i = 0; i < SPIN_GUARD_LIMITS.SUCCESS_REPEAT_LIMIT; i++) {
+    assert.equal(checkSpinGuard(sid, 'get_x', args), null)
+    recordSpinOutcome(sid, 'get_x', args, { ok: true, data: i })
+  }
+  const blocked = checkSpinGuard(sid, 'get_x', args)
+  assert.ok(blocked)
+  assert.equal(blocked.spin_guard, true)
+  assert.match(blocked.hint, /重复|成稿|换/)
+  assert.match(buildSpinGuardTurnTail(sid), /路径提醒|重复/)
+})
+
+test('failure repeat ≥2 blocks', () => {
+  const sid = 's2'
+  const args = { q: 'news' }
+  for (let i = 0; i < SPIN_GUARD_LIMITS.FAILURE_REPEAT_LIMIT; i++) {
+    assert.equal(checkSpinGuard(sid, 'search_news', args), null)
+    recordSpinOutcome(sid, 'search_news', args, { error: 'timeout' })
+  }
+  const blocked = checkSpinGuard(sid, 'search_news', args)
+  assert.ok(blocked)
+  assert.equal(blocked.spin_guard, true)
+  assert.match(blocked.hint, /失败|路径|成稿/)
+})
+
+test('stale rounds without new fingerprint force close hint', () => {
+  const sid = 's3'
+  recordSpinOutcome(sid, 'get_x', { a: 1 }, { ok: true })
+  const before = beginSpinRound(sid)
+  // same fingerprint again — not new
+  recordSpinOutcome(sid, 'get_x', { a: 1 }, { ok: true })
+  assert.equal(roundHadNewFingerprint(sid, before), false)
+
+  for (let i = 0; i < SPIN_GUARD_LIMITS.STALE_ROUNDS_WITHOUT_PROGRESS; i++) {
+    noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false })
+  }
+  assert.match(buildSpinGuardTurnTail(sid), /收口/)
+})

--- a/tests/agent-steer-bridge.test.mjs
+++ b/tests/agent-steer-bridge.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { SteerBridge, formatSteerUserMessage } from '../packages/agent/dist/loop/steer-bridge.js'
+
+test('formatSteerUserMessage prefixes once', () => {
+  assert.equal(formatSteerUserMessage('关注估值'), '（补充）关注估值')
+  assert.equal(formatSteerUserMessage('（补充）已有'), '（补充）已有')
+})
+
+test('enqueue / consume / clear', () => {
+  const bridge = new SteerBridge()
+  bridge.enqueue('s1', ' 第一 ')
+  bridge.enqueue('s1', '第二')
+  assert.equal(bridge.hasPending('s1'), true)
+  assert.deepEqual(bridge.peek('s1'), ['第一', '第二'])
+  assert.deepEqual(bridge.consume('s1'), ['第一', '第二'])
+  assert.equal(bridge.hasPending('s1'), false)
+  assert.deepEqual(bridge.consume('s1'), [])
+
+  bridge.enqueue('s2', 'x')
+  bridge.clear('s2')
+  assert.equal(bridge.hasPending('s2'), false)
+})
+
+test('empty enqueue ignored', () => {
+  const bridge = new SteerBridge()
+  bridge.enqueue('s', '   ')
+  assert.equal(bridge.hasPending('s'), false)
+})

--- a/tests/agent-tool-parallel.test.mjs
+++ b/tests/agent-tool-parallel.test.mjs
@@ -1,0 +1,124 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  isSerialTool,
+  SERIAL_TOOL_NAMES,
+  partitionToolCallsForExecution,
+} from '../packages/agent/dist/loop/tool-parallel.js'
+
+function tc(id, name) {
+  return { id, function: { name, arguments: '{}' } }
+}
+
+test('isSerialTool covers Explorer serial set', () => {
+  for (const name of [
+    'ask_user',
+    'workspace_write',
+    'workspace_mkdir',
+    'workspace_delete',
+    'download_file',
+    'request_folder_access',
+    'opptrix_run',
+    'shell_run',
+    'shell_install',
+    'ensure_python',
+    'request_secret',
+    'grant_session_secret',
+    'create_scheduled_job',
+    'update_scheduled_job',
+    'enable_scheduled_job',
+    'disable_scheduled_job',
+    'delete_scheduled_job',
+    'run_scheduled_job_now',
+    'activate_tool_pack',
+    'activate_agent_skill',
+    'enable_mcp_server',
+    'disable_mcp_server',
+    'edit_mcp_server',
+    'install_mcp_server',
+    'uninstall_mcp_server',
+    'reorder_mcp_servers',
+    'update_research_checklist',
+    'browser_navigate',
+    'browser_click',
+    'browser_type',
+    'browser_close',
+    'browser_screenshot',
+  ]) {
+    assert.equal(isSerialTool(name), true, name)
+    assert.equal(SERIAL_TOOL_NAMES.has(name), true, name)
+  }
+})
+
+test('namespaced external MCP tools are serial by default', () => {
+  assert.equal(isSerialTool('my_server__get_quote'), true)
+  assert.equal(isSerialTool('alpha__tool'), true)
+})
+
+test('read-only research tools are parallel-eligible', () => {
+  for (const name of [
+    'get_instrument_realtime',
+    'search_instruments',
+    'workspace_list',
+    'workspace_read',
+    'browser_snapshot',
+    'http_fetch',
+    'evaluate_instrument',
+  ]) {
+    assert.equal(isSerialTool(name), false, name)
+  }
+})
+
+test('partition: consecutive reads → one parallel batch', () => {
+  const calls = [tc('1', 'workspace_read'), tc('2', 'get_instrument_realtime'), tc('3', 'search_instruments')]
+  const batches = partitionToolCallsForExecution(calls)
+  assert.equal(batches.length, 1)
+  assert.equal(batches[0].mode, 'parallel')
+  assert.deepEqual(batches[0].calls.map(c => c.id), ['1', '2', '3'])
+})
+
+test('partition: serial tool splits batches and stays alone', () => {
+  const calls = [
+    tc('a', 'workspace_read'),
+    tc('b', 'get_instrument_realtime'),
+    tc('c', 'ask_user'),
+    tc('d', 'workspace_read'),
+    tc('e', 'shell_run'),
+  ]
+  const batches = partitionToolCallsForExecution(calls)
+  assert.deepEqual(
+    batches.map(b => ({ mode: b.mode, ids: b.calls.map(c => c.id) })),
+    [
+      { mode: 'parallel', ids: ['a', 'b'] },
+      { mode: 'serial', ids: ['c'] },
+      { mode: 'parallel', ids: ['d'] },
+      { mode: 'serial', ids: ['e'] },
+    ],
+  )
+})
+
+test('partition: order contract — flat call ids match input order', () => {
+  const calls = [
+    tc('1', 'search_instruments'),
+    tc('2', 'ask_user'),
+    tc('3', 'workspace_read'),
+    tc('4', 'workspace_write'),
+    tc('5', 'get_instrument_realtime'),
+  ]
+  const batches = partitionToolCallsForExecution(calls)
+  const flat = batches.flatMap(b => b.calls.map(c => c.id))
+  assert.deepEqual(flat, ['1', '2', '3', '4', '5'])
+})
+
+test('partition: all-serial stays serial singles', () => {
+  const calls = [tc('1', 'ask_user'), tc('2', 'shell_run')]
+  const batches = partitionToolCallsForExecution(calls)
+  assert.equal(batches.every(b => b.mode === 'serial' && b.calls.length === 1), true)
+})
+
+test('partition: single read is parallel batch of one', () => {
+  const batches = partitionToolCallsForExecution([tc('x', 'workspace_read')])
+  assert.equal(batches.length, 1)
+  assert.equal(batches[0].mode, 'parallel')
+  assert.equal(batches[0].calls.length, 1)
+})

--- a/tests/session-stream-runtime.test.mjs
+++ b/tests/session-stream-runtime.test.mjs
@@ -258,4 +258,19 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
     assert.equal(snap.liveTrace?.estimatedTokens, 50)
     assert.equal(snap.liveTrace?.thinkingLabel, '模型正在思考 · 约 50 tokens · 第 1 步…')
   })
+
+  it('ignores unknown event types; steer_applied updates live phase lightly', () => {
+    const base = createEmptyStreamSnapshot()
+    const withUnknown = applyChatProgressEvent(base, {
+      type: 'future_unknown_event',
+      payload: { x: 1 },
+    })
+    assert.deepEqual(withUnknown, base)
+
+    const withSteer = applyChatProgressEvent(base, {
+      type: 'steer_applied',
+      message: '（补充）关注现金流',
+    })
+    assert.equal(withSteer.liveTrace?.phaseLabel, '已收到补充说明')
+  })
 })


### PR DESCRIPTION
## Summary
- Read-only same-round tool parallelism with serial gates for HITL/write/shell/secret/activate/browser.
- Research checklist + spin-guard (anti-repeat) injected via turn-tail; session cleanup on delete/archive.
- Staged `tool_choice` with L3/skill evidence-verify round; effective tier matches system prompt (`expert.defaultResearchTier ?? route`).
- Mid-chat soft steer (`POST /api/sessions/:id/chat/steer`) without aborting the run.

## Test plan
- [x] `npm run build -w @opptrix/shared && npm run build -w @opptrix/agent`
- [x] Related `node --test` suites for parallel / spin / checklist / steer / tool-choice / stream runtime
- [x] Independent Verifier AC pass (+ verify-tier gate fix)


Made with [Cursor](https://cursor.com)