### PR TITLE
fix(llm): end-to-end SSE streaming and 10m timeout

### DIFF
--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -28,7 +28,7 @@ const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 const REQUEST_TIMEOUT = 10000 // 10s — quick reads / mutations
 /** 本机重活（语义模型卸载、深度整理卸载、大附件上传等）；勿抬高全局 REQUEST_TIMEOUT。 */
 const LOCAL_HEAVY_TIMEOUT = 180_000
-/** Agent chat: multiple LLM + tool rounds (server LLM timeout up to 120s per round). */
+/** Agent chat: multiple LLM + tool rounds (server LLM timeout up to 10m per round). */
 const CHAT_REQUEST_TIMEOUT = 300_000
 
 async function fetchWithTimeout(path: string, init?: RequestInit, timeoutMs = REQUEST_TIMEOUT): Promise<Response> {

--- a/packages/agent/src/llm/outbound-fetch.ts
+++ b/packages/agent/src/llm/outbound-fetch.ts
@@ -2,6 +2,7 @@ import {
   outboundFetch as sharedOutboundFetch,
   formatOutboundFetchError as sharedFormatOutboundFetchError,
   isOutboundConnectError,
+  isOutboundTimeoutError,
 } from '@opptrix/shared'
 
 export const outboundFetch = sharedOutboundFetch
@@ -9,6 +10,9 @@ export const outboundFetch = sharedOutboundFetch
 export function formatOutboundFetchError(error: unknown): string {
   if (error instanceof Error && isOutboundConnectError(error)) {
     return '无法连接模型服务，请检查网络与设置中的 API 地址'
+  }
+  if (isOutboundTimeoutError(error)) {
+    return '模型响应超时，请稍后重试'
   }
   return sharedFormatOutboundFetchError(error)
 }

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -612,7 +612,8 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       return body
     }
 
-    const timeoutSignal = AbortSignal.timeout(this.cfg.timeout ?? 120_000)
+    /** 单次 LLM 请求默认 10 分钟（长思考 / 流式输出）；可经 LlmConfig.timeout 覆盖 */
+    const timeoutSignal = AbortSignal.timeout(this.cfg.timeout ?? 600_000)
     const requestSignal = signal
       ? AbortSignal.any([signal, timeoutSignal])
       : timeoutSignal
@@ -732,6 +733,11 @@ export class OpenAiCompatibleProvider implements LlmProvider {
             noteAbort()
             const msg = '已取消'
             return { message: { role: 'assistant', content: msg }, finishReason: 'error', error: 'cancelled' }
+          }
+          // 超时 abort：勿用同一已 abort 的 signal 做非流式 fallback（会二次失败并泄漏英文 TimeoutError）
+          if (timeoutSignal.aborted || requestSignal.aborted) {
+            const msg = `⚠️ ${formatOutboundFetchError(streamErr)}`
+            return { message: { role: 'assistant', content: msg }, finishReason: 'error', error: msg }
           }
           // 尚未开始读流时回退非流式；中途失败不再重放整轮
           if (!streamConsumeStarted) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -48,7 +48,7 @@ export {
   type OutboundFamilyMode,
   type OutboundNetworkStatus,
 } from './outbound-network.js'
