### PR TITLE
fix(desktop): macOS Playwright Chromium signing for web export

### DIFF
--- a/.cursor/rules/desktop-mac-signing.mdc
+++ b/.cursor/rules/desktop-mac-signing.mdc
@@ -33,7 +33,8 @@ afterPack（叶子 Mach-O 预签 + heavy trees stash）
 
 Playwright / Chrome nested `*.framework/.../Libraries/*.dylib`（如 libEGL、libGLESv2、libvk_swiftshader）等：
 
-- **必须**叶子 Mach-O 先 `codesign`（Developer ID + timestamp），再 deepest-first 封嵌套 bundle。
+- **必须**叶子 Mach-O 先 `codesign`（Developer ID + timestamp + **entitlements**），再 deepest-first 封嵌套 bundle。
+- **禁止** `--options runtime` 裸签 Playwright Chromium（无 entitlements 时 `browser.newPage()` 会永久挂起）。
 - **禁止**只靠 `codesign --deep` 指望嵌套 Libraries 被正确签上。
 - **collectSignableLeafMachOs**：`lstat` **跳过 symlink**（framework 顶层主二进制常为指向 `Versions/*` 的符号链接；hardFail 也不得对其 codesign）；`realpath` 去重后按 **path 段数降序、再 path.length 降序**（Libraries 先于 framework tip）。
 

--- a/apps/desktop/resources/mac-sign-checklist.json
+++ b/apps/desktop/resources/mac-sign-checklist.json
@@ -6,7 +6,8 @@
     "New nested .app / .framework under playwright-browsers",
     "New native .node/.dylib under runtime-stage/node_modules",
     "Bundled python layout change",
-    "Leaf Mach-O collect must skip symlink + depth-sort (Libraries before framework tip)"
+    "Leaf Mach-O collect must skip symlink + depth-sort (Libraries before framework tip)",
+    "Playwright pre-sign must pass --entitlements with --options runtime (else Chromium newPage hangs)"
   ],
   "signTrees": [
     { "id": "python", "rel": "python", "mode": "leaf-macho", "hardFail": false },

--- a/apps/desktop/scripts/after-pack-adhoc.cjs
+++ b/apps/desktop/scripts/after-pack-adhoc.cjs
@@ -17,6 +17,8 @@
  *    (`build.mac.notarize: false` so builder does not notarize before restore).
  *    Pipeline: afterPack(pre-sign+stash) → sign → afterSign(restore+reseal+notarize+spctl) → dmg
  *    Leaf collect: skip symlink + realpath dedupe + depth-sort (Libraries before framework tip).
+ *    Playwright pre-sign **must** pass `--entitlements` with `--options runtime`; runtime-only
+ *    seals hang Chromium `newPage()` in packaged desktop builds.
  *    **When bumping Playwright / Chromium (CFT), native .node/.dylib, or python
  *    layout — update `mac-sign-checklist.json` (mustVerify + signTrees).**
  * 4) Optional ad-hoc mac codesign when OPPTRIX_MAC_UNSIGNED=1.
@@ -30,6 +32,10 @@ const {
   loadMacSignChecklist,
   assertMustVerifySigned,
 } = require('./lib/mac-sign-checklist.cjs')
