### PR TITLE
fix(chat): 整理态原文预览、状态文案与技能斜杠匹配

### DIFF
--- a/client-ui/src/chat/ChatReplyDraftPreview.tsx
+++ b/client-ui/src/chat/ChatReplyDraftPreview.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react'
+import { makeStyles } from '@fluentui/react-components'
+import { opptrixCssVars } from '../theme/tokens'
+
+const FADE_PX = 12
+const LINE_HEIGHT = 1.45
+const VISIBLE_LINES = 5
+
+/** 上沿淡出略强、下沿略弱：最新一行仍可读，两端仍融入画布 */
+const MASK = `linear-gradient(to bottom, transparent 0, #000 ${FADE_PX}px, #000 calc(100% - ${Math.round(FADE_PX * 0.55)}px), transparent 100%)`
+
+const useStyles = makeStyles({
+  root: {
+    alignSelf: 'stretch',
+    marginTop: '6px',
+    maxHeight: `calc(var(--opptrix-font-sm) * ${LINE_HEIGHT} * ${VISIBLE_LINES})`,
+    height: `calc(var(--opptrix-font-sm) * ${LINE_HEIGHT} * ${VISIBLE_LINES})`,
+    overflow: 'hidden',
+    border: 'none',
+    borderRadius: 0,
+    boxShadow: 'none',
+    backgroundColor: 'transparent',
+    maskImage: MASK,
+    WebkitMaskImage: MASK,
+  },
+  text: {
+    margin: 0,
+    padding: 0,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    fontSize: 'var(--opptrix-font-sm)',
+    lineHeight: LINE_HEIGHT,
+    color: opptrixCssVars.textTertiary,
+    fontFamily: 'inherit',
+  },
+})
+
+interface Props {
+  draft: string
+}
+
+/** 「正在整理消息」时挂在过程区下方的原始文本流预览（无边框，上下渐隐） */
+export default function ChatReplyDraftPreview({ draft }: Props) {
+  const s = useStyles()
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const reduced = typeof window !== 'undefined'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    el.scrollTo({
+      top: el.scrollHeight,
+      behavior: reduced ? 'auto' : 'smooth',
+    })
+  }, [draft])
+
+  if (!draft) return null
+
+  return (
+    <div
+      ref={scrollRef}
+      className={s.root}
+      aria-live="polite"
+      aria-label="正在整理的回复预览"
+    >
+      <p className={s.text}>{draft}</p>
+    </div>
+  )
+}

--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -21,6 +21,7 @@ import ChatComposer from './ChatComposer'
 import type { ChatComposerHandle } from './ChatComposer'
 import ChatMessageItem from './ChatMessageItem'
 import ChatProcessTrace from './ChatProcessTrace'
+import ChatReplyDraftPreview from './ChatReplyDraftPreview'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import OpptrixSpinner from '../components/opptrix/OpptrixSpinner'
 import MessageSelectionToolbar from './MessageSelectionToolbar'
@@ -1183,6 +1184,9 @@ function ChatView({
                     thinkingSegments={collaborationChildLiveTrace?.thinkingSegments}
                     live
                   />
+                  {collaborationChildLiveTrace?.replyDraft ? (
+                    <ChatReplyDraftPreview draft={collaborationChildLiveTrace.replyDraft} />
+                  ) : null}
                 </div>
               )}
 
