### PR TITLE
feat(eastmoney): fund F10 profile provider and lightweight fund panel

### DIFF
--- a/client-ui/src/market/FundDetailTab.tsx
+++ b/client-ui/src/market/FundDetailTab.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Spinner, Tab, TabList, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { research } from '../api/client'
 import type { WatchlistItem } from '../types/market'
-import type { FundHoldingRow, FundNavPoint, FundProfileData, FundSnapshotData } from '../types/market'
+import type { FundHoldingRow, FundProfileData, FundSnapshotData } from '../types/market'
 import {
   formatCompactNumber,
   formatPct,
@@ -10,11 +10,11 @@ import {
   pctTone,
   resolveDisplayStockName,
 } from './format'
-import { displayCodeFromInstrument, resolveWatchlistInstrument, watchlistItemKey, normalizeWatchlistItem } from './instrument'
+import { displayCodeFromInstrument, resolveWatchlistInstrument } from './instrument'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { listRowKey } from '../utils/listRowKey'
 
-type FundTab = 'overview' | 'chart' | 'nav' | 'holdings'
+type FundTab = 'overview' | 'holdings'
 
 const CONTENT_PAD = '15px'
 
@@ -105,11 +105,6 @@ const useStyles = makeStyles({
     gap: '8px',
     marginBottom: '12px',
   },
-  sectionTitle: {
-    fontSize: 'var(--opptrix-font-sm)',
-    fontWeight: 600,
-    color: opptrixCssVars.textSecondary,
-  },
   grid: {
     display: 'grid',
     gridTemplateColumns: '1fr 1fr',
@@ -151,9 +146,7 @@ type Props = {
   stock: WatchlistItem
 }
 
-function mergeProfile(
-  snapshot: FundSnapshotData | null,
-): FundProfileData | null {
+function mergeProfile(snapshot: FundSnapshotData | null): FundProfileData | null {
   if (!snapshot) return null
   const base = (snapshot.profile ?? {}) as FundProfileData
   const quote = snapshot.quote as Record<string, unknown> | null
@@ -173,11 +166,9 @@ export default function FundDetailTab({ stock }: Props) {
   const s = useStyles()
   const [tab, setTab] = useState<FundTab>('overview')
   const [snapshot, setSnapshot] = useState<FundSnapshotData | null>(null)
-  const [navRows, setNavRows] = useState<FundNavPoint[]>([])
   const [holdings, setHoldings] = useState<FundHoldingRow[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
-  const [navLoading, setNavLoading] = useState(false)
   const [holdingsLoading, setHoldingsLoading] = useState(false)
 
   const instrumentRef = useMemo(
@@ -186,34 +177,12 @@ export default function FundDetailTab({ stock }: Props) {
   )
   const stockCode = instrumentRef?.symbol ?? stock?.code ?? null
   const displayCode = instrumentRef ? displayCodeFromInstrument(instrumentRef) : (stock?.code ?? '')
-  const stockKey = useMemo(
-    () => (stock ? watchlistItemKey(normalizeWatchlistItem(stock)) : null),
-    [stock],
-  )
-
-  useEffect(() => {
-    if (!instrumentRef || tab !== 'chart') return undefined
-    if (navRows.length) return undefined
-    let cancelled = false
-    setNavLoading(true)
-    research.fundNav(instrumentRef)
-      .then(resp => {
-        if (cancelled) return
-        const raw = resp.data as { items?: FundNavPoint[] } | FundNavPoint[] | null | undefined
-        setNavRows(Array.isArray(raw) ? raw : (raw?.items ?? []))
-      })
-      .finally(() => {
-        if (!cancelled) setNavLoading(false)
-      })
-    return () => { cancelled = true }
-  }, [instrumentRef, tab, navRows.length])
 
   const profile = useMemo(() => mergeProfile(snapshot), [snapshot])
 
   useEffect(() => {
     if (!instrumentRef) {
       setSnapshot(null)
-      setNavRows([])
       setHoldings([])
       setError('')
       return undefined
@@ -243,25 +212,6 @@ export default function FundDetailTab({ stock }: Props) {
       })
     return () => { cancelled = true }
   }, [instrumentRef])
-
-  useEffect(() => {
-    if (!instrumentRef || tab !== 'nav') return undefined
-    let cancelled = false
-    setNavLoading(true)
-    research.fundNav(instrumentRef)
-      .then(resp => {
-        if (cancelled) return
-        const raw = resp.data as { items?: FundNavPoint[] } | FundNavPoint[] | null | undefined
-        setNavRows(Array.isArray(raw) ? raw : (raw?.items ?? []))
-      })
-      .catch(() => {
-        if (!cancelled) setNavRows([])
-      })
-      .finally(() => {
-        if (!cancelled) setNavLoading(false)
-      })
-    return () => { cancelled = true }
-  }, [instrumentRef, tab])
 
   useEffect(() => {
     if (!instrumentRef || tab !== 'holdings') return undefined
@@ -321,8 +271,6 @@ export default function FundDetailTab({ stock }: Props) {
         size="small"
       >
         <Tab value="overview">概览</Tab>
-        <Tab value="chart">走势</Tab>
-        <Tab value="nav">净值</Tab>
         <Tab value="holdings">持仓</Tab>
       </TabList>
       <div className={s.body}>
@@ -357,41 +305,6 @@ export default function FundDetailTab({ stock }: Props) {
               </div>
             </div>
           </div>
-        ) : null}
-        {tab === 'chart' ? (
-          navLoading ? (
-            <div className={s.center}><Spinner size="small" label="正在加载净值走势..." /></div>
-          ) : navRows.length ? (
-            <div className={s.list}>
-              <Text size={200} className={s.meta}>公募基金按交易日公布净值，以下为近期走势</Text>
-              {navRows.slice(0, 60).map((row, index) => (
-                <div key={listRowKey(index, row.date, row.nav)} className={s.row}>
-                  <span>{row.date}</span>
-                  <span>{formatPrice(row.nav)}</span>
-                  <span className={pctTone(row.changePct)}>{formatPct(row.changePct)}</span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className={s.center}>暂时无法加载净值走势，请稍后再试</div>
-          )
-        ) : null}
-        {tab === 'nav' ? (
-          navLoading ? (
-            <div className={s.center}><Spinner size="small" label="正在加载净值历史..." /></div>
-          ) : navRows.length ? (
-            <div className={s.list}>
-              {navRows.map((row, index) => (
-                <div key={listRowKey(index, row.date, row.nav)} className={s.row}>
-                  <span>{row.date}</span>
-                  <span>{formatPrice(row.nav)}</span>
-                  <span className={pctTone(row.changePct)}>{formatPct(row.changePct)}</span>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className={s.center}>还没有净值记录，稍后再来看看</div>
-          )
         ) : null}
         {tab === 'holdings' ? (
           holdingsLoading ? (

--- a/packages/a-stock-layer/src/engine.ts
+++ b/packages/a-stock-layer/src/engine.ts
@@ -738,25 +738,34 @@ export class MarketDataEngine {
 
   async fundSnapshot(fundCode: string) {
     const code = normalizeCode(fundCode)
-    const [profile, nav, quote] = await Promise.all([
-      this.fundProfile(code),
-      this.fundNav(code),
-      this.fundQuote(code),
-    ])
-    const navRows = nav.data as Record<string, unknown>[] | undefined
-    const latestNav = navRows?.length
-      ? pickLatestNavRow(navRows)
+    // 右侧面板仅展示最新净值与档案字段，一次 fundProfile 即可（内含 lsjz 首条）
+    const profile = await this.fundProfile(code)
+    const profileRow = profile.data?.[0] as Record<string, unknown> | undefined
+    const latestNav = profileRow
+      ? {
+          date: String(profileRow.navDate ?? '').slice(0, 10),
+          nav: profileRow.unitNav,
+          accNav: profileRow.accNav,
+          changePct: profileRow.changePct,
+        }
       : null
-    const quoteRow = quote.data?.[0] as Record<string, unknown> | undefined
     return {
-      success: profile.success || nav.success || quote.success,
+      success: profile.success,
       data: {
         code,
-        profile: profile.data?.[0] ?? null,
+        profile: profileRow ?? null,
         nav: latestNav ?? null,
-        quote: quoteRow ?? null,
+        quote: profileRow
+          ? {
+              unitNav: profileRow.unitNav,
+              accNav: profileRow.accNav,
+              changePct: profileRow.changePct,
+              navDate: profileRow.navDate,
+              name: profileRow.name,
+            }
+          : null,
       },
-      source: profile.source ?? nav.source ?? quote.source,
+      source: profile.source,
     }
   }
 

--- a/packages/a-stock-layer/src/providers/common/standard-methods.ts
+++ b/packages/a-stock-layer/src/providers/common/standard-methods.ts
@@ -69,6 +69,7 @@ export const PROVIDER_ETF_COVERAGE: Record<string, readonly string[]> = {
 export const PROVIDER_FUND_COVERAGE: Record<string, readonly string[]> = {
   sinafinance: [...CN_FUND_STANDARD_METHODS],
   tushare: [...CN_FUND_STANDARD_METHODS],
+  eastmoney: ['fundProfile', 'fundNav', 'fundHoldings', 'fundQuote'],
 }
 
 /** 建议新增的 Capability（DATA-LAYER Phase-2） */

--- a/packages/a-stock-layer/src/providers/eastmoney/api/fund.ts
+++ b/packages/a-stock-layer/src/providers/eastmoney/api/fund.ts
@@ -1,0 +1,448 @@
+/**
+ * 东方财富 / 天天基金 F10 公募基金档案接口。
+ *
+ * 设计原则：仅请求用户打开基金档案页时浏览器会触发的公开 URL，
+ * 不伪造登录态、不绕过鉴权、不使用 push2 的 `ut` 参数（见 types.ts EM_UT）。
+ *
+ * 与官方前端对应关系（j5.dfcfw.com/sc/js/web/f10_min_*.js / 品种页 HTML）：
+ * - fund.eastmoney.com/pingzhongdata/{code}.js — 品种页图表数据（与 /{code}.html 同载）
+ * - fundf10.eastmoney.com/jbgk_{code}.html — 基本概况 HTML
+ * - fundf10.eastmoney.com/FundArchivesDatas.aspx?type=jjcc — 持仓 Tab Ajax
+ * - api.fund.eastmoney.com/f10/lsjz — 历史净值 JSONP（f10_min 内 f10/lsjz，callback=?）
+ */
+import { isEmptyHttpResponseBody } from '@opptrix/shared'
+import { normalizeCode } from '../../../utils/helpers.js'
+import { eastmoneyHttp, EastmoneyHttpError } from './http.js'
+import {
+  EM_FUND_API,
+  EM_FUND_ARCHIVES,
+  EM_FUND_F10_REFERER,
+  EM_FUND_HOME_REFERER,
+  EM_FUND_PINGZHONG,
+} from './types.js'
+
+export type EmFundLsjzRow = {
+  FSRQ?: string
+  DWJZ?: string
+  LJJZ?: string
+  JZZZL?: string
+  SGZT?: string
+  SHZT?: string
+}
+
+export type EmFundLsjzResponse = {
+  Data?: {
+    LSJZList?: EmFundLsjzRow[]
+    TotalCount?: number
+  }
+  ErrCode?: number
+  TotalCount?: number
+}
+
+export type EmPingzhongData = {
+  fS_name?: string
+  fS_code?: string
+  fund_Rate?: string
+  fund_sourceRate?: string
+  fund_minsg?: string
+  stockCodesNew?: string[]
+  zqCodesNew?: string
+  syl_1y?: string
+  syl_3y?: string
+  syl_6y?: string
+  syl_1n?: string
+  Data_netWorthTrend?: unknown
+  Data_ACWorthTrend?: unknown
+  Data_assetAllocation?: Record<string, unknown>
+  Data_currentFundManager?: unknown[]
+  Data_performanceEvaluation?: Record<string, unknown>
+  Data_holderStructure?: Record<string, unknown>
+  Data_fluctuationScale?: Record<string, unknown>
+  Data_fundSharesPositions?: unknown
+  swithSameType?: unknown
+}
+
+async function fetchEmFundText(
+  url: string,
+  referer: string,
+  encoding: 'utf-8' | 'gbk' = 'utf-8',
+): Promise<string> {
+  const resp = await eastmoneyHttp.fetch(url, {
+    headers: { Referer: referer },
+  })
+  if (!resp.ok) throw new EastmoneyHttpError(resp.status)
+  const buf = await resp.arrayBuffer()
+  const text = new TextDecoder(encoding).decode(buf)
+  if (isEmptyHttpResponseBody(text)) {
+    throw new EastmoneyHttpError(resp.status, 'empty body')
+  }
+  return text
+}
+
+function parseBalancedJson(text: string, start: number): unknown {
+  const open = text[start]
+  const close = open === '[' ? ']' : open === '{' ? '}' : null
+  if (!close) return null
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = start; i < text.length; i++) {
+    const c = text[i]
+    if (inString) {
+      if (escape) {
+        escape = false
+        continue
+      }
+      if (c === '\\') {
+        escape = true
+        continue
+      }
+      if (c === '"') inString = false
+      continue
+    }
+    if (c === '"') {
+      inString = true
+      continue
+    }
+    if (c === open) depth++
+    if (c === close) {
+      depth--
+      if (depth === 0) {
+        try {
+          return JSON.parse(text.slice(start, i + 1))
+        } catch {
+          return null
+        }
+      }
+    }
+  }
+  return null
+}
+
+function extractJsStringVar(raw: string, name: string): string | undefined {
+  const re = new RegExp(`var\\s+${name}\\s*=\\s*"([^"]*)"`)
+  const m = re.exec(raw)
+  return m?.[1]
+}
+
+function extractJsJsonVar(raw: string, name: string): unknown {
+  const re = new RegExp(`var\\s+${name}\\s*=`)
+  const m = re.exec(raw)
+  if (!m) return undefined
+  let i = m.index + m[0].length
+  while (i < raw.length && /\s/.test(raw[i])) i++
+  const ch = raw[i]
+  if (ch === '"' || ch === "'") {
+    const end = raw.indexOf(ch, i + 1)
+    return end > i ? raw.slice(i + 1, end) : undefined
+  }
+  if (ch === '[' || ch === '{') return parseBalancedJson(raw, i)
+  const semi = raw.indexOf(';', i)
+  const slice = raw.slice(i, semi > i ? semi : i + 32).trim()
+  const num = Number(slice)
+  if (Number.isFinite(num) && slice === String(num)) return num
+  return slice || undefined
+}
+
+/** 解析 pingzhongdata/{code}.js 中的档案与图表变量 */
+export function parseEmPingzhongData(raw: string): EmPingzhongData {
+  const out: EmPingzhongData = {}
+  const stringKeys = ['fS_name', 'fS_code', 'fund_Rate', 'fund_sourceRate', 'fund_minsg', 'zqCodesNew', 'syl_1y', 'syl_3y', 'syl_6y', 'syl_1n']
+  for (const key of stringKeys) {
+    const v = extractJsStringVar(raw, key)
+    if (v !== undefined) (out as Record<string, unknown>)[key] = v
+  }
+  const jsonKeys = [
+    'stockCodesNew',
+    'Data_netWorthTrend',
+    'Data_ACWorthTrend',
+    'Data_assetAllocation',
+    'Data_currentFundManager',
+    'Data_performanceEvaluation',
+    'Data_holderStructure',
+    'Data_fluctuationScale',
+    'Data_fundSharesPositions',
+    'swithSameType',
+  ]
+  for (const key of jsonKeys) {
+    const v = extractJsJsonVar(raw, key)
+    if (v !== undefined) (out as Record<string, unknown>)[key] = v
+  }
+  return out
+}
+
+export async function fetchEmPingzhongData(code: string): Promise<EmPingzhongData | null> {
+  const bare = normalizeCode(code)
+  if (!bare) return null
+  const raw = await fetchEmFundText(
+    `${EM_FUND_PINGZHONG}/${bare}.js`,
+    EM_FUND_HOME_REFERER,
+    'utf-8',
+  )
+  return parseEmPingzhongData(raw)
+}
+
+function stripJsonpCallback(raw: string): string {
+  const t = raw.trim()
+  const i = t.indexOf('(')
+  const j = t.lastIndexOf(')')
+  if (i >= 0 && j > i) return t.slice(i + 1, j)
+  return t
+}
+
+export async function fetchEmFundNavPage(
+  code: string,
+  pageIndex = 1,
+  pageSize = 100,
+): Promise<EmFundLsjzResponse | null> {
+  const bare = normalizeCode(code)
+  if (!bare) return null
+  const qs = new URLSearchParams({
+    callback: '?',
+    fundCode: bare,
+    pageIndex: String(pageIndex),
+    pageSize: String(pageSize),
+    startDate: '',
+    endDate: '_',
+  })
+  const raw = await fetchEmFundText(
+    `${EM_FUND_API}/lsjz?${qs}`,
+    EM_FUND_F10_REFERER,
+    'utf-8',
+  )
+  try {
+    return JSON.parse(stripJsonpCallback(raw)) as EmFundLsjzResponse
+  } catch {
+    return null
+  }
+}
+
+export type EmJbgkFields = Record<string, string>
+
+/** 解析 jbgk 基本概况页表格字段（GBK HTML） */
+export function parseEmJbgkHtml(html: string): EmJbgkFields {
+  const fields: EmJbgkFields = {}
+  const tableMatch = html.match(/<table class="info w790"[\s\S]*?<\/table>/i)
+  if (!tableMatch) return fields
+  const rowRe = /<tr[^>]*>([\s\S]*?)<\/tr>/gi
+  let rowMatch: RegExpExecArray | null
+  while ((rowMatch = rowRe.exec(tableMatch[0])) !== null) {
+    const cells: string[] = []
+    const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi
+    let cellMatch: RegExpExecArray | null
+    while ((cellMatch = cellRe.exec(rowMatch[1])) !== null) {
+      const text = cellMatch[1]
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+      if (text) cells.push(text)
+    }
+    for (let i = 0; i + 1 < cells.length; i += 2) {
+      const label = cells[i].replace(/：$/, '')
+      const value = cells[i + 1]
+      if (label && value) fields[label] = value
+    }
+  }
+  return fields
+}
+
+const JBGK_SECTION_LABELS = [
+  '投资目标',
+  '投资理念',
+  '投资范围',
+  '投资策略',
+  '分红政策',
+  '风险收益特征',
+] as const
+
+/** 解析 jbgk 正文段落（投资目标 / 策略等） */
+export function parseEmJbgkSections(html: string): Record<string, string> {
+  const sections: Record<string, string> = {}
+  for (const label of JBGK_SECTION_LABELS) {
+    const re = new RegExp(
+      `<label class="left">${label}</label>[\\s\\S]*?<p>([\\s\\S]*?)</p>`,
+      'i',
+    )
+    const m = re.exec(html)
+    if (!m) continue
+    const text = m[1]
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+    if (text) sections[label] = text
+  }
+  return sections
+}
+
+export async function fetchEmJbgkProfile(code: string): Promise<{
+  fields: EmJbgkFields
+  sections: Record<string, string>
+} | null> {
+  const bare = normalizeCode(code)
+  if (!bare) return null
+  const html = await fetchEmFundText(
+    `https://fundf10.eastmoney.com/jbgk_${bare}.html`,
+    EM_FUND_F10_REFERER,
+    'gbk',
+  )
+  return {
+    fields: parseEmJbgkHtml(html),
+    sections: parseEmJbgkSections(html),
+  }
+}
+
+export type EmJjccHoldingRaw = {
+  symbol: string
+  name: string
+  weight?: string
+  shares?: string
+  marketValue?: string
+  reportDate?: string
+}
+
+function parseEmJjccContent(htmlFragment: string): EmJjccHoldingRaw[] {
+  const rows: EmJjccHoldingRaw[] = []
+  const dateMatch = htmlFragment.match(/(\d{4}-\d{2}-\d{2})/)
+  const reportDate = dateMatch?.[1]
+  const rowRe = /<tr[^>]*>([\s\S]*?)<\/tr>/gi
+  let rowMatch: RegExpExecArray | null
+  while ((rowMatch = rowRe.exec(htmlFragment)) !== null) {
+    const rowHtml = rowMatch[1]
+    if (rowHtml.includes('<th')) continue
+    const cells: string[] = []
+    const cellRe = /<td[^>]*>([\s\S]*?)<\/td>/gi
+    let cellMatch: RegExpExecArray | null
+    while ((cellMatch = cellRe.exec(rowHtml)) !== null) {
+      cells.push(
+        cellMatch[1]
+          .replace(/<[^>]+>/g, '')
+          .replace(/&nbsp;/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim(),
+      )
+    }
+    if (cells.length < 6) continue
+    const symbolCell = rowHtml.match(/unify\/r\/[01]\.(\d{6})/)
+    const symbol = symbolCell?.[1] ?? cells[1].replace(/\D/g, '').slice(-6)
+    const name = cells[2] || ''
+    if (!symbol && !name) continue
+    rows.push({
+      symbol,
+      name,
+      weight: cells[4],
+      shares: cells[5],
+      marketValue: cells[6],
+      reportDate,
+    })
+  }
+  return rows
+}
+
+export function parseEmArchivesApidata(raw: string): string | null {
+  const marker = raw.indexOf('content:"')
+  if (marker < 0) return null
+  let i = marker + 'content:"'.length
+  let out = ''
+  while (i < raw.length) {
+    const c = raw[i]
+    if (c === '\\' && i + 1 < raw.length) {
+      const next = raw[i + 1]
+      if (next === '"') {
+        out += '"'
+        i += 2
+        continue
+      }
+      if (next === 'n') {
+        out += '\n'
+        i += 2
+        continue
+      }
+      if (next === 'r') {
+        out += '\r'
+        i += 2
+        continue
+      }
+      if (next === 't') {
+        out += '\t'
+        i += 2
+        continue
+      }
+      if (next === '/') {
+        out += '/'
+        i += 2
+        continue
+      }
+      out += next
+      i += 2
+      continue
+    }
+    if (c === '"') break
+    out += c
+    i++
+  }
+  return out || null
+}
+
+export function emReportPeriodToArchivesArgs(reportDate: string): { year: number; month: number } | null {
+  const m = /^(\d{4})-(\d{2})-\d{2}$/.exec(reportDate.trim())
+  if (!m) return null
+  return { year: Number(m[1]), month: Number(m[2]) }
+}
+
+export async function fetchEmFundArchivesJjcc(
+  code: string,
+  year: number,
+  month: number,
+): Promise<EmJjccHoldingRaw[]> {
+  const bare = normalizeCode(code)
+  if (!bare) return []
+  const qs = new URLSearchParams({
+    type: 'jjcc',
+    code: bare,
+    topline: '50',
+    year: String(year),
+    month: String(month),
+  })
+  const raw = await fetchEmFundText(
+    `${EM_FUND_ARCHIVES}?${qs}`,
+    EM_FUND_F10_REFERER,
+    'gbk',
+  )
+  const content = parseEmArchivesApidata(raw)
+  if (!content) return []
+  return parseEmJjccContent(content)
+}
+
+/** 从 pingzhongdata 资产配置报告期推断持仓，优先完整季报明细表 */
+export async function fetchEmFundLatestHoldings(code: string): Promise<EmJjccHoldingRaw[]> {
+  const ping = await fetchEmPingzhongData(code)
+  const categories = ping?.Data_assetAllocation?.categories
+  let bestWeighted: EmJjccHoldingRaw[] = []
+  let jjccAttempts = 0
+  const MAX_JJCC_ATTEMPTS = 3
+  if (Array.isArray(categories) && categories.length) {
+    for (let i = categories.length - 1; i >= 0; i--) {
+      if (jjccAttempts >= MAX_JJCC_ATTEMPTS) break
+      const period = emReportPeriodToArchivesArgs(String(categories[i] ?? ''))
+      if (!period) continue
+      jjccAttempts += 1
+      const rows = await fetchEmFundArchivesJjcc(code, period.year, period.month)
+      const weighted = rows.filter(r => String(r.weight ?? '').includes('%'))
+      if (weighted.length >= 5 && weighted.length === rows.length) return rows
+      if (weighted.length > bestWeighted.length) bestWeighted = weighted
+    }
+    if (bestWeighted.length) return bestWeighted
+  }
+  for (const month of [12, 9, 6, 3]) {
+    if (jjccAttempts >= MAX_JJCC_ATTEMPTS) break
+    jjccAttempts += 1
+    const rows = await fetchEmFundArchivesJjcc(code, new Date().getFullYear(), month)
+    const weighted = rows.filter(r => String(r.weight ?? '').includes('%'))
+    if (weighted.length >= 5 && weighted.length === rows.length) return rows
+    if (weighted.length > bestWeighted.length) bestWeighted = weighted
+  }
+  return bestWeighted
+}

--- a/packages/a-stock-layer/src/providers/eastmoney/api/types.ts
+++ b/packages/a-stock-layer/src/providers/eastmoney/api/types.ts
@@ -1,7 +1,23 @@
 /** 东方财富 push2 / datacenter 公共常量与响应形态 */
 
 export const EM_REFERER = 'https://data.eastmoney.com/'
+/** 天天基金 F10 档案页 Referer */
+export const EM_FUND_F10_REFERER = 'https://fundf10.eastmoney.com/'
+/** 天天基金品种页 Referer（pingzhongdata） */
+export const EM_FUND_HOME_REFERER = 'https://fund.eastmoney.com/'
+
+export const EM_FUND_API = 'https://api.fund.eastmoney.com/f10'
+export const EM_FUND_ARCHIVES = 'https://fundf10.eastmoney.com/FundArchivesDatas.aspx'
+export const EM_FUND_PINGZHONG = 'https://fund.eastmoney.com/pingzhongdata'
+
+/**
+ * push2 行情/资金流接口的 `ut` 查询参数。
+ * 来源：data.eastmoney.com / quote.eastmoney.com 官方前端 JS 中的固定客户端标识，
+ * 用于区分 Web 端请求形态（非用户密钥、非登录 Token、不参与基金 F10 档案路径）。
+ * 仅用于 eastmoney push2 / clist 公开行情请求（见 api/client.ts），基金 F10 不使用。
+ */
 export const EM_UT = 'b2884a393a59ad64002292a3e90d46a5'
+/** clist 板块/排名列表使用的 Web 客户端 `ut`（同上，来自官方前端） */
 export const EM_UT_CLIST = '8dec03ba335b81bf4ebdf7b29ec27d15'
 
 export const EM_DATACENTER = 'https://datacenter-web.eastmoney.com/api/data/v1/get'

--- a/packages/a-stock-layer/src/providers/eastmoney/driver.ts
+++ b/packages/a-stock-layer/src/providers/eastmoney/driver.ts
@@ -1,7 +1,9 @@
 import { applyManifestSpec } from '../common/driver-factory.js'
 import { EASTMONEY_SPEC } from './manifest.js'
 import { EastmoneyCnHandler } from './markets/cn/handler.js'
+import { mixEastmoneyFund } from './markets/cn/fund.js'
 
 export class EastmoneyDriver extends EastmoneyCnHandler {}
 
+mixEastmoneyFund(EastmoneyDriver)
 applyManifestSpec(EastmoneyDriver, EASTMONEY_SPEC)

--- a/packages/a-stock-layer/src/providers/eastmoney/manifest.ts
+++ b/packages/a-stock-layer/src/providers/eastmoney/manifest.ts
@@ -14,15 +14,34 @@ export const EASTMONEY_CAPS = [
   Capability.INST_HOLDING,
 ]
 
+/** 天天基金 F10 公募基金档案（概况 / 净值 / 持仓 / 快照） */
+export const EASTMONEY_FUND_CAPS = [
+  Capability.FUND_PROFILE,
+  Capability.FUND_NAV,
+  Capability.FUND_HOLDINGS,
+  Capability.FUND_QUOTE,
+] as const
+
+const EASTMONEY_FUND_BINDING_PRIORITY_OFFSET = 37
+
 export const EASTMONEY_SPEC: ProviderManifestSpec = {
   id: 'eastmoney',
   title: '东方财富',
-  subtitle: '资金流 / 两融 / 宏观 cjsj / 机构持仓 zlsj',
+  subtitle: '资金流 / 两融 / 宏观 cjsj / 机构持仓 zlsj / 天天基金 F10',
   marketGroup: 'CN',
   defaultPriority: 75,
   maxConcurrent: 4,
-  capabilities: EASTMONEY_CAPS,
-  bindingsFor: (p, maxConcurrent) => cnEquityBindings(EASTMONEY_CAPS, p, maxConcurrent),
+  capabilities: [...EASTMONEY_CAPS, ...EASTMONEY_FUND_CAPS],
+  bindingsFor: (p, maxConcurrent) => [
+    ...cnEquityBindings(EASTMONEY_CAPS, p, maxConcurrent),
+    ...EASTMONEY_FUND_CAPS.map(capability => ({
+      market: 'CN' as const,
+      assetClass: 'FUND' as const,
+      capability,
+      defaultPriority: p + EASTMONEY_FUND_BINDING_PRIORITY_OFFSET,
+      ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
+    })),
+  ],
   settings: EASTMONEY_SETTINGS,
   supportsTest: true,
 }
@@ -30,7 +49,7 @@ export const EASTMONEY_SPEC: ProviderManifestSpec = {
 export const EASTMONEY_MANIFEST = providerManifestEntry(
   'eastmoney',
   '东方财富',
-  '资金流、融资融券、宏观与机构持仓公开接口（data.eastmoney.com）',
+  '资金流、融资融券、宏观与机构持仓公开接口（data.eastmoney.com）；天天基金 F10 公募基金档案',
   'CN',
   75,
   EASTMONEY_SETTINGS,

--- a/packages/a-stock-layer/src/providers/eastmoney/markets/cn/fund.ts
+++ b/packages/a-stock-layer/src/providers/eastmoney/markets/cn/fund.ts
@@ -1,0 +1,103 @@
+import { assertCnPublicFundCode, isCnPublicFundRef } from '../../../../core/fund-instrument.js'
+import { rethrowIfFreeProviderThrottleTrigger } from '../../../common/free-provider-call.js'
+import {
+  fetchEmFundLatestHoldings,
+  fetchEmFundNavPage,
+  fetchEmJbgkProfile,
+  fetchEmPingzhongData,
+} from '../../api/fund.js'
+import {
+  mapEmJjccToFundHoldings,
+  mapEmLsjzToFundNavRows,
+  mapEmLsjzToFundQuoteRow,
+  mapEmToFundProfileRow,
+} from '../../normalize/fund.js'
+import type { EastmoneyCnHandler } from './handler.js'
+
+type Handler = EastmoneyCnHandler & Record<string, unknown>
+
+/** 挂载东方财富天天基金 F10 公募基金标准能力 */
+export function mixEastmoneyFund(Driver: { prototype: EastmoneyCnHandler }) {
+  const p = Driver.prototype as Handler
+
+  p.fundProfile = async function fundProfile(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    try {
+      const [jbgk, ping, navPage] = await Promise.all([
+        fetchEmJbgkProfile(bare),
+        fetchEmPingzhongData(bare),
+        fetchEmFundNavPage(bare, 1, 1),
+      ])
+      const latestNav = navPage?.Data?.LSJZList?.[0] ?? null
+      const row = mapEmToFundProfileRow(bare, jbgk, ping, latestNav)
+      return row ? [row] : null
+    } catch (e) {
+      rethrowIfFreeProviderThrottleTrigger(e)
+      return null
+    }
+  }
+
+  p.fundNav = async function fundNav(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    try {
+      const allRows: import('../../api/fund.js').EmFundLsjzRow[] = []
+      let page = 1
+      const pageSize = 20
+      for (;;) {
+        const resp = await fetchEmFundNavPage(bare, page, pageSize)
+        const batch = resp?.Data?.LSJZList ?? []
+        if (!batch.length) break
+        allRows.push(...batch)
+        const total = Number(resp?.Data?.TotalCount ?? resp?.TotalCount ?? 0)
+        if (total > 0 && allRows.length >= total) break
+        if (batch.length < pageSize) break
+        page += 1
+        // lsjz 单页最多 20 条；默认约 120 个交易日（与 Hub/UI 常见 limit 一致）
+        if (page > 6) break
+      }
+      const rows = mapEmLsjzToFundNavRows(bare, allRows)
+      return rows.length ? rows : null
+    } catch (e) {
+      rethrowIfFreeProviderThrottleTrigger(e)
+      return null
+    }
+  }
+
+  p.fundQuote = async function fundQuote(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    try {
+      const [navPage, ping] = await Promise.all([
+        fetchEmFundNavPage(bare, 1, 1),
+        fetchEmPingzhongData(bare),
+      ])
+      const latest = navPage?.Data?.LSJZList?.[0] ?? null
+      const profileHint = ping?.fS_name ? { name: ping.fS_name } : undefined
+      const row = mapEmLsjzToFundQuoteRow(bare, latest, profileHint)
+      return row ? [row] : null
+    } catch (e) {
+      rethrowIfFreeProviderThrottleTrigger(e)
+      return null
+    }
+  }
+
+  p.fundHoldings = async function fundHoldings(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    try {
+      const raw = await fetchEmFundLatestHoldings(bare)
+      const rows = mapEmJjccToFundHoldings(bare, raw)
+      return rows.length ? rows : null
+    } catch (e) {
+      rethrowIfFreeProviderThrottleTrigger(e)
+      return null
+    }
+  }
+}
+
+export function eastmoneyFundGate(ref: unknown): boolean {
+  if (!ref || typeof ref !== 'object') return false
+  return isCnPublicFundRef(ref as import('@opptrix/shared').InstrumentRef)
+}

--- a/packages/a-stock-layer/src/providers/eastmoney/normalize/fund.ts
+++ b/packages/a-stock-layer/src/providers/eastmoney/normalize/fund.ts
@@ -1,0 +1,194 @@
+import { normalizeCode, safeFloat } from '../../../utils/helpers.js'
+import type { StandardFundHoldingRow, StandardFundNavRow, StandardFundProfileRow, StandardFundQuoteRow } from '../../common/standard-fund.js'
+import type {
+  EmJjccHoldingRaw,
+  EmJbgkFields,
+  EmFundLsjzRow,
+  EmPingzhongData,
+} from '../api/fund.js'
+
+const SOURCE = 'eastmoney_fund'
+
+function parsePercentText(raw: unknown): number | null {
+  const text = String(raw ?? '').replace('%', '').trim()
+  if (!text || text === '---') return null
+  return safeFloat(text)
+}
+
+function parseYiFromText(raw: unknown): number | null {
+  const text = String(raw ?? '').trim()
+  if (!text || text === '---') return null
+  const n = safeFloat(text.replace(/[,，]/g, '').replace(/[^\d.-]/g, ''))
+  if (n == null) return null
+  if (text.includes('亿')) return n
+  if (text.includes('万')) return n / 10000
+  return n
+}
+
+function parseSharesYi(raw: unknown): number | null {
+  const text = String(raw ?? '').trim()
+  if (!text || text === '---') return null
+  const n = safeFloat(text.replace(/[,，]/g, '').replace(/[^\d.-]/g, ''))
+  if (n == null) return null
+  if (text.includes('万')) return n / 10000
+  if (text.includes('亿')) return n
+  return n
+}
+
+export function mapEmJbgkToProfileFields(
+  fields: EmJbgkFields,
+): Partial<StandardFundProfileRow> {
+  const establish = fields['成立日期/规模'] ?? fields['成立日期'] ?? ''
+  const [establishDate, establishScale] = establish.split('/').map(s => s.trim())
+  return {
+    fullName: fields['基金全称'] ?? undefined,
+    name: fields['基金简称'] ?? undefined,
+    fundType: fields['基金类型'] ?? undefined,
+    manager: fields['基金经理人'] ?? fields['基金经理'] ?? undefined,
+    company: fields['基金管理人'] ?? undefined,
+    custodian: fields['基金托管人'] ?? undefined,
+    benchmark: fields['业绩比较基准'] ?? undefined,
+    establishDate: establishDate?.slice(0, 10) || undefined,
+    scale: parseYiFromText(fields['净资产规模'] ?? fields['资产规模']),
+    totalShares: parseSharesYi(fields['份额规模'] ?? establishScale),
+    expenseRatio: parsePercentText(fields['管理费率']),
+  }
+}
+
+export function mapEmPingzhongToProfileExtras(
+  ping: EmPingzhongData | null,
+): Record<string, unknown> {
+  if (!ping) return {}
+  const extras: Record<string, unknown> = {
+    trackingTarget: undefined,
+    saleFeeRate: ping.fund_Rate || undefined,
+    sourceSaleFeeRate: ping.fund_sourceRate || undefined,
+    minPurchase: ping.fund_minsg || undefined,
+  }
+  if (ping.syl_1y) extras.return1m = safeFloat(ping.syl_1y)
+  if (ping.syl_3y) extras.return3m = safeFloat(ping.syl_3y)
+  if (ping.syl_6y) extras.return6m = safeFloat(ping.syl_6y)
+  if (ping.syl_1n) extras.return1y = safeFloat(ping.syl_1n)
+  if (ping.Data_assetAllocation) extras.assetAllocation = ping.Data_assetAllocation
+  if (ping.Data_currentFundManager) extras.managers = ping.Data_currentFundManager
+  if (ping.Data_performanceEvaluation) extras.performanceEvaluation = ping.Data_performanceEvaluation
+  if (ping.Data_holderStructure) extras.holderStructure = ping.Data_holderStructure
+  if (ping.Data_fluctuationScale) extras.fluctuationScale = ping.Data_fluctuationScale
+  if (ping.Data_fundSharesPositions) extras.fundSharesPositions = ping.Data_fundSharesPositions
+  if (ping.Data_netWorthTrend) extras.netWorthTrend = ping.Data_netWorthTrend
+  if (ping.swithSameType) extras.sameTypeFunds = ping.swithSameType
+  return extras
+}
+
+export function mapEmToFundProfileRow(
+  code: string,
+  jbgk: { fields: EmJbgkFields; sections: Record<string, string> } | null,
+  ping: EmPingzhongData | null,
+  latestNav?: EmFundLsjzRow | null,
+): StandardFundProfileRow | null {
+  const bare = normalizeCode(code)
+  if (!bare) return null
+  const base = jbgk ? mapEmJbgkToProfileFields(jbgk.fields) : {}
+  const extras = mapEmPingzhongToProfileExtras(ping)
+  const name = base.name ?? ping?.fS_name ?? undefined
+  if (!name && !jbgk && !ping && !latestNav) return null
+
+  const navDate = String(latestNav?.FSRQ ?? '').slice(0, 10) || undefined
+  const unitNav = safeFloat(latestNav?.DWJZ)
+  const accNav = safeFloat(latestNav?.LJJZ)
+  const changePct = safeFloat(latestNav?.JZZZL)
+
+  return {
+    code: bare,
+    name,
+    fullName: base.fullName ?? undefined,
+    fundType: base.fundType ?? undefined,
+    manager: base.manager ?? undefined,
+    company: base.company ?? undefined,
+    custodian: base.custodian ?? undefined,
+    benchmark: base.benchmark ?? undefined,
+    establishDate: base.establishDate ?? undefined,
+    scale: base.scale ?? undefined,
+    totalShares: base.totalShares ?? undefined,
+    expenseRatio: base.expenseRatio ?? undefined,
+    unitNav,
+    accNav,
+    navDate,
+    changePct,
+    investTarget: jbgk?.sections['投资目标'] ?? undefined,
+    investScope: jbgk?.sections['投资范围'] ?? undefined,
+    investStrategy: jbgk?.sections['投资策略'] ?? undefined,
+    investIdea: jbgk?.sections['投资理念'] ?? undefined,
+    dividendPolicy: jbgk?.sections['分红政策'] ?? undefined,
+    riskFeatures: jbgk?.sections['风险收益特征'] ?? undefined,
+    trackingTarget: jbgk?.fields['跟踪标的'] ?? undefined,
+    custodyFeeRate: parsePercentText(jbgk?.fields['托管费率']),
+    maxSubscribeFeeRate: parsePercentText(jbgk?.fields['最高认购费率']),
+    maxPurchaseFeeRate: parsePercentText(jbgk?.fields['最高申购费率']),
+    maxRedeemFeeRate: parsePercentText(jbgk?.fields['最高赎回费率']),
+    saleServiceFeeRate: parsePercentText(jbgk?.fields['销售服务费率']),
+    issueDate: jbgk?.fields['发行日期']?.slice(0, 10) || undefined,
+    ...extras,
+    source: SOURCE,
+  }
+}
+
+export function mapEmLsjzToFundNavRows(
+  code: string,
+  rows: EmFundLsjzRow[],
+): StandardFundNavRow[] {
+  const bare = normalizeCode(code)
+  return rows
+    .map(row => ({
+      code: bare,
+      date: String(row.FSRQ ?? '').slice(0, 10),
+      nav: safeFloat(row.DWJZ),
+      accNav: safeFloat(row.LJJZ),
+      changePct: safeFloat(row.JZZZL),
+      purchaseStatus: row.SGZT ?? undefined,
+      redeemStatus: row.SHZT ?? undefined,
+      source: SOURCE,
+    }))
+    .filter(r => r.date)
+}
+
+export function mapEmLsjzToFundQuoteRow(
+  code: string,
+  row: EmFundLsjzRow | null,
+  profile?: Partial<StandardFundProfileRow>,
+): StandardFundQuoteRow | null {
+  if (!row) return null
+  const bare = normalizeCode(code)
+  return {
+    code: bare,
+    name: profile?.name ?? undefined,
+    unitNav: safeFloat(row.DWJZ),
+    accNav: safeFloat(row.LJJZ),
+    changePct: safeFloat(row.JZZZL),
+    navDate: String(row.FSRQ ?? '').slice(0, 10) || undefined,
+    source: SOURCE,
+  }
+}
+
+export function mapEmJjccToFundHoldings(
+  code: string,
+  rows: EmJjccHoldingRaw[],
+): StandardFundHoldingRow[] {
+  const bare = normalizeCode(code)
+  return rows
+    .map(row => {
+      const symbol = normalizeCode(row.symbol)
+      return {
+        reportDate: String(row.reportDate ?? '').slice(0, 10)
+          || new Date().toISOString().slice(0, 10),
+        holdingSymbol: symbol,
+        holdingName: row.name || null,
+        weight: parsePercentText(row.weight),
+        shares: safeFloat(String(row.shares ?? '').replace(/,/g, '')),
+        marketValue: safeFloat(String(row.marketValue ?? '').replace(/,/g, '')),
+        assetType: 'stock',
+        source: `${SOURCE}_jjcc`,
+      }
+    })
+    .filter(r => r.holdingSymbol || r.holdingName)
+}

--- a/tests/eastmoney-fund-profile.test.mjs
+++ b/tests/eastmoney-fund-profile.test.mjs
@@ -1,0 +1,102 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import {
+  parseEmArchivesApidata,
+  parseEmJbgkHtml,
+  parseEmPingzhongData,
+  emReportPeriodToArchivesArgs,
+} from '../packages/a-stock-layer/src/providers/eastmoney/api/fund.ts'
+import {
+  mapEmJjccToFundHoldings,
+  mapEmLsjzToFundNavRows,
+  mapEmToFundProfileRow,
+} from '../packages/a-stock-layer/src/providers/eastmoney/normalize/fund.ts'
+
+describe('eastmoney fund profile parsers', () => {
+  it('parseEmJbgkHtml extracts paired table labels', () => {
+    const html = `
+      <table class="info w790">
+        <tr><td>基金全称</td><td>测试基金全称</td><td>基金简称</td><td>测试简称</td></tr>
+        <tr><td>基金代码</td><td>515150（主代码）</td><td>基金类型</td><td>指数型-股票</td></tr>
+        <tr><td>基金管理人</td><td>富国基金</td><td>基金托管人</td><td>中国银行</td></tr>
+      </table>`
+    const fields = parseEmJbgkHtml(html)
+    assert.equal(fields['基金全称'], '测试基金全称')
+    assert.equal(fields['基金简称'], '测试简称')
+    assert.equal(fields['基金代码'], '515150（主代码）')
+    assert.equal(fields['基金管理人'], '富国基金')
+  })
+
+  it('parseEmPingzhongData reads string and JSON vars', () => {
+    const raw = `var fS_name = "一带一路ETF富国";var fS_code = "515150";var syl_1n="14.03";var stockCodesNew=["1.600415","0.002202"];`
+    const data = parseEmPingzhongData(raw)
+    assert.equal(data.fS_name, '一带一路ETF富国')
+    assert.equal(data.fS_code, '515150')
+    assert.equal(data.syl_1n, '14.03')
+    assert.deepEqual(data.stockCodesNew, ['1.600415', '0.002202'])
+  })
+
+  it('parseEmArchivesApidata unwraps jjcc HTML fragment', () => {
+    const raw = `var apidata={ content:"<table><tr><td>1</td><td>600415</td></tr>"}`
+    const content = parseEmArchivesApidata(raw)
+    assert.ok(content?.includes('600415'))
+  })
+
+  it('emReportPeriodToArchivesArgs maps ISO date to year/month', () => {
+    assert.deepEqual(emReportPeriodToArchivesArgs('2025-12-31'), { year: 2025, month: 12 })
+  })
+
+  it('mapEmToFundProfileRow merges jbgk + nav snapshot', () => {
+    const row = mapEmToFundProfileRow(
+      '515150',
+      {
+        fields: {
+          '基金简称': '一带一路ETF富国',
+          '基金全称': '富国中证国企一带一路交易型开放式指数证券投资基金',
+          '基金类型': '指数型-股票',
+          '基金管理人': '富国基金',
+          '业绩比较基准': '中证国企一带一路指数收益率',
+        },
+        sections: { '投资目标': '紧密跟踪标的指数' },
+      },
+      { fS_name: '一带一路ETF富国', syl_1n: '14.03' },
+      { FSRQ: '2026-08-21', DWJZ: '1.5604', LJJZ: '1.5604', JZZZL: '0.46' },
+    )
+    assert.equal(row?.code, '515150')
+    assert.equal(row?.name, '一带一路ETF富国')
+    assert.equal(row?.company, '富国基金')
+    assert.equal(row?.unitNav, 1.5604)
+    assert.equal(row?.navDate, '2026-08-21')
+    assert.equal(row?.investTarget, '紧密跟踪标的指数')
+    assert.equal(row?.return1y, 14.03)
+    assert.equal(row?.source, 'eastmoney_fund')
+  })
+
+  it('mapEmLsjzToFundNavRows normalizes lsjz rows', () => {
+    const rows = mapEmLsjzToFundNavRows('515150', [
+      { FSRQ: '2026-08-21', DWJZ: '1.5604', LJJZ: '1.5604', JZZZL: '0.46' },
+    ])
+    assert.equal(rows.length, 1)
+    assert.equal(rows[0].date, '2026-08-21')
+    assert.equal(rows[0].nav, 1.5604)
+    assert.equal(rows[0].changePct, 0.46)
+  })
+
+  it('mapEmJjccToFundHoldings maps stock weights', () => {
+    const rows = mapEmJjccToFundHoldings('515150', [
+      {
+        symbol: '600415',
+        name: '小商品城',
+        weight: '2.77%',
+        shares: '142.47',
+        marketValue: '2,272.40',
+        reportDate: '2025-12-31',
+      },
+    ])
+    assert.equal(rows.length, 1)
+    assert.equal(rows[0].holdingSymbol, '600415')
+    assert.equal(rows[0].holdingName, '小商品城')
+    assert.equal(rows[0].weight, 2.77)
+    assert.equal(rows[0].reportDate, '2025-12-31')
+  })
+})


### PR DESCRIPTION
## Summary
- Add East Money / 天天基金 F10 fund archives (`fund_profile`, `fund_nav`, `fund_holdings`, `fund_quote`) via browser-parity URLs (jbgk, pingzhongdata, lsjz, jjcc).
- `fund_snapshot` uses `fundProfile` only for latest NAV (no bulk lsjz pagination).
- Fund right panel: overview + holdings only; removed trend/nav history tabs (no UI `fund_nav` calls).

## Test plan
- [x] `npm run build:packages`
- [x] `npm run check:ui`
- [x] `node --import tsx/esm --test tests/eastmoney-fund-profile.test.mjs`
- [ ] Restart sidecar; open `CN:PF.009049` — hero shows latest NAV, two tabs only


Made with [Cursor](https://cursor.com)