-export { outboundFetch, formatOutboundFetchError } from './outbound-fetch.js'
+export { outboundFetch, formatOutboundFetchError, isOutboundTimeoutError } from './outbound-fetch.js'
 export { ok, fail, elapsedSince } from './result.js'
 export {
   resolveUserDataRoot,

--- a/packages/shared/src/outbound-fetch.ts
+++ b/packages/shared/src/outbound-fetch.ts
@@ -1,5 +1,6 @@
 import http from 'node:http'
 import https from 'node:https'
+import { Readable } from 'node:stream'
 import {
   ensureOutboundNetworkReady,
   getConnectFamiliesForHost,
@@ -34,6 +35,27 @@ function bodyBytes(body: RequestInit['body']): Buffer | undefined {
   throw new Error('unsupported request body type')
 }
 
+function responseHeadersFromIncoming(res: http.IncomingMessage): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(res.headers).flatMap(([key, value]) =>
+      value == null ? [] : [[key, Array.isArray(value) ? value.join(', ') : value]],
+    ),
+  )
+}
+
+/** TimeoutError / AbortSignal.timeout 原文勿直接展示给用户 */
+export function isOutboundTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error.name === 'TimeoutError') return true
+  return error.message.toLowerCase().includes('aborted due to timeout')
+}
+
+function abortRejectReason(signal: AbortSignal | null | undefined): Error {
+  const reason = signal?.reason
+  if (reason instanceof Error) return reason
+  return new DOMException('Aborted', 'AbortError')
+}
+
 function outboundFetchOnce(
   url: string,
   init: RequestInit,
@@ -49,8 +71,20 @@ function outboundFetchOnce(
   return new Promise((resolve, reject) => {
     const signal = init.signal
     if (signal?.aborted) {
-      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+      reject(abortRejectReason(signal))
       return
+    }
+
+    let settled = false
+    const settleReject = (error: unknown) => {
+      if (settled) return
+      settled = true
+      reject(error instanceof Error ? error : new Error(String(error)))
+    }
+    const settleResolve = (response: Response) => {
+      if (settled) return
+      settled = true
+      resolve(response)
     }
 
     const req = lib.request(
@@ -63,27 +97,26 @@ function outboundFetchOnce(
         family,
       },
       (res) => {
-        const chunks: Buffer[] = []
-        res.on('data', chunk => chunks.push(chunk))
-        res.on('end', () => {
-          resolve(new Response(Buffer.concat(chunks), {
-            status: res.statusCode ?? 500,
-            statusText: res.statusMessage,
-            headers: Object.fromEntries(
-              Object.entries(res.headers).flatMap(([key, value]) =>
-                value == null ? [] : [[key, Array.isArray(value) ? value.join(', ') : value]],
-              ),
-            ),
-          }))
-        })
-        res.on('error', reject)
+        // 响应头到达即 resolve，body 用可读流 — 禁止整包缓冲后再给调用方
+        const webBody = Readable.toWeb(res) as ReadableStream<Uint8Array>
+        settleResolve(new Response(webBody, {
+          status: res.statusCode ?? 500,
+          statusText: res.statusMessage,
+          headers: responseHeadersFromIncoming(res),
+        }))
       },
     )
 
-    req.on('error', reject)
+    req.on('error', (error) => {
+      // 已 resolve（流式读 body）后 destroy/abort 只影响 body，勿再 reject Promise
+      settleReject(error)
+    })
 
     const onAbort = () => {
-      req.destroy(new DOMException('Aborted', 'AbortError'))
+      const reason = abortRejectReason(signal)
+      req.destroy(reason)
+      // 尚未拿到响应头：以 abort reason 结束（含 TimeoutError，由 formatOutboundFetchError 转中文）
+      settleReject(reason)
     }
     signal?.addEventListener('abort', onAbort, { once: true })
     req.on('close', () => signal?.removeEventListener('abort', onAbort))
@@ -95,6 +128,7 @@ function outboundFetchOnce(
 
 /**
  * Outbound HTTP(S) fetch: IPv4 first per host; retry IPv6 only after v4 connect/DNS failure.
+ * 一旦响应头到达并开始流式 body，不再换栈重放。
  */
 export async function outboundFetch(url: string, init: RequestInit = {}): Promise<Response> {
   await ensureOutboundNetworkReady()
@@ -122,6 +156,9 @@ export function formatOutboundFetchError(error: unknown): string {
   if (!(error instanceof Error)) return String(error)
   if (isOutboundConnectError(error)) {
     return '无法连接远程服务，请检查网络与代理设置'
+  }
+  if (isOutboundTimeoutError(error)) {
+    return '请求超时，请稍后重试'
   }
   if (error.name === 'AbortError' || error.message === 'Aborted') {
     return '请求超时，请稍后重试'

--- a/tests/outbound-fetch-stream.test.mjs
+++ b/tests/outbound-fetch-stream.test.mjs
@@ -1,0 +1,115 @@
+/**
+ * outboundFetch 流式 body + TimeoutError 文案
+ */
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import {
+  outboundFetch,
+  formatOutboundFetchError,
+  isOutboundTimeoutError,
+  resetOutboundNetworkForTests,
+  setOutboundNetworkStatusForTests,
+} from '@opptrix/shared'
+
+describe('outboundFetch streaming + timeout copy', () => {
+  /** @type {http.Server} */
+  let server
+  /** @type {number} */
+  let port
+
+  before(async () => {
+    resetOutboundNetworkForTests()
+    setOutboundNetworkStatusForTests({ family: 4 })
+    process.env.OPPTRIX_OUTBOUND_FAMILY = '4'
+
+    server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1')
+      if (url.pathname === '/stream') {
+        res.writeHead(200, {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Transfer-Encoding': 'chunked',
+        })
+        res.write('chunk-a\n')
+        setTimeout(() => {
+          res.write('chunk-b\n')
+          res.end()
+        }, 250)
+        return
+      }
+      if (url.pathname === '/json') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ ok: true, n: 42 }))
+        return
+      }
+      res.writeHead(404)
+      res.end()
+    })
+
+    await new Promise((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve(undefined))
+    })
+    const addr = server.address()
+    assert.ok(addr && typeof addr === 'object')
+    port = addr.port
+  })
+
+  after(async () => {
+    resetOutboundNetworkForTests()
+    delete process.env.OPPTRIX_OUTBOUND_FAMILY
+    await new Promise((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve(undefined)))
+    })
+  })
+
+  it('resolves with readable body before upstream end (incremental read)', async () => {
+    const started = Date.now()
+    const resp = await outboundFetch(`http://127.0.0.1:${port}/stream`)
+    const headerMs = Date.now() - started
+    assert.ok(resp.ok)
+    assert.ok(resp.body, 'body stream present')
+    // 响应头应在 delayed end（250ms）之前就返回
+    assert.ok(headerMs < 150, `headers resolved too late: ${headerMs}ms`)
+
+    const reader = resp.body.getReader()
+    const decoder = new TextDecoder()
+    const { value, done } = await reader.read()
+    assert.equal(done, false)
+    const first = decoder.decode(value)
+    assert.ok(first.includes('chunk-a'), `first chunk: ${first}`)
+    // 读到第一块时服务端尚未 end
+    assert.ok(Date.now() - started < 200, 'first body chunk arrived before delayed end')
+
+    const rest = []
+    while (true) {
+      const next = await reader.read()
+      if (next.done) break
+      rest.push(decoder.decode(next.value))
+    }
+    assert.ok(rest.join('').includes('chunk-b'))
+  })
+
+  it('still supports Response.json() / .text() for buffered callers', async () => {
+    const resp = await outboundFetch(`http://127.0.0.1:${port}/json`)
+    const data = await resp.json()
+    assert.deepEqual(data, { ok: true, n: 42 })
+
+    const resp2 = await outboundFetch(`http://127.0.0.1:${port}/json`)
+    const text = await resp2.text()
+    assert.equal(text, '{"ok":true,"n":42}')
+  })
+
+  it('maps TimeoutError to Chinese without English timeout wording', () => {
+    const timeout = new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    assert.equal(isOutboundTimeoutError(timeout), true)
+    const msg = formatOutboundFetchError(timeout)
+    assert.equal(msg, '请求超时，请稍后重试')
+    assert.ok(!/aborted due to timeout/i.test(msg))
+    assert.ok(!/TimeoutError/i.test(msg))
+  })
+
+  it('maps AbortError similarly', () => {
+    const abort = new DOMException('Aborted', 'AbortError')
+    assert.equal(formatOutboundFetchError(abort), '请求超时，请稍后重试')
+  })
+})


### PR DESCRIPTION
## Summary
- Stream outbound LLM responses as soon as headers arrive (no full-body buffer before `onDelta`)
- Raise default single-round LLM timeout from 2m to 10m; map `TimeoutError` to product copy; skip non-stream fallback after timeout abort

## Test plan
- [x] `npm run build -w @opptrix/shared`
- [x] `node --test --test-force-exit tests/outbound-fetch-stream.test.mjs`
- [x] `node --test --test-force-exit tests/outbound-dual-stack-cross.test.mjs`
- [ ] Manual: long-thinking model shows incremental thinking; no English `aborted due to timeout` on slow rounds under 10m


Made with [Cursor](https://cursor.com)