### PR TITLE
fix(ui): densify ThinkingDots pulse

### DIFF
--- a/client-ui/src/components/ThinkingDots.tsx
+++ b/client-ui/src/components/ThinkingDots.tsx
@@ -4,9 +4,8 @@ import { mergeClasses } from '@fluentui/react-components'
  * Compact 3×3 "thinking" indicator.
  *
  * 9 dots arranged in a square grid. Each dot pulses independently with a
- * unique phase, producing a "twinkling" effect. At any moment roughly
- * 3–5 dots are visible at varying opacities, creating organic motion
- * rather than a rigid chase.
+ * unique phase. Dormant dots keep a soft floor opacity so the field stays
+ * dense; peaks overlap so roughly 6–8 dots read as lit at once.
  *
  * All animation / size styles live in global.css under
  * `.opptrix-thinking-dots` / `.opptrix-thinking-dots__dot`.

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -2717,8 +2717,8 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
 
 /* ── Thinking indicator: 3×3 twinkle (compact, text-sized) ──
    9 dots in a square grid. Each dot pulses on its own phase, producing
-   an organic "twinkling" effect. At any moment roughly 3–5 dots are
-   visible at varying opacities, never a rigid chase.
+   an organic "twinkling" effect. Dormant dots keep a soft floor so the
+   grid stays readable; peaks overlap so roughly 6–8 dots read as lit.
 
    Grid positions (row, col), 1-indexed:
      dot1 (1,1)  dot2 (1,2)  dot3 (1,3)
@@ -2726,23 +2726,22 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
      dot7 (3,1)  dot8 (3,2)  dot9 (3,3)
 
    Pulse cycle (1.6s, ease-in-out):
-     0–28%  fully dark
-     40%    peak opacity (1)
-     55%    bright (0.85)
-     72%    back to dark
-     100%   dark (hold)
-     → lit window = ~44% of cycle → avg ~4 dots visible (3–5 range)
+     0–12%  floor (0.34)
+     28%    peak opacity (1)
+     48%    still bright (0.92)
+     70%    back to floor
+     100%   floor (hold)
+     → bright window ≈ 58% of cycle + floor on rest → denser field
 
-   Delays are pseudo-randomized across the cycle to avoid mechanical
-   regularity while keeping a balanced brightness. */
+   Delays are staggered but compressed so peaks overlap more often. */
 
 @keyframes opptrix-think-pulse {
-  0%   { opacity: 0;    transform: scale(0.4); }
-  28%  { opacity: 0;    transform: scale(0.4); }
-  40%  { opacity: 1;    transform: scale(1); }
-  55%  { opacity: 0.85; transform: scale(0.95); }
-  72%  { opacity: 0;    transform: scale(0.4); }
-  100% { opacity: 0;    transform: scale(0.4); }
+  0%   { opacity: 0.34; transform: scale(0.55); }
+  12%  { opacity: 0.34; transform: scale(0.55); }
+  28%  { opacity: 1;    transform: scale(1); }
+  48%  { opacity: 0.92; transform: scale(0.98); }
+  70%  { opacity: 0.34; transform: scale(0.55); }
+  100% { opacity: 0.34; transform: scale(0.55); }
 }
 
 .opptrix-thinking-dots {
@@ -2769,16 +2768,16 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
 
 /* Row 1 */
 .opptrix-thinking-dots__dot:nth-child(1) { top: 1px; left: 1px;  animation-delay: 0s; }
-.opptrix-thinking-dots__dot:nth-child(2) { top: 1px; left: 5px;  animation-delay: 0.42s; }
-.opptrix-thinking-dots__dot:nth-child(3) { top: 1px; left: 9px;  animation-delay: 0.88s; }
+.opptrix-thinking-dots__dot:nth-child(2) { top: 1px; left: 5px;  animation-delay: 0.22s; }
+.opptrix-thinking-dots__dot:nth-child(3) { top: 1px; left: 9px;  animation-delay: 0.48s; }
 /* Row 2 */
-.opptrix-thinking-dots__dot:nth-child(4) { top: 5px; left: 1px;  animation-delay: 0.18s; }
-.opptrix-thinking-dots__dot:nth-child(5) { top: 5px; left: 5px;  animation-delay: 0.67s; }
-.opptrix-thinking-dots__dot:nth-child(6) { top: 5px; left: 9px;  animation-delay: 1.34s; }
+.opptrix-thinking-dots__dot:nth-child(4) { top: 5px; left: 1px;  animation-delay: 0.12s; }
+.opptrix-thinking-dots__dot:nth-child(5) { top: 5px; left: 5px;  animation-delay: 0.36s; }
+.opptrix-thinking-dots__dot:nth-child(6) { top: 5px; left: 9px;  animation-delay: 0.72s; }
 /* Row 3 */
-.opptrix-thinking-dots__dot:nth-child(7) { top: 9px; left: 1px;  animation-delay: 0.31s; }
-.opptrix-thinking-dots__dot:nth-child(8) { top: 9px; left: 5px;  animation-delay: 1.09s; }
-.opptrix-thinking-dots__dot:nth-child(9) { top: 9px; left: 9px;  animation-delay: 1.52s; }
+.opptrix-thinking-dots__dot:nth-child(7) { top: 9px; left: 1px;  animation-delay: 0.28s; }
+.opptrix-thinking-dots__dot:nth-child(8) { top: 9px; left: 5px;  animation-delay: 0.58s; }
+.opptrix-thinking-dots__dot:nth-child(9) { top: 9px; left: 9px;  animation-delay: 0.94s; }
 
 /* ── Button icon 分级（按按钮 size）──
    small=12px, medium=16px, large=20px


### PR DESCRIPTION
## Summary
- Raise ThinkingDots opacity floor and widen the lit window so more dots stay visible during the spinner animation
- Compress per-dot delays so peaks overlap more often

## Test plan
- [ ] Trigger a thinking/spinner state in chat and confirm the 3×3 grid looks denser (fewer empty gaps)
- [ ] Confirm motion still feels organic (not a rigid chase)
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)