### PR TITLE
fix(fund): pass InstrumentRef to fund detail APIs

### DIFF
--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -477,9 +477,13 @@ export const research = {
       20000,
     ),
 
-  fundSnapshot: async (code: string, signal?: AbortSignal): Promise<
+  fundSnapshot: async (
+    instrument: InstrumentRef,
+    signal?: AbortSignal,
+  ): Promise<
     import('../types/schemas').ApiResponse<import('../types/market').FundSnapshotData>
   > => {
+    const code = instrument.symbol
     const fallback: import('../types/market').FundSnapshotData = {
       code,
       profile: null,
@@ -488,25 +492,25 @@ export const research = {
     }
     const resp = await apiCall<import('../types/market').FundSnapshotData>(
       'fund_snapshot',
-      { code },
+      { instrument, code },
       { signal },
       20000,
     )
     return toApiResponse('fund_snapshot', resp, fallback, resp.data ?? undefined)
   },
 
-  fundNav: (code: string, signal?: AbortSignal) =>
+  fundNav: (instrument: InstrumentRef, signal?: AbortSignal) =>
     apiCall<{ code: string; items: import('../types/market').FundNavPoint[]; source?: string }>(
       'local_fund_nav',
-      { code },
+      { instrument, code: instrument.symbol },
       { signal },
       20000,
     ),
 
-  fundHoldings: (code: string, signal?: AbortSignal) =>
+  fundHoldings: (instrument: InstrumentRef, signal?: AbortSignal) =>
     apiCall<{ code: string; items: import('../types/market').FundHoldingRow[]; source?: string }>(
       'local_fund_holdings',
-      { code },
+      { instrument, code: instrument.symbol },
       { signal },
       20000,
     ),

--- a/client-ui/src/market/FundDetailTab.tsx
+++ b/client-ui/src/market/FundDetailTab.tsx
@@ -192,11 +192,11 @@ export default function FundDetailTab({ stock }: Props) {
   )
 
   useEffect(() => {
-    if (!stockCode || tab !== 'chart') return undefined
+    if (!instrumentRef || tab !== 'chart') return undefined
     if (navRows.length) return undefined
     let cancelled = false
     setNavLoading(true)
-    research.fundNav(stockCode)
+    research.fundNav(instrumentRef)
       .then(resp => {
         if (cancelled) return
         const raw = resp.data as { items?: FundNavPoint[] } | FundNavPoint[] | null | undefined
@@ -206,12 +206,12 @@ export default function FundDetailTab({ stock }: Props) {
         if (!cancelled) setNavLoading(false)
       })
     return () => { cancelled = true }
-  }, [stockCode, tab, navRows.length])
+  }, [instrumentRef, tab, navRows.length])
 
   const profile = useMemo(() => mergeProfile(snapshot), [snapshot])
 
   useEffect(() => {
-    if (!stockCode) {
+    if (!instrumentRef) {
       setSnapshot(null)
       setNavRows([])
       setHoldings([])
@@ -222,7 +222,7 @@ export default function FundDetailTab({ stock }: Props) {
     setTab('overview')
     setLoading(true)
     setError('')
-    research.fundSnapshot(stockCode)
+    research.fundSnapshot(instrumentRef)
       .then(resp => {
         if (cancelled) return
         if (!resp.success || !resp.data) {
@@ -242,13 +242,13 @@ export default function FundDetailTab({ stock }: Props) {
         if (!cancelled) setLoading(false)
       })
     return () => { cancelled = true }
-  }, [stockCode])
+  }, [instrumentRef])
 
   useEffect(() => {
-    if (!stockCode || tab !== 'nav') return undefined
+    if (!instrumentRef || tab !== 'nav') return undefined
     let cancelled = false
     setNavLoading(true)
-    research.fundNav(stockCode)
+    research.fundNav(instrumentRef)
       .then(resp => {
         if (cancelled) return
         const raw = resp.data as { items?: FundNavPoint[] } | FundNavPoint[] | null | undefined
@@ -261,13 +261,13 @@ export default function FundDetailTab({ stock }: Props) {
         if (!cancelled) setNavLoading(false)
       })
     return () => { cancelled = true }
-  }, [stockCode, tab])
+  }, [instrumentRef, tab])
 
   useEffect(() => {
-    if (!stockCode || tab !== 'holdings') return undefined
+    if (!instrumentRef || tab !== 'holdings') return undefined
     let cancelled = false
     setHoldingsLoading(true)
-    research.fundHoldings(stockCode)
+    research.fundHoldings(instrumentRef)
       .then(resp => {
         if (cancelled) return
         const raw = resp.data as { items?: FundHoldingRow[] } | FundHoldingRow[] | null | undefined
@@ -280,7 +280,7 @@ export default function FundDetailTab({ stock }: Props) {
         if (!cancelled) setHoldingsLoading(false)
       })
     return () => { cancelled = true }
-  }, [stockCode, tab])
+  }, [instrumentRef, tab])
 
   const displayName = resolveDisplayStockName(stockCode ?? '', profile?.name, stock?.name)
   const unitNav = profile?.unitNav

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -2321,7 +2321,7 @@ export class ResearchHub {
     const ref = resolveInstrumentFromParams(params)
     if (!ref) return fail('instrument 或 code 必填', t0)
     if (ref.assetClass !== 'FUND') {
-      return fail('仅支持 assetClass=FUND 的公募基金标的', t0)
+      return fail('当前标的不是公募基金，请重新搜索并选择基金', t0)
     }
     const labels = {
       fund_nav: '基金净值',


### PR DESCRIPTION
## Summary
- Fund detail panel passes full `InstrumentRef` (FUND/PF) to `fund_snapshot` / `fund_nav` / `fund_holdings` instead of bare 6-digit code
- Hub rejects non-fund with user-facing message instead of `assetClass=FUND` technical text

## Test plan
- [x] `npm run check:ui`
- [ ] Search `009049`, open detail panel — loads fund snapshot without error

Made with [Cursor](https://cursor.com)