### PR TITLE
fix(ui): text-sized three-dot ThinkingDots spinner

### DIFF
--- a/client-ui/src/components/ThinkingDots.tsx
+++ b/client-ui/src/components/ThinkingDots.tsx
@@ -1,14 +1,11 @@
 import { mergeClasses } from '@fluentui/react-components'
 
 /**
- * Compact 3×3 "thinking" indicator.
+ * Inline three-dot thinking spinner (horizontal row).
  *
- * 9 dots arranged in a square grid. Each dot pulses independently with a
- * unique phase. Dormant dots keep a soft floor opacity so the field stays
- * dense; peaks overlap so roughly 6–8 dots read as lit at once.
- *
- * All animation / size styles live in global.css under
- * `.opptrix-thinking-dots` / `.opptrix-thinking-dots__dot`.
+ * Canvas height tracks surrounding text (~1em). Classic staggered bounce;
+ * styles live in global.css under `.opptrix-thinking-dots` /
+ * `.opptrix-thinking-dots__dot`.
  */
 
 export interface ThinkingDotsProps {
@@ -25,12 +22,6 @@ export default function ThinkingDots({ className, label = '正在思考' }: Thin
       aria-label={label || undefined}
       aria-hidden={label ? undefined : true}
     >
-      <span className="opptrix-thinking-dots__dot" />
-      <span className="opptrix-thinking-dots__dot" />
-      <span className="opptrix-thinking-dots__dot" />
-      <span className="opptrix-thinking-dots__dot" />
-      <span className="opptrix-thinking-dots__dot" />
-      <span className="opptrix-thinking-dots__dot" />
       <span className="opptrix-thinking-dots__dot" />
       <span className="opptrix-thinking-dots__dot" />
       <span className="opptrix-thinking-dots__dot" />

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -2715,69 +2715,60 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
   }
 }
 
-/* ── Thinking indicator: 3×3 twinkle (compact, text-sized) ──
-   9 dots in a square grid. Each dot pulses on its own phase, producing
-   an organic "twinkling" effect. Dormant dots keep a soft floor so the
-   grid stays readable; peaks overlap so roughly 6–8 dots read as lit.
+/* ── Thinking indicator: three-dot horizontal spinner (text-sized) ──
+   Inline row of 3 dots; canvas height ~1em so it aligns with body text.
+   Classic staggered bounce (~1.05s), currentColor, no scale(0).
 
-   Grid positions (row, col), 1-indexed:
-     dot1 (1,1)  dot2 (1,2)  dot3 (1,3)
-     dot4 (2,1)  dot5 (2,2)  dot6 (2,3)
-     dot7 (3,1)  dot8 (3,2)  dot9 (3,3)
+   Delays: 0 / 0.14s / 0.28s. Reduced-motion: static opacity ~0.55. */
 
-   Pulse cycle (1.6s, ease-in-out):
-     0–12%  floor (0.34)
-     28%    peak opacity (1)
-     48%    still bright (0.92)
-     70%    back to floor
-     100%   floor (hold)
-     → bright window ≈ 58% of cycle + floor on rest → denser field
-
-   Delays are staggered but compressed so peaks overlap more often. */
-
-@keyframes opptrix-think-pulse {
-  0%   { opacity: 0.34; transform: scale(0.55); }
-  12%  { opacity: 0.34; transform: scale(0.55); }
-  28%  { opacity: 1;    transform: scale(1); }
-  48%  { opacity: 0.92; transform: scale(0.98); }
-  70%  { opacity: 0.34; transform: scale(0.55); }
-  100% { opacity: 0.34; transform: scale(0.55); }
+@keyframes opptrix-think-bounce {
+  0%,
+  80%,
+  100% {
+    opacity: 0.28;
+    transform: translateY(0) scale(0.85);
+  }
+  40% {
+    opacity: 1;
+    transform: translateY(-1.5px) scale(1);
+  }
 }
 
 .opptrix-thinking-dots {
-  position: relative;
-  display: inline-block;
-  width: 12px;
-  height: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 1em;
+  width: auto;
   flex-shrink: 0;
-  margin-right: 4px;
-  vertical-align: -2px;
+  margin-right: 0.35em;
+  vertical-align: -0.12em;
 }
 
 .opptrix-thinking-dots__dot {
-  position: absolute;
-  width: 2px;
-  height: 2px;
+  display: block;
+  width: 3px;
+  height: 3px;
   border-radius: 50%;
-  background-color: var(--opptrix-accent);
-  animation-name: opptrix-think-pulse;
-  animation-duration: 1.6s;
-  animation-timing-function: ease-in-out;
+  background: currentColor;
+  opacity: 0.28;
+  animation-name: opptrix-think-bounce;
+  animation-duration: 1.05s;
+  animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
   animation-iteration-count: infinite;
 }
 
-/* Row 1 */
-.opptrix-thinking-dots__dot:nth-child(1) { top: 1px; left: 1px;  animation-delay: 0s; }
-.opptrix-thinking-dots__dot:nth-child(2) { top: 1px; left: 5px;  animation-delay: 0.22s; }
-.opptrix-thinking-dots__dot:nth-child(3) { top: 1px; left: 9px;  animation-delay: 0.48s; }
-/* Row 2 */
-.opptrix-thinking-dots__dot:nth-child(4) { top: 5px; left: 1px;  animation-delay: 0.12s; }
-.opptrix-thinking-dots__dot:nth-child(5) { top: 5px; left: 5px;  animation-delay: 0.36s; }
-.opptrix-thinking-dots__dot:nth-child(6) { top: 5px; left: 9px;  animation-delay: 0.72s; }
-/* Row 3 */
-.opptrix-thinking-dots__dot:nth-child(7) { top: 9px; left: 1px;  animation-delay: 0.28s; }
-.opptrix-thinking-dots__dot:nth-child(8) { top: 9px; left: 5px;  animation-delay: 0.58s; }
-.opptrix-thinking-dots__dot:nth-child(9) { top: 9px; left: 9px;  animation-delay: 0.94s; }
+.opptrix-thinking-dots__dot:nth-child(1) { animation-delay: 0s; }
+.opptrix-thinking-dots__dot:nth-child(2) { animation-delay: 0.14s; }
+.opptrix-thinking-dots__dot:nth-child(3) { animation-delay: 0.28s; }
+
+@media (prefers-reduced-motion: reduce) {
+  .opptrix-thinking-dots__dot {
+    animation: none;
+    opacity: 0.55;
+    transform: none;
+  }
+}
 
 /* ── Button icon 分级（按按钮 size）──
    small=12px, medium=16px, large=20px


### PR DESCRIPTION
## Summary
- Replace the 3×3 twinkle grid with a classic three-dot horizontal spinner
- Canvas height tracks text (~1em); uses currentColor and reduced-motion

## Test plan
- [ ] Trigger thinking/spinner in chat and confirm alignment with status text
- [ ] Confirm bounce reads clearly and reduced-motion is static
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)