### PR TITLE
feat(agent): freeze session tools and surface prompt-cache hit rate

### DIFF
--- a/.cursor/rules/mcp-tool-pack-routing.mdc
+++ b/.cursor/rules/mcp-tool-pack-routing.mdc
@@ -6,20 +6,22 @@ alwaysApply: false
 
 # MCP Tool Pack 路由接入规范
 
-> 完整说明见 `docs/AGENT-GUIDE.md` §4.2。实现源：`tool-packs.ts`、`tool-pack-resolver.ts`、`tool-route-plan.ts`、`engine.ts`。
+> 完整说明见 `docs/AGENT-GUIDE.md` §4.2。实现源：`tool-packs.ts`、`tool-pack-resolver.ts`、`tool-route-plan.ts`、`session-frozen-tools.ts`、`engine.ts`。
 
 ## 架构（禁止绕过）
 
 ```
-用户消息 → resolveToolRoutePlan（意图→首选工具）
-         → resolveActivePackIds（core+meta+workspace+种子+会话激活）
-         → McpToolBroker(子集) + 选型卡 system + preferred 前置
-         → LLM → activate_tool_pack（同轮刷新）/ 业务 tool
+用户消息 → resolveToolRoutePlan（意图→首选工具 + 选型卡文案）
+         → 会话首次 chat：全量 ToolPack + always-on → 冻结 openAiTools（稳定排序）
+         → 后续轮 / mid-loop：复用同字节 tools JSON；路由只影响 turn-tail 选型卡
+         → LLM → activate_tool_pack（no-op 记录）/ 业务 tool
 ```
 
-- **禁止**聊天路径恢复「全量 chatToolNames 固定 Broker」
-- **禁止**只注册 handler 不挂 `TOOL_PACK_MEMBERSHIP` / 意图规则（工具永远不可见或无法被首选）
-- **禁止**改 `AgentEngine` 主循环来硬编码某个新工具；只通过注册扩展
+- **禁止** mid-loop 因 `activate_tool_pack` / `activate_agent_skill` 重建 tools schema 或改序
+- **禁止** `orderToolsByPreference` 用 `preferredTools` 重排发给 LLM 的 tools（preferred 仅进选型卡）
+- **禁止**只注册 handler 不挂 `TOOL_PACK_MEMBERSHIP` / 意图规则
+- **禁止**改 `AgentEngine` 主循环硬编码某个新工具；只通过注册扩展
+- MCP enable/disable 等**必须**改 schema 时：冷启动重建冻结集 + `prompt_cache_key` generation 后缀
 
 ## 新增 MCP 工具 — 强制清单（按序）
 
@@ -34,7 +36,7 @@ alwaysApply: false
 my_new_tool: {
   usageGuide: '何时用（面向选型，一句）',
   compliance: '参数约束、何时不用、调用次数',
-  miningEligible?: true, // 仅挖掘需要时
+  miningEligible?: true,
   hubFeature?: 'my_feature',
 }
 ```
@@ -42,69 +44,65 @@ my_new_tool: {
 ### 3. 单一 pack 归属 `packages/shared/src/tool-packs.ts`
 
 | 动作 | 要求 |
-|------|------|
+|---|---|
 | 已有业务域 | 写入 `TOOL_PACK_MEMBERSHIP['my_new_tool'] = '<pack_id>'` |
-| 新业务域 | 先扩 `TOOL_PACK_IDS` + `TOOL_PACK_DEFS`（title/description/whenToUse），再挂 membership |
-| 始终可用 | 仅当确属入口级（搜索/快照/时间/ask_user）才放 `core`；元工具放 `meta` |
+| 新业务域 | 先扩 `TOOL_PACK_IDS` + `TOOL_PACK_DEFS`，再挂 membership |
+| 始终可用 | 仅当确属入口级才放 `core`；元工具放 `meta` |
 
-每个工具**恰好一个**主 pack。`core`/`meta` = alwaysOn。
+每个工具**恰好一个**主 pack。`core`/`meta`/`workspace` = alwaysOn；会话 chat 时与全部业务 pack 一并冻结加载。
 
-### 4. 意图精排 `tool-route-plan.ts`（准确率关键）
+### 4. 意图精排 `tool-route-plan.ts`
 
-在 `INTENT_RULES` 增加或调整规则（**具体意图优先于宽泛**，提高 `priority`）：
+在 `INTENT_RULES` 增加规则（**具体意图优先于宽泛**）：
 
 ```typescript
 {
   intent: 'my_intent',
-  priority: 85, // 高于 depth_analysis(40)，低于更具体意图
+  priority: 85,
   patterns: [/中文触发词|EnglishTrigger/i],
-  preferredTools: ['my_new_tool', /* 次选 */],
+  preferredTools: ['my_new_tool'],
   avoidTools: ['易混工具名'],
   confidence: 'high',
-  hint: '用户问 X → 首选 my_new_tool；勿用 Y',
+  hint: '用户问 X → 首选 my_new_tool',
 }
 ```
 
-易混对写入 `TOOL_CONFUSION_PAIRS`（`prefer` / `avoid` / `when`）。
+易混对写入 `TOOL_CONFUSION_PAIRS`。
 
-### 5. 播种召回（可选增强）
+### 5. 播种召回（可选）
 
-若关键词需稳定加载该 pack，在 `tool-pack-resolver.ts` 的 `SEED_RULES` 补 pattern；**不必**与 INTENT_RULES 重复到双写失控——以 route-plan 的 `requiredPacks` 为主。
+`tool-pack-resolver.ts` 的 `SEED_RULES` 可补 pattern；选型卡仍以 route-plan 为主。
 
-### 6. UI 标签（可选）
-
-`chat-progress.ts` 的 `TOOL_LABELS` 增加中文标签。
-
-### 7. 文档与测试
+### 6. 文档与测试
 
 - `docs/AGENT-GUIDE.md`：新工具/新 pack 一句说明
-- 黄金用例：`tests/mcp-tool-route-accuracy.test.mjs` 的 `PRIMARY_CASES` 至少 +1
-- 回归：`node --test tests/mcp-tool-route-accuracy.test.mjs tests/mcp-tool-pack-router.test.mjs`
+- 黄金用例：`tests/mcp-tool-route-accuracy.test.mjs`
+- 冻结契约：`tests/session-tools-freeze.test.mjs`
+- 回归：`node --test tests/mcp-tool-route-accuracy.test.mjs tests/mcp-tool-pack-router.test.mjs tests/session-tools-freeze.test.mjs`
 
 ## 选型与提示词原则
 
-1. **召回**：首选工具所属 pack 必须进入本轮 `activeNames`（route-plan `seedPacks`）
-2. **精排**：`preferredTools[0]` = 尽可能最正确的工具；`avoidTools` 抑制混淆
-3. **档位**：`researchTier` L1/L2/L3 — 常驻证据纪律 + 档位输出骨架（`buildResearchEpistemicPlaybook` / `buildResearchOutputPlaybook`）
-4. **提示**：本轮注入 `buildRoundRoutePlaybook`；未加载 pack **不**灌对应长 playbook
-5. **扩展**：`list_tool_packs` / `activate_tool_pack` 处理「播种未覆盖」；勿自动合入幻觉工具名
+1. **Tools 冻结**：会话首次 chat 全量 pack；`orderToolsStable` = remoteFirst + 字典序
+2. **精排**：`preferredTools[0]` 写入 turn-tail 选型卡；**不**重排 tools 数组
+3. **档位**：L1/L2/L3 输出骨架与完备性闭环 → **turn-tail**（`buildResearchTierTurnTail`）
+4. **技能**：`activate_agent_skill` 正文 → turn-tail；不触发 schema rebuild
+5. **activate_tool_pack**：返回 `already_loaded`；playbook 说明全量已加载
 
-新增意图时同步考虑档位：事实查询 → L1；解读 → L2；「分析/全面/深度」→ L3。
 ## 反模式
 
 | ❌ 错误 | ✅ 正确 |
-|---------|---------|
+|---|---|
+| mid-loop activate 后 refreshTools | 冻结集不变；MCP 运维才冷启动 |
+| preferred 改变 tools 顺序 | 仅 turn-tail 选型卡 |
+| system 注入时钟/选型卡/档位长文 | turn-tail 动态注入 |
 | 新工具不写 membership | 必挂单一 pack |
-| 只改 TOOL_META 不改 INTENT_RULES | 有明确用户说法就必须精排 |
-| 全部塞进 `core` | core 只保留真正 always-on |
-| system 里写未加载工具名当默认路径 | 依赖选型卡 + 已加载 tools |
 | 改 Engine 特判某工具 | 注册 + pack + 意图规则 |
 
 ## 提交前自检
 
 - [ ] `tools.ts` + `TOOL_META` + `TOOL_PACK_MEMBERSHIP` 三处一致
-- [ ] 新意图有 `INTENT_RULES`（或确认归属已有意图的 preferred 列表）
-- [ ] `packIdForTool(name)` 非 null；membership 测试绿
-- [ ] D1 首推 / D2 召回：相关黄金用例通过
+- [ ] 新意图有 `INTENT_RULES`
+- [ ] `orderToolsStable` / 冻结路径未引入 preferred 排序
+- [ ] D1 首推 / D2 召回黄金用例通过
 - [ ] `npm run build -w @opptrix/shared && npm run build -w @opptrix/agent`
-- [ ] `docs/AGENT-GUIDE.md` 已同步（若对外可见行为变化）
+- [ ] `docs/AGENT-GUIDE.md` 已同步

--- a/client-ui/src/chat/ContextUsageMeter.tsx
+++ b/client-ui/src/chat/ContextUsageMeter.tsx
@@ -1,13 +1,13 @@
 import { Text, makeStyles } from '@fluentui/react-components'
 import { opptrixCssVars } from '../theme/tokens'
-import { formatContextUsageLabel, resolveContextUsagePercent } from './formatTokenCount'
+import { formatContextUsageLabel, formatCacheHitLabel, resolveContextUsagePercent } from './formatTokenCount'
 import type { ChatContextUsage } from '../types/chat'
 
 const useStyles = makeStyles({
   root: {
     display: 'inline-flex',
     alignItems: 'center',
-    maxWidth: '180px',
+    maxWidth: '220px',
     minWidth: 0,
     flexShrink: 1,
     fontSize: 'var(--opptrix-font-sm)',
@@ -27,8 +27,18 @@ export default function ContextUsageMeter({ usage }: ContextUsageMeterProps) {
   const s = useStyles()
   if (!usage) return null
   const percent = resolveContextUsagePercent(usage)
-  const label = formatContextUsageLabel(percent, usage.compacted)
-  const title = `${label}${percent >= 85 ? ' · 上下文接近上限' : ''}`
+  const contextLabel = formatContextUsageLabel(percent, usage.compacted)
+  const cacheLabel = usage.cacheHitPercent !== undefined
+    ? formatCacheHitLabel(usage.cacheHitPercent)
+    : null
+  const label = cacheLabel ? `${contextLabel} · ${cacheLabel}` : contextLabel
+  const nearLimitHint = percent >= 85 ? ' · 上下文接近上限' : ''
+  const cacheHint = usage.cacheHitPercent !== undefined && usage.cacheHitPercent > 0
+    ? ' · 最近一轮请求中，较早内容复用了缓存'
+    : usage.cacheHitPercent === 0
+      ? ' · 本轮未命中前缀缓存'
+      : ''
+  const title = `${label}${nearLimitHint}${cacheHint}`
   return (
     <Text className={s.root} title={title} aria-label={title}>
       {label}

--- a/client-ui/src/chat/formatTokenCount.ts
+++ b/client-ui/src/chat/formatTokenCount.ts
@@ -24,6 +24,12 @@ export function formatContextUsageLabel(usagePercent: number, compacted?: boolea
   return compacted ? `${base} · 已整理` : base
 }
 
+/** Composer 底栏：前缀缓存命中率（有上游上报时） */
+export function formatCacheHitLabel(percent: number): string {
+  const pct = Math.min(100, Math.max(0, Math.round(percent)))
+  return `缓存约 ${pct}%`
+}
+
 /** 兼容旧字段：无 usagePercent 时由 used/limit 推算 */
 export function resolveContextUsagePercent(usage: {
   usagePercent?: number

--- a/client-ui/src/types/chat.ts
+++ b/client-ui/src/types/chat.ts
@@ -50,6 +50,8 @@ export interface TokenUsage {
   promptTokens: number
   completionTokens: number
   totalTokens: number
+  /** 上游 prefix cache 命中 tokens；缺省表示未上报 */
+  cachedPromptTokens?: number
 }
 
 export interface ChatContextUsage {
@@ -62,6 +64,9 @@ export interface ChatContextUsage {
   usagePercent?: number
   /** 已整理过上下文（刷新仍在） */
   compacted?: boolean
+  /** 最近一轮前缀缓存命中率 0–100；无上报则省略 */
+  cacheHitPercent?: number
+  cachedPromptTokens?: number
 }
 
 export type ReasoningEffort = 'low' | 'medium' | 'high'

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -63,6 +63,9 @@ export interface ChatContextUsageSnapshot {
   estimated: boolean
   usagePercent?: number
   compacted?: boolean
+  /** 最近一轮前缀缓存命中率 0–100；无上报则省略 */
+  cacheHitPercent?: number
+  cachedPromptTokens?: number
 }
 
 export type ChatProgressEvent =

--- a/docs/AGENT-GUIDE.md
+++ b/docs/AGENT-GUIDE.md
@@ -128,13 +128,13 @@ Opptrix/
 ### 4.2 Agent 与 MCP
 
 ```