+
+/** Hardened runtime without entitlements breaks Playwright Chromium newPage() — always pass these. */
+const MAC_ENTITLEMENTS = path.join(__dirname, '..', 'resources', 'entitlements.mac.plist')
+const MAC_ENTITLEMENTS_INHERIT = path.join(__dirname, '..', 'resources', 'entitlements.mac.inherit.plist')
 
 function walkFiles(dir, acc = []) {
   if (!fs.existsSync(dir)) return acc
@@ -317,10 +323,17 @@ function collectSignableLeafMachOs(root) {
 /**
  * @param {string} target
  * @param {string} identity
- * @param {{ deep?: boolean }} [opts]
+ * @param {{ deep?: boolean; inheritEntitlements?: boolean }} [opts]
  */
 function codesignTarget(target, identity, opts = {}) {
-  const args = ['--force', '--options', 'runtime', '--timestamp', '--sign', identity]
+  const entitlements = opts.inheritEntitlements ? MAC_ENTITLEMENTS_INHERIT : MAC_ENTITLEMENTS
+  const args = ['--force', '--options', 'runtime', '--timestamp']
+  if (fs.existsSync(entitlements)) {
+    args.push('--entitlements', entitlements)
+  } else {
+    throw new Error(`afterPack: missing entitlements plist at ${entitlements}`)
+  }
+  args.push('--sign', identity)
   if (opts.deep) args.push('--deep')
   args.push(target)
   try {
@@ -377,7 +390,8 @@ function assertDeveloperIdSigned(filePath) {
  * - `leaf-then-bundles`: Playwright Chrome for Testing — **leaf-first** then seal
  *   nested .framework / .app deepest-first. Leaf collect skips symlinks, dedupes
  *   by realpath, depth-sorts (Libraries before framework tip). Do **not** rely on
- *   `codesign --deep`.
+ *   `codesign --deep`. Every leaf Mach-O and bundle seal uses `--entitlements` with
+ *   `--options runtime` (missing entitlements → Chromium newPage hangs at runtime).
  * After signing, `mustVerify` entries (libEGL / GLESv2 / swiftshader / Chrome.app / …)
  * are hard-checked for Developer ID — missing required globs throw (stale checklist
  * or incomplete stage).
@@ -427,7 +441,7 @@ function preSignHeavyMacTrees(context) {
       } catch {
         /* fall through to codesign */
       }
-      codesignTarget(file, identity)
+      codesignTarget(file, identity, { inheritEntitlements: false })
       signed += 1
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -478,7 +492,9 @@ function preSignHeavyMacTrees(context) {
     )
     for (const bundle of bundles) {
       try {
-        codesignTarget(bundle.path, identity)
+        const inheritEntitlements =
+          bundle.kind === 'app' && /Helper\.app$/i.test(bundle.path)
+        codesignTarget(bundle.path, identity, { inheritEntitlements })
         signed += 1
         console.log(`afterPack: sealed ${bundle.kind} ${path.relative(root, bundle.path)}`)
       } catch (err) {
@@ -620,3 +636,5 @@ exports.pathSegmentCount = pathSegmentCount
 exports.ensurePackagedScheduleHelper = ensurePackagedScheduleHelper
 exports.preSignHeavyMacTrees = preSignHeavyMacTrees
 exports.isMachOCandidate = isMachOCandidate
+exports.codesignTarget = codesignTarget
+exports.MAC_ENTITLEMENTS = MAC_ENTITLEMENTS

--- a/apps/desktop/scripts/verify-packaged-runtime.mjs
+++ b/apps/desktop/scripts/verify-packaged-runtime.mjs
@@ -185,6 +185,45 @@ function assertFfmpegBinary(ffmpegBin, target) {
   }
 }
 
+function assertChromiumEntitlements(playwrightBrowsers: string, chromiumExe: string) {
+  if (process.platform !== 'darwin') return
+
+  const stack = [playwrightBrowsers]
+  let chromeApp = null
+  while (stack.length > 0) {
+    const dir = stack.pop()
+    let entries
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const full = path.join(dir, entry.name)
+      if (entry.name === 'Google Chrome for Testing.app') {
+        chromeApp = full
+        break
+      }
+      stack.push(full)
+    }
+    if (chromeApp) break
+  }
+
+  const probeTarget = chromeApp ?? chromiumExe
+  const ent = spawnSync('codesign', ['-d', '--entitlements', '-', '--xml', probeTarget], {
+    encoding: 'utf8',
+  })
+  const entXml = `${ent.stdout ?? ''}${ent.stderr ?? ''}`
+  if (!entXml.includes('com.apple.security.cs.disable-library-validation')) {
+    fail(
+      `${probeTarget} missing com.apple.security.cs.disable-library-validation `
+        + '(Playwright pre-sign must pass --entitlements with --options runtime)',
+    )
+  }
+  console.log(`verify-packaged-runtime: OK Chromium entitlements (${probeTarget})`)
+}
+
 function assertStage(stageDir, target) {
   const nmFastify = path.join(stageDir, 'node_modules', 'fastify')
   const depsFastify = path.join(stageDir, 'deps', 'fastify')
@@ -222,6 +261,7 @@ function assertStage(stageDir, target) {
     )
   }
   assertFfmpegBinary(ffmpegBin, target)
+  assertChromiumEntitlements(playwrightBrowsers, chromiumExe)
   console.log(`verify-packaged-runtime: OK ${nmFastify}`)
   console.log(`verify-packaged-runtime: OK Chromium ${chromiumExe}`)
   console.log(`verify-packaged-runtime: OK ffmpeg ${ffmpegBin}`)

--- a/apps/server/src/web-preview-export.ts
+++ b/apps/server/src/web-preview-export.ts
@@ -25,8 +25,37 @@ export const EXPORT_DEVICE_SCALE_FACTOR = 3
 
 const NAV_TIMEOUT_MS = 45_000
 const SCREENSHOT_TIMEOUT_MS = 60_000
+/** launch + newPage + goto + screenshot 总上限，避免 UI 永久「正在导出…」 */
+const CAPTURE_TOTAL_TIMEOUT_MS = 120_000
 /** 图表等异步绘制的短暂等待 */
 const SETTLE_MS = 400
+
+function chromiumLaunchEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith('ELECTRON_')) continue
+    if (value !== undefined) env[key] = value
+  }
+  return env
+}
+
+function withCaptureTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timeout`))
+    }, CAPTURE_TOTAL_TIMEOUT_MS)
+    promise.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}
 
 export type WebPreviewExportFailure = {
   ok: false
@@ -122,11 +151,20 @@ export async function captureWebPreviewFullPagePng(
     }
   }
 
+  try {
+    return await withCaptureTimeout(runCapture(trimmed), 'Web preview export')
+  } catch (err) {
+    return userFacingCaptureError(err)
+  }
+}
+
+async function runCapture(trimmed: string): Promise<WebPreviewExportResult> {
   let browser: Awaited<ReturnType<typeof chromium.launch>> | null = null
   try {
     browser = await chromium.launch({
       headless: true,
       executablePath: chromium.executablePath(),
+      env: chromiumLaunchEnv(),
     })
     const context = await browser.newContext({
       viewport: {

--- a/packages/agent-browser/scripts/heal-e2e.mjs
+++ b/packages/agent-browser/scripts/heal-e2e.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Local E2E: heal packaged Opptrix Chromium → launch → newPage → screenshot.
+ * Usage: node packages/agent-browser/scripts/heal-e2e.mjs [packagedBrowsersPath]
+ */
+import { rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chromium } from 'playwright-core'
+import {
+  chromeAppNeedsEntitlementsHeal,
+  ensureDarwinBundledChromiumHealed,
+  findChromeForTestingApp,
+} from '../dist/chromium-darwin-heal.js'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const DEFAULT_PACKAGED = path.join(
+  '/Applications/Opptrix.app/Contents/Resources/runtime-stage/playwright-browsers',
+)
+
+const packagedPath = path.resolve(process.argv[2] ?? DEFAULT_PACKAGED)
+
+if (process.platform !== 'darwin') {
+  console.error('HEAL_E2E SKIP: darwin only')
+  process.exit(0)
+}
+
+const healDir = path.join(os.homedir(), '.opptrix', 'playwright-browsers')
+rmSync(healDir, { recursive: true, force: true })
+console.log(`HEAL_E2E: cleared ${healDir}`)
+console.log(`HEAL_E2E: packaged path ${packagedPath}`)
+
+const chromeBefore = findChromeForTestingApp(packagedPath)
+if (!chromeBefore) {
+  console.error('HEAL_E2E FAIL: Google Chrome for Testing.app not found')
+  process.exit(1)
+}
+console.log(`HEAL_E2E: packaged needs heal = ${chromeAppNeedsEntitlementsHeal(chromeBefore)}`)
+
+const healedPath = await ensureDarwinBundledChromiumHealed(packagedPath)
+console.log(`HEAL_E2E: healed browsers path = ${healedPath}`)
+
+process.env.PLAYWRIGHT_BROWSERS_PATH = healedPath
+const exe = chromium.executablePath()
+console.log(`HEAL_E2E: chromium executable = ${exe}`)
+
+const browser = await chromium.launch({
+  headless: true,
+  executablePath: exe,
+})
+try {
+  const page = await browser.newPage()
+  await page.setContent('<html><body><h1>heal ok</h1></body></html>')
+  const png = await page.screenshot({ type: 'png' })
+  await page.close()
+  if (!png || png.length < 100) {
+    throw new Error('screenshot too small')
+  }
+  console.log(`HEAL_E2E SUCCESS: newPage + screenshot (${png.length} bytes)`)
+} finally {
+  await browser.close()
+}

--- a/packages/agent-browser/src/chromium-darwin-heal.ts
+++ b/packages/agent-browser/src/chromium-darwin-heal.ts
@@ -1,0 +1,238 @@
+/**
+ * macOS desktop: bundled Playwright Chromium signed with hardened runtime but without
+ * disable-library-validation hangs on browser.newPage(). Copy to ~/.opptrix and adhoc re-sign.
+ *
+ * Self-heal uses adhoc deep sign (no --options runtime) — simpler and reliable vs re-sealing
+ * nested frameworks with runtime+entitlements.
+ */
+import { execFileSync, spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { resolveUserDataRoot } from '@opptrix/shared'
+
+const DISABLE_LIB_VALIDATION = 'com.apple.security.cs.disable-library-validation'
+
+export function resolveUserPlaywrightBrowsersDir(): string {
+  return path.join(resolveUserDataRoot(), 'playwright-browsers')
+}
+
+/** Exported for unit tests — detects hardened runtime without disable-library-validation. */
+export function chromeAppNeedsEntitlementsHeal(appPath: string): boolean {
+  if (process.platform !== 'darwin' || !fs.existsSync(appPath)) return false
+
+  const probe = spawnSync('codesign', ['-d', '--verbose=4', appPath], { encoding: 'utf8' })
+  const probeOut = `${probe.stdout ?? ''}${probe.stderr ?? ''}`
+  const hasRuntime =
+    /runtime\b/i.test(probeOut)
+    || /CodeDirectory v=20500/.test(probeOut)
+    || /flags=.*\bruntime\b/.test(probeOut)
+  // Adhoc deep-healed copies have no hardened runtime — treat as healthy.
+  if (!hasRuntime) return false
+
+  const ent = spawnSync('codesign', ['-d', '--entitlements', '-', '--xml', appPath], {
+    encoding: 'utf8',
+  })
+  const entXml = `${ent.stdout ?? ''}${ent.stderr ?? ''}`
+  return !entXml.includes(DISABLE_LIB_VALIDATION)
+}
+
+export function findChromeForTestingApp(browsersDir: string): string | null {
+  if (!fs.existsSync(browsersDir)) return null
+  const stack = [browsersDir]
+  while (stack.length > 0) {
+    const dir = stack.pop()
+    if (!dir) continue
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const full = path.join(dir, entry.name)
+      if (entry.name === 'Google Chrome for Testing.app') return full
+      stack.push(full)
+    }
+  }
+  return null
+}
+
+/** Top-level browser .app bundles to adhoc deep-sign (not nested Helper.apps). */
+export function collectBrowserAppsToResign(root: string): string[] {
+  const apps: string[] = []
+  function walk(dir: string): void {
+    if (!fs.existsSync(dir)) return
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const full = path.join(dir, entry.name)
+      if (!entry.name.endsWith('.app')) {
+        walk(full)
+        continue
+      }
+      if (
+        entry.name === 'Google Chrome for Testing.app'
+        || /^chrome-headless-shell/i.test(entry.name)
+      ) {
+        apps.push(full)
+      }
+      // Do not recurse into .app — Helpers are sealed by outer --deep.
+    }
+  }
+  walk(root)
+  return apps
+}
+
+function collectNestedBundlesUnderApp(appPath: string): { frameworks: string[]; apps: string[] } {
+  const frameworks: string[] = []
+  const apps: string[] = []
+  function walk(dir: string): void {
+    if (!fs.existsSync(dir)) return
+    let entries: fs.Dirent[]
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const full = path.join(dir, entry.name)
+      if (entry.name.endsWith('.framework')) {
+        frameworks.push(full)
+        walk(full)
+        continue
+      }
+      if (entry.name.endsWith('.app')) {
+        apps.push(full)
+        walk(full)
+        continue
+      }
+      walk(full)
+    }
+  }
+  walk(appPath)
+  return { frameworks, apps }
+}
+
+function removeSignature(target: string): void {
+  try {
+    execFileSync('codesign', ['--remove-signature', target], {
+      stdio: ['ignore', 'ignore', 'pipe'],
+    })
+  } catch {
+    // Already unsigned or partial seal — continue.
+  }
+}
+
+function adhocDeepSignApp(appPath: string): void {
+  const { frameworks } = collectNestedBundlesUnderApp(appPath)
+  const nestedFrameworks = frameworks.sort((a, b) => b.length - a.length)
+
+  // Strip outer framework seals only — do not remove Helper.app signatures first
+  // (that leaves unsealed contents inside the embedded framework).
+  for (const framework of nestedFrameworks) {
+    removeSignature(framework)
+  }
+  removeSignature(appPath)
+
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], {
+    stdio: ['ignore', 'ignore', 'pipe'],
+  })
+}
+
+function adhocResignPlaywrightTree(root: string): void {
+  const apps = collectBrowserAppsToResign(root)
+  if (apps.length === 0) {
+    throw new Error(`No Playwright browser .app found under ${root}`)
+  }
+  for (const app of apps) {
+    adhocDeepSignApp(app)
+  }
+}
+
+function readHealManifest(healDir: string): { sourcePath: string; sourceMtimeMs: number } | null {
+  const manifestPath = path.join(healDir, '.heal-manifest.json')
+  if (!fs.existsSync(manifestPath)) return null
+  try {
+    const raw = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      sourcePath?: unknown
+      sourceMtimeMs?: unknown
+    }
+    if (typeof raw.sourcePath !== 'string' || typeof raw.sourceMtimeMs !== 'number') return null
+    return { sourcePath: raw.sourcePath, sourceMtimeMs: raw.sourceMtimeMs }
+  } catch {
+    return null
+  }
+}
+
+function writeHealManifest(
+  healDir: string,
+  sourcePath: string,
+  sourceMtimeMs: number,
+): void {
+  fs.mkdirSync(healDir, { recursive: true })
+  fs.writeFileSync(
+    path.join(healDir, '.heal-manifest.json'),
+    JSON.stringify({ sourcePath, sourceMtimeMs, healedAt: new Date().toISOString() }),
+    'utf8',
+  )
+}
+
+function copyBrowsersTree(src: string, dest: string): void {
+  if (fs.existsSync(dest)) {
+    fs.rmSync(dest, { recursive: true, force: true })
+  }
+  fs.mkdirSync(path.dirname(dest), { recursive: true })
+  // cp -a preserves xattrs/symlinks required for subsequent adhoc deep sign (fs.cpSync breaks seals).
+  execFileSync('cp', ['-a', src, dest], { stdio: ['ignore', 'ignore', 'pipe'] })
+}
+
+/**
+ * When bundled Chromium is runtime-sealed without CS entitlements, copy to user dir and adhoc re-sign.
+ * Returns the browsers path to use (healed user dir or original packaged path).
+ */
+export async function ensureDarwinBundledChromiumHealed(packagedBrowsersPath: string): Promise<string> {
+  if (process.platform !== 'darwin') return packagedBrowsersPath
+
+  const chromeApp = findChromeForTestingApp(packagedBrowsersPath)
+  if (!chromeApp || !chromeAppNeedsEntitlementsHeal(chromeApp)) {
+    return packagedBrowsersPath
+  }
+
+  const healDir = resolveUserPlaywrightBrowsersDir()
+  let sourceMtimeMs = 0
+  try {
+    sourceMtimeMs = fs.statSync(packagedBrowsersPath).mtimeMs
+  } catch {
+    return packagedBrowsersPath
+  }
+
+  const manifest = readHealManifest(healDir)
+  const healedChrome = findChromeForTestingApp(healDir)
+  const healStillValid =
+    manifest
+    && manifest.sourcePath === packagedBrowsersPath
+    && manifest.sourceMtimeMs === sourceMtimeMs
+    && healedChrome
+    && !chromeAppNeedsEntitlementsHeal(healedChrome)
+
+  if (healStillValid) {
+    return healDir
+  }
+
+  copyBrowsersTree(packagedBrowsersPath, healDir)
+  adhocResignPlaywrightTree(healDir)
+  writeHealManifest(healDir, packagedBrowsersPath, sourceMtimeMs)
+
+  const resignedChrome = findChromeForTestingApp(healDir)
+  if (!resignedChrome || chromeAppNeedsEntitlementsHeal(resignedChrome)) {
+    throw new Error('Failed to heal bundled Playwright Chromium signing')
+  }
+  return healDir
+}

--- a/packages/agent-browser/src/chromium-install.ts
+++ b/packages/agent-browser/src/chromium-install.ts
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { chromium } from 'playwright-core'
 import { isDesktopRuntime } from '@opptrix/shared'
+import { ensureDarwinBundledChromiumHealed } from './chromium-darwin-heal.js'
 
 const require = createRequire(import.meta.url)
 const PKG_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
@@ -23,6 +24,7 @@ export const PLAYWRIGHT_BROWSERS_DIR_NAME = 'playwright-browsers'
 const DEFAULT_INSTALL_TIMEOUT_MS = 120_000
 
 let ensureInFlight: Promise<boolean> | null = null
+let healInFlight: Promise<string | null> | null = null
 
 export function resolvePackagedBrowsersPath(): string | null {
   if (!isDesktopRuntime()) return null
@@ -30,13 +32,40 @@ export function resolvePackagedBrowsersPath(): string | null {
   return fs.existsSync(packaged) ? packaged : null
 }
 
+function applyPlaywrightBrowsersPath(browsersPath: string): void {
+  process.env.PLAYWRIGHT_BROWSERS_PATH = browsersPath
+}
+
 /** Apply PLAYWRIGHT_BROWSERS_PATH for packaged desktop before Playwright resolves executables. */
 export function configurePlaywrightBrowsersPath(): void {
   if (process.env.PLAYWRIGHT_BROWSERS_PATH?.trim()) return
   const packaged = resolvePackagedBrowsersPath()
   if (packaged) {
-    process.env.PLAYWRIGHT_BROWSERS_PATH = packaged
+    applyPlaywrightBrowsersPath(packaged)
   }
+}
+
+async function ensurePlaywrightBrowsersPathConfigured(): Promise<void> {
+  if (process.env.PLAYWRIGHT_BROWSERS_PATH?.trim()) return
+  const packaged = resolvePackagedBrowsersPath()
+  if (!packaged) return
+
+  if (process.platform === 'darwin' && isDesktopRuntime()) {
+    if (!healInFlight) {
+      healInFlight = ensureDarwinBundledChromiumHealed(packaged)
+        .then((healed) => {
+          applyPlaywrightBrowsersPath(healed)
+          return healed
+        })
+        .finally(() => {
+          healInFlight = null
+        })
+    }
+    await healInFlight
+    return
+  }
+
+  applyPlaywrightBrowsersPath(packaged)
 }
 
 /** True when the full Chromium executable exists (same path used at launch). */
@@ -100,6 +129,7 @@ export async function ensureChromiumAvailable(
   opts?: { timeoutMs?: number },
 ): Promise<boolean> {
   if (process.env.OPPTRIX_SKIP_PLAYWRIGHT_BROWSER === '1') return false
+  await ensurePlaywrightBrowsersPathConfigured()
   if (isChromiumAvailable()) return true
   if (!ensureInFlight) {
     const timeoutMs = opts?.timeoutMs ?? DEFAULT_INSTALL_TIMEOUT_MS

--- a/tests/chromium-darwin-heal.test.mjs
+++ b/tests/chromium-darwin-heal.test.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  chromeAppNeedsEntitlementsHeal,
+  collectBrowserAppsToResign,
+  findChromeForTestingApp,
+} from '../packages/agent-browser/dist/chromium-darwin-heal.js'
+
+describe('chromium-darwin-heal', () => {
+  it('findChromeForTestingApp returns null for missing dir', () => {
+    assert.equal(findChromeForTestingApp('/nonexistent/playwright-browsers'), null)
+  })
+
+  it('collectBrowserAppsToResign skips nested Helper.apps', () => {
+    assert.deepEqual(collectBrowserAppsToResign('/nonexistent/playwright-browsers'), [])
+  })
+
+  it('chromeAppNeedsEntitlementsHeal is false on non-darwin', () => {
+    if (process.platform === 'darwin') return
+    assert.equal(chromeAppNeedsEntitlementsHeal('/tmp/Google Chrome for Testing.app'), false)
+  })
+
+  it('chromeAppNeedsEntitlementsHeal is false for missing app', () => {
+    assert.equal(chromeAppNeedsEntitlementsHeal('/nonexistent/Google Chrome for Testing.app'), false)
+  })
+})

--- a/tests/desktop-pack-python-ci-contract.test.mjs
+++ b/tests/desktop-pack-python-ci-contract.test.mjs
@@ -164,6 +164,11 @@ describe('desktop pack python / ffmpeg CI contract', () => {
     assert.ok(src.includes('preSignHeavyMacTrees(context)'), 'afterPack must call pre-sign')
     assert.ok(src.includes('--options'), 'pre-sign must use hardened runtime options')
     assert.ok(src.includes("'runtime'"), 'pre-sign must pass runtime option')
+    assert.ok(src.includes('--entitlements'), 'pre-sign must pass entitlements with runtime')
+    assert.ok(
+      src.includes('entitlements.mac.plist'),
+      'pre-sign must use entitlements.mac.plist (runtime-only seals hang Chromium newPage)',
+    )
     assert.ok(src.includes('python'), 'must target python tree')
     assert.ok(src.includes('node_modules'), 'must target node_modules tree')
     assert.ok(src.includes('playwright-browsers'), 'must pre-sign playwright (signIgnore + notary)')


### PR DESCRIPTION
## Summary

- Fix macOS packaged web preview export hang: Playwright Chromium was re-signed with hardened runtime but without CS entitlements, causing `browser.newPage()` to stall indefinitely.
- Add `--entitlements` to `afterPack` Playwright pre-sign (prevents recurrence in signed releases).
- Add darwin runtime self-heal: copy bundled browsers to `~/.opptrix/playwright-browsers` and adhoc deep re-sign when entitlements are missing (fixes already-installed broken builds).
- Harden export path: 120s total capture timeout, strip `ELECTRON_*` from Chromium child env.

## Test plan

- [x] `npm run build -w @opptrix/agent-browser`
- [x] `node --test tests/chromium-darwin-heal.test.mjs tests/desktop-pack-python-ci-contract.test.mjs tests/web-preview-export.test.mjs` (33 pass)
- [x] `node packages/agent-browser/scripts/heal-e2e.mjs` against installed Opptrix 1.3.5 → HEAL_E2E SUCCESS

## Platform scope

- **macOS**: signing fix + self-heal (this bug)
- **Windows/Linux**: export timeout + env scrub only; no equivalent signing bug


Made with [Cursor](https://cursor.com)