### PR TITLE
fix(chat): 放宽 Composer / 技能触发

### DIFF
--- a/client-ui/src/chat/skillDisplay.ts
+++ b/client-ui/src/chat/skillDisplay.ts
@@ -133,17 +133,25 @@ export function compareSkillsForSlash(a: SkillLike, b: SkillLike): number {
 }
 
 /**
- * 检测 `/query` 触发：`/` 前须为行首或空白，避免 URL `http://` 误触。
- * 允许空格（英文多词 / IME）；仅第二个 `/` 关闭面板。
+ * 检测 `/query` 触发（从光标向前找最后一个合法 `/`）：
+ * - 行首、空白或任意非 `:`/`/` 字符后的 `/` 可触发（含中文无空格：`看看茅台/`）
+ * - 前一字符为 `:` 或 `/` 不触发（挡住 `http://`、`https://`、双斜杠）
+ * - 该触发后的 query 内再出现 `/` 则关闭；允许空格（英文多词 / IME）
+ * - 前文可有路径/URL，不影响末尾新的 `/技能` 触发
  */
 export function findSlashTrigger(text: string, cursor: number) {
   const slice = text.slice(0, cursor)
-  const slashIndex = slice.lastIndexOf('/')
-  if (slashIndex < 0) return null
-  if (slashIndex > 0 && !/\s/.test(slice[slashIndex - 1]!)) return null
-  const query = slice.slice(slashIndex + 1)
-  if (query.includes('/')) return null
-  return { query, startIndex: slashIndex }
+  for (let i = slice.length - 1; i >= 0; i--) {
+    if (slice[i] !== '/') continue
+    if (i > 0) {
+      const prev = slice[i - 1]!
+      if (prev === ':' || prev === '/') continue
+    }
+    const query = slice.slice(i + 1)
+    if (query.includes('/')) return null
+    return { query, startIndex: i }
+  }
+  return null
 }
 
 /** `/` 筛选：把 `_` / `-` / `.` 视作同一分隔符，便于 `create_web` 命中 `create-web` */

--- a/tests/skill-slash-query.test.mjs
+++ b/tests/skill-slash-query.test.mjs
@@ -54,9 +54,12 @@ describe('findSlashTrigger', () => {
     assert.equal(trigger.startIndex, 0)
   })
 
-  it('closes when a second slash appears in query', () => {
+  it('uses last slash as new trigger when typing path-like query', () => {
     const text = '/create/web'
-    assert.equal(findSlashTrigger(text, text.length), null)
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, 'web')
+    assert.equal(trigger.startIndex, 7)
   })
 
   it('still opens for compact english id', () => {
@@ -64,5 +67,80 @@ describe('findSlashTrigger', () => {
     const trigger = findSlashTrigger(text, text.length)
     assert.ok(trigger)
     assert.equal(trigger.query, 'createweb')
+  })
+
+  it('opens after whitespace-prefixed slash', () => {
+    const text = 'hello /选股'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '选股')
+    assert.equal(trigger.startIndex, 6)
+  })
+
+  it('opens after Chinese text without space before slash', () => {
+    const text = '看看茅台/'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '')
+    assert.equal(trigger.startIndex, 4)
+  })
+
+  it('opens mid-Chinese with query after slash', () => {
+    const text = '帮我/选股'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '选股')
+    assert.equal(trigger.startIndex, 2)
+  })
+
+  it('opens after Chinese mid-query without trailing slash only', () => {
+    const text = '看看茅台/选'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '选')
+    assert.equal(trigger.startIndex, 4)
+  })
+
+  it('opens after latin letters without space', () => {
+    const text = 'report/'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '')
+    assert.equal(trigger.startIndex, 6)
+  })
+
+  it('opens trailing skill after earlier path slash', () => {
+    const text = 'foo/bar 然后 /技能'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '技能')
+    assert.equal(trigger.startIndex, text.lastIndexOf('/'))
+  })
+
+  it('opens trailing skill after earlier http URL', () => {
+    const text = '前文 http://x.com 然后 /技能'
+    const trigger = findSlashTrigger(text, text.length)
+    assert.ok(trigger)
+    assert.equal(trigger.query, '技能')
+  })
+
+  it('does not open for http:// trailing slash', () => {
+    const text = 'http://'
+    assert.equal(findSlashTrigger(text, text.length), null)
+  })
+
+  it('does not open for https:// trailing slash', () => {
+    const text = 'https://'
+    assert.equal(findSlashTrigger(text, text.length), null)
+  })
+
+  it('does not open for double slash (second slash)', () => {
+    const text = 'foo//'
+    assert.equal(findSlashTrigger(text, text.length), null)
+  })
+
+  it('closes when last valid slash query embeds protocol slashes', () => {
+    const text = '/选股http://'
+    assert.equal(findSlashTrigger(text, text.length), null)
   })
 })


### PR DESCRIPTION
## Summary
- 放宽 Composer 输入中 `/` 唤出技能面板的触发条件：无需前导空格，中文中间/末尾斜杠可用
- 仍跳过 `http(s)://` 与双斜杠误触
- 补充 `skill-slash-query` 相关用例

## Test plan
- [ ] 输入「看看茅台/」应弹出技能面板
- [ ] 输入「帮我/选股」应弹出并带 query
- [ ] `http://` / `https://` / `foo//` 不触发
- [ ] URL 后空格再写 `/技能` 仍可触发
- [ ] `node --test tests/skill-slash-query.test.mjs` 通过


Made with [Cursor](https://cursor.com)