### PR TITLE
fix(agent): exempt job-poll tools from spin-guard

### DIFF
--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -168,7 +168,7 @@ Opptrix/
   - **投研完备性闭环（`buildResearchCompletenessLoop`，仅 L2/L3 注入）**：出报告前强制「缺口自检 → 针对性补齐（换源重试 / activate_tool_pack / 远程重试降级项）→ 重新纳入分析 → 收敛输出」；同一缺口最多补 1 轮，取不到则如实标注缺口。L1 事实快答不注入，避免过度拉数
   - **投研 Agent Loop 增强**（`packages/agent/src/loop/`，engine 仅编排）：
     1. **只读同轮并行**：连续只读工具可 `Promise.all`；`ask_user` / workspace 写删 / shell / secret / schedule 变更 / `activate_*` / MCP 变更 / browser 会话态 / 外部 `serverId__tool` **必须串行**；tool 消息写回仍按原 `tool_calls` 顺序；每 call 各自 `runInToolSession`
-    2. **Checklist + 反空转**：会话内存 checklist（`update_research_checklist`，meta pack）；Skill 激活写入占位步骤；turn-tail 注入未完成项。同 fingerprint（工具名+规范化 args）成功重复 ≥3 或失败 ≥2 → 短路返回 `spin_guard`；连续多轮无新指纹且无 checklist 进展 → 强制收口提示。`deleteSession` / 归档旁路清理
+    2. **Checklist + 反空转**：会话内存 checklist（`update_research_checklist`，meta pack）；Skill 激活写入占位步骤；turn-tail 注入未完成项。同 fingerprint（工具名+规范化 args）成功重复 ≥3 或失败 ≥2 → 短路返回 `spin_guard`；`ensure_python` / `prepare_fuyao_dump` 对 `preparing`/`installing`/`running`/`pending` 轮询豁免（不计入 success/failure，有硬上限防死循环；终态 ready 重复仍拦）；连续多轮无新指纹且无 checklist/轮询进展 → 强制收口提示。`deleteSession` / 归档旁路清理
     3. **证据核对 + 分段 `tool_choice`**：`LlmChatOpts.toolChoice` 可配置，上游 400/422 对该字段 fallback（改 `auto` 或省略）。有效档位（`expert.defaultResearchTier ?? route.researchTier`，与 system 一致）为 L3 或已激活 skill，且本 turn 用过 ≥1 业务工具时，纯文本终答前追加核对轮（`tool_choice:'none'` + 核对说明）；L1/无 skill 不强制。SSE thinking 文案：「正在核对关键依据…」
     4. **Soft steer**：`POST /api/sessions/:id/chat/steer`；仅有进行中 chat 时接受；不 abort；下一 `runLlmRound` 前写入可见 user「（补充）…」；cancel 清 pending；无人值守忽略
   - 默认角色为**投研研究员**：事实与推断分层、标注时效、工具失败不编造、L3 声明数据缺口；配合 MCP 取证后按档位写结论

--- a/packages/agent/src/loop/index.ts
+++ b/packages/agent/src/loop/index.ts
@@ -16,6 +16,9 @@ export {
   buildSpinGuardTurnTail,
   clearSpinGuardSession,
   resetSpinGuardForTests,
+  SPIN_POLL_TOOLS,
+  isSpinPollTool,
+  isInProgressJobStatus,
   SPIN_GUARD_LIMITS,
   type SpinGuardBlock,
 } from './spin-guard.js'

--- a/packages/agent/src/loop/spin-guard.ts
+++ b/packages/agent/src/loop/spin-guard.ts
@@ -3,7 +3,34 @@
 const SUCCESS_REPEAT_LIMIT = 3
 const FAILURE_REPEAT_LIMIT = 2
 const STALE_ROUNDS_WITHOUT_PROGRESS = 3
+/** 白名单轮询工具：同 fingerprint 进行中 status 累计上限，防死循环 */
+const POLL_IN_FLIGHT_HARD_LIMIT = 48
 const ARGS_JSON_MAX = 480
