### PR TITLE
feat(agent): turn wake countdown + friendly LLM errors

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import Fastify from 'fastify'
 import { createBrowserSessionManager, registerBrowserShutdownHooks } from '@opptrix/agent-browser'
-import { AgentEngine, buildAgentSafeProjectInfo, fetchOpenAiModelList, getModelsDevCatalog, initOutboundNetwork, pruneOrphanChatAttachments, type ChatProgressEvent, type SessionContextRef } from '@opptrix/agent'
+import { AgentEngine, buildAgentSafeProjectInfo, fetchOpenAiModelList, getModelsDevCatalog, initOutboundNetwork, pruneOrphanChatAttachments, configureTurnWakeRuntime, setTurnWakeResumeHandler, scheduleTurnWake, clearSessionTurnWakes, listPendingTurnWakes, TURN_WAKE_BUSY_DEFER_SECONDS, type ChatProgressEvent, type SessionContextRef } from '@opptrix/agent'
 import { getWorkspaceService, assertAllowedShellArgv, getSessionSecretAccessStore, PathEscapeError, DenyPathError, WorkspaceError, pruneOrphanSessionState } from '@opptrix/agent-workspace'
 import { getUserDataStore } from '@opptrix/user-store'
 import { ResearchHub } from '@opptrix/research-hub'
@@ -17,6 +17,7 @@ import { closeMarketDuckRuntime, getMarketDataService } from '@opptrix/market-da
 import { registerStaticUi, shouldServeUi, isApiPath, resolveUiDist } from './static-ui.js'
 import { cancelDiscoverJob, deleteDiscoverJob, getDiscoverJob, listDiscoverJobs, startDiscoverCustomJob, startDiscoverJob } from './discover-jobs.js'
 import { cancelSessionChat, clearSessionChat, hasActiveSessionChat, registerSessionChat } from './session-chat-runs.js'