@@ -1217,6 +1221,9 @@ function ChatView({
                     thinkingSegments={liveTrace.thinkingSegments}
                     live
                   />
+                  {liveTrace.replyDraft ? (
+                    <ChatReplyDraftPreview draft={liveTrace.replyDraft} />
+                  ) : null}
                 </div>
               )}
               {!collaborationReadonly && loading && !liveTrace && (

--- a/client-ui/src/chat/sessionStreamRuntime.ts
+++ b/client-ui/src/chat/sessionStreamRuntime.ts
@@ -61,6 +61,8 @@ function rebuildLiveTrace(
     clearEstimatedTokens?: boolean
     thinkingSnippet?: string | undefined
     thinkingSegments?: ReasoningSegment[] | undefined
+    replyDraft?: string | undefined
+    clearReplyDraft?: boolean
   },
 ): ChatLiveTrace {
   const steps = patch.steps ?? prev?.steps ?? []
@@ -76,12 +78,16 @@ function rebuildLiveTrace(
     : (thinkingSegments?.length
       ? joinReasoningSegments(thinkingSegments)
       : prev?.thinkingSnippet)
+  const replyDraft = patch.clearReplyDraft
+    ? undefined
+    : ('replyDraft' in patch ? patch.replyDraft : prev?.replyDraft)
   return {
     steps,
     phaseLabel: phaseLabel || undefined,
     estimatedTokens,
     thinkingSnippet,
     thinkingSegments,
+    replyDraft,
     thinkingLabel: formatLiveThinkingStatus(
       phaseLabel || undefined,
       estimatedTokens,
@@ -130,11 +136,15 @@ export function applyChatProgressEvent(
         thinkingSegments = snapshot.liveTrace?.thinkingSegments
       }
       const segmentsOrUndef = thinkingSegments?.length ? thinkingSegments : undefined
+      const phaseLabel = stripPhaseEllipsis(event.label)
+      // 新一轮思考（非「正在整理消息」）清空回复草稿预览
+      const clearReplyDraft = phaseLabel !== '正在整理消息'
       return {
         ...snapshot,
         liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
-          phaseLabel: stripPhaseEllipsis(event.label),
+          phaseLabel,
           clearEstimatedTokens: true,
+          clearReplyDraft,
           thinkingSegments: segmentsOrUndef,
           thinkingSnippet: event.snippet
             ?? (segmentsOrUndef ? joinReasoningSegments(segmentsOrUndef) : undefined)
@@ -167,6 +177,7 @@ export function applyChatProgressEvent(
         ...snapshot,
         liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
           steps: [...(snapshot.liveTrace?.steps ?? []), event.step],
+          clearReplyDraft: true,
         }),
       }
     case 'tool_done':
@@ -181,10 +192,16 @@ export function applyChatProgressEvent(
         }),
       }
     case 'reply': {
-      // 与思考态同位文案；多轮工具后若已是「整理」态则保持，避免回跳
-      const prevPhase = resolvePhaseLabel(snapshot.liveTrace, '')
-      const consolidating = prevPhase.includes('整理')
-      const phaseLabel = prevPhase || (consolidating ? '模型正在整理结果' : '模型正在思考')
+      // 终答有 content →「正在整理消息」；仅 estimatedTokens 流式进度则保持思考/工具后整理态
+      const hasContent = typeof event.content === 'string' && event.content.length > 0
+      let phaseLabel: string
+      if (hasContent) {
+        phaseLabel = '正在整理消息'
+      } else {
+        const prevPhase = resolvePhaseLabel(snapshot.liveTrace, '')
+        const consolidating = prevPhase.includes('整理')
+        phaseLabel = prevPhase || (consolidating ? '模型正在整理结果' : '模型正在思考')
+      }
       return {
         ...snapshot,
         liveTrace: rebuildLiveTrace(snapshot.liveTrace, {
@@ -192,6 +209,9 @@ export function applyChatProgressEvent(
           // reply 无估算时清空，与旧行为一致（不残留假数字）
           estimatedTokens: event.estimatedTokens,
           clearEstimatedTokens: event.estimatedTokens == null,
+          ...(hasContent
+            ? { replyDraft: event.content }
+            : {}),
         }),
       }
     }

--- a/client-ui/src/chat/skillDisplay.ts
+++ b/client-ui/src/chat/skillDisplay.ts
@@ -132,16 +132,26 @@ export function compareSkillsForSlash(a: SkillLike, b: SkillLike): number {
   return skillDisplayTitle(a).localeCompare(skillDisplayTitle(b), 'zh')
 }
 
+/** `/` 筛选：把 `_` / `-` / `.` 视作同一分隔符，便于 `create_web` 命中 `create-web` */
+function normalizeSlashSeparators(value: string): string {
+  return value.replace(/[_.-]+/g, '-')
+}
+
 export function skillMatchesSlashQuery(skill: SkillLike, query: string): boolean {
   const q = query.trim().toLowerCase()
   if (!q) return true
+  const qNorm = normalizeSlashSeparators(q)
   const haystacks = [
     skill.name,
     skillDisplayTitle(skill),
     skill.metadata?.summary ?? '',
     skill.description ?? '',
   ]
-  return haystacks.some(h => h.toLowerCase().includes(q))
+  return haystacks.some(h => {
+    const lower = h.toLowerCase()
+    if (lower.includes(q)) return true
+    return normalizeSlashSeparators(lower).includes(qNorm)
+  })
 }
 
 /** 消息气泡：`@skill:name` → 中文短标题（无则原 name） */

--- a/client-ui/src/types/chatProgress.ts
+++ b/client-ui/src/types/chatProgress.ts
@@ -80,7 +80,13 @@ export type ChatProgressEvent =
   | { type: 'tool_done'; step: ChatToolStep }
   | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
   | { type: 'steer_applied'; message: string }
-  | { type: 'reply'; content?: string; estimatedTokens?: number }
+  | {
+    type: 'reply'
+    content?: string
+    estimatedTokens?: number
+    /** 流式 delta 预览片段；终答勿带 true */
+    draft?: boolean
+  }
   | {
     type: 'done'
     reply: string
@@ -165,7 +171,12 @@ export type ChatProgressEvent =
       }
       | { type: 'tool_start'; step: ChatToolStep }
       | { type: 'tool_done'; step: ChatToolStep }
-      | { type: 'reply'; content?: string; estimatedTokens?: number }
+      | {
+        type: 'reply'
+        content?: string
+        estimatedTokens?: number
+        draft?: boolean
+      }
     /** 兼容字段名：event / progress / child_progress */
     event?: ChatProgressEvent
     progress?: ChatProgressEvent
@@ -183,5 +194,7 @@ export interface ChatLiveTrace {
   thinkingSnippet?: string
   /** 结构化思考分段（竖轴） */
   thinkingSegments?: ReasoningSegment[]
+  /** 「正在整理消息」时未渲染的原始回复草稿预览 */
+  replyDraft?: string
   steps: ChatToolStep[]
 }

--- a/packages/agent/src/chat-progress.ts
+++ b/packages/agent/src/chat-progress.ts
@@ -126,7 +126,13 @@ export type ChatProgressEvent =
   | { type: 'tool_done'; step: ChatToolStep }
   | { type: 'user_prompt'; prompt: ChatUserPromptPayload }
   | { type: 'steer_applied'; message: string }
-  | { type: 'reply'; content?: string; estimatedTokens?: number }
+  | {
+    type: 'reply'
+    content?: string
+    estimatedTokens?: number
+    /** 流式 delta 预览片段；终答勿带 true */
+    draft?: boolean
+  }
   | {
     type: 'done'
     /** Agent 最终回复文本 */
@@ -218,7 +224,12 @@ export type ChatProgressEvent =
       }
       | { type: 'tool_start'; step: ChatToolStep }
       | { type: 'tool_done'; step: ChatToolStep }
-      | { type: 'reply'; content?: string; estimatedTokens?: number }
+      | {
+        type: 'reply'
+        content?: string
+        estimatedTokens?: number
+        draft?: boolean
+      }
   }
 
 /**

--- a/packages/agent/src/engine.ts
+++ b/packages/agent/src/engine.ts
@@ -1884,7 +1884,12 @@ export class AgentEngine {
           lastEmitAt = Date.now()
           lastTokens = n
           pendingTokens = null
-          emit({ type: 'reply', estimatedTokens: n })
+          emit({
+            type: 'reply',
+            estimatedTokens: n,
+            content: accumulated,
+            draft: true,
+          })
         }
         const turn = await llm.chat(modelView, roundTools, signal, {
           sessionId,
@@ -2347,11 +2352,12 @@ export class AgentEngine {
         .map(s => ({ ...s, content: s.content.trim() }))
         .filter(s => s.content)
       // 与工具轮对称：stop 前再推一次完整时间线，保证 live 末态与历史一致
+      // 终答后勿再推「模型正在思考」，避免 UI 从「正在整理消息」被盖回思考态
       if (turnTimeline) {
         emit({
           type: 'thinking',
           round: round + 1,
-          label: '模型正在思考…',
+          label: '正在整理消息…',
           snippet: turnTimeline,
           segments: persistedSegments,
         })

--- a/tests/session-stream-runtime.test.mjs
+++ b/tests/session-stream-runtime.test.mjs
@@ -125,22 +125,107 @@ describe('applyChatProgressEvent pendingUserPrompt', () => {
     assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 128 tokens…')
   })
 
-  it('prefers estimatedTokens label even when content is present', () => {
+  it('uses composing phase when reply has content (even with estimatedTokens)', () => {
     const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
       type: 'reply',
       content: '最终正文',
       estimatedTokens: 1500,
     })
-    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考 · 约 1.5k tokens…')
+    assert.equal(next.liveTrace?.phaseLabel, '正在整理消息')
+    assert.equal(next.liveTrace?.thinkingLabel, '正在整理消息 · 约 1.5k tokens…')
+    assert.equal(next.liveTrace?.replyDraft, '最终正文')
   })
 
-  it('falls back to thinking label when reply has no estimatedTokens', () => {
+  it('uses composing phase when reply has content and no estimatedTokens', () => {
     const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
       type: 'reply',
       content: '正文',
     })
     assert.equal(next.liveTrace?.estimatedTokens, undefined)
-    assert.equal(next.liveTrace?.thinkingLabel, '模型正在思考…')
+    assert.equal(next.liveTrace?.phaseLabel, '正在整理消息')
+    assert.equal(next.liveTrace?.thinkingLabel, '正在整理消息…')
+    assert.equal(next.liveTrace?.replyDraft, '正文')
+  })
+
+  it('writes replyDraft and composing phase for draft reply stream', () => {
+    const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '草稿片段一二三',
+      estimatedTokens: 42,
+      draft: true,
+    })
+    assert.equal(next.liveTrace?.phaseLabel, '正在整理消息')
+    assert.equal(next.liveTrace?.replyDraft, '草稿片段一二三')
+    assert.equal(next.liveTrace?.estimatedTokens, 42)
+  })
+
+  it('clears replyDraft on tool_start', () => {
+    const withDraft = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '将清空的草稿',
+      draft: true,
+    })
+    assert.equal(withDraft.liveTrace?.replyDraft, '将清空的草稿')
+    const next = applyChatProgressEvent(withDraft, {
+      type: 'tool_start',
+      step: {
+        id: 't1',
+        tool: 'search',
+        label: '搜索',
+        status: 'running',
+        startedAt: new Date().toISOString(),
+      },
+    })
+    assert.equal(next.liveTrace?.replyDraft, undefined)
+  })
+
+  it('clears replyDraft on new thinking round but keeps when composing', () => {
+    const withDraft = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '草稿',
+      draft: true,
+    })
+    const cleared = applyChatProgressEvent(withDraft, {
+      type: 'thinking',
+      round: 2,
+      label: '模型正在思考…',
+    })
+    assert.equal(cleared.liveTrace?.replyDraft, undefined)
+
+    const kept = applyChatProgressEvent(withDraft, {
+      type: 'thinking',
+      round: 1,
+      label: '正在整理消息…',
+      snippet: '时间线摘要',
+    })
+    assert.equal(kept.liveTrace?.replyDraft, '草稿')
+    assert.equal(kept.liveTrace?.phaseLabel, '正在整理消息')
+  })
+
+  it('final reply content without draft still writes replyDraft', () => {
+    const next = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '终答全文',
+      estimatedTokens: 200,
+    })
+    assert.equal(next.liveTrace?.replyDraft, '终答全文')
+    assert.equal(next.liveTrace?.phaseLabel, '正在整理消息')
+  })
+
+  it('post-reply timeline thinking keeps composing phase (not thinking)', () => {
+    const withReply = applyChatProgressEvent(createEmptyStreamSnapshot(), {
+      type: 'reply',
+      content: '终答正文',
+    })
+    const next = applyChatProgressEvent(withReply, {
+      type: 'thinking',
+      round: 1,
+      label: '正在整理消息…',
+      snippet: '时间线摘要',
+    })
+    assert.equal(next.liveTrace?.phaseLabel, '正在整理消息')
+    assert.match(next.liveTrace?.thinkingLabel ?? '', /^正在整理消息/)
+    assert.equal(next.liveTrace?.replyDraft, '终答正文')
   })
 
   it('keeps consolidating label after tools when reply streams tokens', () => {

--- a/tests/skill-slash-query.test.mjs
+++ b/tests/skill-slash-query.test.mjs
@@ -1,0 +1,34 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { skillMatchesSlashQuery } from '../client-ui/src/chat/skillDisplay.ts'
+
+const createWeb = {
+  name: 'create-web',
+  description: 'Generate a standalone web research report',
+  metadata: {
+    title: '网页报告',
+    summary: '一页可读的投研网页',
+  },
+}
+
+describe('skillMatchesSlashQuery', () => {
+  it('matches hyphenated skill id with underscore query', () => {
+    assert.equal(skillMatchesSlashQuery(createWeb, 'create_web'), true)
+  })
+
+  it('matches dotted query against hyphenated id', () => {
+    assert.equal(skillMatchesSlashQuery(createWeb, 'create.web'), true)
+  })
+
+  it('still matches exact hyphenated id', () => {
+    assert.equal(skillMatchesSlashQuery(createWeb, 'create-web'), true)
+  })
+
+  it('still matches Chinese title', () => {
+    assert.equal(skillMatchesSlashQuery(createWeb, '网页'), true)
+  })
+
+  it('rejects unrelated query', () => {
+    assert.equal(skillMatchesSlashQuery(createWeb, 'dcf'), false)
+  })
+})


### PR DESCRIPTION
## Summary
- 终答流式阶段在思考/执行过程下方展示约 5 行、无边框、上下渐隐的原文草稿预览；正式消息出现后拆除
- 有回复正文时状态文案为「正在整理消息」，避免被后续思考时间线盖回「模型正在思考」
- `/` 技能筛选将 `_` / `-` / `.` 视为同一分隔符（如 `create_web` 可命中 `create-web`）

## Test plan
- [ ] `node --test --test-force-exit tests/session-stream-runtime.test.mjs`
- [ ] `node --test --test-force-exit tests/skill-slash-query.test.mjs`
- [ ] `npm run check:ui`
- [ ] 手动：发送一轮对话，整理阶段过程区下方出现渐隐原文流；正式气泡出现后预览消失
- [ ] 手动：输入 `/create` 可筛到 `create_web` / `create-web` 类技能


Made with [Cursor](https://cursor.com)