+
+/** 异步 job 轮询工具：preparing/installing 等不计入 success/failure 重复 */
+export const SPIN_POLL_TOOLS = new Set([
+  'ensure_python',
+  'prepare_fuyao_dump',
+])
+
+const IN_PROGRESS_JOB_STATUSES = new Set([
+  'preparing',
+  'installing',
+  'running',
+  'pending',
+])
+
+export function isSpinPollTool(toolName: string): boolean {
+  return SPIN_POLL_TOOLS.has(toolName.trim())
+}
+
+/** 从 result.status 判断是否为进行中（大小写不敏感，trim） */
+export function isInProgressJobStatus(result: unknown): boolean {
+  if (result == null || typeof result !== 'object' || Array.isArray(result)) return false
+  const status = (result as Record<string, unknown>).status
+  if (typeof status !== 'string') return false
+  return IN_PROGRESS_JOB_STATUSES.has(status.trim().toLowerCase())
+}
 
 export type SpinGuardBlock = {
   error: string
@@ -14,6 +41,8 @@ export type SpinGuardBlock = {
 type FingerprintStats = {
   success: number
   failure: number
+  /** 白名单工具进行中轮询次数（不计入 success/failure） */
+  pollInFlight: number
 }
 
 type SessionSpinState = {
@@ -24,9 +53,15 @@ type SessionSpinState = {
   staleRounds: number
   forceCloseHint: boolean
   lastBlockedHint: string | null
+  /** 本轮是否有白名单进行中轮询（视为有进展） */
+  pollProgressThisRound: boolean
 }
 
 const sessions = new Map<string, SessionSpinState>()
+
+function emptyStats(): FingerprintStats {
+  return { success: 0, failure: 0, pollInFlight: 0 }
+}
 
 function getOrCreate(sessionId: string): SessionSpinState {
   let state = sessions.get(sessionId)
@@ -37,6 +72,7 @@ function getOrCreate(sessionId: string): SessionSpinState {
       staleRounds: 0,
       forceCloseHint: false,
       lastBlockedHint: null,
+      pollProgressThisRound: false,
     }
     sessions.set(sessionId, state)
   }
@@ -95,6 +131,17 @@ export function checkSpinGuard(
   const stats = state.byFingerprint.get(fp)
   if (!stats) return null
 
+  if (isSpinPollTool(toolName) && stats.pollInFlight >= POLL_IN_FLIGHT_HARD_LIMIT) {
+    const hint =
+      '同一任务轮询次数过多，可能已卡住。请换路径、说明进度异常，或基于已有材料继续，勿无限等待。'
+    state.lastBlockedHint = hint
+    return {
+      error: '已拦截过久轮询',
+      spin_guard: true,
+      hint,
+    }
+  }
+
   if (stats.success >= SUCCESS_REPEAT_LIMIT) {
     const hint = '同一查询已重复多次且结果无新意。请换数据源或角度，或开始整理成稿，勿继续空转。'
     state.lastBlockedHint = hint
@@ -130,7 +177,15 @@ export function recordSpinOutcome(
     // 新证据路径出现 → 重置空转轮计数（本轮结束时再评估）
     state.forceCloseHint = false
   }
-  const stats = state.byFingerprint.get(fp) ?? { success: 0, failure: 0 }
+  const stats = state.byFingerprint.get(fp) ?? emptyStats()
+
+  if (isSpinPollTool(toolName) && isInProgressJobStatus(result)) {
+    stats.pollInFlight += 1
+    state.pollProgressThisRound = true
+    state.byFingerprint.set(fp, stats)
+    return
+  }
+
   if (isFailureResult(result)) stats.failure += 1
   else stats.success += 1
   state.byFingerprint.set(fp, stats)
@@ -138,6 +193,7 @@ export function recordSpinOutcome(
 
 /**
  * 每 LLM 工具轮结束后调用：若本轮无新 fingerprint 且 checklist 无进展，累计空转轮。
+ * 白名单进行中轮询（pollProgressThisRound）视为有进展。
  * @returns 是否应注入强制收口 turn-tail
  */
 export function noteRoundProgress(
@@ -145,7 +201,9 @@ export function noteRoundProgress(
   opts: { hadNewFingerprint: boolean; checklistProgressed: boolean },
 ): boolean {
   const state = getOrCreate(sessionId)
-  if (opts.hadNewFingerprint || opts.checklistProgressed) {
+  const pollProgress = state.pollProgressThisRound
+  state.pollProgressThisRound = false
+  if (opts.hadNewFingerprint || opts.checklistProgressed || pollProgress) {
     state.staleRounds = 0
     state.forceCloseHint = false
     return false
@@ -204,4 +262,5 @@ export const SPIN_GUARD_LIMITS = {
   SUCCESS_REPEAT_LIMIT,
   FAILURE_REPEAT_LIMIT,
   STALE_ROUNDS_WITHOUT_PROGRESS,
+  POLL_IN_FLIGHT_HARD_LIMIT,
 } as const

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -774,7 +774,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
     usageGuide:
       '运行 Python 脚本或 pip 安装前调用；未就绪时立即返回 preparing/installing+job_id，须再调 ensure_python({ job_id }) 轮询至 ready；成功后优先使用 Opptrix 托管解释器。',
     compliance:
-      '勿在本轮死等安装；status=preparing|installing 时用返回的 job_id 轮询；ready 时 ready=true 且 prefer 托管；failed 时 ready=false，勿假装已安装。opptrix_run 在 python 未就绪时会快速失败并提示先 ensure_python。',
+      '勿在本轮死等安装；status=preparing|installing 时用返回的 job_id 轮询（反空转对进行中 status 豁免）；ready 后勿空转同参；ready 时 ready=true 且 prefer 托管；failed 时 ready=false，勿假装已安装。opptrix_run 在 python 未就绪时会快速失败并提示先 ensure_python。',
   },
   list_local_data_apis: {
     packId: 'workspace',
@@ -790,7 +790,7 @@ export const TOOL_META: Record<string, ToolMeta> = {
     packId: 'workspace',
     usageGuide: '需要扶摇全量/增量日 K 或复权因子 Parquet 时调用；落盘 shared/data/dumps 或返回短时效 URL；冷下载可能先返回 preparing+job_id，须轮询。',
     compliance:
-      '服务端持密钥；禁止明文注入沙盒；勿引导 sync/dailyDump；缓存命中/presigned_url 同步 ready；local_path 冷下载立即 preparing，用 job_id 再调本工具轮询；full|incremental + local_path 就绪后自动写 offline-k-meta；adjustment_factors/presigned_url 不写 meta；成功用 root_id=shared + relative_path。',
+      '服务端持密钥；禁止明文注入沙盒；勿引导 sync/dailyDump；缓存命中/presigned_url 同步 ready；local_path 冷下载立即 preparing，用 job_id 再调本工具轮询（反空转对 preparing/installing 等进行中 status 豁免；ready 后勿空转同参）；full|incremental + local_path 就绪后自动写 offline-k-meta；adjustment_factors/presigned_url 不写 meta；成功用 root_id=shared + relative_path。',
   },
   request_session_lan_access: {
     packId: 'workspace',

--- a/tests/agent-spin-guard.test.mjs
+++ b/tests/agent-spin-guard.test.mjs
@@ -10,6 +10,9 @@ import {
   buildSpinGuardTurnTail,
   resetSpinGuardForTests,
   SPIN_GUARD_LIMITS,
+  SPIN_POLL_TOOLS,
+  isSpinPollTool,
+  isInProgressJobStatus,
 } from '../packages/agent/dist/loop/spin-guard.js'
 
 test.beforeEach(() => {
@@ -67,4 +70,100 @@ test('stale rounds without new fingerprint force close hint', () => {
     noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false })
   }
   assert.match(buildSpinGuardTurnTail(sid), /收口/)
+})
+
+test('SPIN_POLL_TOOLS and isInProgressJobStatus helpers', () => {
+  assert.ok(SPIN_POLL_TOOLS.has('ensure_python'))
+  assert.ok(SPIN_POLL_TOOLS.has('prepare_fuyao_dump'))
+  assert.equal(isSpinPollTool('ensure_python'), true)
+  assert.equal(isSpinPollTool('get_x'), false)
+  assert.equal(isInProgressJobStatus({ status: 'Preparing' }), true)
+  assert.equal(isInProgressJobStatus({ status: ' installing ' }), true)
+  assert.equal(isInProgressJobStatus({ status: 'ready' }), false)
+  assert.equal(isInProgressJobStatus({ ok: true }), false)
+})
+
+test('ensure_python preparing×5 same job_id does not block via SUCCESS_REPEAT', () => {
+  const sid = 'poll-prep'
+  const args = { job_id: 'job-1' }
+  for (let i = 0; i < 5; i++) {
+    assert.equal(checkSpinGuard(sid, 'ensure_python', args), null)
+    recordSpinOutcome(sid, 'ensure_python', args, { status: 'preparing', job_id: 'job-1' })
+  }
+  assert.equal(checkSpinGuard(sid, 'ensure_python', args), null)
+})
+
+test('poll progress resets stale rounds (no force-close after preparing round)', () => {
+  const sid = 'poll-stale'
+  const args = { job_id: 'job-stale' }
+  // Round 1: in-flight poll counts as progress
+  recordSpinOutcome(sid, 'ensure_python', args, { status: 'preparing' })
+  assert.equal(
+    noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false }),
+    false,
+  )
+  // Next rounds without progress would accumulate — but after reset, need full STALE limit
+  for (let i = 0; i < SPIN_GUARD_LIMITS.STALE_ROUNDS_WITHOUT_PROGRESS - 1; i++) {
+    assert.equal(
+      noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false }),
+      false,
+    )
+  }
+  // One more preparing poll mid-way resets again
+  recordSpinOutcome(sid, 'ensure_python', args, { status: 'installing' })
+  assert.equal(
+    noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false }),
+    false,
+  )
+  // Without further poll, still need STALE_ROUNDS full count from zero
+  for (let i = 0; i < SPIN_GUARD_LIMITS.STALE_ROUNDS_WITHOUT_PROGRESS - 1; i++) {
+    assert.equal(
+      noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false }),
+      false,
+    )
+  }
+  assert.equal(
+    noteRoundProgress(sid, { hadNewFingerprint: false, checklistProgressed: false }),
+    true,
+  )
+})
+
+test('ensure_python ready success repeat ≥ SUCCESS_REPEAT_LIMIT still blocks', () => {
+  const sid = 'poll-ready'
+  const args = { job_id: 'job-ready' }
+  for (let i = 0; i < SPIN_GUARD_LIMITS.SUCCESS_REPEAT_LIMIT; i++) {
+    assert.equal(checkSpinGuard(sid, 'ensure_python', args), null)
+    recordSpinOutcome(sid, 'ensure_python', args, { status: 'ready', ready: true })
+  }
+  const blocked = checkSpinGuard(sid, 'ensure_python', args)
+  assert.ok(blocked)
+  assert.equal(blocked.spin_guard, true)
+  assert.match(blocked.hint, /重复|成稿|换/)
+})
+
+test('non-whitelist tool unchanged: preparing status still counts as success', () => {
+  const sid = 'non-poll'
+  const args = { id: 1 }
+  for (let i = 0; i < SPIN_GUARD_LIMITS.SUCCESS_REPEAT_LIMIT; i++) {
+    assert.equal(checkSpinGuard(sid, 'get_x', args), null)
+    recordSpinOutcome(sid, 'get_x', args, { status: 'preparing', ok: true })
+  }
+  const blocked = checkSpinGuard(sid, 'get_x', args)
+  assert.ok(blocked)
+  assert.equal(blocked.spin_guard, true)
+})
+
+test('pollInFlight hard limit blocks whitelist tool', () => {
+  const sid = 'poll-hard'
+  const args = { job_id: 'job-hard' }
+  const limit = SPIN_GUARD_LIMITS.POLL_IN_FLIGHT_HARD_LIMIT
+  assert.ok(typeof limit === 'number' && limit > 0)
+  for (let i = 0; i < limit; i++) {
+    assert.equal(checkSpinGuard(sid, 'prepare_fuyao_dump', args), null)
+    recordSpinOutcome(sid, 'prepare_fuyao_dump', args, { status: 'pending' })
+  }
+  const blocked = checkSpinGuard(sid, 'prepare_fuyao_dump', args)
+  assert.ok(blocked)
+  assert.equal(blocked.spin_guard, true)
+  assert.match(blocked.hint, /卡住|轮询|进度/)
 })


### PR DESCRIPTION
## Summary
- Whitelist `ensure_python` / `prepare_fuyao_dump` for spin-guard.
- In-progress statuses (`preparing|installing|running|pending`) do not count toward success/failure repeats; hard poll cap remains.
- Poll activity resets stale-round force-close so legitimate job polling is not treated as empty spinning.

## Test plan
- [x] `npm run build -w @opptrix/agent`
- [x] `node --test --test-force-exit tests/agent-spin-guard.test.mjs`