### PR TITLE
feat(tonghuashun): Fuyao fund API for CN:PF fund detail

### DIFF
--- a/client-ui/src/market/FundDetailTab.tsx
+++ b/client-ui/src/market/FundDetailTab.tsx
@@ -296,6 +296,26 @@ export default function FundDetailTab({ stock }: Props) {
                 </div>
               </div>
               <div>
+                <div className={s.label}>成立日期</div>
+                <div className={s.value}>{profile.establishDate ?? '—'}</div>
+              </div>
+              <div>
+                <div className={s.label}>近一年收益</div>
+                <div className={mergeClasses(s.value, pctTone(profile.return1y))}>
+                  {formatPct(profile.return1y)}
+                </div>
+              </div>
+              <div>
+                <div className={s.label}>托管人</div>
+                <div className={s.value}>{profile.custodian ?? '—'}</div>
+              </div>
+              <div>
+                <div className={s.label}>管理费率</div>
+                <div className={s.value}>
+                  {profile.expenseRatio != null ? `${profile.expenseRatio}%` : '—'}
+                </div>
+              </div>
+              <div>
                 <div className={s.label}>累计净值</div>
                 <div className={s.value}>{formatPrice(profile.accNav)}</div>
               </div>

--- a/client-ui/src/types/market.ts
+++ b/client-ui/src/types/market.ts
@@ -477,6 +477,7 @@ export interface FundProfileData {
   scale?: number | null
   benchmark?: string
   establishDate?: string
+  return1y?: number | null
   source?: string
 }
 

--- a/docs/FUYAO-FUND-API.md
+++ b/docs/FUYAO-FUND-API.md
@@ -1,0 +1,125 @@
+# 扶摇（Fuyao）基金 API — Opptrix 对接说明
+
+> 官方文档：<https://fuyao.aicubes.cn/docs/api-reference/fund-profile/>
+> Provider ID：`tonghuashun`（同花顺金融数据，Base URL `https://fuyao.aicubes.cn`）
+
+## 认证与通用约定
+
+| 项 | 说明 |
+|---|---|
+| Base URL | `https://fuyao.aicubes.cn` |
+| 请求头 | `X-api-key: <用户配置的 API Key>`（存于 Provider 设置，非代码硬编码） |
+| 响应信封 | `{ code, message, request_id, data }`；`code=0` 为成功 |
+| 时间戳 | 毫秒 Unix，时区 `Asia/Shanghai` |
+| `fund_type` | `otc`（场外开放式）、`exchange`（场内 ETF/LOF）、`reits`（公募 REITs） |
+| `thscode` | 必须带后缀：`025480.OF`、`510300.SH`、`161725.SZ` |
+
+### Opptrix 代码路由（`resolveFuyaoFundRoute`）
+
+| 输入 | `fund_type` | `thscode` |
+|---|---|---|
+| 6 位场外基金（非场内代码表） | `otc` | `{code}.OF` |
+| 6 位场内基金 / ETF / LOF | `exchange` | `{code}.SH` 或 `.SZ` |
+| 已带 `.OF` / `.SH` / `.SZ` | 按后缀推断 | 原样规范化 |
+
+## 全量 REST 端点清单
+
+| 分类 | 路径 | FuyaoClient 方法 | Opptrix 状态 |
+|---|---|---|---|
+| 基本资料 | `GET /api/fund/profile/detail` | `fundProfileDetail` | ✅ `fundProfile` |
+| 重仓持仓 | `GET /api/fund/portfolio/holdings` | `fundPortfolioHoldings` | ✅ `fundHoldings` |
+| 股票持仓历史 | `GET /api/fund/portfolio/stock-history` | `fundPortfolioStockHistory` | ✅ Client（Agent 扩展） |
+| 债券持仓历史 | `GET /api/fund/portfolio/bond-history` | `fundPortfolioBondHistory` | ✅ Client |
+| 股票报告期 | `GET /api/fund/portfolio/stock-report-dates` | `fundPortfolioStockReportDates` | ✅ Client |
+| 债券报告期 | `GET /api/fund/portfolio/bond-report-dates` | `fundPortfolioBondReportDates` | ✅ Client |
+| 资产配置 | `GET /api/fund/portfolio/asset-allocation` | `fundPortfolioAssetAllocation` | ✅ Client |
+| 行业配置 | `GET /api/fund/portfolio/industry-allocation` | `fundPortfolioIndustryAllocation` | ✅ Client |
+| 净值序列 | `GET /api/fund/performance/nav` | `fundPerformanceNav` | ✅ `fundProfile` / `fundNav` / `fundQuote` |
+| 区间收益 | `GET /api/fund/performance/returns` | `fundPerformanceReturns` | ✅ `fundProfile`（概览近一年） |
+| 风险指标历史 | `GET /api/fund/performance/indicators-historical` | `fundPerformanceIndicatorsHistorical` | ✅ Client |
+| 回撤 | `GET /api/fund/performance/drawdowns` | `fundPerformanceDrawdowns` | ✅ Client |
+| 持有人结构 | `GET /api/fund/holders/detail` | `fundHoldersDetail` | ✅ `fundProfile`（扩展字段） |
+| 十大持有人 | `GET /api/fund/holders/top` | `fundHoldersTop` | ✅ Client |
+| 分红 | `GET /api/fund/corporate-actions/dividends` | `fundCorporateActionsDividends` | ✅ Client |
+| 经理详情 | `GET /api/fund/managers/detail` | `fundManagersDetail` | ✅ Client |
+| 经理业绩 | `GET /api/fund/managers/performance` | `fundManagersPerformance` | ✅ Client |
+| 经理经历 | `GET /api/fund/managers/experience` | `fundManagersExperience` | ✅ Client |
+| 投资风格 | `GET /api/fund/managers/investment-style` | `fundManagersInvestmentStyle` | ✅ Client |
+| 基金公司 | `GET /api/fund/companies/detail` | `fundCompaniesDetail` | ✅ Client |
+| 基金诊断 | `GET /api/fund/diagnostics/detail` | `fundDiagnosticsDetail` | ✅ Client |
+| 财务指标 | `GET /api/fund/financials/indicators` | `fundFinancialsIndicators` | ✅ Client |
+| 利润表 | `GET /api/fund/financials/income-statements` | `fundFinancialsIncomeStatements` | ✅ Client |
+| 资产负债表 | `GET /api/fund/financials/balance-sheets` | `fundFinancialsBalanceSheets` | ✅ Client |
+| 场内快照 | `GET /api/fund/market/snapshot` | `fundMarketSnapshot` | ✅ ETF 路径 |
+| 场内历史 | `GET /api/fund/market/historical` | `fundMarketHistorical` | ✅ ETF K 线 |
+| 资讯列表 | `GET /api/fund/news/article-list` | `fundNewsArticleList` | ✅ Client |
+| 募集公告 | `GET /api/fund/offerings/list` | `fundOfferingsList` | ✅ Client |
+
+## Opptrix Capability 映射
+
+| Capability | Driver 方法 | 绑定 | 默认优先级 |
+|---|---|---|---|
+| `FUND_PROFILE` | `fundProfile` | CN / FUND | 120（同花顺全局） |
+| `FUND_HOLDINGS` | `fundHoldings` | CN / FUND | 120 |
+| `FUND_QUOTE` | `fundQuote` | CN / FUND | 120 |
+| `FUND_NAV` | `fundNav` | CN / FUND | 120（UI 未拉取；Agent/Hub 可用） |
+| `ETF_*` | `etfProfile` 等 | CN / ETF | 120（`fund_type=exchange`） |
+
+无 API Key 或 Provider 未启用时，`withFuyaoClient` 返回 `null`，Engine 自动 failover 至东方财富（优先级 112）或新浪 / Tushare。
+
+## 右侧基金详情（`FundDetailTab`）数据流
+
+```
+InstrumentRef (CN:PF)
+  → research.fundSnapshot
+    → Engine.fundSnapshot → fundProfile（单次）
+  → Tab「持仓」→ research.fundHoldings
+```
+
+**请求量（扶摇，打开一只基金）**
+
+| 动作 | 上游调用 |
+|---|---|
+| 打开详情 | `profile/detail` + `performance/nav`（最新）+ `performance/returns` + `holders/detail` ≈ **4 次** |
+| 点持仓 | `portfolio/holdings` ≈ **1 次** |
+
+**概览 Tab 字段来源**
+
+| UI 字段 | Standard 字段 | 扶摇来源 |
+|---|---|---|
+| 头部净值 / 涨跌 | `unitNav`, `changePct`, `navDate` | `performance/nav` 最近两日 |
+| 基金类型 | `fundType` | `profile/detail` |
+| 基金经理 / 公司 | `manager`, `company` | `profile/detail` |
+| 规模 | `scale`（亿） | `fund_scale` ÷ 1e8 |
+| 成立日期 | `establishDate` | `estab_date` |
+| 近一年收益 | `return1y` | `returns.return_year` |
+| 托管人 / 费率 | `custodian`, `expenseRatio` | `profile` + `rate_info` |
+| 业绩基准 | `benchmark` | `profile` |
+| 累计净值 | `accNav` | `performance/nav` `adj_nav` |
+
+## 实现文件索引
+
+| 路径 | 职责 |
+|---|---|
+| `providers/tonghuashun/api/client.ts` | 全量基金 REST 方法 |
+| `providers/tonghuashun/api/fund-symbols.ts` | `resolveFuyaoFundRoute` |
+| `providers/tonghuashun/normalize/fund.ts` | 标准化 `StandardFund*` 行 |
+| `providers/tonghuashun/markets/cn/fund.ts` | `mixTonghuashunFund` |
+| `providers/tonghuashun/manifest.ts` | `cnFundBindings` |
+| `client-ui/src/market/FundDetailTab.tsx` | 右侧详情 UI |
+
+## 验证
+
+```bash
+npm run build:packages
+npm run check:ui
+node --import tsx/esm --test tests/fuyao-fund-profile.test.mjs
+```
+
+配置同花顺 API Key 并启用 Provider 后，打开 CN:PF 基金详情，`source` 应为 `tonghuashun`。
+
+## 已知限制
+
+- `adj_nav` 为复权净值，**不等同**累计净值；UI「累计净值」在扶摇路径下展示复权净值，与天天基金口径可能略有差异。
+- `fundList` 未实现（与东方财富对齐）；列表仍走搜索 / 新浪 / Tushare。
+- 扩展接口（诊断、财务、经理详情等）已挂 Client，待 Hub Feature / Agent Tool 按需接入。

--- a/docs/PROVIDER-STANDARD-API.md
+++ b/docs/PROVIDER-STANDARD-API.md
@@ -110,7 +110,7 @@ bindingsFor: () => []
 | **tencent** | ✅ | CN + **US/HK registry binding**；`mixTencent*Equity` 单 Driver 内路由 | ✅ CN ETF | ✅ 三市场标准方法 + US/HK 详情维度（news/notices/shareholders/dividend/technical） | HK/US 深度财报等 custom | **合规** |
 | **tushare** | ✅ | CN cnEquityEtfIndex + **cnFundBindings** | CN | 弱（无 ETF_LIST） | ✅ | **fund_* 五件套 + fund_company/div/daily/adj 自定义** | **合规（CN）** |
 | **zzshare** | ✅ | CN；ETF 绑定 FREE_CN_ETF | CN | ✅ ETF_LIST/NAV/PROFILE | ✅ | custom | **合规** |
-| **tonghuashun** | ✅ | CN；**CN ETF 分拆**（`CN_ETF_CAPABILITIES`，priority 120）；含 BALANCE_SHEET / CASH_FLOW | CN | ✅ ETF_LIST/PROFILE/NAV/HOLDINGS + STOCK_REALTIME/KLINE | ✅ `limitUpdown`；Hub `market_dynamics` 可选消费 `thsSkyrocketList` / `thsLimitUpLadder` | `ths*` 指数/特色数据（10，含 `thsValuationsSnapshot`）；Fuyao `/api/fund/*` 场内 ETF；**realtime enrich** `valuations/snapshot`→pe/pb；**etfProfile enrich** `fund/holders/detail` | **合规（CN 个股 + ETF）** |
+| **tonghuashun** | ✅ | CN；**CN ETF 分拆**（`CN_ETF_CAPABILITIES`，priority 120）；**CN FUND** `fundProfile/fundNav/fundHoldings/fundQuote`（见 `docs/FUYAO-FUND-API.md`）；含 BALANCE_SHEET / CASH_FLOW | CN | ✅ ETF_LIST/PROFILE/NAV/HOLDINGS + FUND_PROFILE/HOLDINGS/QUOTE + STOCK_REALTIME/KLINE | ✅ `limitUpdown`；Hub `market_dynamics` 可选消费 `thsSkyrocketList` / `thsLimitUpLadder` | `ths*` 指数/特色数据（10，含 `thsValuationsSnapshot`）；Fuyao `/api/fund/*` 全量 Client + CN:PF 标准四件套；**realtime enrich** `valuations/snapshot`→pe/pb；**etfProfile enrich** `fund/holders/detail` | **合规（CN 个股 + ETF + 公募基金）** |
 | **binance / okx** | ✅ | cryptoSpotBindings | CRYPTO | N/A | ✅ | 无 | **合规** |
 | **akshare** | ⚠️ 须 register | `capabilities: []` | 另类数据 | N/A | 无（设计如此） | 216+ custom | **自定义专用**；须注册 Driver 否则 invoke 失败 |
 

--- a/packages/a-stock-layer/src/providers/common/standard-methods.ts
+++ b/packages/a-stock-layer/src/providers/common/standard-methods.ts
@@ -70,6 +70,7 @@ export const PROVIDER_FUND_COVERAGE: Record<string, readonly string[]> = {
   sinafinance: [...CN_FUND_STANDARD_METHODS],
   tushare: [...CN_FUND_STANDARD_METHODS],
   eastmoney: ['fundProfile', 'fundNav', 'fundHoldings', 'fundQuote'],
+  tonghuashun: ['fundProfile', 'fundNav', 'fundHoldings', 'fundQuote'],
 }
 
 /** 建议新增的 Capability（DATA-LAYER Phase-2） */

--- a/packages/a-stock-layer/src/providers/tonghuashun/api/client.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/api/client.ts
@@ -475,6 +475,174 @@ export class FuyaoClient {
     bars.sort((a, b) => Number(a.date_ms) - Number(b.date_ms))
     return bars
   }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/companies/detail */
+  fundCompaniesDetail(companyId: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/companies/detail',
+      { company_id: companyId },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/corporate-actions/dividends */
+  fundCorporateActionsDividends(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/corporate-actions/dividends',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/diagnostics/detail */
+  fundDiagnosticsDetail(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/diagnostics/detail',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/financials/indicators */
+  fundFinancialsIndicators(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/financials/indicators',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/financials/income-statements */
+  fundFinancialsIncomeStatements(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/financials/income-statements',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/financials/balance-sheets */
+  fundFinancialsBalanceSheets(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/financials/balance-sheets',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/holders/top */
+  fundHoldersTop(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/holders/top',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/managers/investment-style */
+  fundManagersInvestmentStyle(managerId: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/managers/investment-style',
+      { manager_id: managerId },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/managers/performance */
+  fundManagersPerformance(managerId: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/managers/performance',
+      { manager_id: managerId },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/managers/experience */
+  fundManagersExperience(managerId: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/managers/experience',
+      { manager_id: managerId },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/managers/detail */
+  fundManagersDetail(managerId: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/managers/detail',
+      { manager_id: managerId },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/news/article-list */
+  fundNewsArticleList(fundType: string, thscode: string, opts?: { limit?: number }) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/news/article-list',
+      { fund_type: fundType, thscode, limit: opts?.limit },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/offerings/list */
+  fundOfferingsList(opts?: { fund_type?: string; limit?: number }) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/offerings/list',
+      { fund_type: opts?.fund_type, limit: opts?.limit },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/performance/indicators-historical */
+  fundPerformanceIndicatorsHistorical(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/performance/indicators-historical',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/performance/drawdowns */
+  fundPerformanceDrawdowns(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/performance/drawdowns',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/portfolio/stock-history */
+  fundPortfolioStockHistory(fundType: string, thscode: string, reportDateMs?: number) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/portfolio/stock-history',
+      { fund_type: fundType, thscode, report_date_ms: reportDateMs },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/portfolio/bond-history */
+  fundPortfolioBondHistory(fundType: string, thscode: string, reportDateMs?: number) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/portfolio/bond-history',
+      { fund_type: fundType, thscode, report_date_ms: reportDateMs },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/portfolio/stock-report-dates */
+  fundPortfolioStockReportDates(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/portfolio/stock-report-dates',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/portfolio/bond-report-dates */
+  fundPortfolioBondReportDates(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/portfolio/bond-report-dates',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/portfolio/asset-allocation */
+  fundPortfolioAssetAllocation(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/portfolio/asset-allocation',
+      { fund_type: fundType, thscode },
+    )
+  }
+
+  /** @sourceUrl https://fuyao.aicubes.cn/api/fund/portfolio/industry-allocation */
+  fundPortfolioIndustryAllocation(fundType: string, thscode: string) {
+    return this.get<{ item?: Record<string, unknown>[] }>(
+      '/api/fund/portfolio/industry-allocation',
+      { fund_type: fundType, thscode },
+    )
+  }
 }
 
 export async function testTonghuashunConnection(

--- a/packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts
@@ -1,0 +1,23 @@
+import { isCnListedFundSymbol } from '../../../core/fund-instrument.js'
+import { normalizeCode, resolveMarket } from '../../../utils/helpers.js'
+
+export type FuyaoFundType = 'otc' | 'exchange' | 'reits'
+
+/** 6 位公募基金代码 → 扶摇 fund_type + thscode */
+export function resolveFuyaoFundRoute(code: string): { fundType: FuyaoFundType; thscode: string } | null {
+  let raw = String(code ?? '').trim().toUpperCase()
+  const ofMatch = /^(\d{6})\.OF$/i.exec(raw)
+  if (ofMatch) {
+    return { fundType: 'otc', thscode: `${ofMatch[1]}.OF` }
+  }
+  const listedMatch = /^(\d{6})\.(SH|SZ|BJ)$/i.exec(raw)
+  if (listedMatch) {
+    return { fundType: 'exchange', thscode: `${listedMatch[1]}.${listedMatch[2]}` }
+  }
+  const bare = normalizeCode(raw)
+  if (!bare || !/^\d{6}$/.test(bare)) return null
+  if (isCnListedFundSymbol(bare)) {
+    return { fundType: 'exchange', thscode: `${bare}.${resolveMarket(bare)}` }
+  }
+  return { fundType: 'otc', thscode: `${bare}.OF` }
+}

--- a/packages/a-stock-layer/src/providers/tonghuashun/driver.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/driver.ts
@@ -3,11 +3,13 @@ import { TONGHUASHUN_SPEC } from './manifest.js'
 import { TonghuashunMarketHandler } from './markets/cn/handler.js'
 import { mixTonghuashunExt } from './markets/cn/ext.js'
 import { mixTonghuashunEtf } from './markets/cn/etf.js'
+import { mixTonghuashunFund } from './markets/cn/fund.js'
 import { isTonghuashunEnabled } from './config.js'
 
 export class TonghuashunDriver extends TonghuashunMarketHandler {}
 
 mixTonghuashunExt(TonghuashunDriver)
 mixTonghuashunEtf(TonghuashunDriver)
+mixTonghuashunFund(TonghuashunDriver)
 applyManifestSpec(TonghuashunDriver, TONGHUASHUN_SPEC, { isRuntimeEnabled: isTonghuashunEnabled })
 export { testTonghuashunConnection } from './api/client.js'

--- a/packages/a-stock-layer/src/providers/tonghuashun/fund-capabilities.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/fund-capabilities.ts
@@ -1,0 +1,9 @@
+import { Capability } from '../../core/capabilities.js'
+
+/** 同花顺 Fuyao — 公募基金标准能力（与东方财富对齐：无 fundList） */
+export const TONGHUASHUN_CN_FUND_CAPABILITIES = [
+  Capability.FUND_PROFILE,
+  Capability.FUND_NAV,
+  Capability.FUND_HOLDINGS,
+  Capability.FUND_QUOTE,
+] as const

--- a/packages/a-stock-layer/src/providers/tonghuashun/manifest.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/manifest.ts
@@ -1,9 +1,10 @@
 import { Capability } from '../../core/capabilities.js'
-import { CN_ETF_CAPABILITIES } from '../../core/bindings.js'
+import { CN_ETF_CAPABILITIES, cnFundBindings } from '../../core/bindings.js'
 import { type ProviderManifestSpec } from '../common/types.js'
 import { providerManifestEntry } from '../common/manifest.js'
 import { TONGHUASHUN_SETTINGS } from './settings.js'
 import { cnEquityEtfIndex } from '../common/bindings.js'
+import { TONGHUASHUN_CN_FUND_CAPABILITIES } from './fund-capabilities.js'
 
 export const TONGHUASHUN_CAPS = [
   Capability.STOCK_REALTIME,
@@ -39,14 +40,21 @@ export const TONGHUASHUN_SPEC: ProviderManifestSpec = {
   marketGroup: 'CN',
   defaultPriority: 120,
   maxConcurrent: 5,
-  capabilities: [...new Set([...TONGHUASHUN_CAPS, ...CN_ETF_CAPABILITIES])],
-  bindingsFor: (p, maxConcurrent) => cnEquityEtfIndex(
-    EQUITY_CAPS,
-    INDEX_CAPS,
-    p,
-    CN_ETF_CAPABILITIES,
-    maxConcurrent,
-  ),
+  capabilities: [...new Set([
+    ...TONGHUASHUN_CAPS,
+    ...CN_ETF_CAPABILITIES,
+    ...TONGHUASHUN_CN_FUND_CAPABILITIES,
+  ])],
+  bindingsFor: (p, maxConcurrent) => [
+    ...cnEquityEtfIndex(
+      EQUITY_CAPS,
+      INDEX_CAPS,
+      p,
+      CN_ETF_CAPABILITIES,
+      maxConcurrent,
+    ),
+    ...cnFundBindings(p, maxConcurrent),
+  ],
   settings: TONGHUASHUN_SETTINGS,
   supportsTest: true,
 }

--- a/packages/a-stock-layer/src/providers/tonghuashun/markets/cn/fund.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/markets/cn/fund.ts
@@ -1,0 +1,127 @@
+import { assertCnPublicFundCode } from '../../../../core/fund-instrument.js'
+import { FuyaoClient } from '../../api/client.js'
+import { resolveFuyaoFundRoute } from '../../api/fund-symbols.js'
+import { isTonghuashunEnabled } from '../../config.js'
+import {
+  mapFundHoldersToProfileFields,
+  mapFundHoldingsToFundRows,
+  mapFundNavRowsForFund,
+  mapFundProfileToFundProfileRow,
+} from '../../normalize/fund.js'
+import type { TonghuashunMarketHandler } from './handler.js'
+
+type Handler = TonghuashunMarketHandler & Record<string, unknown>
+
+async function withFuyaoClient<T>(fn: (client: FuyaoClient) => Promise<T>): Promise<T | null> {
+  if (!isTonghuashunEnabled()) return null
+  const client = FuyaoClient.fromConfig()
+  if (!client) return null
+  try {
+    return await fn(client)
+  } catch {
+    return null
+  }
+}
+
+function msToYmd(ms: unknown): string {
+  const n = Number(ms)
+  if (!Number.isFinite(n) || n <= 0) return ''
+  const d = new Date(n)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/** 同花顺 Fuyao 公募基金标准 Capability（fundProfile / fundNav / fundHoldings / fundQuote） */
+export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler }) {
+  const p = Driver.prototype as Handler
+
+  p.fundProfile = async function fundProfile(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    const route = resolveFuyaoFundRoute(bare)
+    if (!route) return null
+    return withFuyaoClient(async client => {
+      const { fundType, thscode } = route
+      const [profileData, navData, returnsData, holdersData] = await Promise.all([
+        client.fundProfileDetail(fundType, thscode),
+        client.fundPerformanceNav(fundType, thscode, { nav_type: 'unit,adj' }),
+        client.fundPerformanceReturns(fundType, thscode),
+        client.fundHoldersDetail(fundType, thscode).catch(() => ({ item: [] })),
+      ])
+      const profile = profileData.item?.[0]
+      if (!profile) return null
+      const row = mapFundProfileToFundProfileRow(bare, profile, {
+        navItems: navData.item ?? [],
+        returns: returnsData.item?.[0] ?? null,
+        holders: mapFundHoldersToProfileFields(holdersData.item ?? []),
+      })
+      return [row]
+    })
+  }
+
+  p.fundNav = async function fundNav(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    const route = resolveFuyaoFundRoute(bare)
+    if (!route) return null
+    return withFuyaoClient(async client => {
+      const { fundType, thscode } = route
+      const navData = await client.fundPerformanceNav(fundType, thscode, {
+        range: 'year',
+        nav_type: 'unit,adj',
+      })
+      const rows = mapFundNavRowsForFund(bare, navData.item ?? [])
+      return rows.length ? rows : null
+    })
+  }
+
+  p.fundQuote = async function fundQuote(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    const route = resolveFuyaoFundRoute(bare)
+    if (!route) return null
+    return withFuyaoClient(async client => {
+      const { fundType, thscode } = route
+      const [navData, profileData] = await Promise.all([
+        client.fundPerformanceNav(fundType, thscode, { nav_type: 'unit,adj' }),
+        client.fundProfileDetail(fundType, thscode).catch(() => ({ item: [] })),
+      ])
+      const items = navData.item ?? []
+      if (!items.length) return null
+      const sorted = [...items].sort((a, b) => Number(b.nav_date) - Number(a.nav_date))
+      const latest = sorted[0]
+      const prev = sorted[1]
+      const unitNav = Number(latest.unit_nav)
+      const prevNav = prev ? Number(prev.unit_nav) : null
+      const changePct = Number.isFinite(unitNav) && prevNav != null && prevNav > 0
+        ? ((unitNav - prevNav) / prevNav) * 100
+        : null
+      const profile = profileData.item?.[0]
+      return [{
+        code: bare,
+        name: String(profile?.fund_name ?? '').trim() || undefined,
+        unitNav: Number.isFinite(unitNav) ? unitNav : null,
+        accNav: Number(latest.adj_nav) || null,
+        prevNav: prevNav != null && Number.isFinite(prevNav) ? prevNav : null,
+        changePct,
+        navDate: msToYmd(latest.nav_date),
+        source: 'tonghuashun',
+      }]
+    })
+  }
+
+  p.fundHoldings = async function fundHoldings(fundCode: string): Promise<Record<string, unknown>[] | null> {
+    const bare = assertCnPublicFundCode(fundCode)
+    if (!bare) return null
+    const route = resolveFuyaoFundRoute(bare)
+    if (!route) return null
+    return withFuyaoClient(async client => {
+      const { fundType, thscode } = route
+      const data = await client.fundPortfolioHoldings(fundType, thscode)
+      const rows = mapFundHoldingsToFundRows(bare, data.item ?? [])
+      return rows.length ? rows : null
+    })
+  }
+}

--- a/packages/a-stock-layer/src/providers/tonghuashun/normalize/fund.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/normalize/fund.ts
@@ -7,6 +7,11 @@ import type {
   StandardEtfNavRow,
   StandardEtfProfileRow,
 } from '../../common/standard-etf.js'
+import type {
+  StandardFundHoldingRow,
+  StandardFundNavRow,
+  StandardFundProfileRow,
+} from '../../common/standard-fund.js'
 import { mapSnapshotToStockRealtime } from './index.js'
 
 export const FUYAO_EXCHANGE_FUND_TYPE = 'exchange' as const
@@ -216,4 +221,115 @@ export function latestUnitNavFromNavItems(items: Record<string, unknown>[]): num
   if (!items.length) return null
   const sorted = [...items].sort((a, b) => Number(b.nav_date) - Number(a.nav_date))
   return safeFloat(sorted[0]?.unit_nav)
+}
+
+function scaleToYi(raw: unknown): number | null {
+  const n = safeFloat(raw)
+  if (n == null) return null
+  if (n >= 1e6) return n / 1e8
+  return n
+}
+
+function pickMgmtExpenseRate(rateInfo: unknown): number | null {
+  if (!Array.isArray(rateInfo)) return null
+  for (const entry of rateInfo) {
+    if (!entry || typeof entry !== 'object') continue
+    const row = entry as Record<string, unknown>
+    const label = String(row.rate_type ?? row.rate_name ?? '').trim()
+    if (label.includes('管理')) {
+      const rate = safeFloat(row.standard_rate ?? row.rate)
+      if (rate != null) return rate
+    }
+  }
+  return null
+}
+
+/** CN:PF 公募基金档案 — 对齐 StandardFundProfileRow / FundDetailTab */
+export function mapFundProfileToFundProfileRow(
+  code: string,
+  profile: Record<string, unknown>,
+  opts?: {
+    navItems?: Record<string, unknown>[]
+    returns?: Record<string, unknown> | null
+    holders?: ReturnType<typeof mapFundHoldersToProfileFields>
+  },
+): StandardFundProfileRow {
+  const c = normalizeCode(code)
+  const navItems = opts?.navItems ?? []
+  const sortedNav = [...navItems].sort((a, b) => Number(b.nav_date) - Number(a.nav_date))
+  const latestNav = sortedNav[0]
+  const prevNavRow = sortedNav[1]
+  const unitNav = safeFloat(latestNav?.unit_nav) ?? safeFloat(profile.unit_nav)
+  const accNav = safeFloat(latestNav?.adj_nav)
+  const navDate = msToYmd(latestNav?.nav_date)
+  let changePct: number | null = null
+  if (unitNav != null && prevNavRow) {
+    const prev = safeFloat(prevNavRow.unit_nav)
+    if (prev != null && prev > 0) changePct = ((unitNav - prev) / prev) * 100
+  }
+  const performance = mapFundReturnsToPerformance(opts?.returns)
+  const expenseRatio = pickMgmtExpenseRate(profile.rate_info)
+  return {
+    code: c,
+    name: String(profile.fund_name ?? '').trim() || undefined,
+    fundType: String(profile.invest_type ?? profile.fund_type ?? '').trim() || undefined,
+    manager: String(profile.manager_name ?? '').trim() || undefined,
+    company: String(profile.mgmt_name ?? '').trim() || undefined,
+    custodian: String(profile.custodian_name ?? profile.custodian ?? '').trim() || undefined,
+    expenseRatio,
+    scale: scaleToYi(profile.fund_scale),
+    unitNav,
+    accNav,
+    navDate,
+    changePct,
+    benchmark: String(profile.benchmark ?? profile.benchmark_name ?? '').trim() || undefined,
+    investTarget: String(profile.invest_target ?? '').trim() || undefined,
+    investScope: String(profile.invest_scope ?? '').trim() || undefined,
+    establishDate: msToYmd(profile.estab_date) || undefined,
+    performance,
+    return1y: performance?.w52 ?? null,
+    source: 'tonghuashun',
+    ...opts?.holders,
+  }
+}
+
+export function mapFundNavRowsForFund(
+  code: string,
+  items: Record<string, unknown>[],
+): StandardFundNavRow[] {
+  const c = normalizeCode(code)
+  const sorted = [...items].sort((a, b) => Number(a.nav_date) - Number(b.nav_date))
+  return sorted.map((row, i) => {
+    const nav = safeFloat(row.unit_nav)
+    const accNav = safeFloat(row.adj_nav)
+    const prev = i > 0 ? safeFloat(sorted[i - 1]?.unit_nav) : null
+    const changePct = nav != null && prev != null && prev > 0
+      ? ((nav - prev) / prev) * 100
+      : null
+    return {
+      code: c,
+      date: msToYmd(row.nav_date),
+      nav,
+      accNav,
+      changePct,
+      source: 'tonghuashun',
+    }
+  }).filter(r => r.date)
+}
+
+export function mapFundHoldingsToFundRows(
+  fundCode: string,
+  items: Record<string, unknown>[],
+): StandardFundHoldingRow[] {
+  const c = normalizeCode(fundCode)
+  return items.map(row => ({
+    reportDate: msToYmd(row.end_date_ms) || msToYmd(row.publish_date_ms) || new Date().toISOString().slice(0, 10),
+    holdingSymbol: fromThsCode(String(row.ticker ?? row.thscode ?? '')),
+    holdingName: String(row.stock_name ?? '').trim() || null,
+    weight: safeFloat(row.hold_ratio ?? row.security_market_value_rate_pct),
+    shares: safeFloat(row.position_count),
+    marketValue: safeFloat(row.position_capital),
+    assetType: String(row.asset_type ?? 'stock'),
+    source: 'tonghuashun',
+  })).filter(r => r.holdingSymbol.length > 0 || (r.holdingName && r.holdingName.length > 0))
 }

--- a/tests/fuyao-fund-profile.test.mjs
+++ b/tests/fuyao-fund-profile.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { resolveFuyaoFundRoute } from '../packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts'
+import {
+  mapFundHoldingsToFundRows,
+  mapFundNavRowsForFund,
+  mapFundProfileToFundProfileRow,
+  mapFundReturnsToPerformance,
+} from '../packages/a-stock-layer/src/providers/tonghuashun/normalize/fund.ts'
+
+describe('fuyao fund profile', () => {
+  it('resolveFuyaoFundRoute maps OTC and exchange codes', () => {
+    assert.deepEqual(resolveFuyaoFundRoute('009049'), { fundType: 'otc', thscode: '009049.OF' })
+    assert.deepEqual(resolveFuyaoFundRoute('515150'), { fundType: 'exchange', thscode: '515150.SH' })
+    assert.deepEqual(resolveFuyaoFundRoute('161725'), { fundType: 'exchange', thscode: '161725.SZ' })
+    assert.deepEqual(resolveFuyaoFundRoute('025480.OF'), { fundType: 'otc', thscode: '025480.OF' })
+  })
+
+  it('mapFundReturnsToPerformance maps return_year to w52', () => {
+    const perf = mapFundReturnsToPerformance({ return_year: 12.5, return_month: 1.2 })
+    assert.equal(perf?.w52, 12.5)
+    assert.equal(perf?.w4, 1.2)
+  })
+
+  it('mapFundProfileToFundProfileRow merges nav and returns', () => {
+    const row = mapFundProfileToFundProfileRow('009049', {
+      fund_name: '测试基金',
+      manager_name: '张三',
+      mgmt_name: '测试公司',
+      fund_scale: 5e9,
+      estab_date: 1609459200000,
+      rate_info: [{ rate_type: '管理费', standard_rate: 1.2 }],
+    }, {
+      navItems: [
+        { nav_date: 1752595200000, unit_nav: 1.01, adj_nav: 1.15 },
+        { nav_date: 1752508800000, unit_nav: 1.0, adj_nav: 1.14 },
+      ],
+      returns: { return_year: 8.5 },
+    })
+    assert.equal(row.code, '009049')
+    assert.equal(row.name, '测试基金')
+    assert.equal(row.unitNav, 1.01)
+    assert.equal(row.accNav, 1.15)
+    assert.equal(row.changePct != null && Math.abs(row.changePct - 1) < 1e-6, true)
+    assert.equal(row.return1y, 8.5)
+    assert.equal(row.scale, 50)
+    assert.equal(row.expenseRatio, 1.2)
+    assert.equal(row.establishDate, '2021-01-01')
+  })
+
+  it('mapFundHoldingsToFundRows normalizes portfolio holdings', () => {
+    const rows = mapFundHoldingsToFundRows('009049', [
+      {
+        ticker: '300750',
+        stock_name: '宁德时代',
+        hold_ratio: 4.67,
+        asset_type: 'stock',
+        end_date_ms: 1785513600000,
+      },
+    ])
+    assert.equal(rows.length, 1)
+    assert.equal(rows[0].holdingSymbol, '300750')
+    assert.equal(rows[0].holdingName, '宁德时代')
+    assert.equal(rows[0].weight, 4.67)
+    assert.equal(rows[0].source, 'tonghuashun')
+  })
+
+  it('mapFundNavRowsForFund computes daily change', () => {
+    const rows = mapFundNavRowsForFund('009049', [
+      { nav_date: 1752508800000, unit_nav: 1.0 },
+      { nav_date: 1752595200000, unit_nav: 1.02 },
+    ])
+    assert.equal(rows.length, 2)
+    assert.equal(rows[1].changePct != null && Math.abs(rows[1].changePct - 2) < 1e-6, true)
+  })
+})


### PR DESCRIPTION
## Summary
- Wire full Fuyao `/api/fund/*` client surface and CN FUND capability bindings (priority 120)
- Map profile/holdings/nav/quote for CN:PF via `mixTonghuashunFund`
- Expand FundDetailTab overview (establish date, 1Y return, custodian, expense ratio)
- Add `docs/FUYAO-FUND-API.md` and mapping tests

## Test plan
- [x] `npm run build:packages`
- [x] `npm run check:ui`
- [x] `node --import tsx/esm --test tests/fuyao-fund-profile.test.mjs`


Made with [Cursor](https://cursor.com)