+import { publishSessionProgress, subscribeSessionProgress } from './session-progress-bus.js'
 import {
   deleteCustomDiscoverStrategy,
   listCustomDiscoverStrategies,
@@ -109,6 +110,40 @@ agent = new AgentEngine(hub, {
   appContext: serverAppContext,
 })
 agent.setApiBaseUrl(`http://${HOST}:${PORT}/api`)
+
+configureTurnWakeRuntime({
+  isSessionAlive: (sessionId) => Boolean(agent.getSession(sessionId)),
+  isChatBusy: hasActiveSessionChat,
+})
+setTurnWakeResumeHandler(async (job, wakeMessage) => {
+  if (!agent.getSession(job.sessionId)) return
+  if (hasActiveSessionChat(job.sessionId)) {
+    // 竞态：到期瞬间用户又开了新轮 — 延期，禁止 registerSessionChat abort
+    scheduleTurnWake({
+      sessionId: job.sessionId,
+      prompt: job.prompt,
+      seconds: TURN_WAKE_BUSY_DEFER_SECONDS,
+      reason: job.reason,
+      jobId: job.jobId,
+      model: job.model,
+    })
+    return
+  }
+  const ac = registerSessionChat(job.sessionId)
+  const onProgress = (event: ChatProgressEvent) => {
+    publishSessionProgress(job.sessionId, event)
+  }
+  try {
+    onProgress({ type: 'thinking', round: 0, label: '正在继续' })
+    await agent.chat(job.sessionId, wakeMessage, job.model, {
+      signal: ac.signal,
+      unattended: false,
+      onProgress,
+    })
+  } finally {
+    clearSessionChat(job.sessionId, ac)
+  }
+})
 
 setSessionPersistHooks({
   onPersist: syncSessionSearchIndex,
@@ -1139,8 +1174,56 @@ app.patch<{
 
 app.delete<{ Params: { id: string } }>('/api/sessions/:id', async (req, reply) => {
   if (!agent.getSession(req.params.id)) return reply.code(404).send({ error: 'session not found' })
+  clearSessionTurnWakes(req.params.id)
   agent.deleteSession(req.params.id)
   return { status: 'deleted' }
+})
+
+app.get<{ Params: { id: string } }>('/api/sessions/:id/pending-wakes', async (req, reply) => {
+  if (!agent.getSession(req.params.id)) return reply.code(404).send({ error: 'session not found' })
+  return { wakes: listPendingTurnWakes(req.params.id) }
+})
+
+app.get<{ Params: { id: string } }>('/api/sessions/:id/live-progress', async (req, reply) => {
+  if (!agent.getSession(req.params.id)) return reply.code(404).send({ error: 'session not found' })
+
+  reply.hijack()
+  reply.raw.writeHead(200, {
+    'Content-Type': 'text/event-stream; charset=utf-8',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no',
+  })
+
+  const write = (event: ChatProgressEvent) => {
+    if (reply.raw.writableEnded) return
+    reply.raw.write(`data: ${JSON.stringify(event)}\n\n`)
+  }
+
+  // 心跳：避免中间代理断开长连接
+  const heartbeat = setInterval(() => {
+    if (reply.raw.writableEnded) return
+    reply.raw.write(': ping\n\n')
+  }, 25_000)
+  if (typeof heartbeat === 'object' && heartbeat !== null && 'unref' in heartbeat) {
+    try {
+      ;(heartbeat as { unref: () => void }).unref()
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const unsubscribe = subscribeSessionProgress(req.params.id, write)
+  let cleaned = false
+  const cleanup = () => {
+    if (cleaned) return
+    cleaned = true
+    clearInterval(heartbeat)
+    unsubscribe()
+    if (!reply.raw.writableEnded) reply.raw.end()
+  }
+  req.raw.on('aborted', cleanup)
+  reply.raw.on('close', cleanup)
 })
 
 app.get<{ Params: { id: string } }>('/api/sessions/:id/workspace/grants', async (req, reply) => {

--- a/apps/server/src/session-progress-bus.ts
+++ b/apps/server/src/session-progress-bus.ts
@@ -1,0 +1,52 @@
+/**
+ * 按 sessionId 广播 ChatProgressEvent（用于 turn-wake 续跑等无 HTTP 流客户端的进度）。
+ */
+import type { ChatProgressEvent } from '@opptrix/agent'
+
+export type SessionProgressListener = (event: ChatProgressEvent) => void
+
+const listeners = new Map<string, Set<SessionProgressListener>>()
+
+export function publishSessionProgress(sessionId: string, event: ChatProgressEvent): void {
+  const id = String(sessionId ?? '').trim()
+  if (!id) return
+  const set = listeners.get(id)
+  if (!set || set.size === 0) return
+  for (const fn of [...set]) {
+    try {
+      fn(event)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`[session-progress-bus] listener error (${id}): ${msg}`)
+    }
+  }
+}
+
+export function subscribeSessionProgress(
+  sessionId: string,
+  listener: SessionProgressListener,
+): () => void {
+  const id = String(sessionId ?? '').trim()
+  if (!id) return () => {}
+  let set = listeners.get(id)
+  if (!set) {
+    set = new Set()
+    listeners.set(id, set)
+  }
+  set.add(listener)
+  return () => {
+    const cur = listeners.get(id)
+    if (!cur) return
+    cur.delete(listener)
+    if (cur.size === 0) listeners.delete(id)
+  }
+}
+
+/** 测试：某会话当前订阅数 */
+export function sessionProgressListenerCountForTests(sessionId: string): number {
+  return listeners.get(String(sessionId ?? '').trim())?.size ?? 0
+}
+
+export function resetSessionProgressBusForTests(): void {
+  listeners.clear()
+}

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -2030,6 +2030,62 @@ export async function streamSessionChat(
   }
 }
 
+/** 订阅会话后台进度（turn-wake 续跑等）；连接保持到 signal abort。 */
+export async function subscribeSessionLiveProgress(
+  sessionId: string,
+  onEvent: (event: ChatProgressEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const resp = await fetch(`${API_BASE}/sessions/${sessionId}/live-progress`, {
+    method: 'GET',
+    headers: { Accept: 'text/event-stream' },
+    signal,
+  })
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({})) as { error?: string }
+    throw new Error(err.error || `订阅进度失败（${resp.status}）`)
+  }
+  if (!resp.body) throw new Error('流式响应不可用')
+
+  const reader = resp.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  while (true) {
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError')
+    }
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const chunks = buffer.split('\n\n')
+    buffer = chunks.pop() ?? ''
+    for (const chunk of chunks) {
+      // 心跳行 `: ping`
+      if (chunk.startsWith(':')) continue
+      const line = chunk.split('\n').find(row => row.startsWith('data: '))
+      if (!line) continue
+      try {
+        onEvent(JSON.parse(line.slice(6)) as ChatProgressEvent)
+      } catch {
+        /* ignore malformed chunk */
+      }
+    }
+  }
+}
+
+export async function fetchSessionPendingWakes(sessionId: string): Promise<{
+  wakes: Array<{
+    wake_id: string
+    fire_at: string
+    reason?: string
+    seconds_left: number
+    seconds: number
+  }>
+}> {
+  return jsonFetch(`/sessions/${sessionId}/pending-wakes`)
+}
+
 // ─── News feed API ───
 
 export type SenseVoiceEnsurePhase =

--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -23,6 +23,13 @@ import {
   type QueuedPrompt,
 } from './sessionPromptQueue'
 import type { ChatProgressEvent } from '../types/chatProgress'
+import {
+  formatWakeCountdownLabel,
+  parsePendingWakesApi,
+  parseScheduleTurnWakeFromStep,
+  secondsLeftUntil,
+  type PendingWakeInfo,
+} from './turnWakeCountdown'
 import SettingsPage from '../pages/SettingsPage'
 import NewsCenterPage from '../pages/news/NewsCenterPage'
 import ExpertMarketPage from '../pages/experts/ExpertMarketPage'
@@ -39,6 +46,7 @@ import {
   archiveSession,
   listArchivedSessions, createSessionArchiveFolder, renameSessionArchiveFolder, deleteSessionArchiveFolder,
   clearSessionArchiveFolder, renameSession, listWorkspaceGrants,
+  subscribeSessionLiveProgress, fetchSessionPendingWakes,
 } from '../api/client'
 import type {
   ChatDisplayMessage, ChatContextUsage, EphemeralAskTurn, MessageSelection, SessionContextRef, SessionSelectionContextRef,
@@ -374,6 +382,7 @@ export default function ChatApp() {
     setComposerDraft(prev => ({ revision: prev.revision + 1, text }))
   }, [])
   const [streamingSessionIds, setStreamingSessionIds] = useState<string[]>([])
+  const [wakeWaitingSessionIds, setWakeWaitingSessionIds] = useState<string[]>([])
   const streamUiRef = useRef<ChatStreamUiRef['current']>(null)
   const [error, setError] = useState('')
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
@@ -389,6 +398,10 @@ export default function ChatApp() {
   const sessionStreamGenRef = useRef(new Map<string, number>())
   const stoppingSessionsRef = useRef(new Set<string>())
   const streamingSessionIdsRef = useRef(new Set<string>())
+  const wakeWaitingSessionIdsRef = useRef(new Set<string>())
+  /** schedule_turn_wake 到期前本地倒计时 */
+  const pendingWakeRef = useRef(new Map<string, PendingWakeInfo>())
+  const wakeCountdownTimersRef = useRef(new Map<string, number>())
   /** 每会话 drain 意图：Stop=none；失败/成功=auto；打断指定项=runItem */
   const drainIntentRef = useRef(new Map<string, DrainIntent>())
   /** 当前会话排队提示（localStorage 镜像） */
@@ -406,12 +419,77 @@ export default function ChatApp() {
   const sessionsRef = useRef(sessions)
   const activeSessionMetaRef = useRef(activeSessionMeta)
   const loading = activeId ? streamingSessionIds.includes(activeId) : false
+  const wakeWaiting = activeId ? wakeWaitingSessionIds.includes(activeId) : false
   const markSessionStreaming = useCallback((sessionId: string, streaming: boolean) => {
     if (streaming) streamingSessionIdsRef.current.add(sessionId)
     else streamingSessionIdsRef.current.delete(sessionId)
     setStreamingSessionIds(Array.from(streamingSessionIdsRef.current))
   }, [])
+  const markSessionWakeWaiting = useCallback((sessionId: string, waiting: boolean) => {
+    if (waiting) wakeWaitingSessionIdsRef.current.add(sessionId)
+    else wakeWaitingSessionIdsRef.current.delete(sessionId)
+    setWakeWaitingSessionIds(Array.from(wakeWaitingSessionIdsRef.current))
+  }, [])
 
+  const stopWakeCountdown = useCallback((sessionId: string) => {
+    const timer = wakeCountdownTimersRef.current.get(sessionId)
+    if (timer != null) {
+      window.clearInterval(timer)
+      wakeCountdownTimersRef.current.delete(sessionId)
+    }
+  }, [])
+
+  const clearSessionWakeState = useCallback((sessionId: string) => {
+    pendingWakeRef.current.delete(sessionId)
+    stopWakeCountdown(sessionId)
+    markSessionWakeWaiting(sessionId, false)
+  }, [markSessionWakeWaiting, stopWakeCountdown])
+
+  const applyWakeCountdownSnapshot = useCallback((sessionId: string, fireAt: string) => {
+    const left = secondsLeftUntil(fireAt)
+    const phaseLabel = left > 0 ? formatWakeCountdownLabel(left) : '正在继续'
+    const prev = streamCacheRef.current.get(sessionId)
+    const next: SessionStreamSnapshot = {
+      liveTrace: {
+        steps: prev?.liveTrace?.steps ?? [],
+        phaseLabel,
+        thinkingLabel: `${phaseLabel}…`,
+      },
+      pendingUserPrompt: null,
+      userPromptSubmitting: false,
+      contextHint: prev?.contextHint ?? null,
+    }
+    streamCacheRef.current.set(sessionId, next)
+    if (activeIdRef.current === sessionId) {
+      syncStreamSnapshotToUi(next, streamUiRef.current)
+    }
+  }, [])
+
+  const startWakeCountdown = useCallback((sessionId: string, wake: PendingWakeInfo) => {
+    pendingWakeRef.current.set(sessionId, wake)
+    markSessionWakeWaiting(sessionId, true)
+    applyWakeCountdownSnapshot(sessionId, wake.fireAt)
+    stopWakeCountdown(sessionId)
+    const timer = window.setInterval(() => {
+      const current = pendingWakeRef.current.get(sessionId)
+      if (!current) {
+        stopWakeCountdown(sessionId)
+        return
+      }
+      applyWakeCountdownSnapshot(sessionId, current.fireAt)
+      if (secondsLeftUntil(current.fireAt) <= 0) {
+        void fetchSessionPendingWakes(sessionId).then((data) => {
+          const next = parsePendingWakesApi(data)[0]
+          if (!next) return
+          if (secondsLeftUntil(next.fireAt) > 0) {
+            pendingWakeRef.current.set(sessionId, next)
+            applyWakeCountdownSnapshot(sessionId, next.fireAt)
+          }
+        }).catch(() => { /* ignore */ })
+      }
+    }, 1000)
+    wakeCountdownTimersRef.current.set(sessionId, timer)
+  }, [applyWakeCountdownSnapshot, markSessionWakeWaiting, stopWakeCountdown])
   const resolveSessionTitle = useCallback((targetSessionId: string, eventTitle?: string) => {
     return eventTitle
       ?? (activeSessionMetaRef.current?.id === targetSessionId
@@ -489,6 +567,21 @@ export default function ChatApp() {
     const prev = streamCacheRef.current.get(targetSessionId) ?? createThinkingStreamSnapshot()
     const next = applyChatProgressEvent(prev, event)
     streamCacheRef.current.set(targetSessionId, next)
+
+    if (event.type === 'tool_done') {
+      const wake = parseScheduleTurnWakeFromStep(event.step)
+      if (wake) pendingWakeRef.current.set(targetSessionId, wake)
+    }
+    if (event.type === 'done' && Array.isArray(event.tool_steps)) {
+      for (const step of event.tool_steps) {
+        const wake = parseScheduleTurnWakeFromStep(step)
+        if (wake) {
+          pendingWakeRef.current.set(targetSessionId, wake)
+          break
+        }
+      }
+    }
+
     if (activeIdRef.current === targetSessionId) {
       syncStreamSnapshotToUi(next, streamUiRef.current)
       if (event.type === 'context_compact' && next.contextHint) {
@@ -535,10 +628,13 @@ export default function ChatApp() {
   }, [handleNotificationResult, maybeNotifyChatDone, resolveSessionTitle])
 
   const resolveStreamSnapshot = useCallback((id: string | null) => {
-    if (!id || !streamingSessionIdsRef.current.has(id)) return null
+    if (!id) return null
+    if (
+      !streamingSessionIdsRef.current.has(id)
+      && !wakeWaitingSessionIdsRef.current.has(id)
+    ) return null
     return streamCacheRef.current.get(id) ?? createThinkingStreamSnapshot()
-  }, [streamingSessionIds])
-
+  }, [streamingSessionIds, wakeWaitingSessionIds])
   const clearPendingUserPrompt = useCallback((sessionId: string | null) => {
     if (!sessionId || !streamingSessionIdsRef.current.has(sessionId)) return
     const prev = streamCacheRef.current.get(sessionId)
@@ -624,6 +720,112 @@ export default function ChatApp() {
     setSessions(list)
     return list
   }, [])
+
+  // 订阅 live-progress：wake 到期续跑的 thinking/tool/done 推到同一会话 UI
+  useEffect(() => {
+    if (!activeId) return
+    const sessionId = activeId
+    const ac = new AbortController()
+    let cancelled = false
+
+    const finishWakeResume = async (sid: string) => {
+      clearSessionWakeState(sid)
+      markSessionStreaming(sid, false)
+      streamCacheRef.current.delete(sid)
+      try {
+        const fresh = await getSession(sid)
+        if (cancelled || activeIdRef.current !== sid) return
+        setActiveSessionMeta(fresh.session)
+        setMessages(fresh.messages)
+        setContextRef(fresh.contextRef ?? null)
+        setSessionModelState(fresh.session.model)
+        setSessionLlmParamsState(fresh.session.llmParams)
+        setContextUsage(fresh.contextUsage ?? null)
+        await refreshSessions()
+      } catch {
+        /* keep current */
+      }
+      if (activeIdRef.current === sid && !streamingSessionIdsRef.current.has(sid)) {
+        window.setTimeout(() => {
+          if (activeIdRef.current !== sid) return
+          if (streamingSessionIdsRef.current.has(sid)) return
+          if (wakeWaitingSessionIdsRef.current.has(sid)) return
+          streamUiRef.current?.resetStreamUi()
+        }, 500)
+      }
+    }
+
+    const onLiveEvent = (event: ChatProgressEvent) => {
+      // 用户本轮已在 chat/stream 中：忽略 bus，避免双写
+      if (streamHandlesRef.current.has(sessionId)) return
+
+      const progressive =
+        event.type === 'thinking'
+        || event.type === 'tool_start'
+        || event.type === 'tool_done'
+        || event.type === 'reply'
+        || event.type === 'context_compact'
+        || event.type === 'user_prompt'
+        || event.type === 'steer_applied'
+
+      if (progressive && !streamingSessionIdsRef.current.has(sessionId)) {
+        clearSessionWakeState(sessionId)
+        const gen = (sessionStreamGenRef.current.get(sessionId) ?? 0) + 1
+        sessionStreamGenRef.current.set(sessionId, gen)
+        streamCacheRef.current.set(sessionId, createThinkingStreamSnapshot('正在继续…'))
+        markSessionStreaming(sessionId, true)
+      }
+
+      pushStreamEvent(sessionId, event)
+
+      if (event.type === 'done' || event.type === 'error') {
+        void finishWakeResume(sessionId)
+      }
+    }
+
+    void (async () => {
+      try {
+        const data = await fetchSessionPendingWakes(sessionId)
+        if (cancelled) return
+        const wake = parsePendingWakesApi(data)[0]
+        if (
+          wake
+          && secondsLeftUntil(wake.fireAt) > 0
+          && !streamingSessionIdsRef.current.has(sessionId)
+        ) {
+          startWakeCountdown(sessionId, wake)
+        }
+      } catch {
+        /* ignore */
+      }
+
+      while (!cancelled && !ac.signal.aborted) {
+        try {
+          await subscribeSessionLiveProgress(sessionId, onLiveEvent, ac.signal)
+          break
+        } catch (e) {
+          const aborted = (
+            (e instanceof DOMException && e.name === 'AbortError')
+            || (e instanceof Error && e.name === 'AbortError')
+          )
+          if (aborted || cancelled) break
+          await new Promise(r => setTimeout(r, 1500))
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+      ac.abort()
+    }
+  }, [
+    activeId,
+    clearSessionWakeState,
+    markSessionStreaming,
+    pushStreamEvent,
+    refreshSessions,
+    startWakeCountdown,
+  ])
 
   const refreshArchived = useCallback(async () => {
     const { groups } = await listArchivedSessions()
@@ -813,6 +1015,7 @@ export default function ChatApp() {
       if (streamingSessionIdsRef.current.has(id)) {
         await abortSessionStream(id)
       }
+      clearSessionWakeState(id)
       clearSessionPromptQueue(id)
       drainIntentRef.current.delete(id)
       syncPromptQueueUi(activeIdRef.current === id ? null : activeIdRef.current)
@@ -831,7 +1034,7 @@ export default function ChatApp() {
     } catch (e) {
       setError(e instanceof Error ? e.message : '删除失败')
     }
-  }, [activeId, abortSessionStream, confirm, loadSession, refreshSessions])
+  }, [activeId, abortSessionStream, clearSessionWakeState, confirm, loadSession, refreshSessions])
 
   const handleSelectExpert = useCallback(async (expertId: string) => {
     restoreChatColumn()
@@ -1172,6 +1375,8 @@ export default function ChatApp() {
     }
     // 新一轮默认自动续跑下一条；Stop / runNow 会在本轮中途覆盖
     drainIntentRef.current.set(sessionId, { kind: 'auto' })
+    stopWakeCountdown(sessionId)
+    markSessionWakeWaiting(sessionId, false)
     const initialSnapshot = createThinkingStreamSnapshot()
     streamCacheRef.current.set(sessionId, initialSnapshot)
     markSessionStreaming(sessionId, true)
@@ -1257,19 +1462,27 @@ export default function ChatApp() {
       streamHandlesRef.current.delete(sessionId)
       stoppingSessionsRef.current.delete(sessionId)
       const hadPendingAsk = Boolean(streamCacheRef.current.get(sessionId)?.pendingUserPrompt)
-      streamCacheRef.current.delete(sessionId)
+      const pendingWake = pendingWakeRef.current.get(sessionId)
       markSessionStreaming(sessionId, false)
-      if (activeIdRef.current === sessionId) {
-        const prevTimer = streamResetTimersRef.current.get(sessionId)
-        if (prevTimer != null) window.clearTimeout(prevTimer)
-        const timer = window.setTimeout(() => {
-          streamResetTimersRef.current.delete(sessionId)
-          if (activeIdRef.current !== sessionId) return
-          if (streamGen !== (sessionStreamGenRef.current.get(sessionId) ?? 0)) return
-          if (streamingSessionIdsRef.current.has(sessionId)) return
-          streamUiRef.current?.resetStreamUi()
-        }, 500)
-        streamResetTimersRef.current.set(sessionId, timer)
+      if (pendingWake) {
+        // 保留过程条，进入秒级倒计时（已到期则显示「正在继续」）
+        startWakeCountdown(sessionId, pendingWake)
+      } else {
+        streamCacheRef.current.delete(sessionId)
+        clearSessionWakeState(sessionId)
+        if (activeIdRef.current === sessionId) {
+          const prevTimer = streamResetTimersRef.current.get(sessionId)
+          if (prevTimer != null) window.clearTimeout(prevTimer)
+          const timer = window.setTimeout(() => {
+            streamResetTimersRef.current.delete(sessionId)
+            if (activeIdRef.current !== sessionId) return
+            if (streamGen !== (sessionStreamGenRef.current.get(sessionId) ?? 0)) return
+            if (streamingSessionIdsRef.current.has(sessionId)) return
+            if (wakeWaitingSessionIdsRef.current.has(sessionId)) return
+            streamUiRef.current?.resetStreamUi()
+          }, 500)
+          streamResetTimersRef.current.set(sessionId, timer)
+        }
       }
       if (hadPendingAsk) {
         const intent = drainIntentRef.current.get(sessionId)
@@ -1968,6 +2181,7 @@ export default function ChatApp() {
                   contextRef={contextRef}
                   composerDraft={composerDraft}
                   loading={loading}
+                  wakeWaiting={wakeWaiting}
                   streamUiRef={streamUiRef}
                   error={error}
                   availableModels={availableModels}

--- a/client-ui/src/chat/ChatProcessTrace.tsx
+++ b/client-ui/src/chat/ChatProcessTrace.tsx
@@ -205,6 +205,10 @@ const useStyles = makeStyles({
       '0%, 100%': { opacity: 0.72 },
       '50%': { opacity: 1 },
     },
+    '@media (prefers-reduced-motion: reduce)': {
+      animationName: 'none',
+      opacity: 1,
+    },
   },
   stepLabelError: {
     color: opptrixCssVars.error,

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -364,6 +364,8 @@ interface ChatViewProps {
   contextRef?: SessionContextRef | null
   composerDraft?: { revision: number; text: string }
   loading: boolean
+  /** schedule_turn_wake 等待期：显示动态倒计时过程条，不占用「停止」态 */
+  wakeWaiting?: boolean
   streamUiRef?: ChatStreamUiRef
   error: string
   availableModels?: AvailableModel[]
@@ -409,7 +411,7 @@ interface ChatViewProps {
 }
 
 function ChatView({
-  title = '新对话', titleSlot, headerTrailing, overlaySlot, contextHint, sessionId = null, expertId = null, expertRefreshKey = 0, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, composerDraft, loading, streamUiRef, error,
+  title = '新对话', titleSlot, headerTrailing, overlaySlot, contextHint, sessionId = null, expertId = null, expertRefreshKey = 0, welcomeEpoch = 0, chatScrollEpoch = 0, messages, contextRef = null, composerDraft, loading, wakeWaiting = false, streamUiRef, error,
   availableModels = [],
   sessionModel,
   sessionLlmParams,
@@ -525,7 +527,7 @@ function ChatView({
   const { selection, anchor, clearSelection } = useMessageSelection({
     rootRef: chatBoxRef,
     anchorRef: bodyShellRef,
-    enabled: Boolean(sessionId) && !loading,
+    enabled: Boolean(sessionId) && !loading && !wakeWaiting,
   })
 
   useEffect(() => {
@@ -593,7 +595,7 @@ function ChatView({
     return onEphemeralAsk(message, sel, priorTurns)
   }, [onEphemeralAsk])
 
-  const isEmpty = messages.length === 0 && !loading && !contextRef
+  const isEmpty = messages.length === 0 && !loading && !wakeWaiting && !contextRef
   const welcome = pickWelcomeVariant(welcomeEpoch)
   const isExpertSession = Boolean(expertId)
 
@@ -753,11 +755,11 @@ function ChatView({
   }, [])
 
   useEffect(() => {
-    if (loading || liveTrace) {
+    if (loading || wakeWaiting || liveTrace) {
       if (stickToBottomRef.current) {
         scrollToBottom(messages.length <= 1 ? 'auto' : 'smooth')
       }
-      prevLoadingRef.current = loading
+      prevLoadingRef.current = loading || wakeWaiting
       return
     }
 
@@ -776,16 +778,16 @@ function ChatView({
       }
     }
 
-    prevLoadingRef.current = loading
-  }, [messages, loading, liveTrace, scrollToBottom, scrollMessageStartToCenter])
+    prevLoadingRef.current = loading || wakeWaiting
+  }, [messages, loading, wakeWaiting, liveTrace, scrollToBottom, scrollMessageStartToCenter])
 
   useEffect(() => {
-    if (!chatScrollEpoch || !sessionId || loading || liveTrace || messages.length === 0) return
+    if (!chatScrollEpoch || !sessionId || loading || wakeWaiting || liveTrace || messages.length === 0) return
     const idx = messages.length - 1
     window.requestAnimationFrame(() => {
       window.requestAnimationFrame(() => scrollToMessageStart(idx, 'auto'))
     })
-  }, [chatScrollEpoch, sessionId, loading, liveTrace, messages.length, scrollToMessageStart])
+  }, [chatScrollEpoch, sessionId, loading, wakeWaiting, liveTrace, messages.length, scrollToMessageStart])
 
   const handleSubmit = (text?: string, attachmentIds?: string[], attachmentMetas?: ChatAttachmentMeta[]) => {
     stickToBottomRef.current = true
@@ -1000,7 +1002,7 @@ function ChatView({
                 />
               ))}
 
-              {loading && liveTrace && (
+              {((loading || wakeWaiting) && liveTrace) && (
                 <div className={s.loadingRow} data-message-role="assistant">
                   <ChatProcessTrace
                     steps={liveTrace.steps}

--- a/client-ui/src/chat/turnWakeCountdown.ts
+++ b/client-ui/src/chat/turnWakeCountdown.ts
@@ -1,0 +1,96 @@
+/**
+ * schedule_turn_wake 倒计时：解析工具结果 + 秒级文案。
+ */
+
+export type PendingWakeInfo = {
+  wakeId: string
+  fireAt: string
+  seconds: number
+  reason?: string
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** 与服务端 formatWakeSecondsLabel 同口径 */
+export function formatWakeCountdownLabel(secondsLeft: number): string {
+  const s = Math.max(0, Math.floor(secondsLeft))
+  if (s < 60) return `约 ${s} 秒后继续检查`
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  if (r === 0) return `约 ${m} 分后继续检查`
+  return `约 ${m} 分 ${r} 秒后继续检查`
+}
+
+export function secondsLeftUntil(fireAtIso: string, nowMs = Date.now()): number {
+  const fireMs = Date.parse(fireAtIso)
+  if (!Number.isFinite(fireMs)) return 0
+  return Math.max(0, Math.ceil((fireMs - nowMs) / 1000))
+}
+
+function parseWakePayload(raw: unknown): PendingWakeInfo | null {
+  if (!isRecord(raw) || raw.ok === false) return null
+  const fireAt = typeof raw.fire_at === 'string' ? raw.fire_at.trim() : ''
+  const wakeId = typeof raw.wake_id === 'string' ? raw.wake_id.trim() : ''
+  if (!fireAt || !wakeId) return null
+  const seconds = typeof raw.seconds === 'number'
+    ? raw.seconds
+    : Number(raw.seconds)
+  const reason = typeof raw.reason === 'string' && raw.reason.trim()
+    ? raw.reason.trim()
+    : undefined
+  return {
+    wakeId,
+    fireAt,
+    seconds: Number.isFinite(seconds) && seconds > 0 ? Math.floor(seconds) : secondsLeftUntil(fireAt),
+    ...(reason ? { reason } : {}),
+  }
+}
+
+/** 从工具步骤 resultDetail / resultPreview 解析 schedule_turn_wake 结果 */
+export function parseScheduleTurnWakeFromStep(step: {
+  tool?: string
+  resultDetail?: string
+  resultPreview?: string
+}): PendingWakeInfo | null {
+  if (step.tool !== 'schedule_turn_wake') return null
+  for (const text of [step.resultDetail, step.resultPreview]) {
+    if (!text?.trim()) continue
+    try {
+      const parsed = JSON.parse(text) as unknown
+      const wake = parseWakePayload(parsed)
+      if (wake) return wake
+    } catch {
+      /* try next */
+    }
+  }
+  return null
+}
+
+export function parsePendingWakesApi(payload: unknown): PendingWakeInfo[] {
+  if (!isRecord(payload) || !Array.isArray(payload.wakes)) return []
+  const out: PendingWakeInfo[] = []
+  for (const item of payload.wakes) {
+    if (!isRecord(item)) continue
+    const wakeId = typeof item.wake_id === 'string' ? item.wake_id.trim() : ''
+    const fireAt = typeof item.fire_at === 'string' ? item.fire_at.trim() : ''
+    if (!wakeId || !fireAt) continue
+    const secondsLeft = typeof item.seconds_left === 'number'
+      ? item.seconds_left
+      : Number(item.seconds_left)
+    const seconds = typeof item.seconds === 'number' ? item.seconds : Number(item.seconds)
+    const reason = typeof item.reason === 'string' && item.reason.trim()
+      ? item.reason.trim()
+      : undefined
+    out.push({
+      wakeId,
+      fireAt,
+      seconds: Number.isFinite(seconds) && seconds > 0
+        ? Math.floor(seconds)
+        : (Number.isFinite(secondsLeft) ? Math.max(0, Math.floor(secondsLeft)) : secondsLeftUntil(fireAt)),
+      ...(reason ? { reason } : {}),
+    })
+  }
+  return out.sort((a, b) => Date.parse(a.fireAt) - Date.parse(b.fireAt))
+}

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -210,7 +210,7 @@ Opptrix/
     - **工具**：`workspace_list` / `workspace_read` / `workspace_write` / `workspace_mkdir` / `workspace_delete` / `download_file` / `http_fetch` / `request_folder_access` / `list_workspace_grants` / `resolve_workspace_path_uri` / `shell_platform_status` / `opptrix_run`（兼容别名 `shell_run`） / `shell_install` / `request_shell_network` / `python_env_status` / `ensure_python` / `list_local_data_apis` / `get_local_data_catalog` / `prepare_fuyao_dump` / `request_session_lan_access` / `request_secret` / `list_vault_secrets` / `grant_session_secret` / `revoke_session_secret` / `delete_vault_secret`
     - **消息内文件引用**：聊天 Markdown 展示工作区图片/音视频/文件时，使用协议 `opptrix-ws://{root_id}/{相对路径}`（例：`opptrix-ws://shared/charts/a.png`）。可先调 `resolve_workspace_path_uri({ root_id, path })` 得到规范 `uri` 与 `exists` / `kind_hint`（合法且已授权即返回 uri，不返回本机绝对路径）。UI 将 URI 解析为 `GET /api/sessions/:id/workspace/file` 流。**禁止**消息中写 `file://` 或绝对路径。
     - **激活**：非 always-on；意图播种（本地读写/下载/开放 API/授权文件夹/运行代码/编程类处理）或 `activate_tool_pack({ pack_ids: ["workspace"] })`；须在聊天会话中调用（依赖 session bridge）。**能力不足兜底**：内置/已匹配工具无法完成或无匹配 pack 时 → activate `workspace`，用 `opptrix_run` / `ensure_python` / `workspace_*` 沙盒编程实现（可先标准工具取数再沙盒计算）；标准 API 能做的禁止先上沙盒；首选已加载时勿仪式化重复 activate
-    - **Python 就绪（`ensure_python` / 轮询）**：`ensure_python` **不阻塞**整轮对话。已就绪时同步返回 `status: "ready"`（`ready=true`，`active_source=opptrix` 或系统）。未就绪时启动托管安装并**立即**返回 `status: "preparing"|"installing"`、`job_id`、`poll_hint`；Agent **必须**再次调用 `ensure_python({ job_id })` 轮询直至 `ready` 或 `failed`。成功后写入 `prefer_opptrix_python=true`。失败不假 ready。`opptrix_run` 解析 `python`/`pip` 时若尚未就绪会快速失败并提示先 `ensure_python` 轮询，**不会**在 tool 内死等 20 分钟；勿引导用户去设置页干等。设置页仍用 `/api/settings/python/install` 的 job+poll（行为不变）。系统 Python 探测：Windows 扫 PATH + `%LOCALAPPDATA%\Programs\Python\Python*`（任意 3.x，非写死 311/312）及可选 Program Files；mac/Linux 为 which + 常见路径（含 Homebrew / Framework）。
+    - **Python 就绪（`ensure_python` / 异步唤醒）**：`ensure_python` **不阻塞**整轮对话。已就绪时同步返回 `status: "ready"`。未就绪时启动托管安装并**立即**返回 `status: "preparing"|"installing"`、`job_id`、`eta_seconds` / `suggested_wake_seconds`、`async_hint` / `poll_hint`。**优先** `schedule_turn_wake({ seconds: suggested_wake_seconds, prompt, job_id })` 结束本轮、到期同会话自动续跑；必要时再调 `ensure_python({ job_id })`。**禁止 tight-poll**。成功后写入 `prefer_opptrix_python=true`。失败不假 ready。`opptrix_run` 解析 `python`/`pip` 时若尚未就绪会快速失败并提示先 `ensure_python`，**不会**在 tool 内死等。设置页仍用 `/api/settings/python/install` 的 job+poll（行为不变）。
     - **可访问目录（唯一清单）**：Agent 问「能访问哪些目录」时**只**用 `list_workspace_grants`（属 `workspace` pack，须已播种或 `activate_tool_pack`；返回 `summary` + 脱敏后的 `grants[]`：`root_id` / `label` / `mode` / `path_hint`）。默认项**不**返回 `~/.opptrix` 绝对路径；落在用户数据根下的额外 grant 亦脱敏为 basename +「应用内部路径」提示。用户侧界面与 Agent 摘要均称「**本对话工作区**」，**不**把 `~/.opptrix` 根目录或跨会话全局目录标为默认可写区。
     - **`get_project_info`（已脱敏，非授权清单）**：经 `buildAgentSafeProjectInfo` 剥离 `paths` / `project_root` / `agent_package`，仅保留版本/运行时等元数据 + `user_data_configured`；**勿**当作目录清单，亦**勿**向用户复述内部数据根路径。
     - **根目录布局**：容器根 `{userData}/agent-workspace/`（quota / 清理统计）；每会话默认 `root_id=default` → `agent-workspace/sessions/<sessionId>/`（读写，**会话隔离**）；**公共复用区** `root_id=shared` → `agent-workspace/shared/`（`packages/` / `data/dumps|exports|cache` / `docs/` + README；会话自动 grant rw；**`clearSession` 不删 shared**）；旧版全局根下散落文件幂等迁入 `_legacy/`。额外目录由用户在界面「授权文件夹」或 REST grant 写入本会话（`ro`/`rw`）
@@ -279,12 +279,21 @@ Opptrix/
   - `job_id`（可选）：轮询用；上次返回 `status: "preparing"` 时带上，可省略 `dump_kind`
 - **返回（兼容说明）**：
   - **快速路径**（`presigned_url`，或 `local_path` 缓存命中）：`status: "ready"` + 原有字段（`url` 或 `relative_path` / `bytes` / `from_cache`）
-  - **冷下载**（`local_path` 且需联网下载）：**立即**返回 `ok: true`、`status: "preparing"`、`job_id`、`poll_hint`（不再阻塞 5–25 分钟）；Agent **必须**再次调用 `prepare_fuyao_dump({ job_id })` 轮询直至 `status: "ready"` 或 `failed`
+  - **冷下载**（`local_path` 且需联网下载）：**立即**返回 `ok: true`、`status: "preparing"`、`job_id`、`eta_seconds` / `suggested_wake_seconds`、`async_hint` / `poll_hint`（不再阻塞 5–25 分钟）；**优先** `schedule_turn_wake({ seconds: suggested_wake_seconds, prompt, job_id })` 到期后再查；必要时再调 `prepare_fuyao_dump({ job_id })`。**禁止 tight-poll**、勿重复 `force_refresh` 另起任务
   - 就绪后 `full` / `incremental` + `local_path`：**额外**自动写 `shared/data/cache/offline-k-meta.json`（`meta_written` / `meta_warning`）
   - `adjustment_factors` / `presigned_url`：**不**写 offline-k-meta
 - **沙盒侧**：用 `workspace_read` / `workspace_list` / `opptrix_run`（`root_id=shared` + `relative_path`）或下载 `url`；**禁止**向 shell 环境注入 `API_KEY` / `TOKEN` / 扶摇凭证。
 - **失败**：返回 `ok: false` + `status: "failed"` + `error` + `sandbox_hint`；勿改用 sync/dailyDump 兜底。
-- **旧 Agent**：若只认同步 `ok`+`path`/`url`、忽略 `status`，冷下载时看不到路径——须按 `poll_hint` 用 `job_id` 轮询。
+- **旧 Agent**：若只认同步 `ok`+`path`/`url`、忽略 `status`，冷下载时看不到路径——须按 `poll_hint` / `suggested_wake_seconds` 唤醒或用 `job_id` 再查。
+
+**`schedule_turn_wake`（core always-on）**
+
+- **用途**：任意场景延后续跑——结束本轮后按秒数在**同会话**自动注入含 callback `prompt` + 时间元数据的 user 消息，并**新开一轮** `agent.chat`（`unattended: false`；**不用** steer）。
+- **参数**：`seconds`∈[5, 1800]（超出钳制）；`prompt` 必填；可选 `reason` / `job_id`。每会话最多 8 个挂起 timer。
+- **返回**：`wake_id` / `fire_at` / `seconds` / `scheduled_at` 等。
+- **行为**：若到期时该会话仍有活跃 chat → **延期**再试，禁止 `registerSessionChat` 打断当前轮；会话删除取消全部 timer。
+- **限制**：timer 仅存**进程内存**；关闭应用/进程后丢失，需文档与 `note` 说明。
+- **与异步任务**：`prepare_fuyao_dump` / `ensure_python` 的 preparing 响应带 `suggested_wake_seconds` 时优先本工具，勿 tight-poll。
 
 **已废弃：Agent 侧 `market sync` / `dailyDump` 作为主取 dump 路径**
 
@@ -327,6 +336,7 @@ Opptrix/
   - **SSE**：`context_compact`（`level`: micro/structured/overflow_retry）；会话内轻提示「已整理较早对话要点…」。`done` 可含 `turn_usage`（本轮 LLM 累计用量，含 tool 循环与 structured 压缩）与 `context_usage`（Composer：`usagePercent` / `compacted`，文案「上下文约 N%」+ 可选「已整理」；不下发 projection 全文）。测试：`tests/session-context-compact.test.mjs`、`tests/chat-token-usage.test.mjs`、`tests/session-projection-disk.test.mjs`。
 - 系统提示与引擎：`packages/agent/src/engine.ts`；用户确认规则见 `packages/shared/src/agent-prompt-guide.ts` 中 `buildUserInteractionPlaybook`
 - **`ask_user`**：Agent 需用户确认/选择/填空时调用；SSE 推送 `user_prompt`。**confirm**：省略 `options`（或 `[]`）且未设 `mode=text`/`allow_custom=true` → 底部「拒绝/确认」（可用 `reject_label`/`confirm_label`；回传 id 固定 `reject`/`confirm`）。**choice**：预置选项 2–50。**text**：`mode:"text"` 或空 options + `allow_custom=true` → 仅开放填空，无授权双钮。禁止用 confirm 收集开放答案。`allow_custom`：confirm 默认关、choice 默认开。多选支持全选；prompt/label 勿用 emoji。作答经 `POST /api/sessions/:id/chat/user-prompt` 回传后继续工具链
+- **`schedule_turn_wake`**（`core`）：延后同会话自动续跑；见上文「`schedule_turn_wake`（core always-on）」。异步 preparing 优先本工具 + `suggested_wake_seconds`，勿 tight-poll。
 - **行业 / 产业链**：激活工作流技能 `industry-chain`（读 `references/chain-knowledge.json`）→ 代表公司用 `get_sector_list` / `get_sector_constituents` / `search_instruments` + `get_instrument_*`
 - **早报 / 收盘**：激活 `morning-market-brief` / `closing-market-brief` → 用 `get_market_dynamics`、`get_limit_updown`、`get_watchlist` 等取数后按技能 Schema 输出 JSON
 - **市场宏观**：`get_market_regime` / `get_market_dynamics` / `get_trend_brief` 等属 `market` pack（提供事实表；开闭市叙事走工作流技能，非独立报告工具）

--- a/packages/agent-workspace/src/python/ensure-python.ts
+++ b/packages/agent-workspace/src/python/ensure-python.ts
@@ -27,6 +27,9 @@ export interface EnsurePythonResult {
   install?: PythonInstallJobSnapshot
   job_id?: string
   poll_hint?: string
+  eta_seconds?: number
+  suggested_wake_seconds?: number
+  async_hint?: string
 }
 
 export interface EnsurePythonDeps {
@@ -38,8 +41,8 @@ export interface EnsurePythonDeps {
   saveSettings: (input: Partial<PythonSettings>) => ValidatePythonSettingsResult
 }
 
-const POLL_HINT =
-  '托管 Python 安装进行中。请再次调用 ensure_python({ job_id }) 轮询，直至 status 为 ready 或 failed。勿在本轮阻塞等待。'
+const ASYNC_HINT =
+  '安装在后台进行。可结束本轮并用 schedule_turn_wake 按 suggested_wake_seconds 唤醒后续跑；勿 tight-poll。'
 
 const defaultDeps: EnsurePythonDeps = {
   getStatus: getPythonPlatformStatus,
@@ -66,20 +69,71 @@ function agentStatusFromJob(job: PythonInstallJobSnapshot): Exclude<EnsurePython
   return 'preparing'
 }
 
+function estimatePythonEtaSeconds(job: PythonInstallJobSnapshot): number {
+  const now = Date.now()
+  const started = job.started_at_ms
+  const elapsedSec =
+    started != null && started > 0 ? Math.max(1, (now - started) / 1000) : null
+
+  if (
+    elapsedSec != null
+    && job.bytes_total != null
+    && job.bytes_total > 0
+    && job.bytes_downloaded > 0
+    && job.bytes_downloaded < job.bytes_total
+  ) {
+    const rate = job.bytes_downloaded / elapsedSec
+    if (rate > 0) {
+      return Math.ceil(((job.bytes_total - job.bytes_downloaded) / rate) * 1.15)
+    }
+  }
+
+  const pct = job.percent
+  if (elapsedSec != null && pct >= 5 && pct < 99) {
+    return Math.ceil(elapsedSec * (100 - pct) / pct * 1.15)
+  }
+
+  // 托管安装启发式：下载+解压+pip 常需数分钟
+  return 180
+}
+
+function clampSuggestedWake(eta: number): number {
+  return Math.min(1800, Math.max(5, Math.ceil(eta)))
+}
+
 function inProgressResult(job: PythonInstallJobSnapshot): EnsurePythonResult {
   const status = agentStatusFromJob(job)
   const jobId = job.job_id ?? PYTHON_INSTALL_JOB_ID
+  if (status === 'failed') {
+    return {
+      ok: false,
+      ready: false,
+      status,
+      active_source: 'none',
+      active_version: null,
+      recommend_install: true,
+      message: job.message || '托管 Python 安装未完成',
+      install: job,
+      job_id: jobId,
+    }
+  }
+  const eta = estimatePythonEtaSeconds(job)
+  const suggested = clampSuggestedWake(eta)
   return {
-    ok: status !== 'failed',
+    ok: true,
     ready: false,
     status,
     active_source: 'none',
     active_version: null,
     recommend_install: true,
-    message: job.message || (status === 'failed' ? '托管 Python 安装未完成' : '正在准备托管 Python…'),
+    message: job.message || '正在准备托管 Python…',
     install: job,
     job_id: jobId,
-    poll_hint: status === 'failed' ? undefined : POLL_HINT,
+    eta_seconds: eta,
+    suggested_wake_seconds: suggested,
+    async_hint: ASYNC_HINT,
+    poll_hint:
+      `托管 Python 安装进行中（约 ${suggested}s）。优先 schedule_turn_wake({ seconds: ${suggested}, prompt: "检查 ensure_python job_id=${jobId} 是否就绪并继续", job_id: "${jobId}" })；必要时再调 ensure_python({ job_id })。勿 tight-poll。`,
   }
 }
 

--- a/packages/agent-workspace/src/python/install-job.ts
+++ b/packages/agent-workspace/src/python/install-job.ts
@@ -31,6 +31,8 @@ export interface PythonInstallJobSnapshot {
   error: string | null
   /** 有进行中/已结束的安装任务时为 PYTHON_INSTALL_JOB_ID；idle 为 null */
   job_id: string | null
+  /** 任务开始时间（ms）；idle 为 null */
+  started_at_ms: number | null
 }
 
 export interface PythonInstallPipelineDeps {
@@ -72,6 +74,7 @@ function createIdleSnapshot(): PythonInstallJobSnapshot {
     steps: [...DEFAULT_STEPS],
     error: null,
     job_id: null,
+    started_at_ms: null,
   }
 }
 
@@ -247,6 +250,7 @@ export function startPythonInstallJob(): PythonInstallJobSnapshot {
     phase: 'prepare',
     percent: 1,
     job_id: PYTHON_INSTALL_JOB_ID,
+    started_at_ms: Date.now(),
   }
 
   activePromise = runInstallPipeline()

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -164,6 +164,16 @@ export interface ChatProgressOptions {
 
 // ── 工具中文标签映射 ──
 
+/** 倒计时文案（工具结果 / 步骤标签；UI 动态倒计时复用同口径） */
+export function formatWakeSecondsLabel(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds))
+  if (s < 60) return `约 ${s} 秒后继续检查`
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  if (r === 0) return `约 ${m} 分后继续检查`
+  return `约 ${m} 分 ${r} 秒后继续检查`
+}
+
 const TOOL_LABELS: Record<string, string> = {
   get_market_regime: '分析宏观市场状态',
   get_market_dynamics: '获取市场动态全景',
@@ -209,6 +219,7 @@ const TOOL_LABELS: Record<string, string> = {
   import_agent_skill: '导入工作流技能',
   delete_agent_skill: '删除工作流技能',
   get_current_time: '获取当前时间',
+  schedule_turn_wake: '等待后继续',
   get_system_info: '读取运行环境信息',
   get_app_settings: '读取应用设置',
   get_project_info: '读取应用信息',
@@ -589,6 +600,16 @@ export function formatToolLabel(tool: string, args: Record<string, unknown> = {}
       if (!q) return base
       const short = q.length > 36 ? `${q.slice(0, 36)}…` : q
       return `等待你的确认：${short}`
+    }
+    case 'schedule_turn_wake': {
+      const fromResult = result && typeof result === 'object' && 'seconds' in result
+        ? Number((result as { seconds?: unknown }).seconds)
+        : NaN
+      const fromArgs = typeof args.seconds === 'number' ? args.seconds : Number(args.seconds)
+      const sec = Number.isFinite(fromResult) && fromResult > 0
+        ? Math.floor(fromResult)
+        : (Number.isFinite(fromArgs) && fromArgs > 0 ? Math.floor(fromArgs) : 0)
+      return sec > 0 ? formatWakeSecondsLabel(sec) : base
     }
     case 'opptrix_run':
     case 'shell_run': {
@@ -1024,6 +1045,16 @@ function summarizeToolResult(tool: string, result: unknown): string | null {
         : []
       if (labels.length) return `已选择：${labels.join('、')}`
       return '已收到你的确认'
+    }
+    case 'schedule_turn_wake': {
+      if (!result || typeof result !== 'object') return null
+      const r = result as Record<string, unknown>
+      if (r.ok === false) {
+        return typeof r.error === 'string' ? r.error : '未能安排稍后继续'
+      }
+      const sec = typeof r.seconds === 'number' ? r.seconds : Number(r.seconds)
+      if (Number.isFinite(sec) && sec > 0) return formatWakeSecondsLabel(sec)
+      return '已安排稍后继续检查'
     }
     case 'opptrix_run':
     case 'shell_run':

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -40,6 +40,7 @@ import {
   buildTurnTailPrompt,
   parseNamespacedMcpTool,
 } from '@opptrix/shared'
+import { clearSessionTurnWakes } from './turn-wake.js'
 import {
   buildChecklistTurnTail,
   buildSpinGuardTurnTail,
@@ -904,6 +905,7 @@ export class AgentEngine {
     this.agentSkillSessions.clear(id)
     this.clearExpertPacksSeeded(id)
     this.workspaceService.clearSession(id)
+    clearSessionTurnWakes(id)
     void deleteSessionStateDirectory(id).catch(err => {
       const msg = err instanceof Error ? err.message : String(err)
       console.warn(`[agent] 清理会话状态目录失败 (${id}): ${msg}`)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -364,6 +364,28 @@ export {
   type LlmToolChoice,
 } from './llm/provider.js'
 export { initOutboundNetwork, type OutboundConnectFamily, type OutboundNetworkStatus } from './llm/outbound-network.js'
+export {
+  scheduleTurnWake,
+  cancelTurnWake,
+  clearSessionTurnWakes,
+  listPendingTurnWakes,
+  configureTurnWakeRuntime,
+  setTurnWakeResumeHandler,
+  clampWakeSeconds,
+  clampSuggestedWakeSeconds,
+  estimateEtaFromProgress,
+  formatWakeMessage,
+  TURN_WAKE_MIN_SECONDS,
+  TURN_WAKE_MAX_SECONDS,
+  TURN_WAKE_MAX_PER_SESSION,
+  TURN_WAKE_BUSY_DEFER_SECONDS,
+  resetTurnWakeForTests,
+  listTurnWakeIdsForTests,
+  type TurnWakeJob,
+  type TurnWakeResumeHandler,
+  type TurnWakeRuntime,
+  type PendingTurnWakeInfo,
+} from './turn-wake.js'
 
 /** 注册 PDF → doc-library ingest hook */
 import './doc-library-bridge.js'

--- a/packages/agent/src/llm/llm-error-message.ts
+++ b/packages/agent/src/llm/llm-error-message.ts
@@ -1,0 +1,229 @@
+/**
+ * LLM 上游 HTTP 错误 → 聊天侧用户文案（方案 A：无 HTTP/JSON/密钥细节）。
+ * 技术细节仅经 logLlmHttpError 打到服务端日志。
+ */
+
+export const LLM_ERR_BALANCE =
+  '当前模型余额不足，请到服务商充值或更换模型后再试'
+export const LLM_ERR_AUTH =
+  '当前模型的访问密钥无效，请到设置里检查大模型配置'
+export const LLM_ERR_RATE_LIMIT =
+  '当前模型请求过于频繁，请稍后再试'
+export const LLM_ERR_MODEL_UNAVAILABLE =
+  '当前选用的模型暂时不可用，请在设置中更换后再试'
+export const LLM_ERR_OVERFLOW =
+  '对话内容过多，正在整理后重试…'
+export const LLM_ERR_GENERIC =
+  '当前模型暂时无法回复。请检查大模型配置或稍后再试'
+
+export type LlmHttpErrorKind =
+  | 'overflow'
+  | 'balance'
+  | 'auth'
+  | 'rate_limit'
+  | 'model_unavailable'
+  | 'generic'
+
+export type LlmErrorCfgHint = {
+  /** 展示名 / id，勿含密钥或 URL */
+  provider?: string
+  model?: string
+}
+
+const BODY_LOG_MAX = 400
+
+/** 从上游 body 抽出可读文本（含 JSON error.message），供分类用，不进聊天。 */
+export function extractUpstreamErrorHaystack(bodyText: string): string {
+  const raw = (bodyText ?? '').trim()
+  if (!raw) return ''
+  const parts: string[] = [raw]
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    collectJsonErrorStrings(parsed, parts, 0)
+  } catch {
+    // 非 JSON：仅用原文
+  }
+  return parts.join('\n')
+}
+
+function collectJsonErrorStrings(value: unknown, out: string[], depth: number): void {
+  if (depth > 4 || value == null) return
+  if (typeof value === 'string') {
+    const t = value.trim()
+    if (t) out.push(t)
+    return
+  }
+  if (typeof value !== 'object') return
+  if (Array.isArray(value)) {
+    for (const item of value.slice(0, 8)) collectJsonErrorStrings(item, out, depth + 1)
+    return
+  }
+  const rec = value as Record<string, unknown>
+  for (const key of ['message', 'msg', 'error', 'code', 'type', 'detail', 'details']) {
+    if (key in rec) collectJsonErrorStrings(rec[key], out, depth + 1)
+  }
+}
+
+export function isContextLengthHttpError(status: number, body: string): boolean {
+  const text = extractUpstreamErrorHaystack(body).toLowerCase()
+  if (
+    text.includes('context_length_exceeded')
+    || text.includes('context length')
+    || text.includes('maximum context')
+    || text.includes('too many tokens')
+    || text.includes('prompt is too long')
+    || text.includes('token limit')
+    || (text.includes('context window') && text.includes('exceed'))
+  ) {
+    return true
+  }
+  if ((status === 400 || status === 413) && (
+    text.includes('token') || text.includes('context') || text.includes('length')
+  )) {
+    return /exceed|too (?:long|large|many)|maximum|limit/i.test(text)
+  }
+  return false
+}
+
+function isBalanceError(status: number, haystack: string): boolean {
+  if (status === 402) return true
+  const t = haystack.toLowerCase()
+  return (
+    t.includes('insufficient balance')
+    || t.includes('insufficient_quota')
+    || t.includes('insufficient quota')
+    || t.includes('quota exceeded')
+    || t.includes('quota_exceeded')
+    || (t.includes('billing') && (t.includes('hard_limit') || t.includes('exceed')))
+    || t.includes('余额不足')
+    || t.includes('额度不足')
+    || t.includes('欠费')
+  )
+}
+
+function isAuthError(status: number, haystack: string): boolean {
+  if (status === 401) return true
+  const t = haystack.toLowerCase()
+  return (
+    t.includes('unauthorized')
+    || t.includes('invalid_api_key')
+    || t.includes('invalid api key')
+    || t.includes('incorrect api key')
+    || t.includes('authentication')
+    || t.includes('鉴权失败')
+    || t.includes('密钥无效')
+    || t.includes('无效的密钥')
+  )
+}
+
+function isRateLimitError(status: number, _haystack: string): boolean {
+  return status === 429
+}
+
+function isModelUnavailableError(haystack: string): boolean {
+  const t = haystack.toLowerCase()
+  if (
+    t.includes('model_not_found')
+    || t.includes('model not found')
+    || t.includes('no such model')
+    || t.includes('invalid model')
+    || t.includes('unknown model')
+  ) {
+    return true
+  }
+  if (t.includes('does not exist') && t.includes('model')) return true
+  if (/模型.*(不存在|不可用)|不存在.*模型/.test(haystack)) return true
+  return false
+}
+
+export function classifyLlmHttpError(status: number, bodyText: string): LlmHttpErrorKind {
+  const haystack = extractUpstreamErrorHaystack(bodyText)
+  if (isContextLengthHttpError(status, bodyText)) return 'overflow'
+  if (isBalanceError(status, haystack)) return 'balance'
+  if (isAuthError(status, haystack)) return 'auth'
+  if (isRateLimitError(status, haystack)) return 'rate_limit'
+  if (isModelUnavailableError(haystack)) return 'model_unavailable'
+  return 'generic'
+}
+
+/**
+ * 聊天可见文案。cfg 仅用于可选点缀模型名，永不含密钥/URL。
+ */
+export function formatLlmHttpUserMessage(
+  status: number,
+  bodyText: string,
+  cfg?: LlmErrorCfgHint,
+): { kind: LlmHttpErrorKind; userMessage: string; contextOverflow: boolean } {
+  const kind = classifyLlmHttpError(status, bodyText)
+  let userMessage: string
+  switch (kind) {
+    case 'overflow':
+      userMessage = LLM_ERR_OVERFLOW
+      break
+    case 'balance':
+      userMessage = LLM_ERR_BALANCE
+      break
+    case 'auth':
+      userMessage = LLM_ERR_AUTH
+      break
+    case 'rate_limit':
+      userMessage = LLM_ERR_RATE_LIMIT
+      break
+    case 'model_unavailable':
+      userMessage = LLM_ERR_MODEL_UNAVAILABLE
+      break
+    default:
+      userMessage = LLM_ERR_GENERIC
+  }
+  // 可选：在通用/模型不可用时带上模型名，便于用户对照设置（勿拼 URL/密钥）
+  const model = cfg?.model?.trim()
+  if (
+    model
+    && (kind === 'generic' || kind === 'model_unavailable')
+    && model.length <= 64
+    && !/[/:\\]/.test(model)
+    && !userMessage.includes(model)
+  ) {
+    userMessage = `${userMessage.replace(/。$/, '')}（${model}）。`
+  }
+  return {
+    kind,
+    userMessage,
+    contextOverflow: kind === 'overflow',
+  }
+}
+
+/** 脱敏截断 body，供服务端日志；禁止打出疑似密钥。 */
+export function sanitizeBodyForLog(bodyText: string, maxLen = BODY_LOG_MAX): string {
+  let s = (bodyText ?? '').replace(/\s+/g, ' ').trim()
+  s = s
+    .replace(/sk-[a-zA-Z0-9_-]{8,}/gi, '[redacted]')
+    .replace(/Bearer\s+[a-zA-Z0-9._\-+=/]+/gi, 'Bearer [redacted]')
+    .replace(/("?(?:api[_-]?key|token|authorization)"?\s*[:=]\s*")([^"]{4,})(")/gi, '$1[redacted]$3')
+  if (s.length > maxLen) s = `${s.slice(0, maxLen)}…`
+  return s
+}
+
+export function logLlmHttpError(
+  status: number,
+  bodyText: string,
+  cfg?: LlmErrorCfgHint,
+): void {
+  const provider = cfg?.provider?.trim() || '-'
+  const model = cfg?.model?.trim() || '-'
+  const body = sanitizeBodyForLog(bodyText)
+  console.warn(`[llm] upstream HTTP ${status} provider=${provider} model=${model} body=${body}`)
+}
+
+/** 断言聊天文案不含技术泄漏（供单测）。 */
+export function assertUserSafeLlmErrorMessage(msg: string): void {
+  if (/\bHTTP\s+\d/i.test(msg) || msg.includes('HTTP ')) {
+    throw new Error(`user message leaks HTTP status: ${msg}`)
+  }
+  if (msg.includes('{') || msg.includes('}')) {
+    throw new Error(`user message looks like JSON: ${msg}`)
+  }
+  if (/API\s*Key/i.test(msg)) {
+    throw new Error(`user message leaks API Key wording: ${msg}`)
+  }
+}

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -20,6 +20,11 @@ import {
   LEGACY_DEFAULT_MAX_TOKENS,
   resolveRequestMaxTokens,
 } from './output-budget.js'
+import {
+  formatLlmHttpUserMessage,
+  logLlmHttpError,
+  type LlmErrorCfgHint,
+} from './llm-error-message.js'
 
 export {
   LEGACY_DEFAULT_MAX_TOKENS,
@@ -173,28 +178,6 @@ export function createProvider(cfg: LlmConfig): LlmProvider {
   return new OpenAiCompatibleProvider(cfg)
 }
 
-function isContextLengthHttpError(status: number, body: string): boolean {
-  const text = body.toLowerCase()
-  if (
-    text.includes('context_length_exceeded')
-    || text.includes('context length')
-    || text.includes('maximum context')
-    || text.includes('too many tokens')
-    || text.includes('prompt is too long')
-    || text.includes('token limit')
-    || (text.includes('context window') && text.includes('exceed'))
-  ) {
-    return true
-  }
-  // 部分网关用 400/413 表示超限
-  if ((status === 400 || status === 413) && (
-    text.includes('token') || text.includes('context') || text.includes('length')
-  )) {
-    return /exceed|too (?:long|large|many)|maximum|limit/i.test(text)
-  }
-  return false
-}
-
 function serializeMessageContent(content: ChatMessage['content']): string | ContentPart[] | null {
   if (content == null) return null
   if (typeof content === 'string') return content
@@ -218,20 +201,21 @@ function serializeMessage(m: ChatMessage): Record<string, unknown> {
   }
 }
 
-function httpErrorTurn(status: number, bodyText: string): LlmTurn {
-  const overflow = isContextLengthHttpError(status, bodyText)
-  const msg = status === 401
-    ? '⚠️ API Key 无效'
-    : status === 429
-      ? '⚠️ 请求过于频繁'
-      : overflow
-        ? '对话内容过多，正在整理后重试…'
-        : `⚠️ HTTP ${status}: ${bodyText}`
+function httpErrorTurn(
+  status: number,
+  bodyText: string,
+  cfg?: LlmErrorCfgHint,
+): LlmTurn {
+  const hint: LlmErrorCfgHint | undefined = cfg
+    ? { provider: cfg.provider, model: cfg.model }
+    : undefined
+  logLlmHttpError(status, bodyText, hint)
+  const { userMessage, contextOverflow } = formatLlmHttpUserMessage(status, bodyText, hint)
   return {
-    message: { role: 'assistant', content: msg },
+    message: { role: 'assistant', content: userMessage },
     finishReason: 'error',
-    error: overflow ? 'context_length_exceeded' : msg,
-    contextOverflow: overflow,
+    error: contextOverflow ? 'context_length_exceeded' : userMessage,
+    contextOverflow,
   }
 }
 
@@ -679,19 +663,19 @@ export class OpenAiCompatibleProvider implements LlmProvider {
               if (!fallback.ok) {
                 const fbText = (await fallback.text()).slice(0, 300)
                 noteHttpError(fallback.status, fbText)
-                return httpErrorTurn(fallback.status, fbText)
+                return httpErrorTurn(fallback.status, fbText, this.cfg)
               }
               return await parseJsonTurn(fallback)
             }
             noteHttpError(streamResp.status, text)
-            return httpErrorTurn(streamResp.status, text)
+            return httpErrorTurn(streamResp.status, text, this.cfg)
           }
           if (!streamResp.body) {
             const fallback = await postWithToolChoiceFallback(false)
             if (!fallback.ok) {
               const fbText = (await fallback.text()).slice(0, 300)
               noteHttpError(fallback.status, fbText)
-              return httpErrorTurn(fallback.status, fbText)
+              return httpErrorTurn(fallback.status, fbText, this.cfg)
             }
             return await parseJsonTurn(fallback)
           }
@@ -709,7 +693,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
             if (!fallback.ok) {
               const fbText = (await fallback.text()).slice(0, 300)
               noteHttpError(fallback.status, fbText)
-              return httpErrorTurn(fallback.status, fbText)
+              return httpErrorTurn(fallback.status, fbText, this.cfg)
             }
             return await parseJsonTurn(fallback)
           }
@@ -721,7 +705,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       if (!resp.ok) {
         const text = (await resp.text()).slice(0, 300)
         noteHttpError(resp.status, text)
-        return httpErrorTurn(resp.status, text)
+        return httpErrorTurn(resp.status, text, this.cfg)
       }
       return await parseJsonTurn(resp)
     } catch (e) {

--- a/packages/agent/src/local-data-catalog.ts
+++ b/packages/agent/src/local-data-catalog.ts
@@ -237,8 +237,15 @@ const AGENT_TOOLS: Array<{
     id: 'tool.prepare_fuyao_dump',
     title: 'prepare_fuyao_dump',
     summary: '服务端取扶摇 dump 到 shared；冷下载异步 job；full/incr 就绪自动写 offline-k-meta',
-    how: 'Agent tool prepare_fuyao_dump({ dump_kind, mode?, force_refresh? })；若 status=preparing 则 prepare_fuyao_dump({ job_id }) 轮询',
+    how: 'Agent tool prepare_fuyao_dump({ dump_kind, mode?, force_refresh? })；若 status=preparing 则优先 schedule_turn_wake(suggested_wake_seconds) 再查，或 prepare_fuyao_dump({ job_id })',
     example: 'prepare_fuyao_dump({ dump_kind: "incremental", mode: "local_path" })',
+  },
+  {
+    id: 'tool.schedule_turn_wake',
+    title: 'schedule_turn_wake',
+    summary: '延后同会话自动续跑（异步 preparing 优先）',
+    how: 'Agent tool schedule_turn_wake({ seconds, prompt, reason?, job_id? })；seconds∈[5,1800]',
+    example: 'schedule_turn_wake({ seconds: 90, prompt: "检查 prepare_fuyao_dump 是否就绪并继续", job_id: "<id>" })',
   },
   {
     id: 'tool.request_session_lan_access',
@@ -323,7 +330,7 @@ const CN_OFFLINE_DAILY_K: LocalDataApiDetail = {
   access: 'shared',
   how_to_call:
     '初始化 shared 时自动落到 packages/cn-offline-daily-k（内置模板，不覆盖用户已改文件）。'
-    + '先 decideDumpKind（>10 日未成功更新则 full）→ prepare_fuyao_dump（冷下载可能 preparing+job_id，须 prepare_fuyao_dump({ job_id }) 轮询；full|incremental + local_path 就绪后自动写 data/cache/offline-k-meta.json）→ 计算全市场指标落盘 data/cache/indicators/ → query/screen；'
+    + '先 decideDumpKind（>10 日未成功更新则 full）→ prepare_fuyao_dump（冷下载可能 preparing+suggested_wake_seconds，优先 schedule_turn_wake 再查；full|incremental + local_path 就绪后自动写 data/cache/offline-k-meta.json）→ 计算全市场指标落盘 data/cache/indicators/ → query/screen；'
     + 'markUpdateSuccess 仅作手动补写保留',
   layer_entry: 'templates/cn-offline-daily-k → shared/packages/cn-offline-daily-k（auto-seed）',
   params: [
@@ -333,7 +340,7 @@ const CN_OFFLINE_DAILY_K: LocalDataApiDetail = {
   notes: [
     '禁止 market sync / importDailyKDump / 写 App 主行情库',
     '禁止 API Key 进沙盒；扶摇鉴权仅经 prepare_fuyao_dump',
-    '冷下载非同步：status=preparing 时用 job_id 再调 prepare_fuyao_dump 轮询，勿死等',
+    '冷下载非同步：status=preparing 时优先 schedule_turn_wake(suggested_wake_seconds)，勿 tight-poll',
     '元数据只写 shared/data/cache/offline-k-meta.json',
     '本地指标缓存约定：shared/data/cache/indicators/（按标的或指标族 Parquet/JSON；Agent 自行计算，非包内引擎）',
   ],
@@ -341,6 +348,7 @@ const CN_OFFLINE_DAILY_K: LocalDataApiDetail = {
     'get_local_data_catalog({ api_id: "shared.packages.cn-offline-daily-k" })',
     'prepare_fuyao_dump({ dump_kind: "full" })',
     'prepare_fuyao_dump({ job_id: "<from preparing>" })',
+    'schedule_turn_wake({ seconds: 90, prompt: "检查 dump 是否就绪并继续", job_id: "<from preparing>" })',
     'workspace_list({ root_id: "shared", path: "packages/cn-offline-daily-k" })',
   ],
 }
@@ -353,7 +361,7 @@ const FUYAO_DUMP: LocalDataApiDetail = {
   access: 'agent_tool',
   how_to_call:
     'prepare_fuyao_dump({ dump_kind: "full"|"incremental"|"adjustment_factors", mode: "local_path"|"presigned_url", force_refresh? })；'
-    + '冷下载立即 preparing+job_id，须再调 prepare_fuyao_dump({ job_id }) 轮询至 ready，勿死等',
+    + '冷下载立即 preparing+suggested_wake_seconds，优先 schedule_turn_wake 再查（勿 tight-poll）',
   params: [
     { name: 'dump_kind', type: 'string', required: true, description: 'full | incremental | adjustment_factors（轮询时可不传）' },
     { name: 'mode', type: 'string', description: 'local_path（默认）| presigned_url' },
@@ -363,13 +371,14 @@ const FUYAO_DUMP: LocalDataApiDetail = {
   layer_entry: 'shared/data/dumps via prepareFuyaoDumpForAgent',
   notes: [
     '禁止向沙盒注入 API Key；勿引导 market sync / dailyDump',
-    '缓存命中/presigned_url 可同步 ready；local_path 冷下载为异步 preparing，勿当旧同步语义死等',
+    '缓存命中/presigned_url 可同步 ready；local_path 冷下载为异步 preparing，优先 schedule_turn_wake，勿 tight-poll',
     '成功返回 root_id=shared + relative_path',
     'full|incremental + local_path 就绪后服务端自动写 shared/data/cache/offline-k-meta.json（meta_written）；adjustment_factors / presigned_url 不写',
   ],
   examples: [
     'prepare_fuyao_dump({ dump_kind: "incremental" })',
     'prepare_fuyao_dump({ job_id: "<from preparing>" })',
+    'schedule_turn_wake({ seconds: 120, prompt: "检查 prepare_fuyao_dump 是否就绪并继续" })',
     'prepare_fuyao_dump({ dump_kind: "full", mode: "presigned_url" })',
   ],
 }

--- a/packages/agent/src/mcp/tool-route-plan.ts
+++ b/packages/agent/src/mcp/tool-route-plan.ts
@@ -448,7 +448,20 @@ const INTENT_RULES: IntentRule[] = [
     preferredTools: ['python_env_status', 'ensure_python', 'shell_platform_status'],
     avoidTools: ['get_system_info'],
     confidence: 'high',
-    hint: '问 Python 环境/版本 → python_env_status；运行脚本前 ensure_python（未就绪立即 preparing|installing+job_id，须 ensure_python({ job_id }) 轮询至 ready，勿死等）',
+    hint: '问 Python 环境/版本 → python_env_status；运行脚本前 ensure_python（未就绪返回 preparing|installing+suggested_wake_seconds，优先 schedule_turn_wake 再查，勿 tight-poll）',
+  },
+  {
+    intent: 'turn_wake',
+    priority: 86,
+    patterns: [
+      /定时唤醒|延后(?:检查|续跑|继续)|稍后(?:再|继续)|等一会儿|几分钟后再/i,
+      /schedule_turn_wake/i,
+      /等(?:下载|安装|准备).*(?:完|好|就绪)/,
+    ],
+    preferredTools: ['schedule_turn_wake', 'get_current_time'],
+    avoidTools: [],
+    confidence: 'high',
+    hint: '延后续跑/等异步任务 → schedule_turn_wake（seconds∈[5,1800]，prompt 必填）；优先于对 prepare_fuyao_dump/ensure_python 的 tight-poll',
   },
   {
     intent: 'workspace_network_latency',
@@ -536,7 +549,7 @@ const INTENT_RULES: IntentRule[] = [
     preferredTools: ['prepare_fuyao_dump', 'list_local_data_apis', 'workspace_list'],
     avoidTools: ['http_fetch', 'opptrix_run'],
     confidence: 'high',
-    hint: '扶摇离线 dump → prepare_fuyao_dump 落盘 shared；冷下载 preparing+job_id，须 prepare_fuyao_dump({ job_id }) 轮询；禁止 Key 进沙盒，勿 sync/dailyDump',
+    hint: '扶摇离线 dump → prepare_fuyao_dump 落盘 shared；冷下载 preparing+suggested_wake_seconds，优先 schedule_turn_wake 再查（勿 tight-poll）；禁止 Key 进沙盒，勿 sync/dailyDump',
   },
   {
     intent: 'session_lan',

--- a/packages/agent/src/mcp/workspace-tools.ts
+++ b/packages/agent/src/mcp/workspace-tools.ts
@@ -762,7 +762,7 @@ export function buildWorkspaceTools(): WorkspaceToolDef[] {
       name: 'ensure_python',
       category: '工作区',
       description:
-        '确认 Python 是否可用；不可用时启动 Opptrix 托管安装并立即返回 preparing/installing+job_id，须用 job_id 轮询至 ready；已就绪则同步返回 ready',
+        '确认 Python 是否可用；不可用时启动 Opptrix 托管安装并立即返回 preparing/installing+job_id+suggested_wake_seconds，优先 schedule_turn_wake 再查；已就绪则同步返回 ready',
       parameters: S({
         job_id: {
           type: 'string',
@@ -825,7 +825,7 @@ export function buildWorkspaceTools(): WorkspaceToolDef[] {
       name: 'prepare_fuyao_dump',
       category: '工作区',
       description:
-        '服务端鉴权下载扶摇 Parquet 到公共区 shared/data/dumps，或返回短时效 URL；冷下载立即返回 preparing+job_id，需用 job_id 轮询；禁止把密钥注入沙盒，勿引导 sync/dailyDump',
+        '服务端鉴权下载扶摇 Parquet 到公共区 shared/data/dumps，或返回短时效 URL；冷下载立即返回 preparing+job_id+suggested_wake_seconds，优先 schedule_turn_wake 再查；禁止把密钥注入沙盒，勿引导 sync/dailyDump',
       parameters: S({
         dump_kind: {
           type: 'string',
@@ -859,6 +859,9 @@ export function buildWorkspaceTools(): WorkspaceToolDef[] {
                 dump_kind: polled.dump_kind,
                 percent: polled.percent,
                 message: polled.message,
+                eta_seconds: polled.eta_seconds,
+                suggested_wake_seconds: polled.suggested_wake_seconds,
+                async_hint: polled.async_hint,
                 poll_hint: polled.poll_hint,
                 sandbox_hint: polled.sandbox_hint,
               }
@@ -901,6 +904,9 @@ export function buildWorkspaceTools(): WorkspaceToolDef[] {
               dump_kind: result.dump_kind,
               percent: result.percent,
               message: result.message,
+              eta_seconds: result.eta_seconds,
+              suggested_wake_seconds: result.suggested_wake_seconds,
+              async_hint: result.async_hint,
               poll_hint: result.poll_hint,
               sandbox_hint: result.sandbox_hint,
             }

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -456,6 +456,13 @@ export const TOOL_META: Record<string, ToolMeta> = {
     usageGuide: '仅当用户明确问「现在几点/星期几」或需二次核对时间时调用；日常「截至」时效请用 system【会话时钟】，勿每轮必调。',
     compliance: '只读；与会话时钟重复时优先会话时钟。',
   },
+  schedule_turn_wake: {
+    miningEligible: false,
+    usageGuide:
+      '异步任务（prepare_fuyao_dump / ensure_python 等返回 preparing）或需延后续跑时：挂起本轮并用本工具按 suggested_wake_seconds 到期同会话自动唤醒；任何场景可调用（core always-on）。',
+    compliance:
+      'seconds∈[5,1800]；prompt 必填；可多次挂（每会话上限 8）；到期注入含时间元数据的 user 消息并新开一轮（非 steer）；活跃对话中不打断；进程内存 timer，关应用丢失。优先于 tight-poll。',
+  },
   get_system_info: {
     miningEligible: false,
     usageGuide: '运行 opptrix_run 前先调用，确认 platform 与沙盒 node/python/npm 是否就绪；桌面端 node 由应用内嵌运行时提供，勿因 PATH 无 node 声称无法执行。',
@@ -772,9 +779,9 @@ export const TOOL_META: Record<string, ToolMeta> = {
   ensure_python: {
     packId: 'workspace',
     usageGuide:
-      '运行 Python 脚本或 pip 安装前调用；未就绪时立即返回 preparing/installing+job_id，须再调 ensure_python({ job_id }) 轮询至 ready；成功后优先使用 Opptrix 托管解释器。',
+      '运行 Python 脚本或 pip 安装前调用；未就绪时立即返回 preparing/installing+job_id+suggested_wake_seconds；优先 schedule_turn_wake 到期后再查，勿 tight-poll。',
     compliance:
-      '勿在本轮死等安装；status=preparing|installing 时用返回的 job_id 轮询（反空转对进行中 status 豁免）；ready 后勿空转同参；ready 时 ready=true 且 prefer 托管；failed 时 ready=false，勿假装已安装。opptrix_run 在 python 未就绪时会快速失败并提示先 ensure_python。',
+      '勿在本轮死等安装；status=preparing|installing 时用 suggested_wake_seconds + schedule_turn_wake（prompt 含检查 ensure_python job_id），或必要时再调 ensure_python({ job_id })；反空转对进行中 status 豁免；ready 后勿空转同参；failed 勿假装已安装。',
   },
   list_local_data_apis: {
     packId: 'workspace',
@@ -788,9 +795,10 @@ export const TOOL_META: Record<string, ToolMeta> = {
   },
   prepare_fuyao_dump: {
     packId: 'workspace',
-    usageGuide: '需要扶摇全量/增量日 K 或复权因子 Parquet 时调用；落盘 shared/data/dumps 或返回短时效 URL；冷下载可能先返回 preparing+job_id，须轮询。',
+    usageGuide:
+      '需要扶摇全量/增量日 K 或复权因子 Parquet 时调用；落盘 shared/data/dumps 或短时效 URL；冷下载可能 preparing+job_id+suggested_wake_seconds，优先 schedule_turn_wake 再查。',
     compliance:
-      '服务端持密钥；禁止明文注入沙盒；勿引导 sync/dailyDump；缓存命中/presigned_url 同步 ready；local_path 冷下载立即 preparing，用 job_id 再调本工具轮询（反空转对 preparing/installing 等进行中 status 豁免；ready 后勿空转同参）；full|incremental + local_path 就绪后自动写 offline-k-meta；adjustment_factors/presigned_url 不写 meta；成功用 root_id=shared + relative_path。',
+      '服务端持密钥；禁止明文注入沙盒；勿引导 sync/dailyDump；缓存命中/presigned_url 同步 ready；local_path 冷下载立即 preparing，用 suggested_wake_seconds + schedule_turn_wake（或必要时 job_id 再调本工具）；勿 tight-poll；full|incremental + local_path 就绪后自动写 offline-k-meta。',
   },
   request_session_lan_access: {
     packId: 'workspace',

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -25,6 +25,7 @@ import { currentToolSessionId } from './mcp/tool-session-context.js'
 import { buildRsshubTools } from './rsshub/rsshub-tools.js'
 import { resolveInstrumentFromParams, resolveOpptrixAppVersion } from '@opptrix/shared'
 import { assembleSystemPrompt } from './experts/prompt-assembler.js'
+import { scheduleTurnWake } from './turn-wake.js'
 
 /** @deprecated 使用 DATA_LAYER_MINING_TOOL_NAMES */
 export const DISCOVER_MINING_TOOL_NAMES = DATA_LAYER_MINING_TOOL_NAMES
@@ -614,6 +615,43 @@ export class ToolRegistry {
         description: '获取当前时间（ISO、本地时区、Unix 毫秒、星期）',
         parameters: S({}),
         handler: async () => getCurrentTime(),
+      },
+      {
+        name: 'schedule_turn_wake',
+        category: '基础',
+        description:
+          '结束本轮后按秒数在同会话自动唤醒续跑（注入含 prompt 的用户消息并新开一轮）；用于异步准备（如 dump/Python）勿 tight-poll；seconds 5–1800',
+        parameters: S({
+          seconds: {
+            type: 'number',
+            description: '延迟秒数，闭区间 [5, 1800]（30 分钟）；超出将钳制',
+          },
+          prompt: {
+            type: 'string',
+            description: '到期后注入的续跑说明（必填）；应写清要检查什么、如何继续',
+          },
+          reason: {
+            type: 'string',
+            description: '可选：挂起原因（如 waiting_fuyao_dump / waiting_python）',
+          },
+          job_id: {
+            type: 'string',
+            description: '可选：关联异步任务 id（prepare_fuyao_dump / ensure_python 的 job_id）',
+          },
+        }, ['seconds', 'prompt']),
+        handler: async (args: Record<string, unknown>) => {
+          const sessionId = currentToolSessionId()
+          if (!sessionId) {
+            return { ok: false, error: 'schedule_turn_wake 须在聊天会话工具上下文中调用' }
+          }
+          return scheduleTurnWake({
+            sessionId,
+            seconds: args.seconds,
+            prompt: String(args.prompt ?? ''),
+            reason: args.reason != null ? String(args.reason) : undefined,
+            jobId: args.job_id != null ? String(args.job_id) : undefined,
+          })
+        },
       },
       {
         name: 'get_system_info', category: '基础',

--- a/packages/agent/src/turn-wake.ts
+++ b/packages/agent/src/turn-wake.ts
@@ -1,0 +1,346 @@
+/**
+ * 同会话定时唤醒（进程内存 timer）。
+ * 到期后新开一轮 agent.chat；活跃 chat 时延期，不 abort 当前轮。
+ * 关进程后 timer 丢失，须在文档中说明。
+ */
+import { randomUUID } from 'node:crypto'
+
+export const TURN_WAKE_MIN_SECONDS = 5
+export const TURN_WAKE_MAX_SECONDS = 1800
+export const TURN_WAKE_MAX_PER_SESSION = 8
+export const TURN_WAKE_PROMPT_MAX_CHARS = 4000
+/** 会话有活跃 chat 时延期再试（秒） */
+export const TURN_WAKE_BUSY_DEFER_SECONDS = 10
+
+export interface TurnWakeJob {
+  id: string
+  sessionId: string
+  prompt: string
+  seconds: number
+  scheduledAt: string
+  fireAt: string
+  reason?: string
+  /** 关联的异步任务 id（如 prepare_fuyao_dump / ensure_python 的 job_id） */
+  jobId?: string
+  model?: string
+}
+
+export type TurnWakeResumeHandler = (job: TurnWakeJob, wakeMessage: string) => Promise<void>
+
+export interface TurnWakeRuntime {
+  isSessionAlive: (sessionId: string) => boolean
+  isChatBusy: (sessionId: string) => boolean
+  now?: () => number
+  setTimeout?: typeof setTimeout
+  clearTimeout?: typeof clearTimeout
+}
+
+interface InternalEntry {
+  job: TurnWakeJob
+  timer: ReturnType<typeof setTimeout>
+}
+
+const byId = new Map<string, InternalEntry>()
+const bySession = new Map<string, Set<string>>()
+
+let resumeHandler: TurnWakeResumeHandler | null = null
+let runtime: TurnWakeRuntime | null = null
+
+export function setTurnWakeResumeHandler(handler: TurnWakeResumeHandler | null): void {
+  resumeHandler = handler
+}
+
+export function configureTurnWakeRuntime(next: TurnWakeRuntime | null): void {
+  runtime = next
+}
+
+export function clampWakeSeconds(raw: unknown): number {
+  const n = typeof raw === 'number' ? raw : Number(raw)
+  if (!Number.isFinite(n)) return TURN_WAKE_MIN_SECONDS
+  return Math.min(TURN_WAKE_MAX_SECONDS, Math.max(TURN_WAKE_MIN_SECONDS, Math.floor(n)))
+}
+
+export function clampSuggestedWakeSeconds(etaSeconds: number | undefined | null): number {
+  if (etaSeconds == null || !Number.isFinite(etaSeconds)) {
+    return 60
+  }
+  return clampWakeSeconds(Math.ceil(etaSeconds))
+}
+
+/**
+ * 由进度百分比 + 已用时间估算剩余秒数；无有效进度时用 heuristicDefault。
+ */
+export function estimateEtaFromProgress(opts: {
+  percent?: number | null
+  startedAtMs?: number | null
+  nowMs?: number
+  heuristicDefaultSeconds?: number
+  bytesDownloaded?: number | null
+  bytesTotal?: number | null
+}): number {
+  const now = opts.nowMs ?? Date.now()
+  const started = opts.startedAtMs
+  const elapsedSec =
+    started != null && Number.isFinite(started) && started > 0
+      ? Math.max(1, (now - started) / 1000)
+      : null
+
+  const bytesTotal = opts.bytesTotal
+  const bytesDownloaded = opts.bytesDownloaded
+  if (
+    elapsedSec != null
+    && bytesTotal != null
+    && bytesTotal > 0
+    && bytesDownloaded != null
+    && bytesDownloaded > 0
+    && bytesDownloaded < bytesTotal
+  ) {
+    const rate = bytesDownloaded / elapsedSec
+    if (rate > 0) {
+      const remaining = (bytesTotal - bytesDownloaded) / rate
+      return Math.ceil(remaining * 1.15)
+    }
+  }
+
+  const pct = opts.percent
+  if (
+    elapsedSec != null
+    && pct != null
+    && Number.isFinite(pct)
+    && pct >= 5
+    && pct < 99
+  ) {
+    const remaining = elapsedSec * (100 - pct) / pct
+    return Math.ceil(remaining * 1.15)
+  }
+
+  return Math.max(TURN_WAKE_MIN_SECONDS, opts.heuristicDefaultSeconds ?? 60)
+}
+
+export function formatWakeMessage(job: TurnWakeJob, firedAtIso?: string): string {
+  const lines = [
+    '【定时唤醒】',
+    '请根据下列回调继续执行（同会话自动续跑）：',
+    '',
+    job.prompt.trim(),
+    '',
+    '---',
+    `wake_id: ${job.id}`,
+    `scheduled_at: ${job.scheduledAt}`,
+    `fire_at: ${job.fireAt}`,
+    `delay_s: ${job.seconds}`,
+  ]
+  if (firedAtIso) lines.push(`fired_at: ${firedAtIso}`)
+  if (job.reason?.trim()) lines.push(`reason: ${job.reason.trim()}`)
+  if (job.jobId?.trim()) lines.push(`job_id: ${job.jobId.trim()}`)
+  lines.push('说明: 先检查关联异步任务是否就绪，再继续原计划；勿 tight-poll。')
+  return lines.join('\n')
+}
+
+function sessionSet(sessionId: string): Set<string> {
+  let s = bySession.get(sessionId)
+  if (!s) {
+    s = new Set()
+    bySession.set(sessionId, s)
+  }
+  return s
+}
+
+function removeEntry(id: string): void {
+  const entry = byId.get(id)
+  if (!entry) return
+  const clear = runtime?.clearTimeout ?? clearTimeout
+  clear(entry.timer)
+  byId.delete(id)
+  const set = bySession.get(entry.job.sessionId)
+  if (set) {
+    set.delete(id)
+    if (set.size === 0) bySession.delete(entry.job.sessionId)
+  }
+}
+
+function scheduleTimer(job: TurnWakeJob, delayMs: number): void {
+  const setT = runtime?.setTimeout ?? setTimeout
+  const timer = setT(() => {
+    void onTimerFire(job.id)
+  }, Math.max(0, delayMs))
+  if (typeof timer === 'object' && timer !== null && 'unref' in timer) {
+    try {
+      ;(timer as { unref: () => void }).unref()
+    } catch {
+      /* ignore */
+    }
+  }
+  byId.set(job.id, { job, timer })
+  sessionSet(job.sessionId).add(job.id)
+}
+
+async function onTimerFire(id: string): Promise<void> {
+  const entry = byId.get(id)
+  if (!entry) return
+  const { job } = entry
+  // 从 map 移除但先不删 job 元数据；busy 时会重新挂
+  byId.delete(id)
+  const set = bySession.get(job.sessionId)
+  if (set) {
+    set.delete(id)
+    if (set.size === 0) bySession.delete(job.sessionId)
+  }
+
+  const alive = runtime?.isSessionAlive(job.sessionId) ?? true
+  if (!alive) return
+
+  if (runtime?.isChatBusy(job.sessionId)) {
+    const now = runtime.now?.() ?? Date.now()
+    const deferMs = TURN_WAKE_BUSY_DEFER_SECONDS * 1000
+    const deferred: TurnWakeJob = {
+      ...job,
+      fireAt: new Date(now + deferMs).toISOString(),
+    }
+    scheduleTimer(deferred, deferMs)
+    return
+  }
+
+  const handler = resumeHandler
+  if (!handler) {
+    console.warn('[turn-wake] resume handler unset; drop wake', job.id)
+    return
+  }
+  const wakeMessage = formatWakeMessage(job, new Date(runtime?.now?.() ?? Date.now()).toISOString())
+  try {
+    await handler(job, wakeMessage)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.warn(`[turn-wake] resume failed (${job.id}): ${msg}`)
+  }
+}
+
+export function scheduleTurnWake(input: {
+  sessionId: string
+  prompt: string
+  seconds: unknown
+  reason?: string
+  jobId?: string
+  model?: string
+}): { ok: true; wake_id: string; session_id: string; seconds: number; fire_at: string; scheduled_at: string; prompt: string; reason?: string; job_id?: string; note: string }
+  | { ok: false; error: string } {
+  const sessionId = String(input.sessionId ?? '').trim()
+  if (!sessionId) return { ok: false, error: 'session_id 不可用（须在聊天会话中调用）' }
+
+  if (runtime && !runtime.isSessionAlive(sessionId)) {
+    return { ok: false, error: '会话不存在或已删除' }
+  }
+
+  const prompt = String(input.prompt ?? '').trim()
+  if (!prompt) return { ok: false, error: 'prompt 必填（到期后注入的续跑说明）' }
+  if (prompt.length > TURN_WAKE_PROMPT_MAX_CHARS) {
+    return { ok: false, error: `prompt 过长（上限 ${TURN_WAKE_PROMPT_MAX_CHARS} 字）` }
+  }
+
+  const existing = bySession.get(sessionId)
+  if (existing && existing.size >= TURN_WAKE_MAX_PER_SESSION) {
+    return { ok: false, error: `本会话定时唤醒已达上限（${TURN_WAKE_MAX_PER_SESSION}）` }
+  }
+
+  const seconds = clampWakeSeconds(input.seconds)
+  const now = runtime?.now?.() ?? Date.now()
+  const scheduledAt = new Date(now).toISOString()
+  const fireAt = new Date(now + seconds * 1000).toISOString()
+  const reason = input.reason?.trim() || undefined
+  const jobId = input.jobId?.trim() || undefined
+
+  const job: TurnWakeJob = {
+    id: randomUUID(),
+    sessionId,
+    prompt,
+    seconds,
+    scheduledAt,
+    fireAt,
+    reason,
+    jobId,
+    model: input.model?.trim() || undefined,
+  }
+
+  scheduleTimer(job, seconds * 1000)
+
+  return {
+    ok: true,
+    wake_id: job.id,
+    session_id: sessionId,
+    seconds,
+    fire_at: fireAt,
+    scheduled_at: scheduledAt,
+    prompt,
+    ...(reason ? { reason } : {}),
+    ...(jobId ? { job_id: jobId } : {}),
+    note:
+      '本轮可结束。到期后将在同会话自动注入续跑消息并新开一轮（交互模式）。定时器仅存进程内存，关闭应用会丢失。',
+  }
+}
+
+export function cancelTurnWake(wakeId: string): boolean {
+  const id = String(wakeId ?? '').trim()
+  if (!id || !byId.has(id)) return false
+  removeEntry(id)
+  return true
+}
+
+export function clearSessionTurnWakes(sessionId: string): number {
+  const id = String(sessionId ?? '').trim()
+  const set = bySession.get(id)
+  if (!set || set.size === 0) return 0
+  const ids = [...set]
+  for (const wakeId of ids) removeEntry(wakeId)
+  return ids.length
+}
+
+export type PendingTurnWakeInfo = {
+  wake_id: string
+  fire_at: string
+  reason?: string
+  seconds_left: number
+  seconds: number
+}
+
+/** 列出会话未到期唤醒（供 UI 恢复倒计时） */
+export function listPendingTurnWakes(
+  sessionId: string,
+  nowMs?: number,
+): PendingTurnWakeInfo[] {
+  const id = String(sessionId ?? '').trim()
+  if (!id) return []
+  const set = bySession.get(id)
+  if (!set || set.size === 0) return []
+  const now = nowMs ?? runtime?.now?.() ?? Date.now()
+  const out: PendingTurnWakeInfo[] = []
+  for (const wakeId of set) {
+    const entry = byId.get(wakeId)
+    if (!entry) continue
+    const fireMs = Date.parse(entry.job.fireAt)
+    const secondsLeft = Number.isFinite(fireMs)
+      ? Math.max(0, Math.ceil((fireMs - now) / 1000))
+      : Math.max(0, entry.job.seconds)
+    out.push({
+      wake_id: entry.job.id,
+      fire_at: entry.job.fireAt,
+      ...(entry.job.reason ? { reason: entry.job.reason } : {}),
+      seconds_left: secondsLeft,
+      seconds: entry.job.seconds,
+    })
+  }
+  return out.sort((a, b) => a.seconds_left - b.seconds_left)
+}
+
+/** 测试：当前挂起数量 */
+export function listTurnWakeIdsForTests(sessionId?: string): string[] {
+  if (sessionId) return [...(bySession.get(sessionId) ?? [])]
+  return [...byId.keys()]
+}
+
+export function resetTurnWakeForTests(): void {
+  for (const id of [...byId.keys()]) removeEntry(id)
+  byId.clear()
+  bySession.clear()
+  resumeHandler = null
+  runtime = null
+}

--- a/packages/market-data/src/sync/fuyao-dump-job.ts
+++ b/packages/market-data/src/sync/fuyao-dump-job.ts
@@ -22,6 +22,12 @@ export interface FuyaoDumpJobResult {
   status: FuyaoDumpJobState
   job_id?: string
   poll_hint?: string
+  /** 估算剩余秒数（下载进度或启发式） */
+  eta_seconds?: number
+  /** 建议 schedule_turn_wake 的 seconds */
+  suggested_wake_seconds?: number
+  /** 异步说明：可先干别的再醒 */
+  async_hint?: string
   path?: string
   url?: string
   url_expires_hint?: string
@@ -42,6 +48,7 @@ interface JobRecord {
   destDir: string
   percent: number
   message: string
+  startedAt: number
   result?: Awaited<ReturnType<typeof prepareFuyaoDump>>
   error?: string
   updatedAt: number
@@ -59,6 +66,29 @@ const DUMP_FILE_NAMES: Record<FuyaoDumpKind, string> = {
 
 const SANDBOX_HINT =
   '已在服务端完成鉴权下载；沙盒请用返回的 path（root_id=shared）或短时效 url，禁止注入 API Key。图表与诊断请用在线行情，勿引导跑 market sync / 主库日 K 导入。'
+
+const ASYNC_HINT =
+  '任务在后台进行。可结束本轮并用 schedule_turn_wake({ seconds: suggested_wake_seconds, prompt: "检查 prepare_fuyao_dump 是否就绪并继续", job_id }) 到期后同会话自动续跑；勿 tight-poll。'
+
+function heuristicDumpEtaSeconds(kind: FuyaoDumpKind): number {
+  if (kind === 'full') return 180
+  if (kind === 'incremental') return 60
+  return 45
+}
+
+function estimateDumpEtaSeconds(job: JobRecord): number {
+  const now = Date.now()
+  const elapsedSec = Math.max(1, (now - job.startedAt) / 1000)
+  const pct = Math.min(99, Math.max(0, job.percent))
+  if (pct >= 5 && pct < 99) {
+    return Math.ceil(elapsedSec * (100 - pct) / pct * 1.15)
+  }
+  return heuristicDumpEtaSeconds(job.dumpKind)
+}
+
+function clampSuggestedWake(eta: number): number {
+  return Math.min(1800, Math.max(5, Math.ceil(eta)))
+}
 
 function jobKey(kind: FuyaoDumpKind, destDir: string, forceRefresh: boolean): string {
   return `${kind}|${path.resolve(destDir)}|force=${forceRefresh ? 1 : 0}`
@@ -86,6 +116,8 @@ export function isFuyaoDumpLocalCacheReady(
 
 function recordToResult(job: JobRecord): FuyaoDumpJobResult {
   if (job.status === 'preparing') {
+    const eta = estimateDumpEtaSeconds(job)
+    const suggested = clampSuggestedWake(eta)
     return {
       ok: true,
       status: 'preparing',
@@ -94,8 +126,11 @@ function recordToResult(job: JobRecord): FuyaoDumpJobResult {
       sandbox_hint: SANDBOX_HINT,
       percent: job.percent,
       message: job.message,
+      eta_seconds: eta,
+      suggested_wake_seconds: suggested,
+      async_hint: ASYNC_HINT,
       poll_hint:
-        '冷下载进行中。请再次调用 prepare_fuyao_dump({ job_id }) 轮询；就绪后返回 path/url。勿重复 force_refresh 另起任务。',
+        `冷下载进行中（约 ${suggested}s）。优先 schedule_turn_wake({ seconds: ${suggested}, prompt: "检查 prepare_fuyao_dump job_id=${job.id} 是否就绪并继续", job_id: "${job.id}" })；必要时再调 prepare_fuyao_dump({ job_id })。勿 tight-poll、勿重复 force_refresh。`,
     }
   }
   if (job.status === 'failed' || !job.result?.ok) {
@@ -159,6 +194,7 @@ function startBackgroundJob(opts: {
     destDir: opts.destDir,
     percent: 5,
     message: '正在后台准备离线数据包…',
+    startedAt: Date.now(),
     updatedAt: Date.now(),
   }
   jobs.set(id, record)

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -165,7 +165,7 @@ export function buildWorkspaceAccessPlaybook(): string {
     '- 运行 opptrix_run 前先 get_system_info（或 python_env_status 查 Python）；确认 node_ready / npm_ready / python_ready / python_priority 与 platform',
     '- opptrix_run / shell_install argv 只用字面量 python / python3 / pip（或 node/npm）；禁止手写系统或 Opptrix 托管绝对路径；运行时会静默改写到当前优先解释器',
     '- install 与 run 共用同一解释器；pip 依赖装进工作区 .opptrix-packages，运行时自动经 PYTHONPATH 可见',
-    '- 依赖安装用 shell_install(manager=pip|npm)；pip 镜像由设置注入；python 未就绪时先 ensure_python（未就绪立即 preparing|installing+job_id → 再调 ensure_python({ job_id }) 轮询，勿死等）',
+    '- 依赖安装用 shell_install(manager=pip|npm)；pip 镜像由设置注入；python 未就绪时先 ensure_python（未就绪立即 preparing|installing+suggested_wake_seconds → 优先 schedule_turn_wake 到期再查，勿 tight-poll）',
     '- python_env_status 只描述当前优先解释器；勿把「系统 / 托管」两套都当可执行选项',
     '',
     '【opptrix_run — 先识平台，再组 argv】',
@@ -206,7 +206,7 @@ export function buildLocalProgrammingPlaybook(): string {
     '2. 扫 shared/packages/*/README，能复用则复用（root_id=shared）',
     '3. 缺依赖：先 request_shell_network({ intent: "install" })，再 shell_install（npm/pip）；禁止 ask_user 冒充联网授权',
     '4. 最后自写；可复用产物写入 shared/packages/<name>/ + README；workspace_write 默认 LF，.bat/.cmd/.ps1 用平台换行；脚本用 pathlib/path，禁止硬编码本机用户路径',
-    '5. 离线大数据 → prepare_fuyao_dump（冷下载先 preparing+job_id 再轮询）；行情优先标准工具；禁止明文密钥进沙盒（经保险箱 + secret_refs 注入 sentinel）；勿引导 sync/dailyDump',
+    '5. 离线大数据 → prepare_fuyao_dump（冷下载先 preparing+suggested_wake_seconds，优先 schedule_turn_wake 再查）；行情优先标准工具；禁止明文密钥进沙盒（经保险箱 + secret_refs 注入 sentinel）；勿引导 sync/dailyDump',
     '6. 沙盒前：公网安装/已知外网域名 → request_shell_network；局域网 → request_session_lan_access / ask_user(allow_lan_session)；按 get_system_info.platform 选 ping -c/-n、tracert/traceroute',
     '7. 第三方密钥：list_vault_secrets → 已有 grant_session_secret / 没有 request_secret；opptrix_run 用 secret_refs 传名字',
     '8. 沙盒做计算/清洗/汇总；聊天展示图用 ```chart``` / ```opptrix-chart```（→ @opptrix/canvas Chart），禁止默认沙盒出图代替围栏',
@@ -303,6 +303,12 @@ export function buildUserInteractionPlaybook(): string {
     '  · text：开放式/需用户填内容 → mode:"text"（推荐），或空 options + allow_custom=true；仅文本输入，无拒绝/确认授权钮',
     '- 禁止用 confirm 收集开放答案；禁止用 ask_user 索要密钥（须用 request_secret）；禁止在已有明确用户指令时重复确认',
     '- prompt 与 options.label / 按钮文案均不要使用 emoji；收到 selected_ids / selected_labels / custom_text 后再继续；同一轮最多 1 次 ask_user',
+    '',
+    '【定时唤醒 — schedule_turn_wake】',
+    '- 异步准备（prepare_fuyao_dump / ensure_python 等返回 preparing）或需延后续跑：结束本轮并调用 schedule_turn_wake({ seconds, prompt })；seconds∈[5,1800]，优先用返回的 suggested_wake_seconds',
+    '- prompt 必填：写清到期后要检查什么、如何继续；可带 job_id / reason',
+    '- 到期后同会话自动注入含时间元数据的用户消息并新开一轮（非 steer）；有用户正在聊时会延期，不打断',
+    '- 禁止 tight-poll（短间隔反复轮询）；定时器仅存进程内存，关闭应用会丢失',
   ].join('\n')
 }
 

--- a/packages/shared/src/tool-packs.ts
+++ b/packages/shared/src/tool-packs.ts
@@ -143,6 +143,7 @@ export const TOOL_PACK_MEMBERSHIP: Readonly<Record<string, ToolPackId>> = {
   batch_instrument_snapshots: 'core',
   ask_user: 'core',
   get_current_time: 'core',
+  schedule_turn_wake: 'core',
   get_system_info: 'core',
   get_app_settings: 'core',
   get_project_info: 'core',

--- a/tests/llm-http-error-message.test.mjs
+++ b/tests/llm-http-error-message.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * LLM HTTP 错误 → 用户可见文案（无 HTTP/JSON/API Key）
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  LLM_ERR_AUTH,
+  LLM_ERR_BALANCE,
+  LLM_ERR_GENERIC,
+  LLM_ERR_MODEL_UNAVAILABLE,
+  LLM_ERR_OVERFLOW,
+  LLM_ERR_RATE_LIMIT,
+  assertUserSafeLlmErrorMessage,
+  classifyLlmHttpError,
+  extractUpstreamErrorHaystack,
+  formatLlmHttpUserMessage,
+  sanitizeBodyForLog,
+} from '../packages/agent/dist/llm/llm-error-message.js'
+
+function assertChatSafe(msg) {
+  assertUserSafeLlmErrorMessage(msg)
+  assert.equal(/\bHTTP\s+\d/i.test(msg), false)
+  assert.equal(msg.includes('{'), false)
+  assert.equal(/API\s*Key/i.test(msg), false)
+}
+
+test('402 Insufficient Balance → 余额文案', () => {
+  const body = JSON.stringify({
+    error: { message: 'Insufficient Balance', type: 'billing_error', code: 'insufficient_balance' },
+  })
+  const r = formatLlmHttpUserMessage(402, body)
+  assert.equal(r.kind, 'balance')
+  assert.equal(r.userMessage, LLM_ERR_BALANCE)
+  assert.equal(r.contextOverflow, false)
+  assertChatSafe(r.userMessage)
+})
+
+test('body 含 insufficient quota（非 402）→ 余额文案', () => {
+  const r = formatLlmHttpUserMessage(403, 'Error: insufficient_quota for this key')
+  assert.equal(r.kind, 'balance')
+  assert.equal(r.userMessage, LLM_ERR_BALANCE)
+  assertChatSafe(r.userMessage)
+})
+
+test('401 / unauthorized / invalid api key → 访问密钥文案（无 API Key 字样）', () => {
+  const cases = [
+    [401, 'Unauthorized'],
+    [403, JSON.stringify({ error: { message: 'Invalid API Key', code: 'invalid_api_key' } })],
+    [401, '{"error":{"message":"Incorrect API key provided"}}'],
+  ]
+  for (const [status, body] of cases) {
+    const r = formatLlmHttpUserMessage(status, body)
+    assert.equal(r.kind, 'auth', `status=${status} body=${body}`)
+    assert.equal(r.userMessage, LLM_ERR_AUTH)
+    assertChatSafe(r.userMessage)
+  }
+})
+
+test('429 → 频繁请求文案', () => {
+  const r = formatLlmHttpUserMessage(429, '{"error":{"message":"Rate limit exceeded"}}')
+  assert.equal(r.kind, 'rate_limit')
+  assert.equal(r.userMessage, LLM_ERR_RATE_LIMIT)
+  assertChatSafe(r.userMessage)
+})
+
+test('context overflow → 整理后重试，不把 raw body 给用户', () => {
+  const body = JSON.stringify({
+    error: {
+      message: 'This model\'s maximum context length is 128000 tokens',
+      code: 'context_length_exceeded',
+    },
+  })
+  const r = formatLlmHttpUserMessage(400, body)
+  assert.equal(r.kind, 'overflow')
+  assert.equal(r.contextOverflow, true)
+  assert.equal(r.userMessage, LLM_ERR_OVERFLOW)
+  assert.equal(r.userMessage.includes('128000'), false)
+  assertChatSafe(r.userMessage)
+})
+
+test('model not found / 不存在 → 模型不可用', () => {
+  const cases = [
+    [404, JSON.stringify({ error: { message: 'The model `foo` does not exist', code: 'model_not_found' } })],
+    [400, '模型不存在：bar-v1'],
+  ]
+  for (const [status, body] of cases) {
+    const r = formatLlmHttpUserMessage(status, body)
+    assert.equal(r.kind, 'model_unavailable', body)
+    assert.equal(r.userMessage, LLM_ERR_MODEL_UNAVAILABLE)
+    assertChatSafe(r.userMessage)
+  }
+})
+
+test('未知 500 → 通用友好文案，不含 HTTP/JSON', () => {
+  const body = '{"error":{"message":"Internal server error","type":"server_error"}}'
+  const r = formatLlmHttpUserMessage(500, body)
+  assert.equal(r.kind, 'generic')
+  assert.ok(r.userMessage.includes('暂时无法回复'))
+  assert.equal(r.userMessage, LLM_ERR_GENERIC)
+  assertChatSafe(r.userMessage)
+})
+
+test('带 JSON message 的解析进入 haystack', () => {
+  const body = JSON.stringify({
+    error: { message: 'Insufficient Balance', code: 402 },
+  })
+  const hay = extractUpstreamErrorHaystack(body)
+  assert.match(hay, /Insufficient Balance/i)
+  assert.equal(classifyLlmHttpError(200, body), 'balance')
+})
+
+test('可选 cfg.model 可拼进通用文案，且不泄漏 URL/密钥', () => {
+  const r = formatLlmHttpUserMessage(503, 'upstream down', { provider: 'Acme', model: 'deepseek-chat' })
+  assert.equal(r.kind, 'generic')
+  assert.match(r.userMessage, /deepseek-chat/)
+  assertChatSafe(r.userMessage)
+  assert.equal(r.userMessage.includes('http'), false)
+})
+
+test('sanitizeBodyForLog 脱敏密钥并截断', () => {
+  const raw = `Bearer sk-abcdefghijklmnopqrstuvwxyz123456 ${'x'.repeat(500)}`
+  const out = sanitizeBodyForLog(raw, 80)
+  assert.equal(out.includes('sk-abcdefgh'), false)
+  assert.match(out, /\[redacted\]/)
+  assert.ok(out.length <= 81)
+})
+
+test('任意 status+body 聊天 content 无技术泄漏（抽样）', () => {
+  const samples = [
+    [402, '{"error":{"message":"Insufficient Balance"}}'],
+    [401, '⚠️ API Key 无效 from upstream'],
+    [429, 'HTTP 429 Too Many Requests'],
+    [500, '{"status":500,"error":{"message":"boom"}}'],
+    [404, '{"error":{"code":"model_not_found","message":"model xyz not found"}}'],
+    [400, '{"error":{"code":"context_length_exceeded","message":"too many tokens"}}'],
+  ]
+  for (const [status, body] of samples) {
+    const { userMessage } = formatLlmHttpUserMessage(status, body)
+    assertChatSafe(userMessage)
+  }
+})

--- a/tests/mcp-tool-route-accuracy.test.mjs
+++ b/tests/mcp-tool-route-accuracy.test.mjs
@@ -100,6 +100,8 @@ const PRIMARY_CASES = [
   { message: '申请沙盒联网安装依赖', expectPrimary: 'request_shell_network', intent: 'workspace_shell_network' },
   { message: '检查一下 Python 环境', expectPrimary: 'python_env_status', intent: 'python_env' },
   { message: 'ensure_python 返回 preparing 后用 job_id 轮询', expectPrimary: 'python_env_status', intent: 'python_env' },
+  { message: '等一会儿再检查下载是否完成然后继续', expectPrimary: 'schedule_turn_wake', intent: 'turn_wake' },
+  { message: 'schedule_turn_wake 延后续跑', expectPrimary: 'schedule_turn_wake', intent: 'turn_wake' },
   { message: '今天涨跌榜和龙虎榜', expectPrimary: 'get_market_dynamics', intent: 'market_dynamics' },
   { message: '最近几个月 CPI 同比多少', expectPrimary: 'get_macro_series', intent: 'macro_series' },
   { message: '现在是牛市还是熊市', expectPrimary: 'get_market_regime', intent: 'market_regime' },

--- a/tests/session-progress-bus.test.mjs
+++ b/tests/session-progress-bus.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const repoRoot = join(import.meta.dirname, '..')
+
+async function loadBus() {
+  return import(pathToFileURL(join(repoRoot, 'apps/server/dist/session-progress-bus.js')).href)
+}
+
+describe('session-progress-bus', () => {
+  /** @type {Awaited<ReturnType<typeof loadBus>> | null} */
+  let bus = null
+
+  afterEach(() => {
+    bus?.resetSessionProgressBusForTests?.()
+    bus = null
+  })
+
+  it('publish delivers to subscribers; unsubscribe stops delivery', async () => {
+    bus = await loadBus()
+    /** @type {unknown[]} */
+    const events = []
+    const unsub = bus.subscribeSessionProgress('sess-1', (e) => {
+      events.push(e)
+    })
+    assert.equal(bus.sessionProgressListenerCountForTests('sess-1'), 1)
+
+    bus.publishSessionProgress('sess-1', { type: 'thinking', label: '正在继续' })
+    bus.publishSessionProgress('sess-other', { type: 'thinking', label: '忽略' })
+    assert.equal(events.length, 1)
+    assert.equal(/** @type {{ label?: string }} */ (events[0]).label, '正在继续')
+
+    unsub()
+    assert.equal(bus.sessionProgressListenerCountForTests('sess-1'), 0)
+    bus.publishSessionProgress('sess-1', { type: 'thinking', label: '不应收到' })
+    assert.equal(events.length, 1)
+  })
+})
+
+/** 与 client-ui/src/chat/turnWakeCountdown.ts 同口径的合约测试（避免直载 Vite/TS） */
+function formatWakeCountdownLabel(secondsLeft) {
+  const s = Math.max(0, Math.floor(secondsLeft))
+  if (s < 60) return `约 ${s} 秒后继续检查`
+  const m = Math.floor(s / 60)
+  const r = s % 60
+  if (r === 0) return `约 ${m} 分后继续检查`
+  return `约 ${m} 分 ${r} 秒后继续检查`
+}
+
+describe('turnWakeCountdown label contract', () => {
+  it('formats seconds / minutes', () => {
+    assert.match(formatWakeCountdownLabel(45), /约 45 秒后继续检查/)
+    assert.match(formatWakeCountdownLabel(90), /约 1 分 30 秒后继续检查/)
+    assert.match(formatWakeCountdownLabel(120), /约 2 分后继续检查/)
+  })
+})

--- a/tests/turn-wake.test.mjs
+++ b/tests/turn-wake.test.mjs
@@ -1,0 +1,266 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const repoRoot = join(import.meta.dirname, '..')
+
+async function loadTurnWake() {
+  // 优先 dist（build 后）；开发时可直读 ts 经已构建包
+  const distUrl = pathToFileURL(join(repoRoot, 'packages/agent/dist/turn-wake.js')).href
+  try {
+    return await import(distUrl)
+  } catch {
+    // fallback：经 package export
+    return await import('@opptrix/agent')
+  }
+}
+
+describe('turn-wake', () => {
+  /** @type {Awaited<ReturnType<typeof loadTurnWake>> | null} */
+  let tw = null
+
+  afterEach(() => {
+    tw?.resetTurnWakeForTests?.()
+    tw = null
+  })
+
+  it('clampWakeSeconds clamps to [5, 1800]', async () => {
+    tw = await loadTurnWake()
+    assert.equal(tw.clampWakeSeconds(1), 5)
+    assert.equal(tw.clampWakeSeconds(5), 5)
+    assert.equal(tw.clampWakeSeconds(90), 90)
+    assert.equal(tw.clampWakeSeconds(1800), 1800)
+    assert.equal(tw.clampWakeSeconds(99999), 1800)
+    assert.equal(tw.clampWakeSeconds('12.9'), 12)
+    assert.equal(tw.clampWakeSeconds(NaN), 5)
+  })
+
+  it('formatWakeMessage includes prompt and time metadata', async () => {
+    tw = await loadTurnWake()
+    const msg = tw.formatWakeMessage({
+      id: 'wake-1',
+      sessionId: 's1',
+      prompt: '检查 dump 是否就绪并继续离线分析',
+      seconds: 90,
+      scheduledAt: '2026-08-14T00:00:00.000Z',
+      fireAt: '2026-08-14T00:01:30.000Z',
+      reason: 'waiting_fuyao_dump',
+      jobId: 'job-abc',
+    }, '2026-08-14T00:01:31.000Z')
+    assert.match(msg, /【定时唤醒】/)
+    assert.match(msg, /检查 dump 是否就绪并继续离线分析/)
+    assert.match(msg, /wake_id: wake-1/)
+    assert.match(msg, /scheduled_at: 2026-08-14T00:00:00\.000Z/)
+    assert.match(msg, /fire_at: 2026-08-14T00:01:30\.000Z/)
+    assert.match(msg, /delay_s: 90/)
+    assert.match(msg, /fired_at: 2026-08-14T00:01:31\.000Z/)
+    assert.match(msg, /reason: waiting_fuyao_dump/)
+    assert.match(msg, /job_id: job-abc/)
+  })
+
+  it('scheduleTurnWake returns wake_id/fire_at/seconds and fires resume', async () => {
+    tw = await loadTurnWake()
+    /** @type {ReturnType<typeof setTimeout>[]} */
+    const timers = []
+    /** @type {Array<(...args: unknown[]) => void>} */
+    const callbacks = []
+    let now = 1_000_000
+    /** @type {{ job: unknown, message: string } | null} */
+    let resumed = null
+
+    tw.configureTurnWakeRuntime({
+      isSessionAlive: () => true,
+      isChatBusy: () => false,
+      now: () => now,
+      setTimeout: (fn, ms) => {
+        callbacks.push(fn)
+        const id = setTimeout(() => {}, 60_000)
+        timers.push(id)
+        assert.ok(typeof ms === 'number' && ms >= 5000)
+        return id
+      },
+      clearTimeout: (id) => clearTimeout(id),
+    })
+    tw.setTurnWakeResumeHandler(async (job, wakeMessage) => {
+      resumed = { job, message: wakeMessage }
+    })
+
+    const r = tw.scheduleTurnWake({
+      sessionId: 'sess-a',
+      seconds: 3, // clamp → 5
+      prompt: '续跑检查',
+      reason: 'test',
+      jobId: 'j1',
+    })
+    assert.equal(r.ok, true)
+    if (!r.ok) return
+    assert.ok(r.wake_id)
+    assert.equal(r.seconds, 5)
+    assert.ok(r.fire_at)
+    assert.equal(r.session_id, 'sess-a')
+    assert.equal(tw.listTurnWakeIdsForTests('sess-a').length, 1)
+
+    // 手动触发到期回调
+    const cb = callbacks[0]
+    assert.ok(cb)
+    await cb()
+    assert.ok(resumed)
+    assert.match(resumed.message, /续跑检查/)
+    assert.match(resumed.message, /wake_id:/)
+    assert.equal(tw.listTurnWakeIdsForTests('sess-a').length, 0)
+
+    for (const t of timers) clearTimeout(t)
+  })
+
+  it('defers when chat is busy instead of calling resume', async () => {
+    tw = await loadTurnWake()
+    let busy = true
+    /** @type {Array<() => void>} */
+    const callbacks = []
+    let resumeCount = 0
+    let now = 2_000_000
+
+    tw.configureTurnWakeRuntime({
+      isSessionAlive: () => true,
+      isChatBusy: () => busy,
+      now: () => now,
+      setTimeout: (fn) => {
+        callbacks.push(fn)
+        return setTimeout(() => {}, 60_000)
+      },
+      clearTimeout: (id) => clearTimeout(id),
+    })
+    tw.setTurnWakeResumeHandler(async () => {
+      resumeCount += 1
+    })
+
+    const r = tw.scheduleTurnWake({
+      sessionId: 'sess-busy',
+      seconds: 5,
+      prompt: '忙时延期',
+    })
+    assert.equal(r.ok, true)
+    assert.equal(callbacks.length, 1)
+
+    // 第一次到期：仍 busy → 延期再挂，不 resume
+    await callbacks[0]()
+    assert.equal(resumeCount, 0)
+    assert.equal(tw.listTurnWakeIdsForTests('sess-busy').length, 1)
+    assert.equal(callbacks.length, 2)
+
+    // 第二次：空闲 → resume
+    busy = false
+    now += 10_000
+    await callbacks[1]()
+    assert.equal(resumeCount, 1)
+    assert.equal(tw.listTurnWakeIdsForTests('sess-busy').length, 0)
+  })
+
+  it('clearSessionTurnWakes cancels timers; dead session drops on fire', async () => {
+    tw = await loadTurnWake()
+    /** @type {Array<() => void>} */
+    const callbacks = []
+    let resumeCount = 0
+    let alive = true
+
+    tw.configureTurnWakeRuntime({
+      isSessionAlive: () => alive,
+      isChatBusy: () => false,
+      now: () => Date.now(),
+      setTimeout: (fn) => {
+        callbacks.push(fn)
+        return setTimeout(() => {}, 60_000)
+      },
+      clearTimeout: (id) => clearTimeout(id),
+    })
+    tw.setTurnWakeResumeHandler(async () => {
+      resumeCount += 1
+    })
+
+    tw.scheduleTurnWake({ sessionId: 's-del', seconds: 5, prompt: 'a' })
+    tw.scheduleTurnWake({ sessionId: 's-del', seconds: 10, prompt: 'b' })
+    assert.equal(tw.listTurnWakeIdsForTests('s-del').length, 2)
+    const n = tw.clearSessionTurnWakes('s-del')
+    assert.equal(n, 2)
+    assert.equal(tw.listTurnWakeIdsForTests('s-del').length, 0)
+
+    tw.scheduleTurnWake({ sessionId: 's-dead', seconds: 5, prompt: 'c' })
+    alive = false
+    await callbacks[callbacks.length - 1]()
+    assert.equal(resumeCount, 0)
+  })
+
+  it('rejects empty prompt and session cap', async () => {
+    tw = await loadTurnWake()
+    tw.configureTurnWakeRuntime({
+      isSessionAlive: () => true,
+      isChatBusy: () => false,
+    })
+    const bad = tw.scheduleTurnWake({ sessionId: 's', seconds: 10, prompt: '  ' })
+    assert.equal(bad.ok, false)
+
+    for (let i = 0; i < tw.TURN_WAKE_MAX_PER_SESSION; i++) {
+      const r = tw.scheduleTurnWake({ sessionId: 'cap', seconds: 60, prompt: `p${i}` })
+      assert.equal(r.ok, true)
+    }
+    const over = tw.scheduleTurnWake({ sessionId: 'cap', seconds: 60, prompt: 'overflow' })
+    assert.equal(over.ok, false)
+  })
+
+  it('estimateEtaFromProgress uses percent and bytes', async () => {
+    tw = await loadTurnWake()
+    const fromPct = tw.estimateEtaFromProgress({
+      percent: 50,
+      startedAtMs: Date.now() - 60_000,
+      heuristicDefaultSeconds: 999,
+    })
+    assert.ok(fromPct > 30 && fromPct < 200)
+
+    const fromBytes = tw.estimateEtaFromProgress({
+      bytesDownloaded: 50_000_000,
+      bytesTotal: 100_000_000,
+      startedAtMs: Date.now() - 50_000,
+    })
+    assert.ok(fromBytes > 20)
+
+    const heuristic = tw.estimateEtaFromProgress({
+      percent: 1,
+      heuristicDefaultSeconds: 120,
+    })
+    assert.equal(heuristic, 120)
+  })
+
+  it('listPendingTurnWakes returns seconds_left and clearSession removes them', async () => {
+    tw = await loadTurnWake()
+    let now = 5_000_000
+    tw.configureTurnWakeRuntime({
+      isSessionAlive: () => true,
+      isChatBusy: () => false,
+      now: () => now,
+      setTimeout: (fn) => setTimeout(fn, 60_000),
+      clearTimeout: (id) => clearTimeout(id),
+    })
+    const r = tw.scheduleTurnWake({
+      sessionId: 's-list',
+      seconds: 90,
+      prompt: '列表检查',
+      reason: 'wait_dump',
+    })
+    assert.equal(r.ok, true)
+    const pending = tw.listPendingTurnWakes('s-list', now)
+    assert.equal(pending.length, 1)
+    assert.equal(pending[0].seconds_left, 90)
+    assert.equal(pending[0].reason, 'wait_dump')
+    assert.ok(pending[0].wake_id)
+    assert.ok(pending[0].fire_at)
+
+    now += 30_000
+    const later = tw.listPendingTurnWakes('s-list', now)
+    assert.equal(later[0].seconds_left, 60)
+
+    const n = tw.clearSessionTurnWakes('s-list')
+    assert.equal(n, 1)
+    assert.equal(tw.listPendingTurnWakes('s-list', now).length, 0)
+  })
+})


### PR DESCRIPTION
## Summary
- Add always-on `schedule_turn_wake` with ETA hints for async jobs (`prepare_fuyao_dump` / `ensure_python`)
- Show a live per-second countdown in chat while waiting; stream wake progress via session live-progress SSE
- Map LLM upstream HTTP failures to product copy (no raw HTTP/JSON/API Key in chat)

## Test plan
- [ ] Ask agent to prepare offline dump / Python when cold — see countdown step, then live continue with thinking/tools
- [ ] Force a 402/insufficient balance model call — chat shows balance-friendly copy, not HTTP JSON
- [ ] `node --test tests/turn-wake.test.mjs tests/session-progress-bus.test.mjs tests/llm-http-error-message.test.mjs`
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)