-用户消息 → AgentEngine → ToolPackResolver（播种 packs）
+用户消息 → AgentEngine → ensureFrozenSessionTools（全业务 pack + always-on，会话级一次）
                 ↓
-         activeNames = core+meta+workspace+播种+会话激活
+         冻结 openAiTools（稳定序）→ AggregatingToolBroker → LLM
                 ↓
-         AggregatingToolBroker（外部 MCP 优先级链 → 本地 McpToolBroker）→ LLM tools
+         resolveToolRoutePlan → 仅 turn-tail 选型卡（不改 tools 字节）
                 ↓
-         activate_tool_pack → 同会话累积 → 同轮刷新 Broker
+         activate_tool_pack → already_loaded no-op（不刷新 Broker）
                 ↓
          ToolRegistry / External MCP Client → ResearchHub / MarketDataService
 ```
@@ -151,16 +151,19 @@ Opptrix/
   - **后台终态续跑**：`mode=background` 且 `completed`/`failed`/`needs_parent_action` 时经 `SessionResumeBus`（`cause: subagent_terminal`）在父会话空闲时自动续跑通知父决定如何处理结果（可用 `get_subagent`；勿 poll）；`cancelled` 与 `foreground`（工具结果已回父）不 enqueue。父忙则沿用 bus 的 busy-defer。
   - **实现**：`packages/agent/src/subagents/`；单测 `tests/subagent-*.test.mjs`
 - 工具元数据（何时使用、调用规范、`packId`）：`packages/agent/src/tool-meta.ts`
-- **工具包路由（Tool Pack Router）**：
+- **工具包路由（Tool Pack Router — 会话级冻结）**：
   - 包定义：`packages/shared/src/tool-packs.ts`（`TOOL_PACK_DEFS` / `TOOL_PACK_MEMBERSHIP`）
-  - 意图播种：`packages/agent/src/mcp/tool-pack-resolver.ts`（关键词/上下文 → ≤2 业务 pack）
-  - 会话激活：`list_tool_packs` / `activate_tool_pack`；同 session 累积 active packs
+  - **会话首次进入 chat**（含 subagent child）：激活**全部**业务 pack + always-on，经 `ensureFrozenSessionTools` 构建一次 `openAiTools` 并缓存；同会话后续轮 **字节不变**
+  - 意图播种 / `resolveToolRoutePlan`：仍每轮运行，但**只**影响 turn-tail「本轮工具选型卡」与档位提示，**不**裁剪或重排 tools
+  - `list_tool_packs` / `activate_tool_pack`：`activate` 为 **no-op**（`already_loaded`），仅记录/文案；勿指望 mid-loop 刷新 schema
+  - 稳定排序：`orderToolsStable`（remoteFirst + 名字典序）；**禁止** `preferredTools` 改变发给 LLM 的 tools 顺序
+  - MCP 运维（enable/disable/install…）若必须改 schema：冷启动重建冻结集 + `prompt_cache_key` generation 后缀
   - **工作流技能（Agent Skills）**：`@opptrix/agent-skills`（meta pack）；与专家「技能专长」persona、Tool Pack **正交**。规范见 [AGENT-SKILLS.md](./AGENT-SKILLS.md)
     - **Meta 工具**：`list_agent_skills` / `activate_agent_skill` / `get_agent_skill` / `get_agent_skill_file`；写操作 `create_agent_skill` / `import_agent_skill` / `delete_agent_skill`（须 `ask_user` + `confirmed=true`）
-    - **激活**：同会话最多 3 个；正文 `` `@skill:name` `` 引用会**依赖自动激活**（循环检测 + 超限记入 `depNotes`）；若 frontmatter 声明 `allowed-tools`（空格分隔工具名）或 metadata `required-packs` / `requiredPacks`，会**自动 `activate` 对应 Tool Pack**（如 `create_web`/`create_canvas` → `artifacts`），返回 `activated_packs` / `tools_hint`，本轮即可调用，无需再手动 `activate_tool_pack`（`allowed-tools` **不是**硬白名单）
+    - **激活**：同会话最多 3 个；技能正文注入 **turn-tail**（非 stable system）；`allowed-tools` / `required-packs` 仅 bookkeeping，**不**触发 tools schema rebuild
     - **内置**（技能名用连字符，对齐工具下划线，如 `create-web` ↔ `create_web`）：`equity-deep-dive`；`multi-role-research-council`（多角色研讨 / 多空辩论，→ `fundamentals`/`market`/`news`/`instrument_analytics` + `artifacts`）；制品类 `create-canvas` / `create-web` / `create-mindmap`（→ `artifacts`）；策略 `run-backtest` / `strategy-report`（→ `strategy_extra`）；`etf-research`（→ `etf`）、`portfolio-review`（→ `portfolio`）、`news-digest`（→ `news`）、`browser-browse`（→ `browser`）、`scheduled-jobs`（→ `automation`）、`instrument-signals`（→ `instrument_analytics`）；`morning-market-brief`（v2 JSON）、`closing-market-brief`、`industry-chain`（`references/chain-knowledge.json`）、`earnings-quick-read`、`create-skill`（新建技能引导）。完整表见 [AGENT-SKILLS.md](./AGENT-SKILLS.md)
     - **意图**：早报 / 收盘 / 产业链 → 激活对应工作流技能，再用 `market` / `fundamentals` 等 pack 取数；**多角色研讨 / 多空辩论 / 研究委员会** → `activate_agent_skill(multi-role-research-council)` 再 `run_subagent`；画布/网页/导图 → `create-canvas` / `create-web` / `create-mindmap`；**新建/定制技能** → 先 `activate_agent_skill(create-skill)` 再 `create_agent_skill`；**勿**再调用已删除的 `get_morning_brief` / `get_closing_report` / `industry_mining` / `industry_mermaid`；**勿**再用已更名的 `visual-report` / `web-page`
-  - 引擎每轮按 `core`+`meta`+播种+已激活 子集创建 `AggregatingToolBroker`（内含本地 `McpToolBroker` + 外部 MCP 注册表）；激活后同轮刷新 tools
+  - 引擎会话级 `AggregatingToolBroker`：**首次 chat 全量工具子集并冻结**；subagent 继承父冻结快照再 `filterToolNamesForSubagent`
   - **外部 MCP（优先级故障转移）**：
     - 配置：`packages/shared/src/mcp-servers.ts`；持久化 user-store `mcp_servers`；设置页 **MCP 服务器** / REST `/api/mcp-servers*`
     - 运行时：`packages/agent/src/mcp/external/`（`ExternalMcpRegistry` / Health / AggregatingToolBroker）；hydrate 跨 server 有界并发（默认 2，`OPPTRIX_MCP_HYDRATE_CONCURRENCY` 可调、上限 3），工具 schema 在 hydrate 时缓存，catalog 优先读缓存避免每轮 `listTools` RPC
@@ -171,11 +174,11 @@ Opptrix/
       - `isMcpServerFailoverError`：`-32602`（structured content 不匹配）、`-32600`（声明 outputSchema 但未返回 structured content）、`Missing X-api-key` / 401 / 429 / 5xx / 网络超时等 → 可 failover；`invalid argument` 等业务参数错误不换源
       - 降级本地时 `_mcp.degraded=true`；若 `extractMcpConfigHint` 识别出缺 Key/鉴权问题，附带 `_mcp.configHint` 供 LLM 提示用户检查设置
     - 外部独有工具：`serverId__toolName` 命名空间注入 catalog
-    - **远程优先排序（三级优先，不可倒置）**：`AggregatingToolBroker.openAiTools()` 远程工具排前 + 同名本地不重复暴露；`orderToolsByPreference(..., { remoteFirst: true })` 进一步保证远程（命名空间）工具整体先于本地，preferred 排序仅在各自分组内生效。本地工具是最低优先级兜底。system 注入 `buildDataSourcingPolicy`：远程 MCP=最高优先、`_mcp.source=local` 视为降级须提示可信度受限
-    - meta 运维：`list_mcp_servers` / `enable_mcp_server` / `pause_mcp_server` / `reorder_mcp_servers`；`install_mcp_server` / `uninstall_mcp_server` **须 ask_user 后 `confirmed=true`**；禁止经 Agent 改已有 server 的 command/url/env
+    - **远程优先排序**：`AggregatingToolBroker.openAiTools()` 远程排前；`orderToolsStable` 保证会话内稳定序（**不用** preferred 重排）
+    - meta 运维：`list_mcp_servers` / `enable_mcp_server` / … — 变更外部 schema 时冷启动重建冻结 tools
     - 单测：`tests/external-mcp-failover.test.mjs`
-  - **分层精排**：`resolveToolRoutePlan` 将用户意图映射为首选工具顺序与研究档位（L1 事实快答 / L2 结构化解读 / L3 深度备忘录），注入「本轮工具选型卡」与证据纪律/输出骨架，并把首选工具排到 tools schema 前列
-  - **投研完备性闭环（`buildResearchCompletenessLoop`，仅 L2/L3 注入）**：出报告前强制「缺口自检 → 针对性补齐（换源重试 / activate_tool_pack / 远程重试降级项）→ 重新纳入分析 → 收敛输出」；同一缺口最多补 1 轮，取不到则如实标注缺口。L1 事实快答不注入，避免过度拉数
+  - **分层精排**：`resolveToolRoutePlan` 映射首选工具与研究档位；**选型卡 + 档位骨架**注入 turn-tail；tools 数组会话级冻结
+  - **投研完备性闭环**：L2/L3 注入 **turn-tail**（`buildResearchTierTurnTail`），非 stable system
   - **投研 Agent Loop 增强**（`packages/agent/src/loop/`，engine 仅编排）：
     1. **只读同轮并行**：连续只读工具可 `Promise.all`；`ask_user` / workspace 写删 / shell / secret / schedule 变更 / `activate_*` / MCP 变更 / browser 会话态 / 外部 `serverId__tool` **必须串行**；tool 消息写回仍按原 `tool_calls` 顺序；每 call 各自 `runInToolSession`
     2. **Checklist + 反空转**：会话内存 checklist（`update_research_checklist`，meta pack）；Skill 激活写入占位步骤；turn-tail 注入未完成项。同 fingerprint（工具名+规范化 args）成功重复 ≥3 或失败 ≥2 → 短路返回 `spin_guard`；`ensure_python` / `prepare_fuyao_dump` 对 `preparing`/`installing`/`running`/`pending` 轮询豁免（不计入 success/failure，有硬上限防死循环；终态 ready 重复仍拦）；`list_jobs` / `list_subagents` / `get_subagent` 对进行中结果只计 pollInFlight（协作硬限 24；`list_subagents` 无参 36）；`run_subagent` / `cancel_subagent` / `reclaim_subagent` 及 `cancel_job` / 会话密钥与 LAN 控制面工具不参与 success/failure 重复拦截；连续多轮无新指纹且无 checklist/轮询进展 → 强制收口提示。`deleteSession` / 归档旁路清理
@@ -183,7 +186,7 @@ Opptrix/
     4. **Soft steer**：`POST /api/sessions/:id/chat/steer`；仅有进行中 chat 时接受；不 abort；下一 `runLlmRound` 前写入可见 user「（补充）…」；cancel 清 pending；无人值守忽略
   - 默认角色为**投研研究员**：事实与推断分层、标注时效、工具失败不编造、L3 声明数据缺口；配合 MCP 取证后按档位写结论
   - **消息正文插图（无需 pack，日常默认）**：L2/L3 有对比/趋势/占比/强弱矩阵等定量数据时，助手回复 Markdown 可用 ` ```chart ` / ` ```opptrix-chart ` 围栏（内容为 JSON，非 TSX）直接渲染 `@opptrix/canvas` 的 `Chart`（与画布同源），无需授权、无需 `artifacts`。「画个图」用围栏，勿误当成完整报告；**禁止**用 `opptrix_run` + Python（matplotlib/seaborn/plotly 等）出图再当聊天插图（用户明确要求导出图像文件到工作区时除外）。多折线/分组柱须 `data[].series`；单折线勿用每点不同 `color` 冒充多指标；类目密时建议 `showValues:false`、`showTooltip:true`。见 `buildResearchEpistemicPlaybook`。
-  - **画布、脑图与网页（`artifacts` pack）**：实现 `packages/agent/src/canvas-tools.ts` / `web-tools.ts`；非 always-on，意图播种（可视化报告/画布/脑图/思维导图/关系梳理/HTML 网页）或 `activate_tool_pack({ pack_ids: ["artifacts"] })`
+  - **画布、脑图与网页（`artifacts` pack）**：实现 `packages/agent/src/canvas-tools.ts` / `web-tools.ts`；会话级全量冻结后已含本 pack；意图播种只影响选型卡优先提示，无需再 `activate_tool_pack`
     - **工具**：`create_canvas` / `update_canvas` / `read_canvas` / `create_mindmap` / `update_mindmap` / `read_mindmap` / `create_web` / `update_web` / `read_web` / `list_web_vendor`
     - **何时用**：投研合适时机（对比表、走势图、结构化表、一页式结论 → `create_canvas` / 正文 chart；产业链/股东/主题关系梳理、流程示意 → `create_mindmap`，**禁止**虚构独立 knowledge-graph 工具；可交互 HTML/离线图表页 → `create_web`）。完整可视化报告仅当用户明确点名报告/画布，或 Agent 自感应值得交付完整多章节图文报告时以 `create_canvas` 为主交付；**禁止**先 `ask_user` 询问是否出报告。简单一句问答不必开 canvas/mindmap/web。日常定量表达优先正文 `chart` 围栏。更新先 `read_*` 再 `update_*`。插图 ≠ 报告：「画个图」用围栏，不必 `create_canvas`
     - **画布源码约束**：`source` 为 TSX 字符串。**UI**：使用 `@opptrix/canvas` curated 组件（`Surface` / `Stack` / `H1`–`H3` / `Text` / `Stat` / `Table` / `Chart` / `Callout` / `Quote` 等）；颜色用 `useCanvasTheme` 或组件默认；禁止渐变、大阴影、装饰 emoji。**语义配色**：文字层级用 `Text` tone（primary/secondary/tertiary）；涨跌默认红涨绿跌（`danger`/`success`）；tips/风险用 `Callout`（tone + 可选 variant）；原文/口径摘录用 `Quote`（`cite` 写来源），勿用 Callout 冒充引用；行内 `Pill` / `Code` / `Link`。**版面**：默认流体宽度 `Surface`；**默认机构调研报告版式**（H1→导语→H2 分章 + 正文与图表穿插；定量对比/变化/构成/强弱矩阵优先 `Chart`（`bar`/`line`/`pie`/`heatmap`）+ 主题配色，heatmap 用 `{ label, row, col, value }`，多折线/分组柱用 `{ label, value, series }`；`Table`/`Stat` 作明细与 KPI；**Chart 勿拉满全宽**（随内容宽自适应：稀疏≈紧凑 320/230/380，密集可增至父容器上限；勿写 `width:'100%'`；图注用 `Chart caption` 与图居中对齐；Chart 已含轴/网格/数值标注，勿手写假坐标）；章节靠标题与 Stack 间距，**避免 Divider**（勿用手写 hr/边框冒充），仅用户明确要求时例外；须含介绍/说明文字；勿用 Card 墙做面板分割；仅用户明确要面板/仪表盘时例外）。**仅允许** `import … from 'react'` 与 `import { … } from '@opptrix/canvas'`（公开导出）；禁止其它依赖（含 echarts）。返回 `attachment`（`kind=canvas`）供消息内点击预览。playbook：`buildArtifactsPlaybook()`
@@ -346,7 +349,7 @@ Opptrix/
   - **板块 / 指数成分**：`get_sector_list` / `get_sector_constituents`；`get_index_constituents`；`get_etf_profile`
   - **对话调试 JSONL**（`preference/chat_debug_logging`，默认 `enabled=false`）：开启后按会话写入 `logs/chat-debug/*.jsonl`；单文件超限 rotate 为 `.1`（截断更旧），目录有会话数/总字节软顶并 prune 最旧会话，避免无限 append。
   - **会话时钟 / 前缀缓存**：Engine 每轮将 `getCurrentTime()`（Asia/Shanghai）写入**本轮 turn-tail**（messages 末尾 ephemeral user），**不**写入稳定 system，以免破坏 DeepSeek 等前缀缓存；选型卡同理。有 `sessionId` 时请求体带稳定 `prompt_cache_key=opptrix-session:{id}`，chat-debug 仅记录 key / `cacheWarmth`（warm|cold|unknown），**不**因命中与否改写上下文。`get_current_time` 仅在用户明确问时刻时调用。未显式定制时输出额度 ladder：普模 32k、推理 32k、`reasoningEffort=high` 为 64k（显式可选 64k / 128k / 384k；显式等于历史默认 4096 或旧 16k 会抬升；更低显式值仍尊重）。上游 `reasoning_content` 会累积；工具轮写入会话并在下一请求 wire 回传（含空串占位）；**整轮思考时间线**以 `turns.reasoningSegments` 结构化分段持久化，并派生 `reasoningContent`（`---` 拼接）兼容旧读；live 推送 segments（末段流式）；UI 竖轴展示「第 N 段思路」，旧仅字符串会话可降级分段；messages 终轮仍仅写本轮 reasoning（wire 不变）；重开会话可在气泡内折叠查看「思考过程」；空正文时提示思考占用输出上限。
-  - 调用未加载工具 → fail-closed，返回 `activate_tool_pack` 提示
+  - 调用未在本轮 tools 列表中的工具 → fail-closed，返回与冻结语义一致的提示（核对 tools / 选型卡，勿仪式 activate）
   - 准确率测试：`tests/mcp-tool-route-accuracy.test.mjs`（首推精确率 / 可见性召回 / 易混消歧 / 选型卡 / 过播种抑制）
 - **系统提示词分层（`assembleSystemPrompt`）**：实现 `packages/agent/src/experts/prompt-assembler.ts`；每轮由 `AgentEngine.buildRoundSystemPrompt` → `ToolRegistry.systemPrompt` 组装，结构固定为三层（空行分隔）：
   - **Layer 0 — 系统底线（不可覆盖）**：`buildLayer0Baseline()`。禁止具体买卖建议、禁止编造数据、须先调工具取数、区分事实与推断等。专家 `persona` 或用户消息若要求违反上述底线，Agent 须拒绝并说明原因；**Layer 0 优先级高于 Layer 1 角色设定**。

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -27,6 +27,9 @@ export interface ChatContextUsageSnapshot {
   usagePercent: number
   /** 已整理过上下文（刷新仍在） */
   compacted: boolean
+  /** 最近一轮前缀缓存命中率 0–100；无上游上报则省略 */
+  cacheHitPercent?: number
+  cachedPromptTokens?: number
 }
 
 export interface ChatTurnUsageSnapshot extends TokenUsage {

--- a/packages/agent/src/context/compact.ts
+++ b/packages/agent/src/context/compact.ts
@@ -10,6 +10,7 @@ import { resolveModelContextTokensAsync } from '../llm/models-dev-context.js'
 import {
   formatSessionMemoryForPrompt,
   parseSessionMemoryFromModelText,
+  sessionMemoryAsUserBlock,
   STRUCTURED_COMPACT_SYSTEM,
   type SessionMemory,
 } from './session-memory.js'
@@ -236,9 +237,9 @@ export function assembleModelView(opts: {
     })
   }
   const out: ChatMessage[] = [{ role: 'system', content: opts.systemPrompt }]
-  const memoryText = formatSessionMemoryForPrompt(opts.sessionMemory)
+  const memoryText = sessionMemoryAsUserBlock(opts.sessionMemory)
   if (memoryText) {
-    out.push({ role: 'system', content: memoryText })
+    out.push({ role: 'user', content: memoryText })
   }
   if (opts.contextPrefix?.length) {
     out.push(...opts.contextPrefix)

--- a/packages/agent/src/context/projection.ts
+++ b/packages/agent/src/context/projection.ts
@@ -8,7 +8,7 @@ import { chatMessageContentToText } from '../content-parts.js'
 import type { ChatMessage } from '../llm/provider.js'
 import { repairToolCallSequences, tailMessagesForLlm } from '../llm/messages.js'
 import {
-  formatSessionMemoryForPrompt,
+  sessionMemoryAsUserBlock,
   type SessionMemory,
 } from './session-memory.js'
 
@@ -84,9 +84,9 @@ export function modelVisibleFromProjection(opts: {
 }): ChatMessage[] {
   const keepRecent = opts.keepRecent ?? opts.projection.keepRecent
   const out: ChatMessage[] = [{ role: 'system', content: opts.systemPrompt }]
-  const memoryText = formatSessionMemoryForPrompt(opts.sessionMemory)
+  const memoryText = sessionMemoryAsUserBlock(opts.sessionMemory)
   if (memoryText) {
-    out.push({ role: 'system', content: memoryText })
+    out.push({ role: 'user', content: memoryText })
   }
   if (opts.contextPrefix?.length) {
     out.push(...opts.contextPrefix)

--- a/packages/agent/src/context/session-memory.ts
+++ b/packages/agent/src/context/session-memory.ts
@@ -66,6 +66,11 @@ export function formatSessionMemoryForPrompt(memory: SessionMemory | null | unde
   ].join('\n\n')
 }
 
+/** 压缩后工作记忆：用 user 尾块注入，避免第二条 role:system 破坏前缀缓存 */
+export function sessionMemoryAsUserBlock(memory: SessionMemory | null | undefined): string | null {
+  return formatSessionMemoryForPrompt(memory)
+}
+
 export function parseSessionMemoryFromModelText(
   raw: string,
   prev: SessionMemory | null | undefined,

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -33,13 +33,22 @@ import {
 import {
   resolveToolRoutePlan,
   buildRoundRoutePlaybook,
-  orderToolsByPreference,
   type ToolRoutePlan,
 } from './mcp/tool-route-plan.js'
+import {
+  type SessionFrozenToolsEntry,
+  businessPackIdsForSessionSeed,
+  filterFrozenToolsForSubagent,
+  filterFrozenToolsForUnattended,
+  orderToolsStable,
+  resolveFullSessionPackIds,
+  resolveFullSessionToolNames,
+} from './mcp/session-frozen-tools.js'
 import {
   appendTurnTailMessages,
   buildSessionClockPlaybook,
   buildTurnTailPrompt,
+  buildResearchTierTurnTail,
   parseNamespacedMcpTool,
 } from '@opptrix/shared'
 import { clearSessionTurnWakes } from './turn-wake.js'
@@ -170,6 +179,8 @@ import {
   emptyTokenUsage,
   promptCacheKeyForSession,
   resolveCacheWarmth,
+  computeCacheHitPercent,
+  resolveSessionCacheHitSource,
   type TokenUsage,
 } from './llm/token-usage.js'
 import {
@@ -194,6 +205,10 @@ export interface SessionContextUsage {
   usagePercent: number
   /** 本会话已做过上下文整理（投影存在；刷新仍在） */
   compacted: boolean
+  /** 最近一轮（或累计）前缀缓存命中率 0–100；无上游上报则省略 */
+  cacheHitPercent?: number
+  /** 观测用；与 cacheHitPercent 同源 */
+  cachedPromptTokens?: number
 }
 
 export interface AgentSettings {
@@ -308,6 +323,9 @@ export class AgentEngine {
   private readonly workspaceService = getWorkspaceService()
   /** 会话上下文用量估算缓存（内存；切会话命中则不再 rebuildRoundTools） */
   private readonly contextUsageCache = new Map<string, SessionContextUsage>()
+  /** 会话级冻结 openAiTools（DSH 前缀缓存；MCP schema 变更时 bump generation 重建） */
+  private readonly frozenToolsBySession = new Map<string, SessionFrozenToolsEntry>()
+  private frozenToolsSchemaGeneration = 0
   /** 附件 GET 与 content parts 本地 URL 前缀 */
   private apiBaseUrl = 'http://127.0.0.1:8711/api'
   /** 进行中 chat 的 AbortController（cancel_subagent / Stop 父用） */
@@ -334,6 +352,16 @@ export class AgentEngine {
   /** @internal 测试用 */
   markExpertPackSeededForTests(sessionId: string, expertId: string): void {
     this.expertPacksSeeded.add(`${sessionId}:${expertId}`)
+  }
+
+  /** @internal 测试用 — 冻结 tools JSON 字节快照 */
+  frozenToolsJsonForTests(sessionId: string): string | null {
+    return this.frozenToolsBySession.get(sessionId)?.toolsJson ?? null
+  }
+
+  /** @internal 测试用 */
+  async ensureFrozenToolsForTests(sessionId: string): Promise<SessionFrozenToolsEntry> {
+    return this.ensureFrozenSessionTools(sessionId, { isSubSession: false })
   }
 
   setApiBaseUrl(url: string) {
@@ -372,9 +400,8 @@ export class AgentEngine {
     })
   }
 
-  /** 构建数据源优先级策略说明（注入 system prompt） */
-  private buildDataSourcingPolicy(plan: ToolRoutePlan | null): string {
-    const tier = plan?.researchTier ?? 'standard'
+  /** 稳定数据源策略（无按轮档位分支） */
+  private buildStaticDataSourcingPolicy(): string {
     const lines = [
       '【数据源优先级策略 — 必须严格遵守】',
       '0. 三级优先，不可倒置：远程 MCP 工具（命名空间 server__tool）= 最高优先，永远先用；本地工具 = 最低优先，仅作兜底。工具列表中远程工具已排在最前，同名能力优先取远程。',
@@ -386,34 +413,32 @@ export class AgentEngine {
       '   - source="local" + degraded=true → 远程不可用，本地兜底降级，结果可能不完整：须在答复中提示该维度为降级数据、可信度受限，并在其它远程工具可用时尝试交叉补全',
       '4. 投研答复引用数据时体现数据源：远程权威源优于本地缓存；降级数据须显式标注不确定性。',
     ]
-    // 高研究档位强调交叉验证
-    if (tier === 'L3') {
-      lines.push(`5. 当前为 ${tier} 档位：对重要标的/事件，即使远程已返回结果，也可主动补充本地交叉验证 — 但须在结果中注明来源与差异。`)
-    }
     return lines.join('\n')
   }
 
-  /** 稳定 system（无每轮时钟/选型卡，利于前缀缓存） */
-  private buildRoundSystemPrompt(sessionId: string, activeNames: readonly string[]) {
+  /** L3 档位交叉验证提示 — 仅 turn-tail */
+  private buildTierDataSourcingTurnTail(tier: import('@opptrix/shared').ResearchTier): string {
+    if (tier !== 'L3') return ''
+    return `5. 当前为 ${tier} 档位：对重要标的/事件，即使远程已返回结果，也可主动补充本地交叉验证 — 但须在结果中注明来源与差异。`
+  }
+
+  /** @deprecated 保留供测试/兼容 */
+  private buildDataSourcingPolicy(plan: ToolRoutePlan | null): string {
+    return this.buildStaticDataSourcingPolicy()
+  }
+
+  /** 稳定 system（无每轮时钟/选型卡/档位长分支，利于前缀缓存） */
+  private buildRoundSystemPrompt(sessionId: string) {
     const record = this.ensureSessionRolePersona(sessionId)
     const expert = record?.expertId
       ? getExpertCatalogService().getDefinitionSync(record.expertId)
       : null
-    const plan = this.lastRoutePlan ?? resolveToolRoutePlan({
-      message: this.lastChatSeedMessage,
-      contextRef: record?.contextRef ?? null,
-    })
-    const activatedSkills = this.agentSkillSessions.getActivated(sessionId)
     return this.tools.systemPrompt({
       expert,
       sessionRolePersona: record?.rolePersona ?? null,
       roleLabel: expert?.title ?? null,
-      activePacks: this.lastRoundPackIds,
-      activeToolNames: activeNames,
-      researchTier: resolveEffectiveResearchTier(expert?.defaultResearchTier, plan.researchTier),
-      dataSourcingPolicy: this.buildDataSourcingPolicy(plan),
+      dataSourcingPolicy: this.buildStaticDataSourcingPolicy(),
       agentSkillCatalog: buildSkillCatalogPrompt(),
-      activatedAgentSkills: buildActivatedSkillsPrompt(activatedSkills),
     })
   }
 
@@ -430,18 +455,26 @@ export class AgentEngine {
     return resolveEffectiveResearchTier(expert?.defaultResearchTier, plan.researchTier)
   }
 
-  /** 本轮动态尾注：会话时钟 + 选型卡 + checklist/反空转（append 到 modelView，不进稳定 system） */
+  /** 本轮动态尾注：时钟 + 选型卡 + 档位 + 技能正文 + checklist/反空转 */
   private buildRoundTurnTail(sessionId: string, activeNames: readonly string[]) {
     const record = this.sessions.get(sessionId)
     const plan = this.lastRoutePlan ?? resolveToolRoutePlan({
       message: this.lastChatSeedMessage,
       contextRef: record?.contextRef ?? null,
     })
+    const expert = record?.expertId
+      ? getExpertCatalogService().getDefinitionSync(record.expertId)
+      : null
+    const tier = resolveEffectiveResearchTier(expert?.defaultResearchTier, plan.researchTier) ?? 'L2'
+    const activatedSkills = this.agentSkillSessions.getActivated(sessionId)
     const base = buildTurnTailPrompt({
       sessionClock: buildSessionClockPlaybook(getCurrentTime()),
       routePlaybook: buildRoundRoutePlaybook(plan, activeNames),
     })
     const extras = [
+      buildResearchTierTurnTail(tier),
+      this.buildTierDataSourcingTurnTail(tier),
+      buildActivatedSkillsPrompt(activatedSkills),
       buildChecklistTurnTail(sessionId),
       buildSpinGuardTurnTail(sessionId),
     ].filter(Boolean)
@@ -502,11 +535,71 @@ export class AgentEngine {
     const names = unattended ? filterToolNamesForUnattended(activeNames) : activeNames
     const broker = await this.createRoundBroker(names)
     const rawTools = await broker.openAiTools()
-    const preferred = this.lastRoutePlan?.preferredTools ?? []
-    // 远程 MCP 工具整体优先于本地兜底工具；preferred 排序仅在各自分组内生效。
-    let openAiTools = orderToolsByPreference(rawTools, preferred, { remoteFirst: true })
+    let openAiTools = orderToolsStable(rawTools)
     if (unattended) openAiTools = filterOpenAiToolsForUnattended(openAiTools)
     return { broker, openAiTools }
+  }
+
+  private clearFrozenTools(sessionId: string) {
+    this.frozenToolsBySession.delete(sessionId)
+  }
+
+  private clearFrozenToolsForSubtree(sessionId: string) {
+    this.clearFrozenTools(sessionId)
+    for (const key of [...this.frozenToolsBySession.keys()]) {
+      const child = this.sessions.get(key)
+      if (child?.parentSessionId === sessionId || child?.rootSessionId === sessionId) {
+        this.frozenToolsBySession.delete(key)
+      }
+    }
+  }
+
+  /** 会话首次 chat 全量 pack + 冻结 openAiTools；subagent 继承父快照再滤 blocked */
+  private async ensureFrozenSessionTools(
+    sessionId: string,
+    opts: {
+      parentSessionId?: string | null
+      unattended?: boolean
+      isSubSession?: boolean
+    },
+  ): Promise<SessionFrozenToolsEntry> {
+    const cached = this.frozenToolsBySession.get(sessionId)
+    if (cached) return cached
+
+    if (opts.isSubSession && opts.parentSessionId) {
+      const parentEntry = this.frozenToolsBySession.get(opts.parentSessionId)
+        ?? await this.ensureFrozenSessionTools(opts.parentSessionId, { isSubSession: false })
+      let entry = filterFrozenToolsForSubagent(parentEntry)
+      if (opts.unattended) entry = filterFrozenToolsForUnattended(entry)
+      this.frozenToolsBySession.set(sessionId, entry)
+      return entry
+    }
+
+    for (const id of businessPackIdsForSessionSeed()) {
+      this.toolPackSessions.activate(sessionId, [id])
+    }
+    let activeNames = resolveFullSessionToolNames()
+    if (opts.unattended) activeNames = filterToolNamesForUnattended(activeNames)
+    const { broker, openAiTools } = await this.rebuildRoundTools(activeNames, opts.unattended)
+    await broker.close().catch(() => {})
+    const entry: SessionFrozenToolsEntry = {
+      openAiTools,
+      activeNames,
+      toolsJson: JSON.stringify(openAiTools),
+      schemaGeneration: this.frozenToolsSchemaGeneration,
+    }
+    this.frozenToolsBySession.set(sessionId, entry)
+    return entry
+  }
+
+  /** MCP 工具 schema 变更：冷启动重建冻结集（prompt_cache_key 后缀随 generation 变） */
+  private async rebuildFrozenToolsAfterSchemaChange(
+    sessionId: string,
+    opts: { unattended?: boolean; isSubSession?: boolean; parentSessionId?: string | null },
+  ): Promise<SessionFrozenToolsEntry> {
+    this.frozenToolsSchemaGeneration += 1
+    this.clearFrozenToolsForSubtree(sessionId)
+    return this.ensureFrozenSessionTools(sessionId, opts)
   }
 
   private bindWorkspaceBridge(
@@ -752,20 +845,20 @@ export class AgentEngine {
   private bindPackBridge(sessionId: string): number {
     return this.tools.bindPackSession({
       sessionId,
-      listPacks: () => listToolPacksPayload(this.lastRoundPackIds),
+      listPacks: () => listToolPacksPayload(resolveFullSessionPackIds()),
       activatePacks: (packIds: string[]) => {
         const { activated, skipped } = this.toolPackSessions.activate(sessionId, packIds)
-        this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
-        this.invalidateContextUsage(sessionId)
+        const frozen = this.frozenToolsBySession.get(sessionId)
         return {
           ok: true,
+          already_loaded: true,
           activated,
           skipped,
-          active_packs: this.lastRoundPackIds,
-          tools_available: toolNamesForPacks(this.lastRoundPackIds).length,
+          active_packs: resolveFullSessionPackIds(),
+          tools_available: frozen?.activeNames.length ?? resolveFullSessionToolNames().length,
           hint: skipped.length
-            ? `部分 id 无效：${skipped.join(', ')}`
-            : '已激活；本轮工具列表将立即刷新',
+            ? `部分 id 无效：${skipped.join(', ')}；本会话 tools 已在首次 chat 全量加载，无需刷新 schema`
+            : '工具包已在会话启动时全量加载；activate_tool_pack 为 no-op，请直接调用 tools 列表中的工具',
         }
       },
     })
@@ -804,9 +897,8 @@ export class AgentEngine {
         if (packIdSet.size > 0) {
           const packResult = this.toolPackSessions.activate(sessionId, [...packIdSet])
           activatedPacks = packResult.activated
-          this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
           if (activatedPacks.length) {
-            toolsHint = `已挂上工具包：${activatedPacks.join(', ')}；本轮可直接调用包内工具，无需再 activate_tool_pack`
+            toolsHint = `已记录技能所需工具包：${activatedPacks.join(', ')}；本会话 tools 已全量加载，可直接调用`
           }
         }
 
@@ -881,8 +973,7 @@ export class AgentEngine {
     const modelId = resolved?.model ?? modelRef.replace(/^[^:]+:/, '') ?? 'default'
     const limitTokens = await resolveModelContextTokensAsync(modelId, providerId)
 
-    const activeNames = toolNamesForPacks(this.resolveRoundPackIds(sessionId))
-    const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
+    const systemPrompt = this.buildRoundSystemPrompt(sessionId)
     const contextMessages = contextRefToChatMessages(record.contextRef)
     const modelView = assembleModelView({
       systemPrompt,
@@ -892,19 +983,28 @@ export class AgentEngine {
       keepRecent: KEEP_RECENT_DEFAULT,
       contextProjection: record.contextProjection,
     })
-    let toolsTokens = activeNames.length * 120
-    try {
-      const { broker, openAiTools } = await this.rebuildRoundTools(activeNames)
+    let toolsTokens = resolveFullSessionToolNames().length * 120
+    const frozen = this.frozenToolsBySession.get(sessionId)
+    if (frozen) {
+      toolsTokens = estimateToolsTokens(frozen.openAiTools)
+    } else {
       try {
-        toolsTokens = estimateToolsTokens(openAiTools)
-      } finally {
-        await broker.close().catch(() => {})
+        const entry = await this.ensureFrozenSessionTools(sessionId, {
+          parentSessionId: record.parentSessionId,
+          isSubSession: record.kind === 'subagent' || Boolean(record.parentSessionId),
+        })
+        toolsTokens = estimateToolsTokens(entry.openAiTools)
+      } catch {
+        /* 粗估 */
       }
-    } catch {
-      /* 无完整 schema 时沿用 activeNames 粗估 */
     }
     // modelView 已含 system + memory + 近端；tools 为 API 侧单独字段，另加固定开销
     const usedTokens = estimateModelViewTokens(modelView) + toolsTokens + 512
+
+    const cacheSource = resolveSessionCacheHitSource(record.turns, record.usageTotals)
+    const cacheHitPercent = cacheSource
+      ? computeCacheHitPercent(cacheSource.cachedPromptTokens, cacheSource.promptTokens)
+      : undefined
 
     const usage: SessionContextUsage = {
       usedTokens,
@@ -914,6 +1014,12 @@ export class AgentEngine {
       estimated: true,
       usagePercent: computeContextUsagePercent(usedTokens, limitTokens),
       compacted: Boolean(record.contextProjection),
+      ...(cacheHitPercent !== undefined
+        ? {
+            cacheHitPercent,
+            cachedPromptTokens: cacheSource?.cachedPromptTokens,
+          }
+        : {}),
     }
     this.contextUsageCache.set(sessionId, usage)
     return usage
@@ -934,8 +1040,7 @@ export class AgentEngine {
     const resolved = this.registry.resolve(activeModel)
     const modelId = resolved?.model ?? activeModel?.replace(/^[^:]+:/, '') ?? 'default'
     const providerId = providerIdFromModelRef(activeModel)
-    const activeNames = toolNamesForPacks(this.resolveRoundPackIds(sessionId))
-    const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
+    const systemPrompt = this.buildRoundSystemPrompt(sessionId)
     const budget = await this.applyContextBudget(record, {
       modelId,
       providerId,
@@ -1158,6 +1263,7 @@ export class AgentEngine {
         // 避免子再 cascade 回父：直接清旁路后删记录
         this.userPromptBridge.cancelSession(childId)
         this.clearLoopSessionState(childId)
+        this.clearFrozenTools(childId)
         this.toolPackSessions.clear(childId)
         this.agentSkillSessions.clear(childId)
         this.clearExpertPacksSeeded(childId)
@@ -1178,6 +1284,7 @@ export class AgentEngine {
     this.chatAbortBySession.get(id)?.abort()
     this.userPromptBridge.cancelSession(id)
     this.clearLoopSessionState(id)
+    this.clearFrozenTools(id)
     this.toolPackSessions.clear(id)
     this.agentSkillSessions.clear(id)
     this.clearExpertPacksSeeded(id)
@@ -1624,11 +1731,15 @@ export class AgentEngine {
         emit,
         signal,
       })
-    this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
-    let activeNames = toolNamesForPacks(this.lastRoundPackIds)
-    if (unattended) activeNames = filterToolNamesForUnattended(activeNames)
-    if (isSubSession) activeNames = filterToolNamesForSubagent(activeNames)
-    let { broker, openAiTools } = await this.rebuildRoundTools(activeNames, unattended)
+    this.lastRoundPackIds = resolveFullSessionPackIds()
+    const frozenEntry = await this.ensureFrozenSessionTools(sessionId, {
+      parentSessionId: record.parentSessionId,
+      unattended,
+      isSubSession,
+    })
+    let activeNames = [...frozenEntry.activeNames]
+    let openAiTools = frozenEntry.openAiTools
+    let broker = await this.createRoundBroker(activeNames)
 
     try {
     let businessToolsUsed = 0
@@ -1683,7 +1794,7 @@ export class AgentEngine {
       }
 
       // 稳定 system（无时钟/选型卡）；动态内容经 turn-tail 追加，利于前缀缓存
-      const systemPrompt = this.buildRoundSystemPrompt(sessionId, activeNames)
+      const systemPrompt = this.buildRoundSystemPrompt(sessionId)
       let turnTail = this.buildRoundTurnTail(sessionId, activeNames)
       if (ephemeralTurnTailExtra) {
         turnTail = [turnTail, ephemeralTurnTailExtra].filter(Boolean).join('\n\n')
@@ -1697,7 +1808,10 @@ export class AgentEngine {
         ?? 'default'
       const providerId = providerIdFromModelRef(activeModel)
 
-      const promptCacheKey = promptCacheKeyForSession(sessionId)
+      const promptCacheKey = promptCacheKeyForSession(
+        sessionId,
+        frozenEntry.schemaGeneration,
+      )
       logChatDebugRoundStart(sessionId, {
         round: round + 1,
         model: activeModel || modelId,
@@ -1754,6 +1868,7 @@ export class AgentEngine {
         }
         const turn = await llm.chat(modelView, roundTools, signal, {
           sessionId,
+          promptCacheKey,
           temperature: record.llmParams?.temperature,
           maxTokens: record.llmParams?.maxTokens,
           reasoningEffort: record.llmParams?.reasoningEffort,
@@ -2024,12 +2139,9 @@ export class AgentEngine {
               result = { error: unloadedToolHint(fn) }
             } else {
               result = await runInToolSession(sessionId, () => broker.call(fn, args, { signal }))
-              // activate_agent_skill 会经 skill bridge 激活 required-packs / allowed-tools 对应 pack，
-              // 须与 activate_tool_pack 一样刷新本轮 activeNames/broker，否则同轮调用 pack 内工具会走 unloadedToolHint。
+              // MCP 运维会改变外部 tools schema → 冷启动重建冻结集（accept cache miss）
               if (
-                fn === 'activate_tool_pack'
-                || fn === 'activate_agent_skill'
-                || fn === 'enable_mcp_server'
+                fn === 'enable_mcp_server'
                 || fn === 'disable_mcp_server'
                 || fn === 'edit_mcp_server'
                 || fn === 'install_mcp_server'
@@ -2129,11 +2241,14 @@ export class AgentEngine {
 
         if (refreshTools) {
           await broker.close()
-          this.lastRoundPackIds = this.resolveRoundPackIds(sessionId)
-          activeNames = toolNamesForPacks(this.lastRoundPackIds)
-          if (unattended) activeNames = filterToolNamesForUnattended(activeNames)
-          if (isSubSession) activeNames = filterToolNamesForSubagent(activeNames)
-          ;({ broker, openAiTools } = await this.rebuildRoundTools(activeNames, unattended))
+          const refrozen = await this.rebuildFrozenToolsAfterSchemaChange(sessionId, {
+            unattended,
+            isSubSession,
+            parentSessionId: record.parentSessionId,
+          })
+          activeNames = [...refrozen.activeNames]
+          openAiTools = refrozen.openAiTools
+          broker = await this.createRoundBroker(activeNames)
         }
         continue
       }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -161,6 +161,14 @@ export {
   unloadedToolHint,
 } from './mcp/tool-pack-session.js'
 export {
+  orderToolsStable,
+  resolveFullSessionPackIds,
+  resolveFullSessionToolNames,
+  businessPackIdsForSessionSeed,
+  filterFrozenToolsForSubagent,
+  type SessionFrozenToolsEntry,
+} from './mcp/session-frozen-tools.js'
+export {
   resolvePackIdsFromSkill,
   splitSkillDeclarationTokens,
   type SkillPackDeclaration,
@@ -346,6 +354,9 @@ export {
   mergeTokenUsage,
   parseOpenAiUsage,
   resolveCacheWarmth,
+  computeCacheHitPercent,
+  resolveLatestTurnCacheUsage,
+  resolveSessionCacheHitSource,
   promptCacheKeyForSession,
 } from './llm/token-usage.js'
 

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -136,6 +136,8 @@ export type LlmToolChoice =
 
 export interface LlmChatOpts {
   sessionId?: string
+  /** 显式 prompt_cache_key；未设则回退 promptCacheKeyForSession(sessionId) */
+  promptCacheKey?: string
   /** 传入时走 SSE 流式；文本增量与 tool_calls 发现会回调 */
   onDelta?: (delta: LlmChatDelta) => void
   /** 本轮覆盖；未设则回退 LlmConfig / 默认 ladder */
@@ -163,6 +165,18 @@ export function resolveBodyToolChoice(
 function toolChoiceNeedsFallback(toolChoice: LlmToolChoice | undefined): boolean {
   if (toolChoice == null || toolChoice === 'auto') return false
   return true
+}
+
+/** 供测试与 buildBody 共用：解析 prompt_cache_key */
+export function resolveBodyPromptCacheKey(
+  sessionId?: string,
+  explicitKey?: string,
+): string | undefined {
+  const trimmedKey = explicitKey?.trim()
+  if (trimmedKey) return trimmedKey
+  const trimmedSession = sessionId?.trim()
+  if (trimmedSession) return promptCacheKeyForSession(trimmedSession)
+  return undefined
 }
 
 export interface LlmProvider {
@@ -585,9 +599,9 @@ export class OpenAiCompatibleProvider implements LlmProvider {
         body.reasoning_effort = opts.reasoningEffort
       }
       // 观测用：稳定 session 级 prompt cache key；不因 warm/cold 改写 messages
-      const sessionId = opts?.sessionId?.trim()
-      if (sessionId) {
-        body.prompt_cache_key = promptCacheKeyForSession(sessionId)
+      const promptCacheKey = resolveBodyPromptCacheKey(opts?.sessionId, opts?.promptCacheKey)
+      if (promptCacheKey) {
+        body.prompt_cache_key = promptCacheKey
       }
       if (tools?.length) {
         body.tools = tools

--- a/packages/agent/src/llm/token-usage.ts
+++ b/packages/agent/src/llm/token-usage.ts
@@ -32,6 +32,9 @@ export function mergeTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
 }
 
 function parseCachedPromptTokens(u: Record<string, unknown>): number | undefined {
+  if (typeof u.prompt_cache_hit_tokens === 'number' && Number.isFinite(u.prompt_cache_hit_tokens)) {
+    return Math.max(0, u.prompt_cache_hit_tokens)
+  }
   if (typeof u.cached_tokens === 'number' && Number.isFinite(u.cached_tokens)) {
     return Math.max(0, u.cached_tokens)
   }
@@ -72,7 +75,43 @@ export function resolveCacheWarmth(
   return usage.cachedPromptTokens > 0 ? 'warm' : 'cold'
 }
 
-/** 稳定 prompt_cache_key（同会话多轮不变） */
-export function promptCacheKeyForSession(sessionId: string): string {
-  return `opptrix-session:${sessionId}`
+/** 上游有 cached 上报时：round(100 * cached / max(prompt, 1))，钳制 0–100；无字段 → undefined */
+export function computeCacheHitPercent(
+  cachedPromptTokens: number | undefined,
+  promptTokens: number,
+): number | undefined {
+  if (cachedPromptTokens === undefined) return undefined
+  const denom = Math.max(promptTokens, 1)
+  return Math.min(100, Math.max(0, Math.round((100 * cachedPromptTokens) / denom)))
+}
+
+/** 最近一轮 assistant turn 含 cached 上报的 usage（从新到旧） */
+export function resolveLatestTurnCacheUsage(
+  turns: Array<{ role: string; usage?: TokenUsage }> | undefined,
+): TokenUsage | undefined {
+  if (!turns?.length) return undefined
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const turn = turns[i]
+    if (turn.role === 'assistant' && turn.usage?.cachedPromptTokens !== undefined) {
+      return turn.usage
+    }
+  }
+  return undefined
+}
+
+/** 最近一轮 turn 优先；否则会话累计 usageTotals（均有 cached 字段才返回） */
+export function resolveSessionCacheHitSource(
+  turns: Array<{ role: string; usage?: TokenUsage }> | undefined,
+  usageTotals?: TokenUsage | null,
+): Pick<TokenUsage, 'cachedPromptTokens' | 'promptTokens'> | undefined {
+  const fromTurn = resolveLatestTurnCacheUsage(turns)
+  if (fromTurn?.cachedPromptTokens !== undefined) return fromTurn
+  if (usageTotals?.cachedPromptTokens !== undefined) return usageTotals
+  return undefined
+}
+
+/** 稳定 prompt_cache_key（同会话多轮不变；schema 冷启动时 generation>0 追加后缀） */
+export function promptCacheKeyForSession(sessionId: string, schemaGeneration = 0): string {
+  const base = `opptrix-session:${sessionId}`
+  return schemaGeneration > 0 ? `${base}:s${schemaGeneration}` : base
 }

--- a/packages/agent/src/mcp/session-frozen-tools.ts
+++ b/packages/agent/src/mcp/session-frozen-tools.ts
@@ -1,0 +1,65 @@
+/**
+ * 会话级冻结 tools — DSH 前缀缓存：首次 chat 全量 pack + 稳定排序，mid-loop 不再变集/变序。
+ */
+
+import { allToolPackIds, businessPackIds, type ToolPackId } from '@opptrix/shared'
+import type { OpenAiTool } from '../tools.js'
+import { orderToolsByPreference } from './tool-route-plan.js'
+import { toolNamesForPacks } from './tool-pack-session.js'
+import {
+  filterOpenAiToolsForUnattended,
+  filterToolNamesForUnattended,
+} from '../unattended.js'
+import {
+  filterToolNamesForSubagent,
+  filterToolsForSubagent,
+} from '../subagents/tool-filter.js'
+
+export interface SessionFrozenToolsEntry {
+  openAiTools: OpenAiTool[]
+  activeNames: readonly string[]
+  /** JSON.stringify(openAiTools) — 同会话字节相等校验 */
+  toolsJson: string
+  schemaGeneration: number
+}
+
+/** 稳定排序：remoteFirst + 名字典序；禁止 preferred 重排 */
+export function orderToolsStable<T extends { function?: { name?: string }; name?: string }>(
+  tools: readonly T[],
+): T[] {
+  return orderToolsByPreference([...tools], [], { remoteFirst: true })
+}
+
+export function resolveFullSessionPackIds(): ToolPackId[] {
+  return allToolPackIds()
+}
+
+export function resolveFullSessionToolNames(): string[] {
+  return toolNamesForPacks(resolveFullSessionPackIds())
+}
+
+export function filterFrozenToolsForSubagent(entry: SessionFrozenToolsEntry): SessionFrozenToolsEntry {
+  const activeNames = filterToolNamesForSubagent([...entry.activeNames])
+  const openAiTools = filterToolsForSubagent(entry.openAiTools) as OpenAiTool[]
+  return {
+    openAiTools,
+    activeNames,
+    toolsJson: JSON.stringify(openAiTools),
+    schemaGeneration: entry.schemaGeneration,
+  }
+}
+
+export function filterFrozenToolsForUnattended(entry: SessionFrozenToolsEntry): SessionFrozenToolsEntry {
+  const activeNames = filterToolNamesForUnattended([...entry.activeNames])
+  const openAiTools = filterOpenAiToolsForUnattended([...entry.openAiTools])
+  return {
+    openAiTools,
+    activeNames,
+    toolsJson: JSON.stringify(openAiTools),
+    schemaGeneration: entry.schemaGeneration,
+  }
+}
+
+export function businessPackIdsForSessionSeed(): ToolPackId[] {
+  return businessPackIds()
+}

--- a/packages/agent/src/mcp/tool-pack-session.ts
+++ b/packages/agent/src/mcp/tool-pack-session.ts
@@ -87,11 +87,11 @@ export function listToolPacksPayload(activePackIds: readonly ToolPackId[]) {
 export function unloadedToolHint(toolName: string): string {
   const pack = packIdForTool(toolName)
   if (pack) {
-    return `工具 ${toolName} 未加载（属于 pack「${pack}」）。请先调用 activate_tool_pack，参数 pack_ids: ["${pack}"]，再重试。`
+    return `工具 ${toolName} 不在本会话冻结的 tools 列表中（映射 pack「${pack}」）。会话启动时已全量加载工具包；请核对本轮 tools 参数与选型卡首选工具，勿重复 activate_tool_pack。`
   }
   // 运行时 shared 与 agent TOOL_META 偶发不同步时，勿误导去 workspace 沙盒兜底
   if (Object.prototype.hasOwnProperty.call(TOOL_META, toolName)) {
-    return `工具 ${toolName} 已注册但未挂入可用 pack 映射（常见于 artifacts 等）。请先 activate_tool_pack 加载对应工具包，或更新应用后再试；勿改走 workspace 沙盒虚构实现。`
+    return `工具 ${toolName} 已注册但未挂入可用 pack 映射（常见于 artifacts 等）。本会话 tools 已冻结；请核对 tools 列表是否含该工具，或更新应用后再试；勿改走 workspace 沙盒虚构实现。`
   }
-  return `未知或不支持的工具：${toolName}。请先 list_tool_packs 查看可用工具包；若无合适 pack → activate_tool_pack，参数 pack_ids: ["workspace"]，用 opptrix_run / workspace_* 沙盒编程实现（ensure_python 仅失败兜底），勿虚构工具名。`
+  return `未知或不支持的工具：${toolName}。请 list_tool_packs 核对；若无对应工具 → 用 opptrix_run / workspace_* 沙盒编程实现（ensure_python 仅失败兜底），勿虚构工具名。`
 }

--- a/packages/agent/src/tool-meta.ts
+++ b/packages/agent/src/tool-meta.ts
@@ -645,8 +645,8 @@ export const TOOL_META: Record<string, ToolMeta> = {
   },
   activate_tool_pack: {
     packId: 'meta',
-    usageGuide: '按需激活业务工具包，使本轮及后续轮次可调用该包内工具；当前 tools 不足时使用。',
-    compliance: 'pack_ids 为字符串数组（如 ["news","instrument_analytics"]）；同会话累积激活；无效 id 会出现在 skipped。',
+    usageGuide: '记录需强调的业务域（本会话 tools 已全量加载）；选型卡已给出首选工具，通常无需再 activate。',
+    compliance: 'pack_ids 为字符串数组；同会话 tools schema 冻结不变；返回 already_loaded。',
   },
   list_agent_skills: {
     packId: 'meta',
@@ -655,8 +655,8 @@ export const TOOL_META: Record<string, ToolMeta> = {
   },
   activate_agent_skill: {
     packId: 'meta',
-    usageGuide: '激活工作流技能，将完整步骤注入本会话 system；用户提到早报/收盘报告/产业链/财报速读/深度分析流程时使用。技能正文中的 `@skill:依赖` 会自动递归激活；声明的 allowed-tools / required-packs 会自动挂上对应工具包。',
-    compliance: 'skill_names 为字符串数组；同会话最多 3 个；无效名或超额进入 skipped；循环依赖会被检测并跳过；返回 activated_packs / tools_hint。',
+    usageGuide: '激活工作流技能，完整步骤注入本轮尾注；技能 required-packs 仅作记录，tools schema 不重建。',
+    compliance: 'skill_names 为字符串数组；同会话最多 3 个；无效名或超额进入 skipped；循环依赖会被检测并跳过；返回 activated_packs。',
   },
   update_research_checklist: {
     packId: 'meta',

--- a/packages/agent/src/tools.ts
+++ b/packages/agent/src/tools.ts
@@ -1025,7 +1025,7 @@ export class ToolRegistry {
       {
         name: 'activate_tool_pack',
         category: '工具包',
-        description: '激活一个或多个业务工具包，使同会话后续（含本轮刷新后）可调用其中工具',
+        description: '记录工具包激活意图（本会话 tools 已在首次 chat 全量加载；调用为 no-op，请直接使用 tools 列表）',
         parameters: S({
           pack_ids: {
             type: 'array',

--- a/packages/shared/src/agent-prompt-guide.ts
+++ b/packages/shared/src/agent-prompt-guide.ts
@@ -466,10 +466,10 @@ export function buildResearchOutputPlaybook(tier: ResearchTier = 'L2'): string {
       '4) 综合判断：条件化结论 + 主要风险与否证条件',
       '5) 数据缺口：列出仍缺的维度或未加载工具包',
       '- 每一维最多一个主证据工具；「全面」不等于堆砌重复工具',
-      '- 声称全面分析前：缺 fundamentals/market/news 等能力时先 activate_tool_pack，或明示缺口',
+      '- 声称全面分析前：缺 fundamentals/market/news 等能力时按选型卡首选工具直接取数，或明示缺口',
       '- 【正文插图（默认）】有可对比/趋势/占比/强弱矩阵等定量事实 → 在答复中灵活插入 ```chart / ```opptrix-chart（→ @opptrix/canvas Chart）；无需授权、无需 activate artifacts；禁止 shell/python（matplotlib 等）绘图代替围栏',
-      '- 【完整可视化报告】仅当用户明确点名报告/画布/可视化报告/机构调研报告版式/create_canvas，或你判断本轮值得交付完整多章节图文报告（深度/全面/系统解读且多维证据齐全）时：activate_tool_pack([\'artifacts\']) → create_canvas；禁止为此先 ask_user；勿用 python 画报告图',
-      '- 【关系梳理】产业链/股东/主题/流程等关系结构 → activate_tool_pack([\'artifacts\']) → create_mindmap；禁止虚构独立知识图谱工具',
+      '- 【完整可视化报告】仅当用户明确点名报告/画布/可视化报告/机构调研报告版式/create_canvas，或你判断本轮值得交付完整多章节图文报告（深度/全面/系统解读且多维证据齐全）时：直接 create_canvas；禁止为此先 ask_user；勿用 python 画报告图',
+      '- 【关系梳理】产业链/股东/主题/流程等关系结构 → 直接 create_mindmap；禁止虚构独立知识图谱工具',
       '- 【自感应边界】单纯报价、一问一答事实、用户只要口头结论、或一两张图即可表达 → 只用正文 chart + 文字，勿主动 create_canvas / create_mindmap',
       '- 【勿混淆】插图 ≠ 报告；用户说「画个图/柱状图/对比一下」用围栏；「可视化报告/画布」才 create_canvas；「关系/脑图/结构梳理」用 create_mindmap',
     ].join('\n')
@@ -479,8 +479,8 @@ export function buildResearchOutputPlaybook(tier: ResearchTier = 'L2'): string {
     '- 结构：结论摘要 → 事实依据（工具+时点）→ 简短解读 → 主要风险一句',
     '- 工具：首选路径取证据后停止；用户未要求则不升维到 L3 全备忘录',
     '- 【正文插图（默认）】有可对比/趋势/占比/强弱矩阵等定量事实 → 在答复中灵活插入 ```chart / ```opptrix-chart（→ @opptrix/canvas Chart）；无需授权、无需 activate artifacts；禁止 shell/python（matplotlib 等）绘图代替围栏',
-    '- 【完整可视化报告】仅当用户明确点名报告/画布/可视化报告/机构调研报告版式/create_canvas，或你判断本轮值得交付完整多章节图文报告（深度/全面/系统解读且多维证据齐全）时：activate_tool_pack([\'artifacts\']) → create_canvas；禁止为此先 ask_user；勿用 python 画报告图',
-    '- 【关系梳理】产业链/股东/主题/流程等关系结构 → activate_tool_pack([\'artifacts\']) → create_mindmap；禁止虚构独立知识图谱工具',
+    '- 【完整可视化报告】仅当用户明确点名报告/画布/可视化报告/机构调研报告版式/create_canvas，或你判断本轮值得交付完整多章节图文报告（深度/全面/系统解读且多维证据齐全）时：直接 create_canvas；禁止为此先 ask_user；勿用 python 画报告图',
+    '- 【关系梳理】产业链/股东/主题/流程等关系结构 → 直接 create_mindmap；禁止虚构独立知识图谱工具',
     '- 【自感应边界】单纯报价、一问一答事实、用户只要口头结论、或一两张图即可表达 → 只用正文 chart + 文字，勿主动 create_canvas / create_mindmap',
     '- 【勿混淆】插图 ≠ 报告；用户说「画个图/柱状图/对比一下」用围栏；「可视化报告/画布」才 create_canvas；「关系/脑图/结构梳理」用 create_mindmap',
   ].join('\n')
@@ -499,7 +499,7 @@ export function buildResearchCompletenessLoop(tier: ResearchTier = 'L2'): string
     '1) 缺口自检：整理本轮已获数据，对照本档位输出骨架逐维核对，列出「缺失维度 / 空数据 / 陈旧数据 / 结果标注 degraded 的降级项」。',
     '2) 针对性补齐：对每个缺口，判断是否有可用工具可补——',
     '   - 首选工具报错/空 → 换数据源或换等价工具重试一次；',
-    '   - 缺整类能力（如基本面/行情/资讯/行业）→ 先 list_tool_packs → activate_tool_pack 再取；',
+    '   - 缺整类能力（如基本面/行情/资讯/行业）→ 先看本轮尾注「工具选型卡」选首选工具；仍无对应工具则 list_tool_packs 核对后明示缺口；',
     '   - 结果为 local 降级 → 尽量重试远程 MCP 补权威数据。',
     '3) 重新纳入：补齐后的数据必须回到分析中重新研判，不得把补充数据仅附在末尾。',
     '4) 收敛：仅当「缺口已补齐」或「确认无工具可补（须在报告『数据缺口』中说明原因）」时，才输出最终报告。',
@@ -559,15 +559,23 @@ function packLoaded(set: Set<string> | null, id: string): boolean {
   return set == null || set.has(id)
 }
 
+/** 按档位注入 turn-tail（稳定 system 不含 L1/L2/L3 长分支） */
+export function buildResearchTierTurnTail(tier: ResearchTier = 'L2'): string {
+  const parts = [buildResearchOutputPlaybook(tier)]
+  if (tier !== 'L1') {
+    parts.push(buildResearchCompletenessLoop(tier))
+  }
+  return parts.filter(Boolean).join('\n\n')
+}
+
 /** 聊天 Agent 完整 system 规则正文（不含角色行） */
 export function buildAgentSystemRules(opts?: AgentSystemRulesOptions): string {
   const packs = packSet(opts?.activePacks)
-  const tier = opts?.researchTier ?? 'L2'
   const sections: string[] = [
     '规则：',
     '- 需要数据时必须先调用工具，禁止编造数字或臆测行情',
     '- 跨市场标的统一用 Stock-index 命名空间（CN:SZ.000009）或 search 返回的 instrument 对象',
-    '- 仅使用当前会话已加载的 MCP 工具（见 tools 列表）；缺能力时 list_tool_packs → activate_tool_pack',
+    '- 本会话 tools 列表已在首次 chat 全量加载并冻结；优先按本轮尾注「工具选型卡」选工具',
   ]
 
   sections.push(
@@ -579,21 +587,13 @@ export function buildAgentSystemRules(opts?: AgentSystemRulesOptions): string {
     '3) 引用须带文档名与页码；禁止臆造未读内容；勿一次灌全文',
   )
 
-  // 会话时钟 / 选型卡 → turn-tail（见 buildTurnTailPrompt），勿写入稳定 system
+  // 会话时钟 / 选型卡 / 档位骨架 → turn-tail（见 buildTurnTailPrompt / buildResearchTierTurnTail）
 
-  sections.push(
-    buildResearchEpistemicPlaybook(),
-    buildResearchOutputPlaybook(tier),
-  )
+  sections.push(buildResearchEpistemicPlaybook())
 
   sections.push(buildWorkspaceAccessPlaybook())
   sections.push(buildLocalDataCatalogIndexPrompt())
   sections.push(buildLocalProgrammingPlaybook())
-
-  // 完备性闭环仅作用于 L2/L3 报告类输出；L1 事实快答保持轻量。
-  if (tier !== 'L1') {
-    sections.push(buildResearchCompletenessLoop(tier))
-  }
 
   sections.push(buildToolPackCatalogPrompt())
   sections.push(buildInstrumentNamespacePlaybook())
@@ -602,10 +602,8 @@ export function buildAgentSystemRules(opts?: AgentSystemRulesOptions): string {
   if (packLoaded(packs, 'core')) {
     sections.push(buildStandardInstrumentApiPlaybook())
   }
-  // 协作委派：本轮暴露 run_subagent，或未列 tool 名但 core 已加载时注入
-  const hasRunSubagentTool = opts?.activeToolNames?.includes('run_subagent') === true
-  const assumeCoreHasSubagent = opts?.activeToolNames == null && packLoaded(packs, 'core')
-  if (hasRunSubagentTool || assumeCoreHasSubagent) {
+  // 协作委派：core 已全量加载
+  if (packLoaded(packs, 'core')) {
     sections.push(buildCollaborationSubagentPlaybook())
   }
   if (packLoaded(packs, 'fundamentals')) {
@@ -631,23 +629,18 @@ export function buildAgentSystemRules(opts?: AgentSystemRulesOptions): string {
     sections.push(buildNewsRetrievalPlaybook())
   }
 
-  if (opts?.activeToolNames?.length) {
-    sections.push(
-      `- 本轮可用工具（共 ${opts.activeToolNames.length} 个）：${opts.activeToolNames.slice(0, 40).join(', ')}${opts.activeToolNames.length > 40 ? '…' : ''}`,
-    )
-  }
-
   sections.push(
-    '- 每个已加载工具描述含【何时使用】【调用规范】，严格遵守；以本轮选型卡与证据纪律为首要决策依据',
+    '- 每个工具描述含【何时使用】【调用规范】，严格遵守；以本轮尾注选型卡与证据纪律为首要决策依据',
     '- 不推荐具体买卖，仅提供研究与数据解读',
-    '- L1 走最短正确路径；L3 按备忘录骨架覆盖并声明缺口；禁止为堆砌而重复调用',
+    '- 答复档位与输出骨架见本轮尾注，勿为堆砌而重复调用',
   )
 
-  const hasShellTools = opts?.activeToolNames?.some(
-    name => name === 'opptrix_run' || name === 'code_preflight'
-      || name === 'workspace_replace_lines'
-      || name.startsWith('workspace_'),
-  )
+  const hasShellTools = packLoaded(packs, 'workspace')
+    || opts?.activeToolNames?.some(
+      name => name === 'opptrix_run' || name === 'code_preflight'
+        || name === 'workspace_replace_lines'
+        || name.startsWith('workspace_'),
+    )
   if (hasShellTools) {
     sections.push(
       '- 【方案 1 / OpenCode 式】读改写文件 = workspace_*（优先于 shell）；跑命令 = opptrix_run（真 shell，含 background）+ 可选 code_preflight；领域工具仅行情/财务/资讯/画布；勿互相替代',
@@ -665,7 +658,7 @@ export function buildAgentSystemRules(opts?: AgentSystemRulesOptions): string {
     )
   } else {
     sections.push(
-      '- 未加载 opptrix_run / workspace_* 时：勿声称具备本地命令、工作区文件或未提供的工具能力；内置工具不够或无匹配时 → 默认已含 workspace pack，直接用 opptrix_run / code_preflight / workspace_* 沙盒编程实现（ensure_python 仅失败兜底；可先标准工具取数再沙盒计算），勿空转 activate 无关 pack，勿直接声称无法完成',
+      '- 沙盒 workspace 工具已随会话全量加载；内置工具不够时直接用 opptrix_run / code_preflight / workspace_* 编程实现（ensure_python 仅失败兜底），勿空转 activate，勿直接声称无法完成',
     )
   }
 

--- a/packages/shared/src/tool-packs.ts
+++ b/packages/shared/src/tool-packs.ts
@@ -343,12 +343,22 @@ export function alwaysOnPackIds(): ToolPackId[] {
   return TOOL_PACK_DEFS.filter(p => p.alwaysOn).map(p => p.id)
 }
 
+/** 会话冻结 Broker 用：全部 pack（always-on + 业务） */
+export function allToolPackIds(): ToolPackId[] {
+  return [...TOOL_PACK_IDS]
+}
+
+/** 非 always-on 的业务 pack（会话首次 chat 一次性激活） */
+export function businessPackIds(): ToolPackId[] {
+  return TOOL_PACK_DEFS.filter(p => !p.alwaysOn).map(p => p.id)
+}
+
 /** system 提示用的简短 pack 目录（替代长 TOOL_ROUTING 表） */
 export function buildToolPackCatalogPrompt(): string {
   const lines = [
     '## 工具包目录（按需加载）',
-    '每轮默认加载 core + meta + workspace；其它包由意图播种或 activate_tool_pack 激活。',
-    '需要未加载能力时：先 list_tool_packs，再 activate_tool_pack({ pack_ids: [...] })。',
+    '会话首次进入 chat 时全量加载所有工具包（core + meta + workspace + 全部业务 pack）；tools 列表本会话冻结不变。',
+    'activate_tool_pack 为 no-op（已加载）；缺能力时先看本轮尾注「工具选型卡」选首选工具，勿重复 activate。',
     '',
     '| pack_id | 标题 | 何时激活 |',
     '|---------|------|----------|',

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -40,6 +40,7 @@ for (const file of testFiles) {
     || label === 'chat-notifications.test.mjs'
     || label === 'canvas-compile-smoke.test.mjs'
     || label === 'news-articles-memory-cap.test.mjs'
+    || label === 'context-usage-format.test.mjs'
   ) {
     nodeArgs.unshift('--experimental-strip-types')
   }

--- a/tests/agent-research-prompt.test.mjs
+++ b/tests/agent-research-prompt.test.mjs
@@ -7,6 +7,8 @@ import {
   buildAgentSystemRules,
   buildResearchEpistemicPlaybook,
   buildResearchOutputPlaybook,
+  buildResearchCompletenessLoop,
+  buildResearchTierTurnTail,
   buildSessionClockPlaybook,
   buildWorkspaceAccessPlaybook,
   buildLocalProgrammingPlaybook,
@@ -138,12 +140,22 @@ test('L2/L3 output playbooks prefer inline chart; no ask_user report gate', () =
     assert.match(text, /关系梳理/)
     assert.match(text, /create_mindmap/)
     assert.match(text, /禁止虚构.*知识图谱|禁止虚构独立知识图谱/)
+    assert.match(text, /直接 create_canvas|直接 create_mindmap/)
+    assert.doesNotMatch(text, /activate_tool_pack/)
     assert.ok(!text.includes('可视化报告确认'))
     assert.ok(!text.includes('跳过询问'))
     assert.ok(!text.includes('同意后'))
     assert.ok(!text.includes('拒绝后'))
     assert.ok(!text.includes('仅文字答复'))
     assert.ok(!/优先 ask_user 询问是否生成可视化/.test(text))
+  }
+})
+
+test('research completeness loop avoids ritual activate_tool_pack', () => {
+  for (const tier of /** @type {const} */ (['L2', 'L3'])) {
+    const text = buildResearchCompletenessLoop(tier)
+    assert.match(text, /工具选型卡/)
+    assert.doesNotMatch(text, /activate_tool_pack/)
   }
 })
 
@@ -166,22 +178,15 @@ test('collaboration subagent playbook covers schema and lifecycle', () => {
   assert.match(text, /忙等|poll/)
 })
 
-test('system rules inject collaboration playbook when run_subagent available', () => {
-  const withTool = buildAgentSystemRules({
+test('system rules inject collaboration playbook when core pack loaded', () => {
+  const withCore = buildAgentSystemRules({
     activePacks: ['core'],
     activeToolNames: ['run_subagent', 'get_instrument_snapshot'],
   })
-  assert.match(withTool, /协作任务 — run_subagent/)
-  assert.match(withTool, /建议强制 summary/)
+  assert.match(withCore, /协作任务 — run_subagent/)
 
   const coreOnly = buildAgentSystemRules({ activePacks: ['core'] })
   assert.match(coreOnly, /协作任务 — run_subagent/)
-
-  const withoutTool = buildAgentSystemRules({
-    activePacks: ['core'],
-    activeToolNames: ['get_instrument_snapshot'],
-  })
-  assert.ok(!withoutTool.includes('协作任务 — run_subagent'))
 })
 
 test('artifacts playbook report-priority without prior ask confirmation', () => {
@@ -191,17 +196,18 @@ test('artifacts playbook report-priority without prior ask confirmation', () => 
   assert.ok(!text.includes('用户已确认要可视化投研报告'))
 })
 
-test('system rules always include epistemic + tier skeleton', () => {
+test('stable system excludes tier skeleton; turn-tail carries L3 branches', () => {
   const rules = buildAgentSystemRules({
     activePacks: ['core', 'meta'],
     researchTier: 'L3',
     routePlaybook: '【本轮工具选型卡】\n- test',
   })
   assert.match(rules, /投研证据纪律/)
-  assert.match(rules, /深度投研备忘录/)
-  // 选型卡进 turn-tail，不进稳定 system
+  assert.ok(!rules.includes('深度投研备忘录'))
   assert.ok(!rules.includes('本轮工具选型卡'))
   assert.ok(!rules.includes('【资讯调阅'))
+  const tail = buildResearchTierTurnTail('L3')
+  assert.match(tail, /深度投研备忘录/)
 })
 
 test('research tier: price=L1, news=L2, depth=L3, 全面 upgrades', () => {
@@ -237,13 +243,13 @@ test('L1 plan playbook asks to stop after short path', () => {
 
 test('ToolRegistry systemPrompt embeds researcher persona and epistemic rules', () => {
   const prompt = new ToolRegistry(new ResearchHub()).systemPrompt({
-    researchTier: 'L2',
     activePacks: ['core', 'meta'],
   })
   assert.match(prompt, /系统底线/)
   assert.match(prompt, /投研研究员/)
   assert.match(prompt, /投研证据纪律/)
-  assert.match(prompt, /答复档位 L2/)
+  assert.ok(!prompt.includes('答复档位 L2'))
+  assert.match(buildResearchTierTurnTail('L2'), /答复档位 L2/)
 })
 
 test('Layer0 baseline cannot be overridden by expert persona injection', () => {

--- a/tests/chat-token-usage.test.mjs
+++ b/tests/chat-token-usage.test.mjs
@@ -136,6 +136,23 @@ describe('parseOpenAiUsage', () => {
   })
 })
 
+describe('resolveBodyPromptCacheKey', () => {
+  it('prefers explicit key with schema generation suffix', async () => {
+    const { resolveBodyPromptCacheKey } = await import('../packages/agent/dist/llm/provider.js')
+    assert.equal(
+      resolveBodyPromptCacheKey('sess-1', 'opptrix-session:sess-1:s2'),
+      'opptrix-session:sess-1:s2',
+    )
+    assert.equal(resolveBodyPromptCacheKey('sess-1', '  '), 'opptrix-session:sess-1')
+    assert.equal(resolveBodyPromptCacheKey(undefined, undefined), undefined)
+  })
+
+  it('falls back to session id without generation', async () => {
+    const { resolveBodyPromptCacheKey } = await import('../packages/agent/dist/llm/provider.js')
+    assert.equal(resolveBodyPromptCacheKey('abc'), 'opptrix-session:abc')
+  })
+})
+
 describe('resolveCacheWarmth / promptCacheKeyForSession', () => {
   it('derives warm|cold|unknown', async () => {
     const { resolveCacheWarmth, promptCacheKeyForSession } = await import(
@@ -146,6 +163,40 @@ describe('resolveCacheWarmth / promptCacheKeyForSession', () => {
     assert.equal(resolveCacheWarmth({ cachedPromptTokens: 0 }), 'cold')
     assert.equal(resolveCacheWarmth({ cachedPromptTokens: 12 }), 'warm')
     assert.equal(promptCacheKeyForSession('abc'), 'opptrix-session:abc')
+  })
+})
+
+describe('computeCacheHitPercent / resolveSessionCacheHitSource', () => {
+  it('computes percent and clamps 0–100', async () => {
+    const { computeCacheHitPercent } = await import('../packages/agent/dist/llm/token-usage.js')
+    assert.equal(computeCacheHitPercent(undefined, 100), undefined)
+    assert.equal(computeCacheHitPercent(80, 100), 80)
+    assert.equal(computeCacheHitPercent(50, 0), 100)
+    assert.equal(computeCacheHitPercent(150, 100), 100)
+    assert.equal(computeCacheHitPercent(-5, 100), 0)
+  })
+
+  it('prefers latest assistant turn over usageTotals', async () => {
+    const { resolveSessionCacheHitSource } = await import('../packages/agent/dist/llm/token-usage.js')
+    const turns = [
+      { role: 'user', usage: undefined },
+      {
+        role: 'assistant',
+        usage: { promptTokens: 200, completionTokens: 10, totalTokens: 210, cachedPromptTokens: 180 },
+      },
+    ]
+    const totals = { promptTokens: 500, completionTokens: 50, totalTokens: 550, cachedPromptTokens: 100 }
+    const hit = resolveSessionCacheHitSource(turns, totals)
+    assert.equal(hit?.cachedPromptTokens, 180)
+    assert.equal(hit?.promptTokens, 200)
+  })
+
+  it('falls back to usageTotals when no turn has cached', async () => {
+    const { resolveSessionCacheHitSource } = await import('../packages/agent/dist/llm/token-usage.js')
+    const turns = [{ role: 'assistant', usage: { promptTokens: 10, completionTokens: 1, totalTokens: 11 } }]
+    const totals = { promptTokens: 100, completionTokens: 5, totalTokens: 105, cachedPromptTokens: 40 }
+    const hit = resolveSessionCacheHitSource(turns, totals)
+    assert.equal(hit?.cachedPromptTokens, 40)
   })
 })
 

--- a/tests/context-usage-format.test.mjs
+++ b/tests/context-usage-format.test.mjs
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  formatCacheHitLabel,
+  formatContextUsageLabel,
+  resolveContextUsagePercent,
+} from '../client-ui/src/chat/formatTokenCount.ts'
+
+describe('formatCacheHitLabel', () => {
+  it('formats cache hit percent', () => {
+    assert.equal(formatCacheHitLabel(72), '缓存约 72%')
+    assert.equal(formatCacheHitLabel(0), '缓存约 0%')
+    assert.equal(formatCacheHitLabel(150), '缓存约 100%')
+    assert.equal(formatCacheHitLabel(-3), '缓存约 0%')
+  })
+})
+
+describe('formatContextUsageLabel with cache', () => {
+  it('context label unchanged', () => {
+    assert.equal(formatContextUsageLabel(42), '上下文约 42%')
+    assert.equal(formatContextUsageLabel(42, true), '上下文约 42% · 已整理')
+  })
+
+  it('resolveContextUsagePercent still works', () => {
+    assert.equal(resolveContextUsagePercent({ usagePercent: 55, usedTokens: 1, limitTokens: 100 }), 55)
+  })
+})

--- a/tests/mcp-tool-pack-router.test.mjs
+++ b/tests/mcp-tool-pack-router.test.mjs
@@ -5,6 +5,7 @@ import {
   TOOL_PACK_MEMBERSHIP,
   TOOL_PACK_DEFS,
   alwaysOnPackIds,
+  allToolPackIds,
   toolsInPack,
   packIdForTool,
   buildToolPackCatalogPrompt,
@@ -98,22 +99,18 @@ test('resolver seeds industry for 指数成分', () => {
   assert.ok(packs.includes('industry'))
 })
 
-test('activate expands active tool names across session', () => {
+test('activate expands session pack bookkeeping without shrinking tool exposure', () => {
   const store = new ToolPackSessionStore()
   const sessionId = 'test-session'
   const before = resolveActivePackIds(store, sessionId, { message: '你好' })
   assert.deepEqual([...before].sort(), ['core', 'meta', 'workspace'])
-  const namesBefore = toolNamesForPacks(before)
-  assert.ok(namesBefore.includes('search_instruments'))
-  assert.ok(namesBefore.includes('opptrix_run'))
-  assert.ok(!namesBefore.includes('list_news_articles'))
-
   store.activate(sessionId, ['news'])
   const after = resolveActivePackIds(store, sessionId, { message: '你好' })
   assert.ok(after.includes('news'))
-  const namesAfter = toolNamesForPacks(after)
-  assert.ok(namesAfter.includes('list_news_articles'))
-  assert.ok(namesAfter.length > namesBefore.length)
+  const fullNames = toolNamesForPacks(allToolPackIds())
+  const coldNames = toolNamesForPacks(before)
+  assert.ok(fullNames.length > coldNames.length)
+  assert.ok(fullNames.includes('list_news_articles'))
 })
 
 test('cold start always includes workspace pack tools', () => {
@@ -127,16 +124,18 @@ test('cold start always includes workspace pack tools', () => {
   assert.ok(!names.includes('workspace_mkdir'))
 })
 
-test('unloaded tool hint points to activate_tool_pack', () => {
+test('unloaded tool hint reflects frozen session tools', () => {
   const hint = unloadedToolHint('evaluate_instrument')
-  assert.match(hint, /activate_tool_pack/)
+  assert.match(hint, /冻结|全量加载/)
   assert.match(hint, /instrument_analytics/)
+  assert.match(hint, /选型卡|tools/)
+  assert.doesNotMatch(hint, /请先调用 activate_tool_pack/)
 })
 
 test('unloaded tool hint for list_web_vendor names artifacts pack', () => {
   assert.equal(packIdForTool('list_web_vendor'), 'artifacts')
   const hint = unloadedToolHint('list_web_vendor')
-  assert.match(hint, /activate_tool_pack/)
+  assert.match(hint, /冻结|tools/)
   assert.match(hint, /artifacts/)
   assert.doesNotMatch(hint, /未知或不支持/)
 })
@@ -149,17 +148,17 @@ test('unknown tool hint falls back to workspace sandbox', () => {
   assert.match(hint, /勿虚构/)
 })
 
-test('engine refreshes tools after activate_agent_skill (same as activate_tool_pack)', () => {
-  // 契约：技能激活会写入 session packs，须同轮 refreshTools，否则 list_web_vendor 等会误报未加载/未知
+test('activate_agent_skill does not trigger mid-loop tools schema rebuild', () => {
   const engineSrc = fs.readFileSync(
     new URL('../packages/agent/src/engine.ts', import.meta.url),
     'utf8',
   )
-  const refreshBlock = engineSrc.match(
-    /if\s*\(\s*fn === 'activate_tool_pack'[\s\S]*?\)\s*\{\s*refreshTools = true/,
+  assert.doesNotMatch(
+    engineSrc,
+    /fn === 'activate_agent_skill'[\s\S]*?\)\s*\{\s*refreshTools = true/,
   )
-  assert.ok(refreshBlock, 'expected refreshTools condition block after pack/skill activate')
-  assert.match(refreshBlock[0], /fn === 'activate_agent_skill'/)
+  assert.match(engineSrc, /buildActivatedSkillsPrompt/)
+  assert.match(engineSrc, /buildRoundTurnTail/)
 })
 
 test('list_tool_packs payload marks loaded state', () => {
@@ -176,6 +175,7 @@ test('pack catalog prompt is slim vs legacy routing tables', () => {
   assert.match(prompt, /activate_tool_pack/)
   assert.match(prompt, /调用纪律/)
   assert.match(prompt, /workspace/)
+  assert.match(prompt, /全量加载|冻结/)
   assert.match(prompt, /core \+ meta \+ workspace|默认加载 core \+ meta \+ workspace/)
   assert.match(prompt, /opptrix_run|沙盒|编程实现/)
   assert.match(prompt, /禁止仅为「开工」再 activate|勿仪式化|已加载/)
@@ -189,28 +189,8 @@ test('workspace seed patterns cover programming fallback without research spam',
   assert.ok(!resolveSeedPacks({ message: '茅台现价多少' }).includes('workspace'))
 })
 
-test('cold start exposed tools << full registry', () => {
-  const store = new ToolPackSessionStore()
-  const packs = resolveActivePackIds(store, 's1', { message: '随便问问' })
-  const exposed = toolNamesForPacks(packs)
+test('full session pack load exposes all registered chat tools', () => {
   const full = new ToolRegistry(new ResearchHub()).list().length
-  assert.ok(exposed.length < full)
-  const alwaysOnMax =
-    toolsInPack('core').length + toolsInPack('meta').length + toolsInPack('workspace').length
-  assert.ok(exposed.length <= alwaysOnMax)
-})
-
-test('analysis seed keeps tools under full set', () => {
-  const store = new ToolPackSessionStore()
-  const packs = resolveActivePackIds(store, 's2', { message: '分析 600519' })
-  assert.ok(packs.includes('instrument_analytics'))
-  assert.ok(
-    packs.filter(p => p !== 'core' && p !== 'meta' && p !== 'workspace').length
-      <= MAX_SEEDED_BUSINESS_PACKS,
-  )
-  const exposed = toolNamesForPacks(packs)
-  const full = new ToolRegistry(new ResearchHub()).list().length
-  assert.ok(exposed.length < full)
-  assert.ok(exposed.includes('evaluate_instrument'))
-  assert.ok(exposed.includes('search_instruments'))
+  const exposed = toolNamesForPacks(allToolPackIds())
+  assert.equal(exposed.length, full)
 })

--- a/tests/session-tools-freeze.test.mjs
+++ b/tests/session-tools-freeze.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * 会话级 tools 冻结 — DSH 前缀缓存
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import {
+  allToolPackIds,
+  businessPackIds,
+  buildResearchTierTurnTail,
+  buildAgentSystemRules,
+} from '../packages/shared/dist/index.js'
+import {
+  orderToolsStable,
+  resolveFullSessionToolNames,
+  filterFrozenToolsForSubagent,
+} from '../packages/agent/dist/index.js'
+import {
+  parseOpenAiUsage,
+  promptCacheKeyForSession,
+} from '../packages/agent/dist/llm/token-usage.js'
+
+test('allToolPackIds includes always-on and all business packs', () => {
+  const ids = allToolPackIds()
+  assert.ok(ids.includes('core'))
+  assert.ok(ids.includes('meta'))
+  assert.ok(ids.includes('workspace'))
+  assert.ok(ids.includes('news'))
+  assert.ok(ids.includes('artifacts'))
+  assert.equal(businessPackIds().includes('core'), false)
+  assert.equal(businessPackIds().includes('meta'), false)
+})
+
+test('orderToolsStable ignores preferred and is byte-stable', () => {
+  const tools = [
+    { type: 'function', function: { name: 'z_local', description: 'z' } },
+    { type: 'function', function: { name: 'ext__remote', description: 'r' } },
+    { type: 'function', function: { name: 'a_local', description: 'a' } },
+  ]
+  const once = JSON.stringify(orderToolsStable(tools))
+  const twice = JSON.stringify(orderToolsStable(tools))
+  assert.equal(once, twice)
+  const ordered = orderToolsStable(tools)
+  assert.equal(ordered[0].function.name, 'ext__remote')
+  assert.equal(ordered[1].function.name, 'a_local')
+  assert.equal(ordered[2].function.name, 'z_local')
+})
+
+test('filterFrozenToolsForSubagent preserves stable toolsJson shape', () => {
+  const entry = {
+    openAiTools: [
+      { type: 'function', function: { name: 'ask_user', description: 'x' } },
+      { type: 'function', function: { name: 'workspace_read', description: 'y' } },
+    ],
+    activeNames: ['ask_user', 'run_subagent', 'workspace_read'],
+    toolsJson: '[]',
+    schemaGeneration: 0,
+  }
+  const filtered = filterFrozenToolsForSubagent(entry)
+  assert.deepEqual(filtered.activeNames, ['workspace_read'])
+  assert.equal(filtered.openAiTools.length, 1)
+  assert.equal(filtered.openAiTools[0].function.name, 'workspace_read')
+  assert.equal(filtered.toolsJson, JSON.stringify(filtered.openAiTools))
+})
+
+test('full session tool names cover registry chat tools', () => {
+  const names = resolveFullSessionToolNames()
+  assert.ok(names.includes('search_instruments'))
+  assert.ok(names.includes('list_news_articles'))
+  assert.ok(names.includes('opptrix_run'))
+  assert.ok(names.length > 80)
+})
+
+test('research tier long branches live in turn-tail not stable system', () => {
+  const rules = buildAgentSystemRules({ activePacks: undefined })
+  assert.ok(!rules.includes('【答复档位 L3 — 深度投研备忘录】'))
+  assert.ok(!rules.includes('【答复档位 L1 — 事实快答】'))
+  const tail = buildResearchTierTurnTail('L3')
+  assert.match(tail, /答复档位 L3/)
+  assert.match(tail, /完备性/)
+})
+
+test('parseOpenAiUsage maps DeepSeek prompt_cache_hit_tokens', () => {
+  const usage = parseOpenAiUsage({
+    prompt_tokens: 1000,
+    completion_tokens: 50,
+    total_tokens: 1050,
+    prompt_cache_hit_tokens: 800,
+  })
+  assert.equal(usage?.cachedPromptTokens, 800)
+})
+
+test('promptCacheKeyForSession appends schema generation suffix', () => {
+  assert.equal(promptCacheKeyForSession('abc'), 'opptrix-session:abc')
+  assert.equal(promptCacheKeyForSession('abc', 2), 'opptrix-session:abc:s2')
+})
+
+test('engine does not refresh tools on activate_tool_pack / activate_agent_skill', () => {
+  const engineSrc = fs.readFileSync(
+    new URL('../packages/agent/src/engine.ts', import.meta.url),
+    'utf8',
+  )
+  assert.doesNotMatch(
+    engineSrc,
+    /fn === 'activate_tool_pack'[\s\S]*refreshTools = true/,
+  )
+  assert.doesNotMatch(
+    engineSrc,
+    /fn === 'activate_agent_skill'[\s\S]*refreshTools = true/,
+  )
+  assert.match(engineSrc, /ensureFrozenSessionTools/)
+  assert.match(engineSrc, /orderToolsStable/)
+})
+
+test('stable system prompt builder omits per-round activeToolNames', () => {
+  const engineSrc = fs.readFileSync(
+    new URL('../packages/agent/src/engine.ts', import.meta.url),
+    'utf8',
+  )
+  assert.doesNotMatch(engineSrc, /buildRoundSystemPrompt\(sessionId,\s*activeNames/)
+})


### PR DESCRIPTION
## Summary
- Session-level full tool-pack freeze keeps LLM tools/schema stable for prompt prefix cache
- Dynamic routing/clock/selection card move to turn-tail; `activate_tool_pack` is a no-op mid-loop
- Pass schema-aware `prompt_cache_key` (`:sN`) into the real LLM request body; Composer shows cache hit percent when reported

## Test plan
- [ ] `npm run build -w @opptrix/shared && npm run build -w @opptrix/agent`
- [ ] `node --test tests/session-tools-freeze.test.mjs tests/chat-token-usage.test.mjs tests/context-usage-format.test.mjs tests/agent-research-prompt.test.mjs`
- [ ] `npm run check:ui`
- [ ] Manual: multi-turn chat — tools schema stable; Composer shows「缓存约 N%」when provider reports cache hits; 0% title says miss not reuse


Made with [Cursor](https://cursor.com)