### PR TITLE
fix(market): TickFlow K-line periods and HK symbol canonicalization

### DIFF
--- a/client-ui/src/market/CrossMarketSnapshotDetail.tsx
+++ b/client-ui/src/market/CrossMarketSnapshotDetail.tsx
@@ -444,7 +444,7 @@ export default function CrossMarketSnapshotDetail({
 
       <div className={s.chartBody}>
         <div className={s.chartPanel}>
-          <TradingViewChart code={chartCode} expanded active />
+          <TradingViewChart code={chartCode} instrument={ref} expanded active />
         </div>
         {error && quote ? <Text className={s.error}>刷新失败：{error}</Text> : null}
         {localIndexed === false ? (

--- a/client-ui/src/market/CrossMarketSnapshotDetail.tsx
+++ b/client-ui/src/market/CrossMarketSnapshotDetail.tsx
@@ -1,32 +1,10 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
-import {
-  Link,
-  Spinner,
-  Tab,
-  TabList,
-  Text,
-  makeStyles,
-  mergeClasses,
-} from '@fluentui/react-components'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { EditRegular } from '@fluentui/react-icons'
 import { research } from '../api/client'
-import { openExternalUrl } from '../platform/openUrl'
-import type {
-  CryptoSnapshotData,
-  CrossMarketRelatedStock,
-  RevenueBreakdownBlock,
-  SeniorTradeItem,
-  StockDividendItem,
-  StockNewsItem,
-  StockProfileData,
-  StockShareholderData,
-  TradingDistributionData,
-  UsSnapshotData,
-  WatchlistItem,
-} from '../types/market'
+import type { CryptoSnapshotData, UsSnapshotData, WatchlistItem } from '../types/market'
 import type { InstrumentRef } from '../types/instrument'
 import {
-  formatCompactNumber,
   formatCompactNumberForMarket,
   formatPct,
   formatPriceForMarket,
@@ -49,7 +27,6 @@ import { listRowKey } from '../utils/listRowKey'
 const CONTENT_PAD = '15px'
 
 type EquityDetail = UsSnapshotData
-type DetailTab = 'chart' | 'basic' | 'company' | 'articles' | 'dividends' | 'holders'
 
 const useStyles = makeStyles({
   root: {
@@ -109,8 +86,8 @@ const useStyles = makeStyles({
     gap: '6px',
     flexShrink: 0,
   },
-  manageBtn: {...ghostInteractive,
-
+  manageBtn: {
+    ...ghostInteractive,
     border: `1px solid ${opptrixCssVars.separator}`,
     backgroundColor: opptrixCssVars.canvasAlt,
     color: opptrixCssVars.textSecondary,
@@ -164,29 +141,20 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  tabBar: {
-    flexShrink: 0,
-    padding: `0 ${CONTENT_PAD}`,
-    minHeight: '28px',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    overflowX: 'auto',
-    scrollbarWidth: 'none',
-    '&::-webkit-scrollbar': { display: 'none' },
-  },
-  tabList: { minWidth: 'max-content' },
-  tabBody: {
+  chartBody: {
     flex: 1,
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
   },
-  tabPanel: {
+  cryptoBody: {
     flex: 1,
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
+    gap: '8px',
+    padding: `8px ${CONTENT_PAD} 10px`,
   },
-  tabPanelHidden: { display: 'none' },
   chartPanel: {
     flex: 1,
     minHeight: 0,
@@ -194,204 +162,35 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     overflowX: 'hidden',
   },
-  scrollPanel: {
-    flex: 1,
-    minHeight: 0,
-    overflowY: 'auto',
-    padding: `8px ${CONTENT_PAD} 10px`,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '10px',
-  },
-  section: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '5px',
-  },
-  sectionTitle: {
-    fontSize: 'var(--opptrix-font-xs)',
-    fontWeight: 650,
-    color: opptrixCssVars.textTertiary,
-    letterSpacing: '0.06em',
-    textTransform: 'uppercase',
-  },
-  metricGrid3: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-    gap: '4px',
-  },
-  metric: {
-    padding: '5px 6px',
-    borderRadius: opptrixTokens.radiusSm,
-    backgroundColor: opptrixCssVars.canvasAlt,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1px',
-    minWidth: 0,
-  },
-  metricLabel: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textTertiary,
-    lineHeight: 1.2,
-  },
-  metricValue: {
-    fontSize: 'var(--opptrix-font-sm)',
-    fontWeight: 600,
-    color: opptrixCssVars.textPrimary,
-    fontVariantNumeric: 'tabular-nums',
-    lineHeight: 1.3,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  prose: {
-    fontSize: 'var(--opptrix-font-sm)',
-    lineHeight: 1.55,
-    color: opptrixCssVars.textSecondary,
-    whiteSpace: 'pre-wrap',
-  },
-  flatList: { display: 'flex', flexDirection: 'column' },
-  annRow: {
-    display: 'grid',
-    gridTemplateColumns: '58px minmax(0, 1fr)',
-    gap: '6px',
-    alignItems: 'start',
-    padding: '5px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  listDate: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textTertiary,
-    fontVariantNumeric: 'tabular-nums',
-    lineHeight: 1.4,
-  },
-  listTitle: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textPrimary,
-    lineHeight: 1.4,
-    textDecoration: 'none',
-    ':hover': { color: opptrixCssVars.accent },
-  },
-  tableHeadWide: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1.2fr) repeat(4, minmax(0, 0.7fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-  },
-  tableRowWide: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1.2fr) repeat(4, minmax(0, 0.7fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  tableHead: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) repeat(3, minmax(0, 0.75fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-  },
-  tableRow: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) repeat(3, minmax(0, 0.75fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  tableHeadCell: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textTertiary,
-  },
-  tableCell: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textPrimary,
-    fontVariantNumeric: 'tabular-nums',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  tableCellName: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textPrimary,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  peerRow: {...ghostInteractive,
-
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 0.55fr) minmax(0, 0.45fr)',
-    gap: '4px',
-    alignItems: 'center',
-    padding: '5px 4px',
-    margin: '0 -4px',
-    borderRadius: opptrixTokens.radiusSm,
-    border: 'none',
-    background: 'transparent',
-    textAlign: 'left',
-    cursor: 'pointer',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  distRow: {
-    display: 'grid',
-    gridTemplateColumns: '52px minmax(0, 1fr) 56px',
-    gap: '6px',
-    alignItems: 'center',
-    padding: '3px 0',
-  },
-  distBarTrack: {
-    height: '6px',
-    borderRadius: opptrixTokens.radiusFull,
-    backgroundColor: opptrixCssVars.surfaceMuted,
-    overflow: 'hidden',
-  },
-  distBarFill: {
-    height: '100%',
-    borderRadius: opptrixTokens.radiusFull,
-    backgroundColor: opptrixCssVars.accentMuted,
-  },
-  emptyHint: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
-    padding: '8px 2px',
-  },
-  error: {
-    fontSize: 'var(--opptrix-font-md)',
-    color: '#C50F1F',
-    lineHeight: 1.45,
-  },
-  foot: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
-    lineHeight: 1.4,
-  },
-  cryptoBody: {
-    flex: 1,
-    padding: CONTENT_PAD,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '12px',
-    overflow: 'auto',
-  },
   card: {
-    padding: '12px',
-    borderRadius: opptrixTokens.radiusMd,
-    backgroundColor: opptrixCssVars.surfaceMuted,
-    border: `1px solid ${opptrixCssVars.separator}`,
     display: 'flex',
     flexDirection: 'column',
-    gap: '8px',
+    gap: '6px',
+    padding: '8px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.canvasAlt,
   },
   cardTitle: {
-    fontSize: 'var(--opptrix-font-sm)',
+    fontSize: 'var(--opptrix-font-xs)',
     fontWeight: 650,
+    color: opptrixCssVars.textTertiary,
+  },
+  foot: {
+    flexShrink: 0,
+    fontSize: 'var(--opptrix-font-xs)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.45,
+  },
+  error: {
+    flexShrink: 0,
+    padding: `0 ${CONTENT_PAD}`,
+    fontSize: 'var(--opptrix-font-xs)',
+    color: opptrixCssVars.error,
+  },
+  muted: {
+    fontSize: 'var(--opptrix-font-md)',
     color: opptrixCssVars.textSecondary,
+    lineHeight: 1.5,
   },
   klineRow: {
     display: 'flex',
@@ -411,11 +210,6 @@ const useStyles = makeStyles({
     backgroundColor: '#34C759',
     opacity: 0.75,
   },
-  muted: {
-    fontSize: 'var(--opptrix-font-md)',
-    color: opptrixCssVars.textSecondary,
-    lineHeight: 1.5,
-  },
 })
 
 interface Props {
@@ -427,279 +221,12 @@ interface Props {
   onSelectPeer?: (item: WatchlistItem) => void
 }
 
-function pctClass(s: ReturnType<typeof useStyles>, tone: ReturnType<typeof pctTone>) {
-  if (tone === 'up') return s.pctUp
-  if (tone === 'down') return s.pctDown
-  return s.pctFlat
-}
-
 function HeroCell({ label, value }: { label: string; value: string }) {
   const s = useStyles()
   return (
     <div className={s.heroCell}>
       <span className={s.heroLabel}>{label}</span>
       <span className={s.heroValue}>{value}</span>
-    </div>
-  )
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  const s = useStyles()
-  return (
-    <div className={s.metric}>
-      <span className={s.metricLabel}>{label}</span>
-      <span className={s.metricValue}>{value}</span>
-    </div>
-  )
-}
-
-function MetricSection({ title, children }: { title: string; children: ReactNode }) {
-  const s = useStyles()
-  return (
-    <div className={s.section}>
-      <Text className={s.sectionTitle}>{title}</Text>
-      {children}
-    </div>
-  )
-}
-
-function NewsPanel({ items, emptyHint }: { items: StockNewsItem[]; emptyHint: string }) {
-  const s = useStyles()
-  if (!items.length) {
-    return <Text className={s.emptyHint}>{emptyHint}</Text>
-  }
-  return (
-    <div className={s.flatList}>
-      {items.map((item, index) => (
-        <div key={listRowKey(index, item.date, item.title, item.url)} className={s.annRow}>
-          <span className={s.listDate}>{item.date || '—'}</span>
-          {item.url ? (
-            <Link
-              className={s.listTitle}
-              href={item.url}
-              target="_blank"
-              rel="noreferrer"
-              onClick={event => openExternalUrl(item.url!, event)}
-            >
-              {item.title}
-            </Link>
-          ) : (
-            <span className={s.listTitle}>{item.title}</span>
-          )}
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function formatShareCount(v: number | null | undefined): string {
-  if (v == null || !Number.isFinite(v)) return '—'
-  if (v >= 1e8) return `${(v / 1e8).toFixed(2)} 亿股`
-  if (v >= 1e4) return `${(v / 1e4).toFixed(2)} 万股`
-  return `${Math.round(v).toLocaleString('zh-CN')} 股`
-}
-
-function RelatedStocksPanel({
-  items,
-  formatPrice,
-  onSelectPeer,
-}: {
-  items: CrossMarketRelatedStock[]
-  formatPrice: (v: number | null | undefined) => string
-  onSelectPeer?: (item: WatchlistItem) => void
-}) {
-  const s = useStyles()
-  if (!items.length) {
-    return <Text className={s.emptyHint}>暂无关联股票</Text>
-  }
-  return (
-    <div className={s.flatList}>
-      {items.slice(0, 12).map((item, index) => {
-        const tone = pctTone(item.changePct ?? null)
-        const toneClass = pctClass(s, tone)
-        const label = `${item.name} (${item.code})`
-        return (
-          <button
-            key={listRowKey(index, item.market, item.code)}
-            type="button"
-            className={s.peerRow}
-            title={onSelectPeer ? `查看 ${label}` : label}
-            disabled={!onSelectPeer}
-            onClick={() => {
-              if (!onSelectPeer) return
-              onSelectPeer({
-                code: `${item.market}:${item.code}`,
-                name: item.name,
-                instrument: { market: item.market, assetClass: 'EQUITY', symbol: item.code },
-              })
-            }}
-          >
-            <span className={s.tableCellName}>{label}</span>
-            <span className={s.tableCell}>{item.price != null ? formatPrice(item.price) : '—'}</span>
-            <span className={mergeClasses(s.tableCell, toneClass)}>
-              {formatPct(item.changePct ?? null)}
-            </span>
-          </button>
-        )
-      })}
-      {!onSelectPeer ? (
-        <Text className={s.muted}>关联标的来自同行业或产业链，暂不支持从此处跳转。</Text>
-      ) : null}
-    </div>
-  )
-}
-
-function TradingDistributionPanel({
-  data,
-  formatPrice,
-}: {
-  data: TradingDistributionData
-  formatPrice: (v: number | null | undefined) => string
-}) {
-  const s = useStyles()
-  const levels = data.priceLevels.filter(row => row.price != null)
-  if (!levels.length && data.largeOrderPct == null) {
-    return <Text className={s.emptyHint}>盘中暂无成交分布数据</Text>
-  }
-  const maxRatio = Math.max(...levels.map(row => row.volumeRatio ?? 0), 0.0001)
-  return (
-    <>
-      {data.largeOrderPct != null ? (
-        <Text className={s.muted}>大单成交占比约 {data.largeOrderPct.toFixed(1)}%</Text>
-      ) : null}
-      <div className={s.flatList}>
-        {levels.map((row, index) => {
-          const widthPct = row.volumeRatio != null
-            ? Math.max(4, (row.volumeRatio / maxRatio) * 100)
-            : 4
-          return (
-            <div key={listRowKey(index, row.price, row.volume)} className={s.distRow}>
-              <span className={s.tableCell}>{formatPrice(row.price)}</span>
-              <div className={s.distBarTrack}>
-                <div className={s.distBarFill} style={{ width: `${widthPct}%` }} />
-              </div>
-              <span className={s.tableCell}>{formatVolume(row.volume ?? null)}</span>
-            </div>
-          )
-        })}
-      </div>
-    </>
-  )
-}
-
-function SeniorTradesPanel({ items }: { items: SeniorTradeItem[] }) {
-  const s = useStyles()
-  if (!items.length) {
-    return <Text className={s.emptyHint}>暂无高管交易记录</Text>
-  }
-  return (
-    <div className={s.flatList}>
-      <div className={s.tableHeadWide}>
-        <span className={s.tableHeadCell}>日期</span>
-        <span className={s.tableHeadCell}>姓名</span>
-        <span className={s.tableHeadCell}>股数</span>
-        <span className={s.tableHeadCell}>金额</span>
-        <span className={s.tableHeadCell}>说明</span>
-      </div>
-      {items.slice(0, 12).map((item, index) => (
-        <div key={listRowKey(index, item.tradeDate, item.personName, item.shares)} className={s.tableRowWide}>
-          <span className={s.tableCell}>{item.tradeDate || '—'}</span>
-          <span className={s.tableCellName} title={item.personName}>{item.personName}</span>
-          <span className={s.tableCell}>{formatVolume(item.shares ?? null)}</span>
-          <span className={s.tableCell}>
-            {item.value != null ? formatCompactNumber(item.value) : '—'}
-          </span>
-          <span className={s.tableCellName} title={item.detail}>{item.detail || '—'}</span>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function RevenueBreakdownPanel({ blocks }: { blocks: RevenueBreakdownBlock[] }) {
-  const s = useStyles()
-  if (!blocks.length) return null
-  const latest = blocks[0]
-  if (!latest?.segments.length) return null
-  return (
-    <MetricSection title={`营收构成${latest.date ? `（${latest.date}）` : ''}`}>
-      <div className={s.flatList}>
-        <div className={s.tableHeadWide}>
-          <span className={s.tableHeadCell}>业务</span>
-          <span className={s.tableHeadCell}>收入</span>
-          <span className={s.tableHeadCell}>占比</span>
-        </div>
-        {latest.segments.map((seg, index) => (
-          <div key={listRowKey(index, seg.label)} className={s.tableRowWide}>
-            <span className={s.tableCellName} title={seg.label}>{seg.label}</span>
-            <span className={s.tableCell}>{seg.sales || '—'}</span>
-            <span className={s.tableCell}>{seg.ratio || '—'}</span>
-          </div>
-        ))}
-      </div>
-      {latest.currency ? (
-        <Text className={s.muted}>单位：{latest.currency}</Text>
-      ) : null}
-    </MetricSection>
-  )
-}
-
-function DividendPanel({ items }: { items: StockDividendItem[] }) {
-  const s = useStyles()
-  if (!items.length) {
-    return <Text className={s.emptyHint}>暂无分红派息记录</Text>
-  }
-  return (
-    <div className={s.flatList}>
-      <div className={s.tableHeadWide}>
-        <span className={s.tableHeadCell}>方案</span>
-        <span className={s.tableHeadCell}>进度</span>
-        <span className={s.tableHeadCell}>登记日</span>
-        <span className={s.tableHeadCell}>除权日</span>
-        <span className={s.tableHeadCell}>派息日</span>
-      </div>
-      {items.slice(0, 12).map((item, index) => (
-        <div key={listRowKey(index, item.exDate, item.plan)} className={s.tableRowWide}>
-          <span className={s.tableCellName} title={item.plan}>{item.plan || '—'}</span>
-          <span className={s.tableCell}>{item.progress || '—'}</span>
-          <span className={s.tableCell}>{item.recordDate || '—'}</span>
-          <span className={s.tableCell}>{item.exDate || '—'}</span>
-          <span className={s.tableCell}>{item.payDate || '—'}</span>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function ShareholderPanel({ data }: { data: StockShareholderData | null | undefined }) {
-  const s = useStyles()
-  const top10 = data?.top10Shareholders ?? []
-  if (!top10.length) {
-    return <Text className={s.emptyHint}>暂无主要股东数据</Text>
-  }
-  return (
-    <div className={s.flatList}>
-      {data?.reportDate ? (
-        <Text className={s.muted} style={{ marginBottom: 4 }}>数据日期：{data.reportDate}</Text>
-      ) : null}
-      <div className={s.tableHead}>
-        <span className={s.tableHeadCell}>股东</span>
-        <span className={s.tableHeadCell}>持股数</span>
-        <span className={s.tableHeadCell}>占比</span>
-        <span className={s.tableHeadCell}>变动</span>
-      </div>
-      {top10.slice(0, 10).map((row, index) => (
-        <div key={listRowKey(index, row.rank, row.name)} className={s.tableRow}>
-          <span className={s.tableCellName} title={row.name}>{row.name}</span>
-          <span className={s.tableCell}>{formatCompactNumber(row.sharesHeld ?? null)}</span>
-          <span className={s.tableCell}>
-            {row.sharePct != null ? `${row.sharePct.toFixed(2)}%` : '—'}
-          </span>
-          <span className={s.tableCell}>
-            {row.change != null ? formatSignedNumber(row.change, 0) : '—'}
-          </span>
-        </div>
-      ))}
     </div>
   )
 }
@@ -746,9 +273,18 @@ async function loadSnapshot(ref: InstrumentRef): Promise<EquityDetail | CryptoSn
   return resp.data as EquityDetail | CryptoSnapshotData
 }
 
-function asProfile(raw: Record<string, unknown> | null | undefined): StockProfileData | null {
-  if (!raw || typeof raw !== 'object') return null
-  return raw as unknown as StockProfileData
+function detailFootnote(ref: InstrumentRef, quote: { quoteSession?: string } | null): string {
+  if (ref.market === 'CRYPTO') {
+    return 'Crypto 行情 7×24 更新，约每 30 秒自动刷新。'
+  }
+  if (
+    ref.market === 'US'
+    && quote
+    && (quote.quoteSession === 'pre' || quote.quoteSession === 'post')
+  ) {
+    return '当前为延长交易时段报价；盘中以常规时段为准。公司资料与新闻请通过助手查询。'
+  }
+  return '行情约每 1–2 分钟刷新；公司资料、财务与新闻请通过助手查询。'
 }
 
 export default function CrossMarketSnapshotDetail({
@@ -757,7 +293,6 @@ export default function CrossMarketSnapshotDetail({
   localIndexed = null,
   loading = false,
   onManage,
-  onSelectPeer,
 }: Props) {
   const s = useStyles()
   const ref = instrumentRef ?? resolveWatchlistInstrument(stock)
@@ -765,7 +300,6 @@ export default function CrossMarketSnapshotDetail({
   const isCrypto = ref.market === 'CRYPTO'
   const isEquity = ref.market === 'US' || ref.market === 'HK'
 
-  const [detailTab, setDetailTab] = useState<DetailTab>('chart')
   const [snapshot, setSnapshot] = useState<EquityDetail | CryptoSnapshotData | null>(null)
   const [fetching, setFetching] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -784,7 +318,6 @@ export default function CrossMarketSnapshotDetail({
   }, [ref])
 
   useEffect(() => {
-    setDetailTab('chart')
     void load()
     const ms = isCrypto ? 30_000 : 90_000
     const timer = window.setInterval(() => { void load() }, ms)
@@ -794,14 +327,6 @@ export default function CrossMarketSnapshotDetail({
   const equity = isEquity ? (snapshot as EquityDetail | null) : null
   const crypto = isCrypto ? (snapshot as CryptoSnapshotData | null) : null
   const quote = equity?.quote ?? crypto?.quote ?? null
-  const profile = asProfile(equity?.profile ?? null)
-  const articles = equity?.articles ?? []
-  const dividends = equity?.dividends ?? []
-  const shareholders = equity?.shareholders ?? null
-  const reviewProspect = equity?.reviewProspect ?? null
-  const relatedStocks = equity?.relatedStocks ?? []
-  const seniorTrades = equity?.seniorTrades ?? []
-  const tradingDistribution = equity?.tradingDistribution ?? null
   const klines = equity?.recentKlines ?? crypto?.recentKlines ?? []
 
   const tone = pctTone(quote?.changePct)
@@ -817,20 +342,11 @@ export default function CrossMarketSnapshotDetail({
   const displayName = useMemo(() => {
     if (equity?.name && equity.name !== equity.code) return equity.name
     if (stock.name && stock.name !== stock.code) return stock.name
-    return quote?.name || profile?.name || profile?.orgName || displayCodeFromInstrument(ref)
-  }, [equity, stock.name, stock.code, quote?.name, profile, ref])
+    return quote?.name || displayCodeFromInstrument(ref)
+  }, [equity, stock.name, stock.code, quote?.name, ref])
 
   const chartCode = formatInstrumentLabel(ref)
-  const showDividendsTab = ref.market === 'HK'
-  const showHoldersTab = ref.market === 'US'
-
-  const footnote = isCrypto
-    ? 'Crypto 行情 7×24 更新，约每 30 秒自动刷新。'
-    : ref.market === 'US'
-      ? (quote && 'quoteSession' in quote && (quote.quoteSession === 'pre' || quote.quoteSession === 'post')
-        ? '当前为延长交易时段报价；盘中以常规时段为准。'
-        : '行情约每 1–2 分钟刷新；深度资料请通过助手查询。')
-      : '行情与业绩展望约每 1–2 分钟刷新；深度资料请通过助手查询。'
+  const footnote = detailFootnote(ref, quote && 'quoteSession' in quote ? quote : null)
 
   if (isCrypto) {
     return (
@@ -926,166 +442,17 @@ export default function CrossMarketSnapshotDetail({
         ) : null}
       </div>
 
-      <div className={s.tabBar}>
-        <TabList
-          className={s.tabList}
-          size="small"
-          selectedValue={detailTab}
-          onTabSelect={(_, data) => setDetailTab(data.value as DetailTab)}
-        >
-          <Tab value="chart">走势</Tab>
-          <Tab value="basic">概况</Tab>
-          <Tab value="company">公司</Tab>
-          <Tab value="articles">资讯</Tab>
-          {showDividendsTab ? <Tab value="dividends">分红</Tab> : null}
-          {showHoldersTab ? <Tab value="holders">股东</Tab> : null}
-        </TabList>
-      </div>
-
-      <div className={s.tabBody}>
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'chart' && s.tabPanelHidden)}>
-          <div className={s.chartPanel}>
-            <TradingViewChart code={chartCode} expanded active={detailTab === 'chart'} />
-          </div>
+      <div className={s.chartBody}>
+        <div className={s.chartPanel}>
+          <TradingViewChart code={chartCode} expanded active />
         </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'basic' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            <MetricSection title="今日行情">
-              <div className={s.metricGrid3}>
-                <Metric label="今开" value={fmtPrice(quote?.open ?? null)} />
-                <Metric label="最高" value={fmtPrice(quote?.high ?? null)} />
-                <Metric label="最低" value={fmtPrice(quote?.low ?? null)} />
-                <Metric label="昨收" value={fmtPrice(quote?.preClose ?? null)} />
-                <Metric label="涨跌额" value={formatSignedNumber(quote?.change ?? null, priceDigits)} />
-                <Metric label="涨跌幅" value={formatPct(quote?.changePct ?? null)} />
-                <Metric label="成交量" value={formatVolume(quote?.volume ?? null)} />
-                <Metric label="成交额" value={fmtCompact(quote?.amount ?? null)} />
-                <Metric label="换手率" value={quote?.turnoverRate != null ? `${quote.turnoverRate.toFixed(2)}%` : '—'} />
-                <Metric label="振幅" value={quote?.amplitude != null ? `${quote.amplitude.toFixed(2)}%` : '—'} />
-                <Metric label="市盈率" value={quote?.pe != null ? quote.pe.toFixed(2) : '—'} />
-                <Metric label="市净率" value={quote?.pb != null ? quote.pb.toFixed(2) : '—'} />
-                <Metric label="总市值" value={fmtCompact(quote?.marketCap ?? null)} />
-                <Metric label="流通市值" value={fmtCompact(quote?.circulatingMarketCap ?? null)} />
-                {quote?.week52High != null ? (
-                  <Metric label="52 周最高" value={fmtPrice(quote.week52High)} />
-                ) : null}
-                {quote?.week52Low != null ? (
-                  <Metric label="52 周最低" value={fmtPrice(quote.week52Low)} />
-                ) : null}
-                {quote?.currency ? (
-                  <Metric label="报价币种" value={quote.currency} />
-                ) : null}
-                <Metric label="所属行业" value={profile?.industry ?? stock.industry ?? '—'} />
-                <Metric label="上市日期" value={profile?.listingDate ?? '—'} />
-                {profile?.weekDividendYield != null ? (
-                  <Metric label="周股息率" value={`${profile.weekDividendYield.toFixed(2)}%`} />
-                ) : null}
-              </div>
-            </MetricSection>
-            {ref.market === 'HK' && tradingDistribution ? (
-              <MetricSection title="今日成交分布">
-                <TradingDistributionPanel data={tradingDistribution} formatPrice={v => fmtPrice(v)} />
-              </MetricSection>
-            ) : null}
-            {relatedStocks.length ? (
-              <MetricSection title="关联股票">
-                <RelatedStocksPanel
-                  items={relatedStocks}
-                  formatPrice={v => fmtPrice(v)}
-                  onSelectPeer={onSelectPeer}
-                />
-              </MetricSection>
-            ) : null}
-            <div className={s.card}>
-              <Text className={s.cardTitle}>近 10 日收盘</Text>
-              <MiniKline bars={klines} formatPriceLabel={v => fmtPrice(v)} />
-            </div>
-            {error && quote ? <Text className={s.error}>刷新失败：{error}</Text> : null}
-            {localIndexed === false ? (
-              <Text className={s.muted}>
-                在线名录暂未匹配到该代码；可用 US:AAPL、HK:00700 格式添加关注。
-              </Text>
-            ) : null}
-            <Text className={s.foot}>{footnote}</Text>
-          </div>
-        </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'company' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            <MetricSection title="公司概况">
-              <div className={s.metricGrid3}>
-                <Metric label="公司全称" value={profile?.orgName || displayName} />
-                <Metric label="证券类型" value={profile?.securityType ?? label} />
-                <Metric label="上市日期" value={profile?.listingDate ?? '—'} />
-                <Metric label="所属行业" value={profile?.industry ?? '—'} />
-                <Metric label="董事长" value={profile?.chairman ?? '—'} />
-                <Metric label="总股本" value={formatShareCount(profile?.totalShares ?? null)} />
-                <Metric label="官网" value={profile?.website ?? '—'} />
-              </div>
-            </MetricSection>
-            {profile?.website ? (
-              <MetricSection title="官网链接">
-                <Link
-                  href={profile.website.startsWith('http') ? profile.website : `https://${profile.website}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={event => {
-                    const href = profile.website!.startsWith('http') ? profile.website! : `https://${profile.website}`
-                    openExternalUrl(href, event)
-                  }}
-                >
-                  {profile.website}
-                </Link>
-              </MetricSection>
-            ) : null}
-            <MetricSection title="业务介绍">
-              <Text className={s.prose} block>
-                {profile?.orgProfile || profile?.mainBusiness || '暂无公司介绍'}
-              </Text>
-            </MetricSection>
-            {profile?.revenueBreakdown?.length ? (
-              <RevenueBreakdownPanel blocks={profile.revenueBreakdown} />
-            ) : null}
-            {reviewProspect?.review ? (
-              <MetricSection title="业绩回顾">
-                <Text className={s.prose} block>{reviewProspect.review}</Text>
-              </MetricSection>
-            ) : null}
-            {reviewProspect?.prospect ? (
-              <MetricSection title="业绩展望">
-                <Text className={s.prose} block>{reviewProspect.prospect}</Text>
-              </MetricSection>
-            ) : null}
-          </div>
-        </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'articles' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            <NewsPanel items={articles} emptyHint="暂无相关资讯" />
-          </div>
-        </div>
-
-        {showDividendsTab ? (
-          <div className={mergeClasses(s.tabPanel, detailTab !== 'dividends' && s.tabPanelHidden)}>
-            <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-              <DividendPanel items={dividends} />
-            </div>
-          </div>
+        {error && quote ? <Text className={s.error}>刷新失败：{error}</Text> : null}
+        {localIndexed === false ? (
+          <Text className={s.muted} style={{ padding: `0 ${CONTENT_PAD}` }}>
+            在线名录暂未匹配到该代码；可用 US:AAPL、HK:00700 格式添加关注。
+          </Text>
         ) : null}
-
-        {showHoldersTab ? (
-          <div className={mergeClasses(s.tabPanel, detailTab !== 'holders' && s.tabPanelHidden)}>
-            <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-              <ShareholderPanel data={shareholders} />
-              {ref.market === 'US' ? (
-                <MetricSection title="高管交易">
-                  <SeniorTradesPanel items={seniorTrades} />
-                </MetricSection>
-              ) : null}
-            </div>
-          </div>
-        ) : null}
+        <Text className={s.foot} style={{ padding: `0 ${CONTENT_PAD} 10px` }}>{footnote}</Text>
       </div>
     </div>
   )

--- a/client-ui/src/market/StockDetailTab.tsx
+++ b/client-ui/src/market/StockDetailTab.tsx
@@ -1,17 +1,8 @@
-import { memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Link, Spinner, Tab, TabList, Text, Badge, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { Spinner, Text, Badge, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { EditRegular } from '@fluentui/react-icons'
 import { research } from '../api/client'
-import type {
-  ProfileInstitutionRating,
-  ProfilePlateItem,
-  StockDetailData,
-  StockDividendItem,
-  StockMoneyFlowItem,
-  StockProfileData,
-  StockShareholderData,
-  WatchlistItem,
-} from '../types/market'
+import type { StockDetailData, WatchlistItem } from '../types/market'
 import {
   formatCompactNumber,
   formatPct,
@@ -20,24 +11,19 @@ import {
   formatVolume,
   pctTone,
 } from './format'
-import OpptrixButton from '../components/opptrix/OpptrixButton'
-import { openExternalUrl } from '../platform/openUrl'
 import TradingViewChart from './TradingViewChart'
 import {
   normalizeWatchlistItem,
   resolveWatchlistInstrument,
   watchlistItemKey,
 } from './instrument'
-import StockDecisionCard, { type StockDiscussPayload } from './StockDecisionCard'
-import StockTrendTab from './StockTrendTab'
-import { listRowKey } from '../utils/listRowKey'
 import type { HoldingSnapshot } from './useFollowPortfolio'
+import type { StockDiscussPayload } from './StockDecisionCard'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { ghostInteractive } from '../theme/mixins'
 
-type DetailTab = 'analysis' | 'chart' | 'trend' | 'basic' | 'company'
-
 const CONTENT_PAD = '15px'
+const DETAIL_FOOTNOTE = '行情约每 1–2 分钟刷新；公司资料、财务与新闻请通过助手查询。'
 
 const useStyles = makeStyles({
   root: {
@@ -88,8 +74,8 @@ const useStyles = makeStyles({
     gap: '6px',
     flexShrink: 0,
   },
-  manageBtn: {...ghostInteractive,
-
+  manageBtn: {
+    ...ghostInteractive,
     border: `1px solid ${opptrixCssVars.separator}`,
     backgroundColor: opptrixCssVars.canvasAlt,
     color: opptrixCssVars.textSecondary,
@@ -149,114 +135,11 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  prepBanner: {
-    flexShrink: 0,
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    backgroundColor: opptrixCssVars.canvasAlt,
-  },
-  prepHead: {...ghostInteractive,
-
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-    padding: `5px ${CONTENT_PAD}`,
-    border: 'none',
-    background: 'transparent',
-    cursor: 'pointer',
-    textAlign: 'left',
-  },
-  prepHeadMain: {
-    flex: 1,
-    minWidth: 0,
-    display: 'flex',
-    alignItems: 'center',
-    gap: '6px',
-  },
-  prepHeadText: {
-    fontSize: 'var(--opptrix-font-xs)',
-    fontWeight: 600,
-    color: opptrixCssVars.textSecondary,
-    lineHeight: 1.35,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  prepHeadTextError: {
-    color: opptrixCssVars.error,
-  },
-  prepBody: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '6px',
-    padding: `0 ${CONTENT_PAD} 6px`,
-  },
-  prepTitle: {
-    fontSize: 'var(--opptrix-font-xs)',
-    fontWeight: 600,
-    color: opptrixCssVars.textPrimary,
-    lineHeight: 1.35,
-  },
-  prepHint: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textTertiary,
-    lineHeight: 1.4,
-  },
-  prepActions: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: '8px',
-  },
-  prepSteps: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '3px',
-  },
-  prepStep: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: '8px',
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textSecondary,
-  },
-  prepStepDone: {
-    color: '#248A3D',
-  },
-  prepStepRunning: {
-    color: opptrixCssVars.textPrimary,
-    fontWeight: 600,
-  },
-  prepStepError: {
-    color: opptrixCssVars.error,
-  },
-  tabBar: {
-    flexShrink: 0,
-    padding: `0 ${CONTENT_PAD}`,
-    minHeight: '28px',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    overflowX: 'auto',
-    scrollbarWidth: 'none',
-    '&::-webkit-scrollbar': { display: 'none' },
-  },
-  tabList: {
-    minWidth: 'max-content',
-  },
-  tabBody: {
+  chartBody: {
     flex: 1,
     minHeight: 0,
     display: 'flex',
     flexDirection: 'column',
-  },
-  tabPanel: {
-    flex: 1,
-    minHeight: 0,
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  tabPanelHidden: {
-    display: 'none',
   },
   chartPanel: {
     flex: 1,
@@ -265,171 +148,12 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     overflowX: 'hidden',
   },
-  scrollPanel: {
-    flex: 1,
-    minHeight: 0,
-    overflowY: 'auto',
-    padding: `8px ${CONTENT_PAD} 10px`,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '10px',
-  },
-  section: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '5px',
-  },
-  sectionTitle: {
-    fontSize: 'var(--opptrix-font-xs)',
-    fontWeight: 650,
-    color: opptrixCssVars.textTertiary,
-    letterSpacing: '0.06em',
-    textTransform: 'uppercase',
-  },
-  metricGrid3: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-    gap: '4px',
-  },
-  metricGrid2: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
-    gap: '4px',
-  },
-  metric: {
-    padding: '5px 6px',
-    borderRadius: opptrixTokens.radiusSm,
-    backgroundColor: opptrixCssVars.canvasAlt,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '1px',
-    minWidth: 0,
-  },
-  metricLabel: {
+  foot: {
+    flexShrink: 0,
+    padding: `0 ${CONTENT_PAD} 10px`,
     fontSize: 'var(--opptrix-font-xs)',
     color: opptrixCssVars.textTertiary,
-    lineHeight: 1.2,
-  },
-  metricValue: {
-    fontSize: 'var(--opptrix-font-sm)',
-    fontWeight: 600,
-    color: opptrixCssVars.textPrimary,
-    fontVariantNumeric: 'tabular-nums',
-    lineHeight: 1.3,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  prose: {
-    fontSize: 'var(--opptrix-font-sm)',
-    lineHeight: 1.55,
-    color: opptrixCssVars.textSecondary,
-    whiteSpace: 'pre-wrap',
-  },
-  tagRow: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: '4px',
-  },
-  tag: {
-    fontSize: 'var(--opptrix-font-xs)',
-    padding: '1px 6px',
-    borderRadius: opptrixTokens.radiusFull,
-    backgroundColor: opptrixCssVars.accentSoft,
-    color: opptrixCssVars.textSecondary,
-  },
-  tagHot: {
-    backgroundColor: 'rgba(255, 59, 48, 0.10)',
-    color: '#C9342B',
-    fontWeight: 600,
-  },
-  list: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0',
-    borderRadius: opptrixTokens.radiusSm,
-    overflow: 'hidden',
-    border: `1px solid ${opptrixCssVars.separator}`,
-  },
-  flatList: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  annRow: {
-    display: 'grid',
-    gridTemplateColumns: '58px minmax(0, 1fr)',
-    gap: '6px',
-    alignItems: 'start',
-    padding: '5px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  listDate: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textTertiary,
-    fontVariantNumeric: 'tabular-nums',
-    lineHeight: 1.4,
-  },
-  listTitle: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textPrimary,
-    lineHeight: 1.4,
-    textDecoration: 'none',
-    ':hover': { color: opptrixCssVars.accent },
-  },
-  tableHead: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) repeat(3, minmax(0, 0.75fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-  },
-  tableHeadCell: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textTertiary,
-  },
-  tableRow: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1fr) repeat(3, minmax(0, 0.75fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  tableRowWide: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1.2fr) repeat(4, minmax(0, 0.7fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-    ':last-child': { borderBottom: 'none' },
-  },
-  tableHeadWide: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(0, 1.2fr) repeat(4, minmax(0, 0.7fr))',
-    gap: '4px',
-    padding: '4px 0',
-    borderBottom: `1px solid ${opptrixCssVars.separator}`,
-  },
-  tableCell: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textPrimary,
-    fontVariantNumeric: 'tabular-nums',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  tableCellName: {
-    fontSize: 'var(--opptrix-font-xs)',
-    color: opptrixCssVars.textPrimary,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
-  emptyHint: {
-    fontSize: 'var(--opptrix-font-sm)',
-    color: opptrixCssVars.textTertiary,
-    padding: '8px 2px',
+    lineHeight: 1.45,
   },
   center: {
     flex: 1,
@@ -440,6 +164,12 @@ const useStyles = makeStyles({
     color: opptrixCssVars.textTertiary,
     fontSize: 'var(--opptrix-font-md)',
   },
+  error: {
+    flexShrink: 0,
+    padding: `0 ${CONTENT_PAD}`,
+    fontSize: 'var(--opptrix-font-xs)',
+    color: opptrixCssVars.error,
+  },
 })
 
 interface Props {
@@ -448,16 +178,6 @@ interface Props {
   holding?: HoldingSnapshot | null
   onManage?: () => void
   onDiscussInChat?: (payload: StockDiscussPayload) => void
-}
-
-function Metric({ label, value }: { label: string; value: string }) {
-  const s = useStyles()
-  return (
-    <div className={s.metric}>
-      <span className={s.metricLabel}>{label}</span>
-      <span className={s.metricValue}>{value}</span>
-    </div>
-  )
 }
 
 function HeroCell({ label, value }: { label: string; value: string }) {
@@ -470,212 +190,22 @@ function HeroCell({ label, value }: { label: string; value: string }) {
   )
 }
 
-function MetricSection({ title, children }: { title: string; children: ReactNode }) {
-  const s = useStyles()
-  return (
-    <div className={s.section}>
-      <Text className={s.sectionTitle}>{title}</Text>
-      {children}
-    </div>
-  )
-}
-
-function DividendPanel({ items }: { items: StockDividendItem[] }) {
-  const s = useStyles()
-  if (!items.length) {
-    return <Text className={s.emptyHint}>暂无分红送转记录</Text>
-  }
-  return (
-    <div className={s.flatList}>
-      <div className={s.tableHeadWide}>
-        <span className={s.tableHeadCell}>方案</span>
-        <span className={s.tableHeadCell}>进度</span>
-        <span className={s.tableHeadCell}>登记日</span>
-        <span className={s.tableHeadCell}>除权日</span>
-        <span className={s.tableHeadCell}>派息日</span>
-      </div>
-      {items.slice(0, 10).map((item, index) => (
-        <div key={listRowKey(index, item.exDate, item.plan)} className={s.tableRowWide}>
-          <span className={s.tableCellName} title={item.plan}>{item.plan || '—'}</span>
-          <span className={s.tableCell}>{item.progress || '—'}</span>
-          <span className={s.tableCell}>{item.recordDate || '—'}</span>
-          <span className={s.tableCell}>{item.exDate || '—'}</span>
-          <span className={s.tableCell}>{item.payDate || '—'}</span>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function MoneyFlowPanel({ items }: { items: StockMoneyFlowItem[] }) {
-  const s = useStyles()
-  if (!items.length) {
-    return <Text className={s.emptyHint}>暂无资金流向数据</Text>
-  }
-  return (
-    <div className={s.list}>
-      <div className={s.tableHead}>
-        <span className={s.tableHeadCell}>日期</span>
-        <span className={s.tableHeadCell}>主力净流入</span>
-        <span className={s.tableHeadCell}>占比</span>
-        <span className={s.tableHeadCell}>涨跌</span>
-      </div>
-      {[...items].reverse().slice(0, 8).map((item, index) => (
-        <div key={listRowKey(index, item.date)} className={s.tableRow}>
-          <span className={s.tableCell}>{item.date}</span>
-          <span className={s.tableCell}>{formatCompactNumber(item.mainNet ?? null)}</span>
-          <span className={s.tableCell}>
-            {item.mainNetPct != null ? `${item.mainNetPct.toFixed(2)}%` : '—'}
-          </span>
-          <span className={s.tableCell}>{formatPct(item.changePct ?? null)}</span>
-        </div>
-      ))}
-    </div>
-  )
-}
-
-function ShareholderPanel({ data }: { data: StockShareholderData | null | undefined }) {
-  const s = useStyles()
-  const top10 = data?.top10Shareholders ?? []
-  if (!data && !top10.length) {
-    return <Text className={s.emptyHint}>暂无股东户数与持股结构</Text>
-  }
-  return (
-    <>
-      <div className={s.metricGrid3}>
-        <Metric label="报告期" value={data?.reportDate || '—'} />
-        <Metric label="股东户数" value={data?.shareholderCount != null ? String(Math.round(data.shareholderCount)) : '—'} />
-        <Metric
-          label="户数变动"
-          value={data?.shareholderCountChange != null ? formatPct(data.shareholderCountChange) : '—'}
-        />
-        <Metric label="户均持股" value={data?.avgFreeShares != null ? formatCompactNumber(data.avgFreeShares) : '—'} />
-        <Metric label="户均市值" value={formatCompactNumber(data?.avgHoldingValue ?? null)} />
-        <Metric label="集中度" value={data?.holdFocus || '—'} />
-      </div>
-      {top10.length > 0 && (
-        <div className={s.flatList}>
-          <div className={s.tableHead}>
-            <span className={s.tableHeadCell}>股东</span>
-            <span className={s.tableHeadCell}>持股数</span>
-            <span className={s.tableHeadCell}>占比</span>
-            <span className={s.tableHeadCell}>变动</span>
-          </div>
-          {top10.slice(0, 10).map((row, index) => (
-            <div key={listRowKey(index, row.rank, row.name)} className={s.tableRow}>
-              <span className={s.tableCellName} title={row.name}>{row.name}</span>
-              <span className={s.tableCell}>{formatCompactNumber(row.sharesHeld ?? null)}</span>
-              <span className={s.tableCell}>
-                {row.sharePct != null ? `${row.sharePct.toFixed(2)}%` : '—'}
-              </span>
-              <span className={s.tableCell}>
-                {row.change != null ? formatSignedNumber(row.change, 0) : '—'}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-    </>
-  )
-}
-
-function formatIndustryLine(profile: StockProfileData | null | undefined, fallback?: string): string {
-  const primary = profile?.industry ?? fallback
-  const secondary = profile?.industrySecondary
-  if (primary && secondary) return `${primary} · ${secondary}`
-  return primary ?? '—'
-}
-
-function formatRankValue(rank: unknown): string {
-  if (rank == null || rank === '') return '—'
-  return String(rank)
-}
-
-function PlateTags({ title, plates }: { title: string; plates: ProfilePlateItem[] }) {
-  const s = useStyles()
-  if (!plates.length) return null
-  return (
-    <MetricSection title={title}>
-      <div className={s.tagRow}>
-        {plates.slice(0, 20).map((plate, index) => (
-          <span
-            key={listRowKey(index, title, plate.code, plate.name)}
-            className={mergeClasses(s.tag, plate.tag && s.tagHot)}
-            title={plate.tag ? `${plate.name} · ${plate.tag}` : plate.name}
-          >
-            {plate.name}
-          </span>
-        ))}
-      </div>
-    </MetricSection>
-  )
-}
-
-function InstitutionRatingPanel({ rating }: { rating: ProfileInstitutionRating }) {
-  const s = useStyles()
-  const hasCounts = [rating.buy, rating.outperform, rating.neutral, rating.underperform, rating.sell]
-    .some(v => v != null && v > 0)
-  const hasTarget = rating.targetPriceAvg || rating.targetPriceHigh || rating.targetPriceLow
-  const reports = rating.recentReports ?? []
-  if (!hasCounts && !hasTarget && !reports.length) {
-    return <Text className={s.emptyHint}>暂无机构评级数据</Text>
-  }
-  return (
-    <>
-      {hasCounts && (
-        <div className={s.metricGrid3}>
-          <Metric label="买入" value={rating.buy != null ? String(rating.buy) : '—'} />
-          <Metric label="增持" value={rating.outperform != null ? String(rating.outperform) : '—'} />
-          <Metric label="中性" value={rating.neutral != null ? String(rating.neutral) : '—'} />
-          <Metric label="减持" value={rating.underperform != null ? String(rating.underperform) : '—'} />
-          <Metric label="卖出" value={rating.sell != null ? String(rating.sell) : '—'} />
-          {rating.period && <Metric label="统计区间" value={rating.period} />}
-        </div>
-      )}
-      {hasTarget && (
-        <div className={s.metricGrid3}>
-          <Metric label="目标均价" value={rating.targetPriceAvg ?? '—'} />
-          <Metric label="目标最高" value={rating.targetPriceHigh ?? '—'} />
-          <Metric label="目标最低" value={rating.targetPriceLow ?? '—'} />
-        </div>
-      )}
-      {reports.length > 0 && (
-        <div className={s.flatList}>
-          {reports.map((item, index) => (
-            <div key={listRowKey(index, item.date, item.title)} className={s.annRow}>
-              <span className={s.listDate}>{item.date || '—'}</span>
-              <span className={s.listTitle}>
-                {item.rating ? `[${item.rating}] ` : ''}{item.title}
-              </span>
-            </div>
-          ))}
-        </div>
-      )}
-    </>
-  )
-}
-
 function StockDetailTab({
   stock,
   isHolding = false,
-  holding,
   onManage,
-  onDiscussInChat,
 }: Props) {
   const s = useStyles()
-  const [detailTab, setDetailTab] = useState<DetailTab>('chart')
   const [detail, setDetail] = useState<StockDetailData | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [detailReload, setDetailReload] = useState(0)
   const stockRef = useRef(stock)
   stockRef.current = stock
-  /** 同标的对象引用抖动时不重置 / 不重拉；仅切换标的才 loading */
   const stockKey = useMemo(
     () => (stock ? watchlistItemKey(normalizeWatchlistItem(stock)) : null),
     [stock],
   )
-  /** 传给 TradingViewChart 的 instrument：按 stockKey 稳定，避免同标的重渲染新建对象 */
   const chartInstrument = useMemo(
     () => (stock ? resolveWatchlistInstrument(stock) : undefined),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by stockKey
@@ -696,7 +226,6 @@ function StockDetailTab({
       return undefined
     }
 
-    setDetailTab('chart')
     let cancelled = false
     setLoading(true)
     setError('')
@@ -724,6 +253,12 @@ function StockDetailTab({
 
     return () => { cancelled = true }
   }, [stockKey, detailReload])
+
+  useEffect(() => {
+    if (!stockKey) return undefined
+    const timer = window.setInterval(() => setDetailReload(n => n + 1), 90_000)
+    return () => window.clearInterval(timer)
+  }, [stockKey])
 
   if (!stock) {
     return <div className={s.center}>请在「关注」中选择一只股票</div>
@@ -755,10 +290,9 @@ function StockDetailTab({
   }
 
   const quote = detail.quote
-  const profile = detail.profile
   const displayName = detail.name && detail.name !== detail.code
     ? detail.name
-    : (stock.name && stock.name !== stock.code ? stock.name : (profile?.name || profile?.orgName || detail.code))
+    : (stock.name && stock.name !== stock.code ? stock.name : detail.code)
   const tone = pctTone(quote?.changePct)
   const toneClass = mergeClasses(
     tone === 'up' && s.pctUp,
@@ -805,248 +339,17 @@ function StockDetailTab({
         </div>
       </div>
 
-      <div className={s.tabBar}>
-        <TabList
-          className={s.tabList}
-          size="small"
-          selectedValue={detailTab}
-          onTabSelect={(_, data) => setDetailTab(data.value as DetailTab)}
-        >
-          <Tab value="chart">走势</Tab>
-          <Tab value="trend">趋势</Tab>
-          <Tab value="analysis">分析</Tab>
-          <Tab value="basic">概况</Tab>
-          <Tab value="company">公司</Tab>
-        </TabList>
-      </div>
-
-      <div className={s.tabBody}>
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'trend' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            {detailTab === 'trend' && (
-              <StockTrendTab
-                code={detail.code}
-                active={detailTab === 'trend'}
-                holdingCost={holding?.costBasis}
-              />
-            )}
-          </div>
+      <div className={s.chartBody}>
+        <div className={s.chartPanel}>
+          <TradingViewChart
+            code={detail.code}
+            instrument={chartInstrument}
+            expanded
+            active
+          />
         </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'analysis' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            {detailTab === 'analysis' && (
-              <StockDecisionCard
-                key={stock.code}
-                stock={{ ...stock, name: displayName }}
-                price={quote?.price ?? null}
-                quotePe={quote?.pe ?? null}
-                quotePb={quote?.pb ?? null}
-                holding={holding}
-                moneyFlow={detail.moneyFlow?.[0] ?? null}
-                onDiscuss={onDiscussInChat}
-              />
-            )}
-          </div>
-        </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'chart' && s.tabPanelHidden)}>
-          <div className={s.chartPanel}>
-            <TradingViewChart
-              code={detail.code}
-              instrument={chartInstrument}
-              expanded
-              active={detailTab === 'chart'}
-            />
-          </div>
-        </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'basic' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            <MetricSection title="今日行情">
-              <div className={s.metricGrid3}>
-                <Metric label="今开" value={formatPrice(quote?.open ?? null)} />
-                <Metric label="最高" value={formatPrice(quote?.high ?? null)} />
-                <Metric label="最低" value={formatPrice(quote?.low ?? null)} />
-                <Metric label="昨收" value={formatPrice(quote?.preClose ?? null)} />
-                <Metric label="涨跌额" value={formatSignedNumber(quote?.change ?? null)} />
-                <Metric label="涨跌幅" value={formatPct(quote?.changePct ?? null)} />
-                <Metric label="振幅" value={quote?.amplitude != null ? `${quote.amplitude.toFixed(2)}%` : '—'} />
-                <Metric label="换手率" value={quote?.turnoverRate != null ? `${quote.turnoverRate.toFixed(2)}%` : '—'} />
-                <Metric label="成交量" value={formatVolume(quote?.volume ?? null)} />
-                <Metric label="成交额" value={formatCompactNumber(quote?.amount ?? null)} />
-                <Metric label="量比" value={quote?.volumeRatio != null ? quote.volumeRatio.toFixed(2) : '—'} />
-                <Metric label="市盈率" value={quote?.pe != null ? quote.pe.toFixed(2) : '—'} />
-                <Metric label="市净率" value={quote?.pb != null ? quote.pb.toFixed(2) : '—'} />
-              </div>
-            </MetricSection>
-
-            <MetricSection title="规模与估值">
-              <div className={s.metricGrid3}>
-                <Metric label="总市值" value={formatCompactNumber(profile?.totalMarketCap ?? quote?.marketCap ?? null)} />
-                <Metric label="流通市值" value={formatCompactNumber(profile?.circulatingMarketCap ?? null)} />
-                <Metric label="所属行业" value={formatIndustryLine(profile, stock.industry)} />
-              </div>
-            </MetricSection>
-
-            {profile?.industryRank && (
-              <MetricSection title={`行业内排名 · ${profile.industryRank.industryName}`}>
-                <div className={s.metricGrid3}>
-                  <Metric label="市盈率排名" value={formatRankValue(profile.industryRank.peRank)} />
-                  <Metric label="市值排名" value={formatRankValue(profile.industryRank.marketCapRank)} />
-                  <Metric label="EPS 排名" value={formatRankValue(profile.industryRank.epsRank)} />
-                  <Metric label="行业平均 PE" value={profile.industryRank.industryAvgPe != null ? profile.industryRank.industryAvgPe.toFixed(2) : '—'} />
-                  <Metric label="本股市盈率" value={profile.industryRank.pe != null ? profile.industryRank.pe.toFixed(2) : '—'} />
-                  <Metric label="行业 EPS" value={profile.industryRank.eps != null ? profile.industryRank.eps.toFixed(2) : '—'} />
-                </div>
-              </MetricSection>
-            )}
-
-            {profile?.profileMetrics?.length ? (
-              <MetricSection title={`最新指标${profile.metricsReportDate ? ` · ${profile.metricsReportDate}` : ''}`}>
-                <div className={s.metricGrid3}>
-                  {profile.profileMetrics.slice(0, 9).map((item, index) => (
-                    <Metric key={listRowKey(index, item.label)} label={item.label} value={item.value} />
-                  ))}
-                </div>
-              </MetricSection>
-            ) : null}
-          </div>
-        </div>
-
-        <div className={mergeClasses(s.tabPanel, detailTab !== 'company' && s.tabPanelHidden)}>
-          <div className={mergeClasses(s.scrollPanel, 'opptrix-scroll')}>
-            <MetricSection title="公司概况">
-              <div className={s.metricGrid3}>
-                <Metric label="公司全称" value={profile?.orgName || detail.name || '—'} />
-                <Metric label="英文名称" value={profile?.orgNameEn ?? '—'} />
-                <Metric label="证券类型" value={profile?.securityType ?? '—'} />
-                <Metric label="曾用名" value={profile?.formerName ?? '—'} />
-                <Metric label="成立日期" value={profile?.foundDate ?? '—'} />
-                <Metric label="上市日期" value={profile?.listingDate ?? '—'} />
-                <Metric label="发行价" value={profile?.issuePrice != null ? formatPrice(profile.issuePrice) : '—'} />
-                <Metric label="注册资本" value={profile?.regCapital != null ? formatCompactNumber(profile.regCapital) : '—'} />
-                <Metric label="员工人数" value={profile?.employees != null ? String(profile.employees) : '—'} />
-                <Metric label="所属行业" value={formatIndustryLine(profile, stock.industry)} />
-                <Metric label="证监会行业" value={profile?.industryCsrc ?? '—'} />
-                <Metric label="注册地址" value={profile?.address || profile?.province || '—'} />
-                <Metric label="办公地址" value={profile?.officeAddress ?? '—'} />
-                <Metric label="联系电话" value={profile?.orgTel ?? '—'} />
-                <Metric label="电子邮箱" value={profile?.orgEmail ?? '—'} />
-                <Metric label="传真" value={profile?.orgFax ?? '—'} />
-                <Metric label="主承销商" value={profile?.leadUnderwriter ?? '—'} />
-              </div>
-            </MetricSection>
-
-            <MetricSection title="治理结构">
-              <div className={s.metricGrid3}>
-                <Metric label="董事长" value={profile?.chairman ?? '—'} />
-                <Metric label="法人代表" value={profile?.legalPerson ?? '—'} />
-                <Metric label="董秘" value={profile?.secretary ?? '—'} />
-              </div>
-            </MetricSection>
-
-            {profile?.executives?.length ? (
-              <MetricSection title="高管团队">
-                <div className={s.flatList}>
-                  <div className={s.tableHeadWide}>
-                    <span className={s.tableHeadCell}>姓名</span>
-                    <span className={s.tableHeadCell}>职务</span>
-                    <span className={s.tableHeadCell}>任职日期</span>
-                    <span className={s.tableHeadCell}>离任日期</span>
-                    <span className={s.tableHeadCell} />
-                  </div>
-                  {profile.executives.slice(0, 10).map((exec, index) => (
-                    <div key={listRowKey(index, exec.name, exec.title, exec.startDate)} className={s.tableRowWide}>
-                      <span className={s.tableCellName}>{exec.name}</span>
-                      <span className={s.tableCell}>{exec.title || '—'}</span>
-                      <span className={s.tableCell}>{exec.startDate || '—'}</span>
-                      <span className={s.tableCell}>{exec.endDate || '—'}</span>
-                      <span className={s.tableCell} />
-                    </div>
-                  ))}
-                </div>
-              </MetricSection>
-            ) : null}
-
-            {profile?.indexMembership?.length ? (
-              <MetricSection title="指数成分">
-                <div className={s.tagRow}>
-                  {profile.indexMembership.map((item, index) => (
-                    <span
-                      key={listRowKey(index, item.indexCode, item.indexName)}
-                      className={s.tag}
-                      title={item.enterDate ? `纳入 ${item.enterDate}` : item.indexName}
-                    >
-                      {item.indexName}
-                    </span>
-                  ))}
-                </div>
-              </MetricSection>
-            ) : null}
-
-            {profile?.website && (
-              <MetricSection title="官网">
-                <Link
-                  href={profile.website.startsWith('http') ? profile.website : `https://${profile.website}`}
-                  target="_blank"
-                  rel="noreferrer"
-                  onClick={event => {
-                    const website = profile.website!
-                    const href = website.startsWith('http') ? website : `https://${website}`
-                    openExternalUrl(href, event)
-                  }}
-                >
-                  {profile.website}
-                </Link>
-              </MetricSection>
-            )}
-
-            <PlateTags title="行业板块" plates={profile?.industryPlates ?? []} />
-            <PlateTags title="概念题材" plates={profile?.conceptPlates ?? []} />
-            <PlateTags title="地域板块" plates={profile?.areaPlates ?? []} />
-
-            {!profile?.conceptPlates?.length && profile?.concepts?.length ? (
-              <MetricSection title="板块 · 题材">
-                <div className={s.tagRow}>
-                  {profile.concepts.slice(0, 16).map((tag, index) => (
-                    <span key={listRowKey(index, tag)} className={s.tag}>{tag}</span>
-                  ))}
-                </div>
-              </MetricSection>
-            ) : null}
-
-            {profile?.institutionRating && (
-              <MetricSection title="机构评级">
-                <InstitutionRatingPanel rating={profile.institutionRating} />
-              </MetricSection>
-            )}
-
-            <MetricSection title="公司简介">
-              <Text className={s.prose} block>
-                {profile?.orgProfile || profile?.mainBusiness || '暂无公司介绍'}
-              </Text>
-            </MetricSection>
-
-            {profile?.businessScope && (
-              <MetricSection title="经营范围">
-                <Text className={s.prose} block>{profile.businessScope}</Text>
-              </MetricSection>
-            )}
-
-            <MetricSection title="分红送转">
-              <DividendPanel items={detail.dividends ?? []} />
-            </MetricSection>
-
-            <MetricSection title="股东结构">
-              <ShareholderPanel data={detail.shareholders} />
-            </MetricSection>
-
-            <MetricSection title="资金流向">
-              <MoneyFlowPanel items={detail.moneyFlow ?? []} />
-            </MetricSection>
-          </div>
-        </div>
+        {error ? <Text className={s.error}>刷新失败：{error}</Text> : null}
+        <Text className={s.foot}>{DETAIL_FOOTNOTE}</Text>
       </div>
     </div>
   )

--- a/client-ui/src/market/TradingViewChart.tsx
+++ b/client-ui/src/market/TradingViewChart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { research } from '../api/client'
 import { instrumentKey, parseInstrumentInput } from './instrument'
@@ -6,9 +6,10 @@ import type { InstrumentRef } from '../types/instrument'
 import { hasApplicationCapability } from './capabilities'
 import type { ChartPeriod, OhlcChartBar, StockChartData } from '../types/market'
 import { ChartWorkspace } from './chartEngine'
-import { buildChartSeries, periodLabel } from './chartSeries'
+import { buildChartSeries, isLineChartView, periodLabel } from './chartSeries'
+import { buildChartPeriodOptions, CN_STOCK_CHART_PERIODS } from './chartPeriodOptions'
 import { initialFetchCount, LOAD_MORE_STEP, maxChartBars } from './chartViewConfig'
-import { isIntradayPeriod, isMinuteOhlcPeriod } from './chartTime'
+import { isLineChartPaneLabel } from './chartTime'
 import { chartLivePollIntervalMs, shouldPollChartLive } from './chartLiveRefresh'
 import CyqProfileStrip from './CyqProfileStrip'
 import { computeCyqPriceSpan, isCyqChartPeriod } from './cyqUtils'
@@ -17,28 +18,6 @@ import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { useTheme } from '../theme/ThemeContext'
 import { ghostInteractive } from '../theme/mixins'
 import { isUnifiedChart, unifiedChartToStockChart } from './instrument-adapters'
-
-const PERIODS: { id: ChartPeriod; label: string; tradingOnly?: boolean }[] = [
-  { id: 'intraday', label: '分时', tradingOnly: true },
-  { id: '1m', label: '1分' },
-  { id: '5m', label: '5分' },
-  { id: '15m', label: '15分' },
-  { id: '30m', label: '30分' },
-  { id: '60m', label: '60分' },
-  { id: 'daily', label: '日K' },
-  { id: 'weekly', label: '周K' },
-  { id: 'monthly', label: '月K' },
-]
-
-const CROSS_MARKET_PERIOD_OPTIONS: { id: ChartPeriod; label: string; tradingOnly?: boolean }[] = [
-  { id: 'daily', label: '日K' },
-  { id: '5day', label: '5日' },
-  { id: 'weekly', label: '周K' },
-  { id: 'monthly', label: '月K' },
-  { id: 'year1', label: '1年' },
-  { id: 'year3', label: '3年' },
-  { id: 'year5', label: '5年' },
-]
 
 const useStyles = makeStyles({
   root: {
@@ -323,26 +302,10 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
     && (hasApplicationCapability(instrumentRef, 'chart_intraday')
       || hasApplicationCapability(instrumentRef, 'chart_daily'))
   const canChart = cnEquityChart || crossMarketChart
-  const cnIntraday = cnEquityChart
-    && hasApplicationCapability(instrumentRef, 'chart_intraday')
-  const crossMarketIntraday = crossMarketChart
-    && hasApplicationCapability(instrumentRef, 'chart_intraday')
-  const periodOptions = useMemo(() => {
-    if (cnEquityChart) {
-      if (cnIntraday) return PERIODS
-      // CN ETF 等仅有日 K：不展示分时/分钟周期，避免整图报「不支持」
-      return PERIODS.filter(item => item.id === 'daily' || item.id === 'weekly' || item.id === 'monthly')
-    }
-    if (crossMarketChart) {
-      const options: { id: ChartPeriod; label: string; tradingOnly?: boolean }[] = []
-      if (hasApplicationCapability(instrumentRef, 'chart_intraday')) {
-        options.push({ id: 'intraday', label: '分时', tradingOnly: true })
-      }
-      options.push(...CROSS_MARKET_PERIOD_OPTIONS)
-      return options
-    }
-    return PERIODS.filter(item => item.id === 'daily' || item.id === 'weekly' || item.id === 'monthly')
-  }, [cnEquityChart, cnIntraday, crossMarketChart, instrumentRef])
+  const periodOptions = useMemo(
+    () => buildChartPeriodOptions(instrumentRef, { cnEquityChart, crossMarketChart }),
+    [instrumentRef, cnEquityChart, crossMarketChart],
+  )
   const { resolvedScheme } = useTheme()
   const maColors = useMemo(() => getMaColors(resolvedScheme), [resolvedScheme])
   const [period, setPeriod] = useState<ChartPeriod>('daily')
@@ -350,7 +313,6 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
   const [loading, setLoading] = useState(false)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState('')
-  const [intradayAvailable, setIntradayAvailable] = useState(true)
 
   const mainRef = useRef<HTMLDivElement>(null)
   const volumeRef = useRef<HTMLDivElement>(null)
@@ -408,9 +370,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
         return
       }
 
-      const useStockApi = cnEquityChart
-        && (isIntradayPeriod(nextPeriod) || isMinuteOhlcPeriod(nextPeriod)
-          || nextPeriod === 'daily' || nextPeriod === 'weekly' || nextPeriod === 'monthly')
+      const useStockApi = cnEquityChart && CN_STOCK_CHART_PERIODS.has(nextPeriod)
 
       const resp = useStockApi
         ? await research.stockChart(
@@ -440,15 +400,6 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
         if (!hasChart) setData(null)
         return
       }
-      if (nextPeriod === 'intraday') {
-        const ok = resp.data.bars.length > 0
-        setIntradayAvailable(ok)
-        if (!ok) {
-          setError(resp.message || '暂无分时数据')
-          if (!hasChart) setData(null)
-          return
-        }
-      }
       if (opts?.append && prevBarCountRef.current > 0) {
         addedBarsRef.current = resp.data.bars.length - prevBarCountRef.current
       } else if (!opts?.append && !isLive) {
@@ -458,10 +409,10 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
         addedBarsRef.current = 0
       }
       fetchCountRef.current = count
-      const chartData = isUnifiedChart(resp.data)
+      const rawChart = isUnifiedChart(resp.data)
         ? unifiedChartToStockChart(resp.data, instrumentRef.symbol)
         : resp.data
-      setData(chartData)
+      setData({ ...rawChart, period: nextPeriod })
     } catch (e) {
       if (seq !== loadSeqRef.current || signal?.aborted) return
       if (e instanceof Error && e.name !== 'AbortError') {
@@ -500,20 +451,30 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
   const handleNeedHistoryRef = useRef(handleNeedHistory)
   handleNeedHistoryRef.current = handleNeedHistory
 
-  useEffect(() => {
-    setPeriod('daily')
-    setData(null)
-    setError('')
-    fetchCountRef.current = initialFetchCount('daily')
-    loadSeqRef.current += 1
-  }, [code])
+  const prevInstrumentIdentityRef = useRef(instrumentIdentity)
 
   useEffect(() => {
-    fetchCountRef.current = initialFetchCount(period)
+    const instrumentChanged = prevInstrumentIdentityRef.current !== instrumentIdentity
+    prevInstrumentIdentityRef.current = instrumentIdentity
+
+    if (instrumentChanged) {
+      setPeriod('daily')
+      loadSeqRef.current += 1
+    }
+
+    dataRef.current = null
+    hasDataRef.current = false
+    setData(null)
+    setLoading(true)
+    setRefreshing(false)
+    setError('')
+
+    const loadPeriod: ChartPeriod = instrumentChanged ? 'daily' : period
+    fetchCountRef.current = initialFetchCount(loadPeriod)
     const controller = new AbortController()
-    void loadChart(period, fetchCountRef.current, controller.signal)
+    void loadChart(loadPeriod, fetchCountRef.current, controller.signal)
     return () => { controller.abort() }
-  }, [code, period, loadChart])
+  }, [instrumentIdentity, period, loadChart])
 
   useEffect(() => {
     const tradingDay = data?.isTradingDay
@@ -540,27 +501,9 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
     return () => { window.clearInterval(id) }
   }, [period, active, data?.isTradingDay, loadChart])
 
-  useEffect(() => {
-    if (!cnIntraday && !crossMarketIntraday) {
-      setIntradayAvailable(false)
-      if (isIntradayPeriod(period) || isMinuteOhlcPeriod(period)) setPeriod('daily')
-      return undefined
-    }
-    const controller = new AbortController()
-    const probe = cnIntraday
-      ? research.stockChart(instrumentRef, 'intraday', undefined, controller.signal)
-      : research.instrumentChart(instrumentRef, 'intraday', 1, controller.signal)
-    probe
-      .then(resp => {
-        if (controller.signal.aborted || !resp.success || !resp.data) return
-        setIntradayAvailable(resp.data.bars.length > 0)
-      })
-      .catch(() => {})
-    return () => { controller.abort() }
-  }, [code, instrumentRef, cnIntraday, crossMarketIntraday, period])
-
-  useEffect(() => {
-    if (!data || !mainRef.current || !volumeRef.current || !macdRef.current) return undefined
+  useLayoutEffect(() => {
+    if (!data || data.bars.length === 0 || data.period !== period) return undefined
+    if (!mainRef.current || !volumeRef.current) return undefined
 
     const workspace = workspaceRef.current
     const preserveRange = preserveRangeRef.current
@@ -578,15 +521,15 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
         },
         series,
         {
-          period: data.period,
+          period,
           colorScheme: resolvedScheme,
           chartTimeZone: data.chartTimeZone,
           preserveRange,
           addedBars,
-          // 经 ref 取最新回调，避免 handleNeedHistory 身份变化时 destroy/remount
           onNeedHistory: () => { handleNeedHistoryRef.current() },
         },
       )
+      requestAnimationFrame(() => { workspace.resize() })
       setError(prev => (prev.startsWith('K线') || prev.includes('渲染') || prev.includes('时间轴') ? '' : prev))
     } catch (e) {
       workspace.destroy()
@@ -594,7 +537,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
     }
 
     return () => { workspace.destroy() }
-  }, [data, resolvedScheme])
+  }, [data, period, resolvedScheme])
 
   useEffect(() => {
     if (!active || !data) return undefined
@@ -604,16 +547,17 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
     return () => { cancelAnimationFrame(id) }
   }, [active, data, expanded])
 
+  const paneMainLabel = isLineChartPaneLabel(period) ? '分' : 'K'
+  const lineChartView = Boolean(data && data.period === period && isLineChartView(period, data.bars))
   const showMacd = Boolean(
-    data && !isIntradayPeriod(data.period) && !isMinuteOhlcPeriod(data.period)
+    data && !lineChartView
     && data.indicators.some(row => row.macd != null),
   )
-  const intraday = data ? isIntradayPeriod(data.period) : isIntradayPeriod(period)
 
   useEffect(() => () => { workspaceRef.current.destroy() }, [])
 
-  const legendIntraday = intraday && data
-  const legendOhlc = !intraday && data
+  const legendLine = lineChartView
+  const legendOhlc = !lineChartView && data
   const cyqLatest = data?.cyqLatest ?? null
   const cyqProfile = data?.cyqProfile ?? null
   const showCyq = Boolean(
@@ -630,9 +574,9 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
 
   const resetZoom = () => { workspaceRef.current.resetView() }
 
-  const chartLegend = (legendIntraday || legendOhlc) && (
+  const chartLegend = (legendLine || legendOhlc) && (
     <div className={mergeClasses(s.legend, s.chartLegend)}>
-      {legendIntraday && (
+      {legendLine && (
         <>
           <span className={s.legendItem}><i className={s.dot} style={{ background: '#FF3B30' }} />价格</span>
           <span className={s.legendItem}><i className={s.dot} style={{ background: indicatorColors.avg }} />均价</span>
@@ -666,8 +610,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
       <div className={s.toolbar}>
         <div className={s.periodGroup}>
           {periodOptions.map(item => {
-            const disabled = (!cnEquityChart && !crossMarketChart && (isIntradayPeriod(item.id) || isMinuteOhlcPeriod(item.id)))
-              || (item.tradingOnly && !intradayAvailable && item.id === 'intraday')
+            const disabled = !cnEquityChart && !crossMarketChart
             const activeTab = period === item.id
             return (
               <button
@@ -686,11 +629,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
 
       <div className={s.zoomRow}>
         <Text className={s.hint}>
-          {intraday
-            ? (data?.sessionDate && !data.isTradingDay
-              ? `${data.sessionDate} 收盘分时 · 滚轮缩放 · 左拖查看更早`
-              : '默认显示最新时段 · 滚轮缩放 · 左拖查看更早')
-            : `默认显示最新 ${periodLabel(period)} · 滚轮缩放 · 左拖加载历史`}
+          默认显示最新 {periodLabel(period)} · 滚轮缩放 · 左拖加载历史
         </Text>
         <button type="button" className={s.zoomBtn} onClick={resetZoom} disabled={!data}>
           最近视图
@@ -742,7 +681,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
         <div className={mergeClasses(s.empty, expanded && s.emptyExpanded)}>{error}</div>
       )}
 
-      <div className={mergeClasses(s.chartArea, expanded && s.chartAreaExpanded, !data && s.paneHidden)}>
+      <div className={mergeClasses(s.chartArea, expanded && s.chartAreaExpanded, !canChart && s.paneHidden)}>
         <div className={mergeClasses(s.chartFrame, expanded && s.chartFrameExpanded)}>
           {refreshing && (
             <div className={s.chartOverlay}>
@@ -752,7 +691,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
 
           <div className={mergeClasses(s.chartStack, expanded && s.chartStackExpanded)}>
             <div className={mergeClasses(s.paneRow, expanded && s.paneRowExpanded)}>
-              <span className={s.paneLabel}>{intraday ? '分' : 'K'}</span>
+              <span className={s.paneLabel}>{paneMainLabel}</span>
               <div className={s.paneKSplit}>
                 <div className={mergeClasses(s.panePlot, expanded ? s.paneMainExpanded : s.paneMain)} ref={mainRef} />
                 {showCyq && cyqProfile && cyqLatest && cyqPriceSpan && (

--- a/client-ui/src/market/chartAxisTime.ts
+++ b/client-ui/src/market/chartAxisTime.ts
@@ -1,4 +1,5 @@
 import { TickMarkType, type Time } from 'lightweight-charts'
+import type { ChartPeriod } from '../types/market'
 import { CN_TIMEZONE } from '../utils/cnTime'
 
 function timeToDate(time: Time): Date | null {
@@ -10,13 +11,20 @@ function timeToDate(time: Time): Date | null {
   return null
 }
 
-function businessDayLabel(time: Time): string | null {
+function businessDay(time: Time): { year: number; month: number; day: number } | null {
   if (typeof time !== 'object' || time === null || !('year' in time)) return null
-  const t = time as { year: number; month: number; day: number }
-  return `${t.year}-${String(t.month).padStart(2, '0')}-${String(t.day).padStart(2, '0')}`
+  return time as { year: number; month: number; day: number }
 }
 
-export function createChartAxisFormatters(timeZone = CN_TIMEZONE) {
+function quarterOf(month: number): number {
+  return Math.floor((month - 1) / 3) + 1
+}
+
+function isMultiYearRange(period?: string): boolean {
+  return period === 'year3' || period === 'year5'
+}
+
+export function createChartAxisFormatters(timeZone = CN_TIMEZONE, chartPeriod?: ChartPeriod) {
   const formatClock = (d: Date, withSeconds: boolean) =>
     new Intl.DateTimeFormat('zh-CN', {
       timeZone,
@@ -40,16 +48,73 @@ export function createChartAxisFormatters(timeZone = CN_TIMEZONE) {
     new Intl.DateTimeFormat('zh-CN', { timeZone, year: 'numeric' }).format(d)
 
   const timeFormatter = (time: Time) => {
-    const day = businessDayLabel(time)
-    if (day) return day
+    const t = businessDay(time)
+    if (t) {
+      if (chartPeriod === 'yearly' || isMultiYearRange(chartPeriod)) {
+        return String(t.year)
+      }
+      if (chartPeriod === 'quarterly') {
+        return `${t.year}Q${quarterOf(t.month)}`
+      }
+      if (chartPeriod === 'year1') {
+        return `${t.year}-${String(t.month).padStart(2, '0')}`
+      }
+      if (chartPeriod === 'monthly') {
+        return `${t.year}-${String(t.month).padStart(2, '0')}`
+      }
+      return `${t.year}-${String(t.month).padStart(2, '0')}-${String(t.day).padStart(2, '0')}`
+    }
     const d = timeToDate(time)
     return d ? formatClock(d, false) : String(time)
   }
 
   const tickMarkFormatter = (time: Time, tickMarkType: TickMarkType, _locale: string) => {
-    const day = businessDayLabel(time)
-    if (day) {
-      const t = time as { year: number; month: number; day: number }
+    const t = businessDay(time)
+    if (t) {
+      if (chartPeriod === 'yearly' || isMultiYearRange(chartPeriod)) {
+        return String(t.year)
+      }
+      if (chartPeriod === 'quarterly') {
+        const q = quarterOf(t.month)
+        switch (tickMarkType) {
+          case TickMarkType.Year:
+            return String(t.year)
+          case TickMarkType.Month:
+            return `Q${q}`
+          default:
+            return `${t.year}Q${q}`
+        }
+      }
+      if (chartPeriod === 'year1') {
+        switch (tickMarkType) {
+          case TickMarkType.Year:
+            return String(t.year)
+          case TickMarkType.Month:
+            return `${t.month}月`
+          default:
+            return `${t.month}/${t.day}`
+        }
+      }
+      if (chartPeriod === 'monthly') {
+        switch (tickMarkType) {
+          case TickMarkType.Year:
+            return String(t.year)
+          case TickMarkType.Month:
+            return `${t.year}-${String(t.month).padStart(2, '0')}`
+          default:
+            return `${t.month}月`
+        }
+      }
+      if (chartPeriod === 'weekly') {
+        switch (tickMarkType) {
+          case TickMarkType.Year:
+            return String(t.year)
+          case TickMarkType.Month:
+            return `${t.month}月`
+          default:
+            return `${t.month}/${t.day}`
+        }
+      }
       switch (tickMarkType) {
         case TickMarkType.Year:
           return String(t.year)
@@ -64,6 +129,9 @@ export function createChartAxisFormatters(timeZone = CN_TIMEZONE) {
 
     const d = timeToDate(time)
     if (!d) return null
+    if (chartPeriod === 'yearly' || isMultiYearRange(chartPeriod)) {
+      return formatYear(d)
+    }
     switch (tickMarkType) {
       case TickMarkType.Year:
         return formatYear(d)

--- a/client-ui/src/market/chartEngine.ts
+++ b/client-ui/src/market/chartEngine.ts
@@ -71,7 +71,7 @@ export class ChartWorkspace {
     const scheme = options.colorScheme ?? 'light'
     const theme = getChartTheme(scheme)
     const chartTimeZone = options.chartTimeZone ?? CN_TIMEZONE
-    const axisFormat = createChartAxisFormatters(chartTimeZone)
+    const axisFormat = createChartAxisFormatters(chartTimeZone, options.period)
 
     try {
       this.mainChart = createChart(refs.main, {
@@ -90,7 +90,7 @@ export class ChartWorkspace {
           borderVisible: false,
           fixLeftEdge: false,
           fixRightEdge: true,
-          timeVisible: true,
+          timeVisible: minuteChart || intradayChart,
           secondsVisible: (minuteChart && options.period === '1m') || intradayChart,
           tickMarkFormatter: axisFormat.tickMarkFormatter,
           ...((minuteChart || intradayChart) ? { barSpacing: 7, minBarSpacing: 2 } : {}),

--- a/client-ui/src/market/chartPeriodOptions.ts
+++ b/client-ui/src/market/chartPeriodOptions.ts
@@ -1,0 +1,44 @@
+import type { ChartPeriod } from '../types/market'
+import type { InstrumentRef } from '../types/instrument'
+import { hasApplicationCapability } from './capabilities'
+
+export interface ChartPeriodOption {
+  id: ChartPeriod
+  label: string
+}
+
+/** 券商 APP 标准周期顺序：日 → 周 → 月 → 季 → 年 */
+const BROKER_KLINE_OPTIONS: ChartPeriodOption[] = [
+  { id: 'daily', label: '日K' },
+  { id: 'weekly', label: '周K' },
+  { id: 'monthly', label: '月K' },
+  { id: 'quarterly', label: '季K' },
+  { id: 'yearly', label: '年K' },
+]
+
+const BASIC_OHLC_OPTIONS: ChartPeriodOption[] = [
+  { id: 'daily', label: '日K' },
+  { id: 'weekly', label: '周K' },
+  { id: 'monthly', label: '月K' },
+]
+
+function cnExtendedOhlc(ref: InstrumentRef, cnEquityChart: boolean): boolean {
+  if (!cnEquityChart) return false
+  return ref.assetClass === 'EQUITY' || ref.assetClass === 'INDEX'
+}
+
+export function buildChartPeriodOptions(
+  ref: InstrumentRef,
+  opts: { cnEquityChart: boolean; crossMarketChart: boolean },
+): ChartPeriodOption[] {
+  if (!hasApplicationCapability(ref, 'chart_daily')) {
+    return BASIC_OHLC_OPTIONS
+  }
+
+  const extendedOhlc = opts.crossMarketChart || cnExtendedOhlc(ref, opts.cnEquityChart)
+  return extendedOhlc ? BROKER_KLINE_OPTIONS : BASIC_OHLC_OPTIONS
+}
+
+export const CN_STOCK_CHART_PERIODS: ReadonlySet<ChartPeriod> = new Set([
+  'daily', 'weekly', 'monthly', 'quarterly', 'yearly',
+])

--- a/client-ui/src/market/chartSeries.ts
+++ b/client-ui/src/market/chartSeries.ts
@@ -1,5 +1,5 @@
 import type { ChartPeriod, IntradayChartBar, OhlcChartBar, StockChartData } from '../types/market'
-import { compareChartTime, isIntradayPeriod, isMinuteOhlcPeriod, chartTimeForPeriod } from './chartTime'
+import { compareChartTime, isIntradayPeriod, isMinuteOhlcPeriod, chartTimeForPeriod, isValidChartTime } from './chartTime'
 import { MARKET_DOWN, MARKET_UP, getMaColors } from './chartTheme'
 import type { ColorScheme } from '../theme/tokens'
 import { getOpptrixTokens } from '../theme/tokens'
@@ -122,6 +122,10 @@ function isLineChartPeriod(period: string, bars: StockChartData['bars']): boolea
   return false
 }
 
+export function isLineChartView(period: string, bars: StockChartData['bars']): boolean {
+  return isLineChartPeriod(period, bars)
+}
+
 /** Normalize API payload → chart-ready series (sorted, deduped, validated). */
 export function buildChartSeries(data: StockChartData, scheme: ColorScheme = 'light'): ChartSeriesBundle {
   const intraday = isLineChartPeriod(data.period, data.bars)
@@ -167,12 +171,25 @@ export function buildChartSeries(data: StockChartData, scheme: ColorScheme = 'li
   }
 
   const bars = data.bars as OhlcChartBar[]
-  const candles = dedupeByTime(bars.map(bar => normalizeOhlc(bar, data.period, tz)))
-  const volume = dedupeByTime(bars.map(bar => ({
-    time: chartTime(bar.time, data.period, tz),
-    value: bar.volume,
-    color: volumeColor(bar.changePct, scheme),
-  })))
+  const candles = dedupeByTime(
+    bars
+      .map(bar => normalizeOhlc(bar, data.period, tz))
+      .filter(c => isValidChartTime(c.time)),
+  )
+  if (candles.length === 0 && bars.length > 0) {
+    throw new Error(`${periodLabel(data.period)} 时间格式无法解析，请稍后重试`)
+  }
+  const volume = dedupeByTime(
+    bars.flatMap(bar => {
+      const time = chartTime(bar.time, data.period, tz)
+      if (!isValidChartTime(time)) return []
+      return [{
+        time,
+        value: bar.volume,
+        color: volumeColor(bar.changePct, scheme),
+      }]
+    }),
+  )
   const macd = dedupeByTime(
     data.indicators
       .filter(row => row.macdHist != null && row.macd != null && row.macdSignal != null)
@@ -231,10 +248,12 @@ const PERIOD_LABELS: Record<ChartPeriod, string> = {
   '30m': '30分',
   '60m': '60分',
   daily: '日K',
-  '5day': '5日K',
+  '5day': '5日',
   weekly: '周K',
   monthly: '月K',
-  year1: '1年',
-  year3: '3年',
-  year5: '5年',
+  quarterly: '季K',
+  yearly: '年K',
+  year1: '近1年日K',
+  year3: '近3年日K',
+  year5: '近5年日K',
 }

--- a/client-ui/src/market/chartTime.ts
+++ b/client-ui/src/market/chartTime.ts
@@ -11,6 +11,11 @@ export function isIntradayPeriod(period: string): boolean {
   return period === 'intraday'
 }
 
+/** 主图左侧 pane 标签：分时 / 5 日折线 / 分钟 K 显示「分」，日周月年 K 显示「K」。 */
+export function isLineChartPaneLabel(period: string): boolean {
+  return isIntradayPeriod(period) || period === '5day' || isMinuteOhlcPeriod(period)
+}
+
 export function isOhlcPeriod(period: string): boolean {
   return period !== 'intraday'
 }
@@ -35,16 +40,63 @@ export function toChartTime(value: string, forceTimestamp = false, timeZone?: st
   return v.slice(0, 10)
 }
 
+/** 日/周/月/年 K — 统一 BusinessDay，避免与 UTC 时间戳混用导致 X 轴错位。 */
+export function toChartBusinessDay(value: string): Time | null {
+  const v = value.trim()
+  if (!v) return null
+
+  if (/^\d{13}$/.test(v)) {
+    const d = new Date(Number(v))
+    if (Number.isNaN(d.getTime())) return null
+    return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() }
+  }
+  if (/^\d{10}$/.test(v)) {
+    const d = new Date(Number(v) * 1000)
+    if (Number.isNaN(d.getTime())) return null
+    return { year: d.getFullYear(), month: d.getMonth() + 1, day: d.getDate() }
+  }
+  if (/^\d{8}$/.test(v)) {
+    const year = Number(v.slice(0, 4))
+    const month = Number(v.slice(4, 6))
+    const day = Number(v.slice(6, 8))
+    if (!year || month < 1 || month > 12 || day < 1 || day > 31) return null
+    return { year, month, day }
+  }
+
+  const normalized = v.replace(/\//g, '-')
+  const datePart = normalized.slice(0, 10)
+  const m = datePart.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!m) return null
+  const year = Number(m[1])
+  const month = Number(m[2])
+  const day = Number(m[3])
+  if (!year || month < 1 || month > 12 || day < 1 || day > 31) return null
+  return { year, month, day }
+}
+
+export function isValidChartTime(time: Time): boolean {
+  if (typeof time === 'number') return Number.isFinite(time) && time > 0
+  if (typeof time === 'string') return /^\d{4}-\d{2}-\d{2}$/.test(time)
+  return (
+    time.year > 0
+    && time.month >= 1 && time.month <= 12
+    && time.day >= 1 && time.day <= 31
+  )
+}
+
 export function timeSortKey(time: Time): number | string {
   if (typeof time === 'number') return time
   if (typeof time === 'string') return time
-  return `${time.year}-${time.month}-${time.day}`
+  return `${time.year}-${String(time.month).padStart(2, '0')}-${String(time.day).padStart(2, '0')}`
 }
 
 export function chartTimeForPeriod(raw: string, period: string, timeZone?: string): Time {
   if (isIntradayPeriod(period)) return toChartTime(raw, true, timeZone)
   if (period === '5day' && (raw.includes(' ') || raw.includes('T'))) return toChartTime(raw, true, timeZone)
-  return toChartTime(raw, isMinuteOhlcPeriod(period), timeZone)
+  if (isMinuteOhlcPeriod(period)) return toChartTime(raw, true, timeZone)
+  const businessDay = toChartBusinessDay(raw)
+  if (businessDay) return businessDay
+  return toChartTime(raw.slice(0, 10), false, timeZone)
 }
 
 function timezoneOffsetSuffix(timeZone: string, localIso: string): string {

--- a/client-ui/src/market/chartViewConfig.ts
+++ b/client-ui/src/market/chartViewConfig.ts
@@ -15,6 +15,8 @@ export function maxChartBars(period: ChartPeriod): number {
     case 'year5': return 1300
     case 'year3': return 780
     case 'year1': return 260
+    case 'quarterly': return 120
+    case 'yearly': return 60
     default: return MAX_CHART_BARS
   }
 }
@@ -28,8 +30,10 @@ export function initialFetchCount(period: ChartPeriod): number {
     case '30m': return 240
     case '60m': return 240
     case '5day': return 120
-    case 'weekly': return 160
-    case 'monthly': return 80
+    case 'weekly': return 200
+    case 'monthly': return 120
+    case 'quarterly': return 80
+    case 'yearly': return 40
     case 'year1': return 260
     case 'year3': return 780
     case 'year5': return 1300
@@ -48,7 +52,9 @@ export function defaultVisibleBars(period: ChartPeriod): number {
     case '60m': return 48
     case '5day': return 48
     case 'weekly': return 52
-    case 'monthly': return 24
+    case 'monthly': return 36
+    case 'quarterly': return 24
+    case 'yearly': return 20
     case 'year1': return 120
     case 'year3': return 180
     case 'year5': return 240

--- a/client-ui/src/market/instrument-adapters.ts
+++ b/client-ui/src/market/instrument-adapters.ts
@@ -46,6 +46,8 @@ export interface UnifiedInstrumentQuoteDto {
   week52_high?: number | null
   week52_low?: number | null
   currency?: string | null
+  quote_session?: string | null
+  session_label?: string | null
 }
 
 export interface UnifiedChartBarDto {
@@ -170,6 +172,8 @@ function quoteDtoToCrossMarket(q: UnifiedInstrumentQuoteDto): CrossMarketQuote {
     week52High: q.week52_high ?? null,
     week52Low: q.week52_low ?? null,
     currency: q.currency ?? null,
+    quoteSession: (q.quote_session as CrossMarketQuote['quoteSession']) ?? undefined,
+    sessionLabel: q.session_label ?? undefined,
   }
 }
 

--- a/client-ui/src/market/instrument-adapters.ts
+++ b/client-ui/src/market/instrument-adapters.ts
@@ -284,7 +284,8 @@ export function unifiedChartToStockChart(
   fallbackCode: string,
 ): StockChartData {
   const period = data.period as ChartPeriod
-  if (period === 'intraday') {
+  const isLinePeriod = period === 'intraday' || period === '5day'
+  if (isLinePeriod) {
     const bars: IntradayChartBar[] = data.bars.map(b => ({
       time: b.time,
       price: b.price ?? b.close ?? 0,

--- a/client-ui/src/market/instrument.ts
+++ b/client-ui/src/market/instrument.ts
@@ -37,7 +37,7 @@ const CN_DOT_SUFFIX = /^(\d{6})\.(SH|SZ|BJ)$/i
 const CN_NAMESPACE = /^CN:(SH|SZ|BJ)[.:](\d{6})$/i
 const CN_FUND_NAMESPACE = /^CN:(?:PF|OF)[.:](\d{6})$/i
 const US_NAMESPACE = /^US:(?:(NYSE|NASDAQ|AMEX)\.)?([A-Z0-9.-]+)$/i
-const HK_NAMESPACE = /^HK:(\d{5})$/i
+const HK_NAMESPACE = /^HK:(?:HK\.)?(\d{1,5})$/i
 const CRYPTO_NAMESPACE = /^CRYPTO:(?:(BINANCE|OKX)\.)?([A-Z0-9]+)\/([A-Z0-9]+)$/i
 
 /** Stock-index 统一命名空间 — 与 @opptrix/shared buildInstrumentNamespace 对齐 */
@@ -95,7 +95,9 @@ function parseInstrumentNamespaceLocal(raw: string): InstrumentRef | null {
   }
   const hk = HK_NAMESPACE.exec(text)
   if (hk) {
-    return { market: 'HK', assetClass: 'EQUITY', symbol: hk[1]!, exchange: 'HK' }
+    const digits = hk[1]!.replace(/\D/g, '')
+    const symbol = digits.length > 5 ? digits.slice(-5) : digits.padStart(5, '0')
+    return { market: 'HK', assetClass: 'EQUITY', symbol, exchange: 'HK' }
   }
   const crypto = CRYPTO_NAMESPACE.exec(text)
   if (crypto) {

--- a/client-ui/src/types/market.ts
+++ b/client-ui/src/types/market.ts
@@ -191,7 +191,7 @@ export interface StockKlineBar {
 export type ChartPeriod =
   | 'intraday'
   | '1m' | '5m' | '15m' | '30m' | '60m'
-  | 'daily' | '5day' | 'weekly' | 'monthly'
+  | 'daily' | '5day' | 'weekly' | 'monthly' | 'quarterly' | 'yearly'
   | 'year1' | 'year3' | 'year5'
 
 export interface IntradayChartBar {

--- a/packages/a-stock-layer/scripts/test-tickflow-apis.mjs
+++ b/packages/a-stock-layer/scripts/test-tickflow-apis.mjs
@@ -7,7 +7,10 @@ import { loadTickflowConfig } from '../dist/providers/tickflow/config.js'
 
 const CN = '600519.SH'
 const CN2 = '000001.SZ'
+const US = 'AAPL.US'
+const HK = '00700.HK'
 const OFFICIAL_PATH_COUNT = 19
+const OFFICIAL_OP_COUNT = 21
 
 const cfg = loadTickflowConfig()
 if (!cfg.apiKey) {
@@ -52,19 +55,31 @@ async function run(name, fn) {
     detail = e instanceof Error ? e.message.slice(0, 100) : String(e).slice(0, 100)
   }
   results[status]++
-  console.log(`${status.padEnd(12)} ${name.padEnd(28)} ${Date.now() - t0}ms ${detail}`)
+  console.log(`${status.padEnd(12)} ${name.padEnd(32)} ${Date.now() - t0}ms ${detail}`)
   return status
 }
 
-console.log('=== TickFlow OpenAPI (19 paths) ===\n')
+console.log('=== TickFlow OpenAPI (19 paths / 21 ops) ===\n')
 
 const tests = [
   ['getExchanges', () => client.getExchanges()],
-  ['getQuotes', () => client.getQuotes({ symbols: CN })],
-  ['postQuotes', () => client.postQuotes({ symbols: [CN, CN2] })],
+  ['getQuotes CN', () => client.getQuotes({ symbols: CN })],
+  ['getQuotes US', () => client.getQuotes({ symbols: US })],
+  ['getQuotes HK', () => client.getQuotes({ symbols: HK })],
+  ['postQuotes', () => client.postQuotes({ symbols: [CN, CN2, US] })],
+  ['getQuotes universes', async () => {
+    const list = await client.getUniverses()
+    const ids = (Array.isArray(list.data) ? list.data : []).slice(0, 1).map(u => String(u.id ?? '')).filter(Boolean)
+    if (!ids.length) return { data: null }
+    return client.getQuotes({ universes: ids.join(',') })
+  }],
   ['getDepth', () => client.getDepth(CN)],
   ['getDepthBatch', () => client.getDepthBatch(`${CN},${CN2}`)],
-  ['getKlines', () => client.getKlines({ symbol: CN, period: '1d', count: 5 })],
+  ['getKlines 1d', () => client.getKlines({ symbol: CN, period: '1d', count: 5 })],
+  ['getKlines 1w US', () => client.getKlines({ symbol: US, period: '1w', count: 10 })],
+  ['getKlines 1M CN', () => client.getKlines({ symbol: CN, period: '1M', count: 5 })],
+  ['getKlines 1Q US', () => client.getKlines({ symbol: US, period: '1Q', count: 5 })],
+  ['getKlines 1Y HK', () => client.getKlines({ symbol: HK, period: '1Y', count: 5 })],
   ['getKlinesBatch', () => client.getKlinesBatch({ symbols: `${CN},${CN2}`, period: '1d', count: 5 })],
   ['getKlinesIntraday', () => client.getKlinesIntraday({ symbol: CN, period: '1m' })],
   ['getKlinesIntradayBatch', () => client.getKlinesIntradayBatch({ symbols: `${CN},${CN2}`, period: '1m' })],
@@ -96,6 +111,6 @@ const tests = [
 for (const [name, fn] of tests) await run(name, fn)
 
 console.log('\n=== Summary ===')
-console.log(`tests=${tests.length} paths=${OFFICIAL_PATH_COUNT}`)
+console.log(`live_tests=${tests.length} official_paths=${OFFICIAL_PATH_COUNT} official_ops=${OFFICIAL_OP_COUNT}`)
 console.log(`OK=${results.OK} EMPTY=${results.EMPTY} SUBSCRIPTION=${results.SUBSCRIPTION} UPSTREAM=${results.UPSTREAM} ERROR=${results.ERROR}`)
 process.exit(results.ERROR > 0 ? 1 : 0)

--- a/packages/a-stock-layer/src/core/custom-methods.ts
+++ b/packages/a-stock-layer/src/core/custom-methods.ts
@@ -173,40 +173,72 @@ const BAOSTOCK_CUSTOM: CustomMethodDef[] = [
 const TICKFLOW_CUSTOM: CustomMethodDef[] = [
   {
     method: 'fetchDepth',
-    description: 'TickFlow 五档盘口深度',
+    description: 'TickFlow 五档盘口深度（GET /v1/depth）',
     params: [
       { name: 'code', type: 'string', description: '股票代码', required: true },
     ],
   },
   {
     method: 'tfDepthBatch',
-    description: 'TickFlow 批量五档盘口',
+    description: 'TickFlow 批量五档盘口（GET /v1/depth/batch）',
     params: [
       { name: 'codes', type: 'string', description: '股票代码数组（invoke 时传 JSON 数组）', required: true },
     ],
   },
   {
     method: 'tfListUniverses',
-    description: 'TickFlow 标的池列表',
+    description: 'TickFlow 标的池列表（GET /v1/universes）',
     params: [],
   },
   {
+    method: 'tfGetUniverse',
+    description: 'TickFlow 单个标的池详情（GET /v1/universes/{id}）',
+    params: [
+      { name: 'id', type: 'string', description: '标的池 ID', required: true },
+    ],
+  },
+  {
     method: 'tfUniverseBatch',
-    description: 'TickFlow 批量标的池详情',
+    description: 'TickFlow 批量标的池详情（POST /v1/universes/batch）',
     params: [
       { name: 'ids', type: 'string', description: '标的池 ID 数组', required: true },
     ],
   },
   {
     method: 'tfExFactors',
-    description: 'TickFlow 除权因子',
+    description: 'TickFlow 除权因子（GET /v1/klines/ex-factors）',
     params: [
       { name: 'code', type: 'string', description: '股票代码', required: true },
     ],
   },
   {
+    method: 'tfKlinesBatch',
+    description: 'TickFlow 批量历史 K 线（GET /v1/klines/batch）',
+    params: [
+      { name: 'codes', type: 'string', description: '股票代码数组', required: true },
+      { name: 'period', type: 'string', description: '周期 1m…1Y，默认 1d' },
+      { name: 'count', type: 'number', description: '根数，默认 120' },
+    ],
+  },
+  {
+    method: 'tfQuotesUniverses',
+    description: 'TickFlow 标的池实时行情（GET /v1/quotes universes=）',
+    params: [
+      { name: 'universeIds', type: 'string', description: '标的池 ID 数组', required: true },
+    ],
+  },
+  {
+    method: 'tfKlinesIntraday',
+    description: 'TickFlow 单标的当日分钟 K（GET /v1/klines/intraday）',
+    params: [
+      { name: 'code', type: 'string', description: '股票代码', required: true },
+      { name: 'period', type: 'string', description: '分钟周期，默认 1m' },
+      { name: 'count', type: 'number', description: '返回条数' },
+    ],
+  },
+  {
     method: 'tfIntradayBatch',
-    description: 'TickFlow 批量当日分钟 K',
+    description: 'TickFlow 批量当日分钟 K（GET /v1/klines/intraday/batch）',
     params: [
       { name: 'codes', type: 'string', description: '股票代码数组', required: true },
     ],

--- a/packages/a-stock-layer/src/core/instrument.ts
+++ b/packages/a-stock-layer/src/core/instrument.ts
@@ -101,13 +101,14 @@ export function toInstrumentRef(
  *  不在这里武断归 CN；返回 'CN' 仅作为兜底，上层应优先经 parseCanonicalInstrumentInput
  *  与 instrument_search 消歧后再构造 InstrumentRef。 */
 export function inferMarketFromSymbol(raw: string): Market {
-  if (/^(US|NYSE|NASDAQ|AMEX):/i.test(raw.trim())) return 'US'
-  if (/^(CRYPTO|BINANCE|OKX):/i.test(raw.trim())) return 'CRYPTO'
-  if (isCryptoPairNotation(raw)) return 'CRYPTO'
   const s = raw.trim()
+  if (/^(US|NYSE|NASDAQ|AMEX):/i.test(s)) return 'US'
+  if (/^(CRYPTO|BINANCE|OKX):/i.test(s)) return 'CRYPTO'
+  // 美股代码优先于「裸字母 = 加密货币 base」启发式（如 AAPL 不应解析为 AAPL/USDT）
+  if (isValidUsSymbol(s)) return 'US'
+  if (isCryptoPairNotation(raw)) return 'CRYPTO'
   // 仅 6 位纯数字可无歧义判为 A 股；短数字码交由上层搜索消歧。
   if (/^\d{6}$/.test(s)) return 'CN'
-  if (isValidUsSymbol(s)) return 'US'
   return 'CN'
 }
 

--- a/packages/a-stock-layer/src/core/schema.ts
+++ b/packages/a-stock-layer/src/core/schema.ts
@@ -211,6 +211,8 @@ export interface StockProfile {
   orgTel?: string
   /** 证券类型（如"主板"、"创业板"、"科创板"） */
   securityType?: string
+  /** 总股本（股） */
+  totalShares?: number
   /** 公司曾用名（如有） */
   formerName?: string
   /** 首次发行价（元） */

--- a/packages/a-stock-layer/src/index.ts
+++ b/packages/a-stock-layer/src/index.ts
@@ -58,6 +58,13 @@ export {
   type HkFdaysDay,
 } from './utils/cross-market-intraday.js'
 export {
+  crossMarketFiveDayMinuteCount,
+  crossMarketIntradayMinuteCount,
+  resolveCrossMarketKlineEngineQuery,
+  type CrossMarketKlineEngineQuery,
+} from './utils/cross-market-kline.js'
+export { resampleOhlcKlines } from './utils/kline-resample.js'
+export {
   parseStockMarket,
   resolveStockMarketCode,
   isShIndexCode,

--- a/packages/a-stock-layer/src/providers/stockindex/normalize.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/normalize.ts
@@ -5,6 +5,7 @@ import {
   instrumentRefLabel,
   normalizeInstrumentRef,
   parseInstrumentNamespace,
+  parseCanonicalInstrumentInput,
 } from '@opptrix/shared'
 import type { StockIndexItem } from './api/client.js'
 import { stockIndexItemLooksLikeCnPublicFund } from '../../core/fund-instrument.js'
@@ -21,7 +22,9 @@ export function stockIndexItemToInstrumentRef(item: StockIndexItem): InstrumentR
   if (!code) return null
 
   const instrumentIdStr = String(item.instrumentId ?? '').trim()
-  const fromId = instrumentIdStr ? parseInstrumentNamespace(instrumentIdStr) : null
+  const fromId = instrumentIdStr
+    ? (parseInstrumentNamespace(instrumentIdStr) ?? parseCanonicalInstrumentInput(instrumentIdStr))
+    : null
 
   if (market === 'CN') {
     if (fromId && (fromId.assetClass === 'FUND' || String(fromId.exchange ?? '').toUpperCase() === 'PF')) {

--- a/packages/a-stock-layer/src/providers/tickflow/API-COVERAGE.md
+++ b/packages/a-stock-layer/src/providers/tickflow/API-COVERAGE.md
@@ -60,13 +60,13 @@ driver.ts + manifest.ts → applyManifestSpec + bindingsFor
 | Capability | Handler 方法 | 市场 | 备注 |
 |---|---|---|---|
 | `STOCK_REALTIME` | `realtime()` / `batchRealtime()` | CN / US / HK | GET/POST quotes |
-| `STOCK_KLINE` | `kline()` | CN / US / HK | `/v1/klines`；A 股默认前复权加法 |
+| `STOCK_KLINE` | `kline()` | CN / US / HK | `GET /v1/klines` + **period**（1m…1Y）；A 股默认前复权加法 |
 | `STOCK_LIST` | `stockList()` | CN / US / HK | 交易所列表或 Universe |
 | `STOCK_BASIC` | `stockBasic()` | CN / US / HK | `/v1/instruments` |
 | `STOCK_PROFILE` | `profile()` | CN / US / HK | `/v1/instruments` |
 | `INDEX_REALTIME` | `indexRealtime()` | CN | 复用 quotes |
 | `INDEX_KLINE` | `indexKline()` | CN | 复用 klines |
-| `INTRADAY_TICK` | `intradayTick()` / `fetchIntradaySessions()` | CN | 当日 `/v1/klines/intraday` |
+| `INTRADAY_TICK` | `intradayTick()` / `fetchIntradaySessions()` | CN / US / HK | `GET /v1/klines` + `period=1m` |
 | `FINANCIAL_SUMMARY` | `financials()` | CN | metrics + income |
 | `BALANCE_SHEET` | `balanceSheet()` | CN | |
 | `INCOME_STMT` | `incomeStatement()` | CN | |
@@ -84,9 +84,13 @@ driver.ts + manifest.ts → applyManifestSpec + bindingsFor
 | `fetchDepth` | `GET /v1/depth` | 五档盘口 |
 | `tfDepthBatch` | `GET /v1/depth/batch` | 批量五档 |
 | `tfListUniverses` | `GET /v1/universes` | 标的池列表 |
+| `tfGetUniverse` | `GET /v1/universes/{id}` | 单个标的池 |
 | `tfUniverseBatch` | `POST /v1/universes/batch` | 批量标的池 |
 | `tfExFactors` | `GET /v1/klines/ex-factors` | 除权因子 |
-| `tfIntradayBatch` | `GET /v1/klines/intraday/batch` | 批量当日分时 |
+| `tfKlinesBatch` | `GET /v1/klines/batch` | 批量历史 K 线 |
+| `tfQuotesUniverses` | `GET /v1/quotes`（`universes`） | 标的池实时行情 |
+| `tfKlinesIntraday` | `GET /v1/klines/intraday` | 单标的当日分钟 K |
+| `tfIntradayBatch` | `GET /v1/klines/intraday/batch` | 批量当日分钟 K |
 
 ---
 
@@ -100,7 +104,7 @@ driver.ts + manifest.ts → applyManifestSpec + bindingsFor
 |---|---|
 | `GET /v1/exchanges` | 交易所列表 |
 | `GET/POST /v1/quotes` | 实时行情（单只/批量） |
-| `GET /v1/klines` | 日/周/月 K 线（单标的） |
+| `GET /v1/klines` | 日/周/月/季/年 K 线（单标的，`period`：1d/1w/1M/1Q/1Y） |
 | `GET/POST /v1/instruments` | 标的基础信息 |
 | `GET /v1/exchanges/{exchange}/instruments` | 交易所成分列表 |
 | `GET /v1/universes` / `{id}` / `batch` | 标的池 |
@@ -139,7 +143,8 @@ driver.ts + manifest.ts → applyManifestSpec + bindingsFor
 |---|---|
 | **API Key 必填** | 未配置时 `fromConfig()` 返回 `null`，驱动静默跳过 |
 | **财务 / 股本** | 主要为 A 股；manifest 仅绑定 CN/EQUITY |
-| **分时** | `/v1/klines/intraday` 仅**当日**分钟 K，不含历史多日 |
+| **分时** | 统一 `GET /v1/klines` + `period=1m`（免费档可用）；`/v1/klines/intraday` 仅扩展方法 `tfIntradayBatch` 等可选路径 |
+| **图表周期** | `resolveTickflowKlineQuery`：UI 周期 → klines `period` + `count` |
 | **指数路由** | 引擎 `indexRealtime` / `indexKline` 使用 `CN/INDEX` scope |
 
 ---

--- a/packages/a-stock-layer/src/providers/tickflow/api/probe.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/api/probe.ts
@@ -22,6 +22,7 @@ const PROBE_CHECKS: ProbeItem[] = [
   { feature: 'depth', run: c => c.getDepth(PROBE_SYMBOL) },
   { feature: 'kline_batch', run: c => c.getKlinesBatch({ symbols: `${PROBE_SYMBOL},${PROBE_SYMBOL2}`, period: '1d', count: 1 }) },
   { feature: 'intraday', run: c => c.getKlinesIntraday({ symbol: PROBE_SYMBOL, period: '1m' }) },
+  { feature: 'intraday_batch', run: c => c.getKlinesIntradayBatch({ symbols: `${PROBE_SYMBOL},${PROBE_SYMBOL2}`, period: '1m' }) },
   { feature: 'financial', run: c => c.getFinancialsMetrics({ symbols: PROBE_SYMBOL, latest: true }) },
   { feature: 'ex_factors', run: c => c.getKlinesExFactors({ symbols: PROBE_SYMBOL }) },
 ]

--- a/packages/a-stock-layer/src/providers/tickflow/api/symbols.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/api/symbols.ts
@@ -1,4 +1,5 @@
 import type { Market } from '@opptrix/shared'
+import { canonicalHkSymbol } from '@opptrix/shared'
 import { inferMarketFromSymbol, isCnEtfCode } from '../../../core/instrument.js'
 import { normalizeCode, resolveStockMarketCode } from '../../../utils/helpers.js'
 import { normalizeUsSymbol } from '../../../utils/us-market.js'
@@ -76,7 +77,9 @@ export function parseTickflowSymbol(symbol: string): ParsedTickflowSymbol {
   const market = TICKFLOW_SUFFIX[suffix]
   if (!market) throw new Error(`未知的 TickFlow 交易所后缀：${suffix}`)
   if (suffix === 'US') return { code: normalizeUsSymbol(code), market, exchange: suffix }
-  if (suffix === 'HK') return { code: code.replace(/^0+/, '') || '0', market, exchange: suffix }
+  if (suffix === 'HK') {
+    return { code: canonicalHkSymbol(code), market, exchange: suffix }
+  }
   return { code: normalizeCode(code), market, exchange: suffix }
 }
 

--- a/packages/a-stock-layer/src/providers/tickflow/manifest.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/manifest.ts
@@ -31,8 +31,8 @@ const TICKFLOW_CN_INDEX_CAPS = [
   Capability.INDEX_KLINE,
 ]
 
-/** A 股个股分时（TickFlow /v1/klines/intraday，仅当日） */
-const TICKFLOW_CN_INTRADAY_CAPS = [Capability.INTRADAY_TICK]
+/** A 股 / 美股 / 港股分时（TickFlow /v1/klines/intraday，仅当日） */
+const TICKFLOW_INTRADAY_CAPS = [Capability.INTRADAY_TICK]
 
 const TICKFLOW_FREE_ETF_CAPS = [
   ...FREE_CN_ETF_CAPABILITIES,
@@ -44,7 +44,7 @@ export const TICKFLOW_CAPS = [
   ...TICKFLOW_EQUITY_CAPS,
   ...TICKFLOW_CN_EXPERT_CAPS,
   ...TICKFLOW_CN_INDEX_CAPS,
-  ...TICKFLOW_CN_INTRADAY_CAPS,
+  ...TICKFLOW_INTRADAY_CAPS,
   ...FREE_CN_ETF_CAPABILITIES,
 ]
 
@@ -57,15 +57,15 @@ export const TICKFLOW_SPEC: ProviderManifestSpec = {
   maxConcurrent: 5,
   capabilities: TICKFLOW_CAPS,
   bindingsFor: (p, maxConcurrent) => [
-    ...usEquityBindings(TICKFLOW_EQUITY_CAPS, p, maxConcurrent),
+    ...usEquityBindings([...TICKFLOW_EQUITY_CAPS, ...TICKFLOW_INTRADAY_CAPS], p, maxConcurrent),
     ...cnEquityEtfIndex(
-      [...TICKFLOW_EQUITY_CAPS, ...TICKFLOW_CN_EXPERT_CAPS, ...TICKFLOW_CN_INTRADAY_CAPS],
+      [...TICKFLOW_EQUITY_CAPS, ...TICKFLOW_CN_EXPERT_CAPS, ...TICKFLOW_INTRADAY_CAPS],
       TICKFLOW_CN_INDEX_CAPS,
       p,
       TICKFLOW_FREE_ETF_CAPS,
       maxConcurrent,
     ),
-    ...regionalEquityBindings('HK', TICKFLOW_EQUITY_CAPS, p, maxConcurrent),
+    ...regionalEquityBindings('HK', [...TICKFLOW_EQUITY_CAPS, ...TICKFLOW_INTRADAY_CAPS], p, maxConcurrent),
   ],
   settings: TICKFLOW_SETTINGS,
   supportsTest: true,

--- a/packages/a-stock-layer/src/providers/tickflow/markets/common.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/markets/common.ts
@@ -15,6 +15,7 @@ import { isTickflowFeatureAllowed } from '../api/permissions.js'
 import { MarketHandlerShell } from '../../common/driver-factory.js'
 import {
   expandCompactKlines,
+  inferMarketFromBareCode,
   mapTickflowInstrumentListItems,
   mapTickflowInstrumentProfiles,
   mergeFinancialSummary,
@@ -139,7 +140,11 @@ export abstract class TickflowCommonHandler extends MarketHandlerShell {
   protected abstract client(): TickflowClient | null
 
   protected tickflowSymbol(code: string): string {
-    return toTickflowSymbol(code)
+    const raw = code.trim()
+    if (/\.(SH|SZ|BJ|US|HK)$/i.test(raw)) return toTickflowSymbol(raw)
+    const bare = raw.replace(/^(US|NYSE|NASDAQ|AMEX|HK):/i, '').trim()
+    const market = inferMarketFromBareCode(bare)
+    return toTickflowSymbol(market, bare)
   }
 
   async stockList(market = 'CN', keyword = ''): Promise<StockListItem[] | null> {

--- a/packages/a-stock-layer/src/providers/tickflow/markets/common.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/markets/common.ts
@@ -26,6 +26,9 @@ import {
   rowsForSymbol,
   mapTickflowDepth,
   mapTickflowQuotes,
+  resolveTickflowKlineQuery,
+  ymdToMs,
+  type ResolvedTickflowKlineQuery,
   type TickflowMarketDepth,
 } from '../normalize/index.js'
 import {
@@ -135,6 +138,15 @@ function buildFinancialsQuery(symbol: string, reportDate = '') {
   }
 }
 
+function normalizeYmdTickflow(input: string): string {
+  const raw = input.trim()
+  if (!raw) return ''
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw
+  const digits = raw.replace(/\D/g, '')
+  if (digits.length === 8) return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
+  return raw.slice(0, 10)
+}
+
 /** Metadata, financials, depth, and intraday helpers shared by TickflowMarketHandler. */
 export abstract class TickflowCommonHandler extends MarketHandlerShell {
   protected abstract client(): TickflowClient | null
@@ -145,6 +157,51 @@ export abstract class TickflowCommonHandler extends MarketHandlerShell {
     const bare = raw.replace(/^(US|NYSE|NASDAQ|AMEX|HK):/i, '').trim()
     const market = inferMarketFromBareCode(bare)
     return toTickflowSymbol(market, bare)
+  }
+
+  /**
+   * 统一 `GET /v1/klines` — 通过 query.period 指定周期（官方支持 1m…1Y）。
+   */
+  protected async fetchKlinesResolved(
+    code: string,
+    resolved: ResolvedTickflowKlineQuery,
+    start = '',
+    end = '',
+    countOverride?: number,
+  ): Promise<StockKline[] | null> {
+    const client = this.client()
+    if (!client) return null
+    const symbol = this.tickflowSymbol(code)
+    const region = tickflowRegion(symbol)
+    if (!region) return null
+
+    const tfPeriod = resolved.tfPeriod
+    const effectiveCount = countOverride ?? resolved.count
+    const query = {
+      symbol,
+      period: tfPeriod,
+      adjust: region === 'CN' ? 'forward_additive' as const : undefined,
+      count: undefined as number | undefined,
+      start_time: undefined as number | undefined,
+      end_time: undefined as number | undefined,
+    }
+    if (effectiveCount != null && effectiveCount > 0) query.count = Math.min(effectiveCount, 10000)
+    const startYmd = normalizeYmdTickflow(start)
+    const endYmd = normalizeYmdTickflow(end)
+    if (startYmd) query.start_time = ymdToMs(startYmd)
+    if (endYmd) query.end_time = ymdToMs(endYmd, true)
+
+    try {
+      const json = await client.getKlines(query)
+      const data = json.data as CompactKlineData | undefined
+      if (!data) return null
+      let rows = expandCompactKlines(symbol, data, tfPeriod, region)
+      const cap = effectiveCount
+      if (cap && rows.length > cap) rows = rows.slice(-cap)
+      return rows.length ? rows : null
+    } catch {
+      return null
+    }
   }
 
   async stockList(market = 'CN', keyword = ''): Promise<StockListItem[] | null> {
@@ -337,7 +394,7 @@ export abstract class TickflowCommonHandler extends MarketHandlerShell {
     }
   }
 
-  /** Optional research helper — TickFlow five-level depth. */
+  /** TickFlow 五档盘口 — `GET /v1/depth` */
   async fetchDepth(code: string): Promise<Record<string, unknown> | null> {
     if (!isTickflowFeatureAllowed('depth')) return null
     const client = this.client()
@@ -353,21 +410,28 @@ export abstract class TickflowCommonHandler extends MarketHandlerShell {
     }
   }
 
-  /** Intraday sessions via TickFlow /v1/klines/intraday (API: 当日分钟 K，不含历史多日). */
+  /** 分时多日 — `GET /v1/klines` period=1m，按日拆 session（非 intraday 专用端点）。 */
   async fetchIntradaySessions(
     code: string,
-    _ndays = 5,
+    ndays = 5,
     _market?: StockMarket,
   ): Promise<IntradayTrendFetchResult | null> {
-    if (!isTickflowFeatureAllowed('intraday')) return null
+    const uiPeriod = ndays >= 5 ? '5day' : 'intraday'
+    const resolved = resolveTickflowKlineQuery(uiPeriod)
+    if (!resolved) return null
     const client = this.client()
     if (!client) return null
     const symbol = this.tickflowSymbol(code)
     try {
-      const json = await client.getKlinesIntraday({ symbol, period: '1m' })
+      const json = await client.getKlines({
+        symbol,
+        period: resolved.tfPeriod,
+        count: resolved.count,
+        adjust: tickflowRegion(symbol) === 'CN' ? 'forward_additive' : undefined,
+      })
       const data = json.data as CompactKlineData | undefined
       if (!data) return null
-      return compactKlineToIntradaySessions(symbol, data, '1m')
+      return compactKlineToIntradaySessions(symbol, data, resolved.tfPeriod)
     } catch {
       return null
     }
@@ -375,42 +439,25 @@ export abstract class TickflowCommonHandler extends MarketHandlerShell {
 
   async minuteTrendKline(
     code: string,
-    _ndays = 1,
+    ndays = 1,
     count = 0,
     _market?: StockMarket,
   ): Promise<StockKline[] | null> {
-    if (!isTickflowFeatureAllowed('intraday')) return null
-    const client = this.client()
-    if (!client) return null
-    const symbol = this.tickflowSymbol(code)
-    const region = tickflowRegion(symbol)
-    if (!region) return null
-    try {
-      const json = await client.getKlinesIntraday({
-        symbol,
-        period: '1m',
-        count: count > 0 ? count : undefined,
-      })
-      const data = json.data as CompactKlineData | undefined
-      if (!data) return null
-      let rows = expandCompactKlines(symbol, data, '1m', region)
-      if (count > 0 && rows.length > count) rows = rows.slice(-count)
-      return rows.length ? rows : null
-    } catch {
-      return null
-    }
+    const uiPeriod = ndays >= 5 ? '5day' : 'intraday'
+    const resolved = resolveTickflowKlineQuery(uiPeriod, count > 0 ? count : undefined)
+    if (!resolved) return null
+    return this.fetchKlinesResolved(code, resolved, '', '', count > 0 ? count : undefined)
   }
 
   /**
    * 当日分时逐条记录 — Capability `INTRADAY_TICK` 标准方法。
    *
-   * TickFlow 仅提供当日分钟 K；`date` 参数保留与引擎接口一致。
+   * 数据来自 `GET /v1/klines` + period=1m；`date` 参数保留与引擎接口一致。
    *
    * @param code 6 位股票代码
-   * @param _date 保留参数（TickFlow 仅当日）
+   * @param _date 保留参数
    */
   async intradayTick(code: string, _date = ''): Promise<Record<string, unknown>[] | null> {
-    if (!isTickflowFeatureAllowed('intraday')) return null
     const rows = await this.minuteTrendKline(code, 1, 0)
     if (!rows) return null
     return rows.map(bar => ({

--- a/packages/a-stock-layer/src/providers/tickflow/markets/extensions.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/markets/extensions.ts
@@ -1,5 +1,12 @@
-import type { TickflowClient } from '../api/client.js'
-import { mapTickflowDepth, type TickflowMarketDepth } from '../normalize/index.js'
+import type { TickflowClient, TickflowPeriod } from '../api/client.js'
+import type { CompactKlineData } from '../api/client.js'
+import {
+  expandCompactKlines,
+  mapTickflowDepth,
+  mapTickflowQuotes,
+  type TickflowMarketDepth,
+} from '../normalize/index.js'
+import { tickflowRegion } from '../api/symbols.js'
 import { isTickflowFeatureAllowed } from '../api/permissions.js'
 import type { TickflowMarketHandler } from './handler.js'
 
@@ -8,8 +15,16 @@ type TickflowHandler = TickflowMarketHandler & {
   tickflowSymbol(code: string): string
   tfDepthBatch?(codes: string[]): Promise<Record<string, unknown>[] | null>
   tfListUniverses?(): Promise<Record<string, unknown>[] | null>
+  tfGetUniverse?(id: string): Promise<Record<string, unknown> | null>
   tfUniverseBatch?(ids: string[]): Promise<Record<string, unknown>[] | null>
   tfExFactors?(code: string, startMs?: number, endMs?: number): Promise<Record<string, unknown>[] | null>
+  tfKlinesBatch?(
+    codes: string[],
+    period?: TickflowPeriod,
+    count?: number,
+  ): Promise<Record<string, unknown>[] | null>
+  tfQuotesUniverses?(universeIds: string[]): Promise<Record<string, unknown>[] | null>
+  tfKlinesIntraday?(code: string, period?: TickflowPeriod, count?: number): Promise<Record<string, unknown> | null>
   tfIntradayBatch?(codes: string[], period?: '1m' | '5m' | '15m' | '30m' | '60m'): Promise<Record<string, unknown>[] | null>
 }
 
@@ -21,8 +36,6 @@ export function mixTickflowExtensions(Driver: { prototype: TickflowMarketHandler
 
   /**
    * 批量五档盘口 — `GET /v1/depth/batch`。
-   *
-   * @param codes 股票代码数组
    */
   p.tfDepthBatch = async function tfDepthBatch(
     codes: string[],
@@ -58,9 +71,23 @@ export function mixTickflowExtensions(Driver: { prototype: TickflowMarketHandler
   }
 
   /**
+   * 单个标的池详情 — `GET /v1/universes/{id}`。
+   */
+  p.tfGetUniverse = async function tfGetUniverse(id: string): Promise<Record<string, unknown> | null> {
+    const client = this.client()
+    if (!client || !id.trim()) return null
+    try {
+      const json = await client.getUniverse(id.trim())
+      const data = json.data
+      if (!data || typeof data !== 'object') return null
+      return data as Record<string, unknown>
+    } catch {
+      return null
+    }
+  }
+
+  /**
    * 批量标的池详情 — `POST /v1/universes/batch`。
-   *
-   * @param ids 标的池 ID 列表
    */
   p.tfUniverseBatch = async function tfUniverseBatch(
     ids: string[],
@@ -70,6 +97,9 @@ export function mixTickflowExtensions(Driver: { prototype: TickflowMarketHandler
     try {
       const json = await client.postUniversesBatch({ ids })
       const rows = json.data
+      if (!Array.isArray(rows) && rows && typeof rows === 'object') {
+        return Object.values(rows as Record<string, Record<string, unknown>>)
+      }
       if (!Array.isArray(rows) || !rows.length) return null
       return rows as Record<string, unknown>[]
     } catch {
@@ -79,10 +109,6 @@ export function mixTickflowExtensions(Driver: { prototype: TickflowMarketHandler
 
   /**
    * 除权因子 — `GET /v1/klines/ex-factors`。
-   *
-   * @param code 6 位股票代码
-   * @param startMs 起始时间戳（毫秒），可选
-   * @param endMs 结束时间戳（毫秒），可选
    */
   p.tfExFactors = async function tfExFactors(
     code: string,
@@ -110,16 +136,94 @@ export function mixTickflowExtensions(Driver: { prototype: TickflowMarketHandler
   }
 
   /**
+   * 批量历史 K 线 — `GET /v1/klines/batch`。
+   */
+  p.tfKlinesBatch = async function tfKlinesBatch(
+    codes: string[],
+    period: TickflowPeriod = '1d',
+    count = 120,
+  ): Promise<Record<string, unknown>[] | null> {
+    if (!isTickflowFeatureAllowed('kline_batch')) return null
+    const client = this.client()
+    if (!client || !codes.length) return null
+    const symbols = codes.map(c => this.tickflowSymbol(c)).join(',')
+    try {
+      const json = await client.getKlinesBatch({
+        symbols,
+        period,
+        count: Math.min(Math.max(count, 1), 10000),
+      })
+      const data = json.data as Record<string, CompactKlineData> | undefined
+      if (!data || typeof data !== 'object') return null
+      const out: Record<string, unknown>[] = []
+      for (const [sym, payload] of Object.entries(data)) {
+        const region = tickflowRegion(sym)
+        if (!region || !payload) continue
+        const bars = expandCompactKlines(sym, payload, period, region)
+        out.push({ symbol: sym, period, bars })
+      }
+      return out.length ? out : null
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * 标的池实时行情 — `GET /v1/quotes`（universes 参数）。
+   */
+  p.tfQuotesUniverses = async function tfQuotesUniverses(
+    universeIds: string[],
+  ): Promise<Record<string, unknown>[] | null> {
+    const client = this.client()
+    if (!client || !universeIds.length) return null
+    const universes = universeIds.map(id => id.trim()).filter(Boolean).join(',')
+    if (!universes) return null
+    try {
+      const json = await client.getQuotes({ universes })
+      const rows = mapTickflowQuotes(json.data)
+      return rows.length ? rows as unknown as Record<string, unknown>[] : null
+    } catch {
+      return null
+    }
+  }
+
+  /**
+   * 单标的当日分钟 K — `GET /v1/klines/intraday`。
+   */
+  p.tfKlinesIntraday = async function tfKlinesIntraday(
+    code: string,
+    period: TickflowPeriod = '1m',
+    count?: number,
+  ): Promise<Record<string, unknown> | null> {
+    if (!isTickflowFeatureAllowed('intraday')) return null
+    const client = this.client()
+    if (!client) return null
+    const symbol = this.tickflowSymbol(code)
+    const region = tickflowRegion(symbol)
+    if (!region) return null
+    try {
+      const json = await client.getKlinesIntraday({
+        symbol,
+        period,
+        count: count != null && count > 0 ? count : undefined,
+      })
+      const data = json.data as CompactKlineData | undefined
+      if (!data) return null
+      const bars = expandCompactKlines(symbol, data, period, region)
+      return { symbol, period, bars }
+    } catch {
+      return null
+    }
+  }
+
+  /**
    * 批量当日分钟 K — `GET /v1/klines/intraday/batch`。
-   *
-   * @param codes 股票代码数组
-   * @param period 分钟周期，默认 `1m`
    */
   p.tfIntradayBatch = async function tfIntradayBatch(
     codes: string[],
     period: '1m' | '5m' | '15m' | '30m' | '60m' = '1m',
   ): Promise<Record<string, unknown>[] | null> {
-    if (!isTickflowFeatureAllowed('intraday')) return null
+    if (!isTickflowFeatureAllowed('intraday_batch')) return null
     const client = this.client()
     if (!client || !codes.length) return null
     const symbols = codes.map(c => this.tickflowSymbol(c)).join(',')
@@ -129,7 +233,7 @@ export function mixTickflowExtensions(Driver: { prototype: TickflowMarketHandler
       if (!data || typeof data !== 'object') return null
       const out: Record<string, unknown>[] = []
       for (const [sym, payload] of Object.entries(data as Record<string, unknown>)) {
-        out.push({ symbol: sym, data: payload })
+        out.push({ symbol: sym, period, data: payload })
       }
       return out.length ? out : null
     } catch {

--- a/packages/a-stock-layer/src/providers/tickflow/markets/handler.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/markets/handler.ts
@@ -1,27 +1,14 @@
 import type { StockKline, StockRealtime } from '@opptrix/shared'
 import type { IndexKline } from '../../../core/schema.js'
-import type { CompactKlineData } from '../api/client.js'
-import { TickflowClient, type TickflowAdjustType, type TickflowPeriod } from '../api/client.js'
-import { tickflowRegion } from '../api/symbols.js'
 import { isCnEtfCode } from '../../../core/instrument.js'
 import { mapKlinesToEtfNavRows } from '../../common/etf.js'
 import { isTickflowEnabled } from '../config.js'
-import {
-  expandCompactKlines,
-  mapTickflowQuotes,
-  opptrixPeriodToTickflow,
-  ymdToMs,
-} from '../normalize/index.js'
+import { mapTickflowQuotes, resolveTickflowKlineQuery } from '../normalize/index.js'
+import { TickflowClient } from '../api/client.js'
 import { TickflowCommonHandler } from './common.js'
 
-function normalizeYmd(input: string): string {
-  const raw = input.trim()
-  if (!raw) return ''
-  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) return raw
-  const digits = raw.replace(/\D/g, '')
-  if (digits.length === 8) return `${digits.slice(0, 4)}-${digits.slice(4, 6)}-${digits.slice(6, 8)}`
-  return raw.slice(0, 10)
-}
+/** GET /v1/quotes 批量 URL 长度友好上限（超出用 POST /v1/quotes） */
+const QUOTES_GET_MAX_SYMBOLS = 12
 
 /** TickFlow — CN / US / HK equities & indices (API Key required) */
 
@@ -31,10 +18,7 @@ export class TickflowMarketHandler extends TickflowCommonHandler {
     return TickflowClient.fromConfig()
   }
 
-  private cnAdjust(symbol: string): TickflowAdjustType | undefined {
-    return tickflowRegion(symbol) === 'CN' ? 'forward_additive' : undefined
-  }
-
+  /** 实时行情 — `GET /v1/quotes`（单标的或少量逗号分隔 symbols） */
   async realtime(code: string): Promise<StockRealtime[] | null> {
     const client = this.client()
     if (!client) return null
@@ -48,12 +32,15 @@ export class TickflowMarketHandler extends TickflowCommonHandler {
     }
   }
 
+  /** 批量实时行情 — `GET /v1/quotes` 或 `POST /v1/quotes`（大批量） */
   async batchRealtime(codes: string[]): Promise<StockRealtime[] | null> {
     const client = this.client()
     if (!client || !codes.length) return null
     const symbols = codes.map(c => this.tickflowSymbol(c))
     try {
-      const json = await client.postQuotes({ symbols })
+      const json = symbols.length <= QUOTES_GET_MAX_SYMBOLS
+        ? await client.getQuotes({ symbols: symbols.join(',') })
+        : await client.postQuotes({ symbols })
       const rows = mapTickflowQuotes(json.data)
       return rows.length ? rows : null
     } catch {
@@ -68,41 +55,9 @@ export class TickflowMarketHandler extends TickflowCommonHandler {
     end = '',
     count?: number,
   ): Promise<StockKline[] | null> {
-    const tfPeriod = opptrixPeriodToTickflow(period) as TickflowPeriod | null
-    if (!tfPeriod) return null
-
-    const client = this.client()
-    if (!client) return null
-
-    const symbol = this.tickflowSymbol(code)
-    const region = tickflowRegion(symbol)
-    if (!region) return null
-
-    const query = {
-      symbol,
-      period: tfPeriod,
-      adjust: this.cnAdjust(symbol),
-      count: undefined as number | undefined,
-      start_time: undefined as number | undefined,
-      end_time: undefined as number | undefined,
-    }
-    if (count != null && count > 0) query.count = Math.min(count, 10000)
-    const startYmd = normalizeYmd(start)
-    const endYmd = normalizeYmd(end)
-    if (startYmd) query.start_time = ymdToMs(startYmd)
-    if (endYmd) query.end_time = ymdToMs(endYmd, true)
-    if (!startYmd && !endYmd && count) query.count = Math.min(count, 10000)
-
-    try {
-      const json = await client.getKlines(query)
-      const data = json.data as CompactKlineData | undefined
-      if (!data) return null
-      let rows = expandCompactKlines(symbol, data, tfPeriod, region)
-      if (count && rows.length > count) rows = rows.slice(-count)
-      return rows.length ? rows : null
-    } catch {
-      return null
-    }
+    const resolved = resolveTickflowKlineQuery(period, count)
+    if (!resolved) return null
+    return this.fetchKlinesResolved(code, resolved, start, end, count)
   }
 
   async indexRealtime(code: string) {

--- a/packages/a-stock-layer/src/providers/tickflow/normalize/index.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/normalize/index.ts
@@ -3,8 +3,10 @@ export {
   expandCompactKlines,
   isIntradayTickflowPeriod,
   opptrixPeriodToTickflow,
+  resolveTickflowKlineQuery,
   timestampToKlineDate,
   ymdToMs,
+  type ResolvedTickflowKlineQuery,
 } from './klines.js'
 export {
   mapTickflowInstrumentToListItem,

--- a/packages/a-stock-layer/src/providers/tickflow/normalize/instruments.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/normalize/instruments.ts
@@ -8,6 +8,44 @@ function extField(ext: Record<string, unknown> | null | undefined, key: string):
   return ext[key]
 }
 
+function strField(v: unknown): string | undefined {
+  if (v == null || v === '') return undefined
+  const s = String(v).trim()
+  return s || undefined
+}
+
+function listingDateFromInstrument(inst: TickflowInstrument, ext: Record<string, unknown>): string | undefined {
+  const fromExt = extField(ext, 'listing_date') ?? extField(ext, 'list_date')
+  if (fromExt != null) {
+    const text = String(fromExt).trim()
+    if (/^\d{4}-\d{2}-\d{2}/.test(text)) return text.slice(0, 10)
+    const n = Number(text)
+    if (Number.isFinite(n) && n > 0) {
+      const ms = n > 1e12 ? n : n * 1000
+      return new Date(ms).toISOString().slice(0, 10)
+    }
+  }
+  if (inst.list_date != null) {
+    const n = Number(inst.list_date)
+    if (Number.isFinite(n) && n > 0) {
+      const ms = n > 1e12 ? n : n * 1000
+      return new Date(ms).toISOString().slice(0, 10)
+    }
+  }
+  return undefined
+}
+
+function industryFromInstrument(inst: TickflowInstrument, ext: Record<string, unknown>): string | undefined {
+  const industry = strField(extField(ext, 'industry'))
+    ?? strField(extField(ext, 'sector'))
+    ?? strField(extField(ext, 'industry_name'))
+    ?? strField(extField(ext, 'gics_sector'))
+  if (industry) return industry
+  const type = strField(inst.type ?? inst.symbol_type)
+  if (type && type.toLowerCase() !== 'stock') return type
+  return undefined
+}
+
 function listMarket(inst: TickflowInstrument): string {
   const region = String(inst.region ?? '').toUpperCase()
   if (region === 'US') return 'US'
@@ -17,10 +55,11 @@ function listMarket(inst: TickflowInstrument): string {
 
 export function mapTickflowInstrumentToListItem(inst: TickflowInstrument): StockListItem {
   const { code } = parseTickflowSymbol(inst.symbol)
+  const ext = (inst.ext ?? {}) as Record<string, unknown>
   return {
     code,
     name: String(inst.name ?? code),
-    industry: String(inst.type ?? inst.symbol_type ?? ''),
+    industry: industryFromInstrument(inst, ext) ?? String(inst.type ?? inst.symbol_type ?? ''),
     market: listMarket(inst),
   }
 }
@@ -28,23 +67,44 @@ export function mapTickflowInstrumentToListItem(inst: TickflowInstrument): Stock
 export function mapTickflowInstrumentToProfile(inst: TickflowInstrument): StockProfile {
   const { code, market } = parseTickflowSymbol(inst.symbol)
   const ext = (inst.ext ?? {}) as Record<string, unknown>
-  const listingDate = extField(ext, 'listing_date')
-  const totalShares = extField(ext, 'total_shares')
+  const listingDate = listingDateFromInstrument(inst, ext)
+  const totalSharesRaw = extField(ext, 'total_shares') ?? extField(ext, 'total_share')
   const floatShares = extField(ext, 'float_shares')
 
   const profile: StockProfile = {
     code,
     name: String(inst.name ?? code),
-    listingDate: listingDate != null ? String(listingDate).slice(0, 10) : undefined,
-    securityType: inst.type != null ? String(inst.type) : inst.symbol_type != null ? String(inst.symbol_type) : undefined,
+    listingDate,
+    securityType: strField(inst.exchange)
+      ?? (inst.type != null ? String(inst.type) : inst.symbol_type != null ? String(inst.symbol_type) : undefined),
+    industry: industryFromInstrument(inst, ext),
+    website: strField(extField(ext, 'website') ?? extField(ext, 'web_site')),
+    orgProfile: strField(
+      extField(ext, 'description')
+      ?? extField(ext, 'long_description')
+      ?? extField(ext, 'company_description'),
+    ),
+    mainBusiness: strField(extField(ext, 'main_business') ?? extField(ext, 'business_summary')),
+    chairman: strField(extField(ext, 'chairman') ?? extField(ext, 'ceo')),
   }
 
-  if (market === 'CN' && typeof totalShares === 'number' && typeof floatShares === 'number') {
+  const totalShares = typeof totalSharesRaw === 'number' ? totalSharesRaw : numShares(totalSharesRaw)
+  if (totalShares != null) {
+    (profile as Record<string, unknown>).totalShares = totalShares
+  }
+
+  if (market === 'CN' && typeof totalSharesRaw === 'number' && typeof floatShares === 'number') {
     profile.totalMarketCap = null
     profile.circulatingMarketCap = null
   }
 
   return profile
+}
+
+function numShares(v: unknown): number | undefined {
+  if (v == null || v === '') return undefined
+  const n = Number(v)
+  return Number.isFinite(n) ? n : undefined
 }
 
 export function mapTickflowInstrumentsToList(

--- a/packages/a-stock-layer/src/providers/tickflow/normalize/instruments.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/normalize/instruments.ts
@@ -90,7 +90,7 @@ export function mapTickflowInstrumentToProfile(inst: TickflowInstrument): StockP
 
   const totalShares = typeof totalSharesRaw === 'number' ? totalSharesRaw : numShares(totalSharesRaw)
   if (totalShares != null) {
-    (profile as Record<string, unknown>).totalShares = totalShares
+    profile.totalShares = totalShares
   }
 
   if (market === 'CN' && typeof totalSharesRaw === 'number' && typeof floatShares === 'number') {

--- a/packages/a-stock-layer/src/providers/tickflow/normalize/klines.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/normalize/klines.ts
@@ -1,6 +1,17 @@
 import type { StockKline } from '@opptrix/shared'
-import type { CompactKlineData } from '../api/client.js'
+import type { CompactKlineData, TickflowPeriod } from '../api/client.js'
 import { parseTickflowSymbol, type TickflowRegion } from '../api/symbols.js'
+
+const YEAR1_BARS = 260
+const YEAR3_BARS = 780
+const YEAR5_BARS = 1300
+const FIVEDAY_MINUTE_BARS = 2000
+const INTRADAY_MINUTE_BARS = 400
+
+export type ResolvedTickflowKlineQuery = {
+  tfPeriod: TickflowPeriod
+  count?: number
+}
 
 function num(v: unknown): number | null {
   if (v == null || v === '') return null
@@ -9,6 +20,15 @@ function num(v: unknown): number | null {
 }
 
 const INTRADAY_PERIODS = new Set(['1m', '5m', '10m', '15m', '30m', '60m'])
+
+/** 券商图表周期 → TickFlow `GET /v1/klines` 的 period（免费档实测 1d/1w/1M/1Q/1Y 可用）。 */
+export const BROKER_CHART_PERIOD_TO_TICKFLOW: Readonly<Record<string, TickflowPeriod>> = {
+  daily: '1d',
+  weekly: '1w',
+  monthly: '1M',
+  quarterly: '1Q',
+  yearly: '1Y',
+}
 
 /** Opptrix period → TickFlow period */
 export function opptrixPeriodToTickflow(period: string): string | null {
@@ -43,6 +63,46 @@ export function opptrixPeriodToTickflow(period: string): string | null {
     year: '1Y',
   }
   return map[p] ?? null
+}
+
+/**
+ * Opptrix 图表 / Engine 周期 → TickFlow `GET /v1/klines` 的 period + count。
+ * 官方周期：1m,5m,10m,15m,30m,60m,1d,1w,1M,1Q,1Y（均经 klines 接口传入 period）。
+ */
+export function resolveTickflowKlineQuery(
+  period: string,
+  count?: number,
+): ResolvedTickflowKlineQuery | null {
+  const p = period.trim().toLowerCase()
+  if (p === 'intraday' || p === 'minute') {
+    const want = count != null && count > 0 ? Math.max(count, INTRADAY_MINUTE_BARS) : INTRADAY_MINUTE_BARS
+    return { tfPeriod: '1m', count: want }
+  }
+  if (p === '5day' || p === 'fdays' || p === 'five') {
+    return {
+      tfPeriod: '1m',
+      count: Math.max(count ?? 0, FIVEDAY_MINUTE_BARS),
+    }
+  }
+  if (p === 'year1' || p === '1y') {
+    return { tfPeriod: '1d', count: Math.max(count ?? 0, YEAR1_BARS) }
+  }
+  if (p === 'year3' || p === '3y') {
+    return { tfPeriod: '1d', count: Math.max(count ?? 0, YEAR3_BARS) }
+  }
+  if (p === 'year5' || p === '5y') {
+    return { tfPeriod: '1d', count: Math.max(count ?? 0, YEAR5_BARS) }
+  }
+  const tfPeriod = opptrixPeriodToTickflow(period) as TickflowPeriod | null
+  if (!tfPeriod) return null
+  const resolvedCount = count != null && count > 0 ? count : undefined
+  return { tfPeriod, count: resolvedCount }
+}
+
+/** 图表 UI 周期是否直接对应 TickFlow klines period（非日 K 根数窗口）。 */
+export function isBrokerOhlcTickflowPeriod(period: string): boolean {
+  const p = period.trim().toLowerCase()
+  return p in BROKER_CHART_PERIOD_TO_TICKFLOW
 }
 
 export function isIntradayTickflowPeriod(period: string): boolean {

--- a/packages/a-stock-layer/src/providers/tickflow/normalize/quotes.ts
+++ b/packages/a-stock-layer/src/providers/tickflow/normalize/quotes.ts
@@ -1,4 +1,5 @@
 import type { StockRealtime } from '@opptrix/shared'
+import { usQuoteSessionLabel, type UsQuoteSession } from '../../../utils/us-market.js'
 import { parseTickflowSymbol } from '../api/symbols.js'
 
 function num(v: unknown): number | null {
@@ -12,6 +13,12 @@ function pctFromDecimal(v: unknown): number | null {
   const n = num(v)
   if (n == null) return null
   return n * 100
+}
+
+function strField(v: unknown): string | null {
+  if (v == null || v === '') return null
+  const s = String(v).trim()
+  return s || null
 }
 
 function quoteExt(quote: Record<string, unknown>): Record<string, unknown> {
@@ -34,11 +41,20 @@ function mapSession(session: unknown): StockRealtime['quoteSession'] | undefined
   }
 }
 
+function sessionLabelForMarket(
+  market: string,
+  session: StockRealtime['quoteSession'] | undefined,
+): string | undefined {
+  if (!session) return undefined
+  if (market === 'US') return usQuoteSessionLabel(session as UsQuoteSession)
+  return undefined
+}
+
 export function mapTickflowQuote(quote: Record<string, unknown>): StockRealtime | null {
   const symbol = String(quote.symbol ?? '')
   if (!symbol) return null
 
-  const { code } = parseTickflowSymbol(symbol)
+  const { code, market } = parseTickflowSymbol(symbol)
   const ext = quoteExt(quote)
   const price = num(quote.last_price)
   const preClose = num(quote.prev_close)
@@ -48,16 +64,18 @@ export function mapTickflowQuote(quote: Record<string, unknown>): StockRealtime 
   }
 
   const session = mapSession(quote.session)
-  const name = String(ext.name ?? code)
+  const name = String(ext.name ?? quote.name ?? code)
 
   return {
     code,
     name,
     price,
     changePct,
-    pe: null,
-    pb: null,
+    pe: num(ext.pe ?? ext.pe_ttm ?? ext.pe_ratio),
+    pb: num(ext.pb ?? ext.pb_ratio),
     turnoverRate: pctFromDecimal(ext.turnover_rate),
+    marketCap: num(ext.market_cap ?? ext.market_capitalization ?? ext.total_market_cap),
+    circulatingMarketCap: num(ext.float_market_cap ?? ext.circulating_market_cap),
     open: num(quote.open),
     high: num(quote.high),
     low: num(quote.low),
@@ -68,7 +86,13 @@ export function mapTickflowQuote(quote: Record<string, unknown>): StockRealtime 
     amplitude: pctFromDecimal(ext.amplitude),
     timestamp: quote.timestamp != null ? String(quote.timestamp) : undefined,
     quoteSession: session,
-  }
+    sessionLabel: sessionLabelForMarket(market, session),
+    preMarketPrice: num(ext.pre_market_price ?? ext.premarket_price),
+    postMarketPrice: num(ext.post_market_price ?? ext.after_hours_price),
+    week52High: num(ext.week52_high ?? ext.week_52_high ?? ext['52w_high'] ?? ext.high_52w),
+    week52Low: num(ext.week52_low ?? ext.week_52_low ?? ext['52w_low'] ?? ext.low_52w),
+    currency: strField(ext.currency) ?? (market === 'US' ? 'USD' : market === 'HK' ? 'HKD' : null),
+  } as StockRealtime
 }
 
 export function mapTickflowQuotes(rows: unknown): StockRealtime[] {

--- a/packages/a-stock-layer/src/utils/cross-market-kline.ts
+++ b/packages/a-stock-layer/src/utils/cross-market-kline.ts
@@ -1,0 +1,49 @@
+/**
+ * 跨市场图表周期 → Engine / TickFlow 查询参数。
+ */
+
+export type CrossMarketKlineEngineQuery = {
+  enginePeriod: string
+  count: number
+  intradayLine: boolean
+}
+
+const INTRADAY_MINUTE_BARS = 400
+const FIVEDAY_MINUTE_BARS = 2000
+
+export function crossMarketFiveDayMinuteCount(count: number): number {
+  return Math.max(count, FIVEDAY_MINUTE_BARS)
+}
+
+export function crossMarketIntradayMinuteCount(count: number): number {
+  return Math.max(count, INTRADAY_MINUTE_BARS)
+}
+
+export function resolveCrossMarketKlineEngineQuery(
+  uiPeriod: string,
+  count: number,
+): CrossMarketKlineEngineQuery {
+  const p = uiPeriod.trim().toLowerCase()
+  switch (p) {
+    case 'intraday':
+      return {
+        enginePeriod: 'intraday',
+        count: crossMarketIntradayMinuteCount(count),
+        intradayLine: true,
+      }
+    case '5day':
+    case 'fdays':
+    case 'five':
+      return {
+        enginePeriod: '5day',
+        count: crossMarketFiveDayMinuteCount(count),
+        intradayLine: true,
+      }
+    default:
+      return {
+        enginePeriod: uiPeriod,
+        count,
+        intradayLine: false,
+      }
+  }
+}

--- a/packages/a-stock-layer/src/utils/kline-resample.ts
+++ b/packages/a-stock-layer/src/utils/kline-resample.ts
@@ -1,64 +1,66 @@
 import type { StockKline } from '@opptrix/shared'
 
-const MINUTE_STEPS: Record<string, number> = {
-  '1m': 1,
-  '5m': 5,
-  '15m': 15,
-  '30m': 30,
-  '60m': 60,
+type ResampleMode = 'weekly' | 'monthly' | 'quarterly' | 'yearly'
+
+function parseYmd(date: string): Date | null {
+  const m = date.slice(0, 10).match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!m) return null
+  const y = Number(m[1])
+  const mo = Number(m[2]) - 1
+  const d = Number(m[3])
+  const dt = new Date(y, mo, d)
+  return Number.isNaN(dt.getTime()) ? null : dt
 }
 
-function parseBarMs(date: string): number | null {
-  const raw = date.trim()
-  const normalized = raw.includes('T') ? raw : raw.replace(' ', 'T')
-  const ms = Date.parse(normalized)
-  return Number.isNaN(ms) ? null : ms
+function bucketKey(d: Date, mode: ResampleMode): string {
+  if (mode === 'yearly') return String(d.getFullYear())
+  if (mode === 'quarterly') {
+    const q = Math.floor(d.getMonth() / 3) + 1
+    return `${d.getFullYear()}-Q${q}`
+  }
+  if (mode === 'monthly') {
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+  }
+  const day = d.getDay() || 7
+  const thursday = new Date(d)
+  thursday.setDate(d.getDate() + 4 - day)
+  const week = Math.ceil(
+    ((thursday.getTime() - new Date(thursday.getFullYear(), 0, 1).getTime()) / 86400000 + 1) / 7,
+  )
+  return `${thursday.getFullYear()}-W${week}`
 }
 
-/** 将 1 分钟 K 聚合为更大分钟周期（仅用于指数腾讯回退路径） */
-export function resampleStockKlinesToPeriod(rows: StockKline[], period: string): StockKline[] {
-  const step = MINUTE_STEPS[period] ?? 1
-  if (step <= 1 || !rows.length) return rows
+function aggregateBars(bars: StockKline[]): StockKline {
+  bars.sort((a, b) => a.date.localeCompare(b.date))
+  const first = bars[0]!
+  const last = bars[bars.length - 1]!
+  return {
+    code: first.code,
+    date: last.date,
+    open: first.open,
+    close: last.close,
+    high: Math.max(...bars.map(b => b.high)),
+    low: Math.min(...bars.map(b => b.low)),
+    volume: bars.reduce((s, b) => s + (b.volume ?? 0), 0),
+    amount: bars.reduce((s, b) => s + (b.amount ?? 0), 0),
+    changePct: last.changePct,
+    turnoverRate: null,
+  }
+}
 
-  const buckets = new Map<number, StockKline[]>()
-  for (const bar of rows) {
-    const ms = parseBarMs(bar.date)
-    if (ms == null) continue
-    const d = new Date(ms)
-    const bucketMin = Math.floor((d.getHours() * 60 + d.getMinutes()) / step) * step
-    const key = new Date(d.getFullYear(), d.getMonth(), d.getDate(), Math.floor(bucketMin / 60), bucketMin % 60).getTime()
+/** 将日/月 K 聚合为周/季/年 K（券商 APP 季K/年K 数据源）。 */
+export function resampleOhlcKlines(klines: StockKline[], mode: ResampleMode): StockKline[] {
+  if (!klines.length) return []
+  const buckets = new Map<string, StockKline[]>()
+  for (const bar of klines) {
+    const d = parseYmd(bar.date)
+    if (!d) continue
+    const key = bucketKey(d, mode)
     const list = buckets.get(key) ?? []
     list.push(bar)
     buckets.set(key, list)
   }
-
-  const out: StockKline[] = []
-  for (const [, bars] of [...buckets.entries()].sort(([a], [b]) => a - b)) {
-    bars.sort((a, b) => a.date.localeCompare(b.date))
-    const first = bars[0]!
-    const last = bars[bars.length - 1]!
-    let high = first.high
-    let low = first.low
-    let volume = 0
-    let amount = 0
-    for (const b of bars) {
-      high = Math.max(high, b.high)
-      low = Math.min(low, b.low)
-      volume += b.volume ?? 0
-      amount += b.amount ?? 0
-    }
-    out.push({
-      code: first.code,
-      date: last.date,
-      open: first.open,
-      close: last.close,
-      high,
-      low,
-      volume,
-      amount,
-      changePct: last.changePct,
-      turnoverRate: last.turnoverRate,
-    })
-  }
-  return out
+  return [...buckets.values()]
+    .map(aggregateBars)
+    .sort((a, b) => a.date.localeCompare(b.date))
 }

--- a/packages/research-hub/src/cross-market-detail.ts
+++ b/packages/research-hub/src/cross-market-detail.ts
@@ -89,12 +89,13 @@ export function normalizeCrossMarketProfile(
     code,
     name,
     orgName: str(raw.orgName ?? raw.name) || undefined,
-    industry: str(raw.industry) || undefined,
+    industry: str(raw.industry ?? raw.sector) || undefined,
     listingDate: str(raw.listingDate) || undefined,
     website: str(raw.website) || undefined,
-    orgProfile: str(raw.orgProfile) || undefined,
+    orgProfile: str(raw.orgProfile ?? raw.description) || undefined,
     mainBusiness: str(raw.mainBusiness) || undefined,
     securityType: str(raw.securityType ?? raw.exchange) || undefined,
+    chairman: str(raw.chairman) || undefined,
     totalShares: num(raw.totalShares),
     market: market,
   }
@@ -166,7 +167,7 @@ export function normalizeHkTencentProfile(
   }
 }
 
-/** 合并腾讯 US quote enrich（52 周高低、币种等）到 snapshot quote */
+/** 合并实时 enrich（52 周高低、币种、估值等）到 snapshot quote */
 export function mergeCrossMarketQuote(
   base: Record<string, unknown> | null | undefined,
   enrich: Record<string, unknown> | null | undefined,
@@ -174,13 +175,15 @@ export function mergeCrossMarketQuote(
   if (!base && !enrich) return null
   const out = { ...(base ?? {}) }
   if (enrich) {
-    if (enrich.week52High != null) out.week52High = enrich.week52High
-    if (enrich.week52Low != null) out.week52Low = enrich.week52Low
-    if (enrich.currency != null) out.currency = enrich.currency
-    if (out.turnoverRate == null && enrich.turnoverRate != null) out.turnoverRate = enrich.turnoverRate
-    if (out.pe == null && enrich.pe != null) out.pe = enrich.pe
-    if (out.pb == null && enrich.pb != null) out.pb = enrich.pb
-    if (out.marketCap == null && enrich.marketCap != null) out.marketCap = enrich.marketCap
+    const fillKeys = [
+      'code', 'name', 'price', 'changePct', 'change', 'open', 'high', 'low', 'preClose',
+      'volume', 'amount', 'turnoverRate', 'amplitude', 'volumeRatio', 'pe', 'pb',
+      'marketCap', 'circulatingMarketCap', 'week52High', 'week52Low', 'currency',
+      'quoteSession', 'sessionLabel', 'preMarketPrice', 'postMarketPrice',
+    ] as const
+    for (const key of fillKeys) {
+      if (out[key] == null && enrich[key] != null) out[key] = enrich[key]
+    }
   }
   return Object.keys(out).length ? out : null
 }

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -1492,122 +1492,28 @@ export class ResearchHub {
   private async stockDetail(ref: InstrumentRef, t0: number) {
     const cnRef = resolveCnInstrumentRef(ref)
     const code = cnRef.symbol
-    const [quoteR, profileR, financialAllR, newsR, dividendR, moneyFlowR, shareholdersR, holderHistoryR] = await Promise.all([
-      this.stockDetailQuote(cnRef),
-      this.stockDetailOptional(
-        this.stockDetailProfile(cnRef).then(profile => ({
-          success: !!profile,
-          data: profile ? [profile] : null,
-        })),
-        25000,
-      ),
-      this.stockDetailOptional(
-        (async () => {
-          const fast = await this.callDetailProviderMethod<FinancialSummary>(
-            ['tushare', 'tonghuashun'],
-            'financials',
-            [code, '', 'all'],
-            cnRef,
-          )
-          if (fast?.length) return { success: true, data: fast }
-          return this.de.queryInstrumentData(cnRef, 'financials', {
-            reportDate: '',
-            reportType: 'all',
-          }) as Promise<{ success: boolean; data?: Array<{ reportType?: string }> | null }>
-        })(),
-        25000,
-      ),
-      this.stockDetailOptional(
-        this.stockDetailNotices(cnRef).then(data => ({ success: data.length > 0, data })),
-      ),
-      this.stockDetailOptional(
-        (async () => {
-          const engineR = await this.de.queryInstrumentData(cnRef, 'dividend')
-          const engineRows = instrumentQueryData<Dividend[]>(engineR)
-          if (engineRows?.length) return { success: true, data: engineRows }
-          const preferred = await this.callDetailProviderMethod<Dividend>(
-            ['tushare'],
-            'dividend',
-            [code],
-            cnRef,
-          )
-          if (preferred?.length) return { success: true, data: preferred }
-          const fallback = await this.callDetailProviderMethod<Dividend>(
-            ['baostock', 'tonghuashun'],
-            'dividend',
-            [code],
-            cnRef,
-          )
-          return fallback?.length ? { success: true, data: fallback } : { success: false }
-        })(),
-      ),
-      this.stockDetailOptional(
-        (async () => {
-          const engineR = await this.de.queryInstrumentData(cnRef, 'money_flow')
-          const engineRows = instrumentQueryData<MoneyFlow[]>(engineR)
-          if (engineRows?.length) return { success: true, data: engineRows }
-          const fallback = await this.callDetailProviderMethod<MoneyFlow>(
-            ['zzshare'],
-            'moneyFlow',
-            [code],
-            cnRef,
-          )
-          return fallback?.length ? { success: true, data: fallback } : { success: false }
-        })(),
-      ),
-      this.stockDetailOptional(
-        this.stockDetailShareholders(cnRef).then(data => ({
-          success: !!data?.length,
-          data,
-        })),
-      ),
-      this.stockDetailOptional(
-        this.stockDetailHolderHistory(cnRef).then(history => ({
-          success: history.length > 0,
-          data: history,
-        })),
-        25000,
-      ),
-    ])
+    const quoteR = await this.stockDetailQuote(cnRef)
+    const quote = quoteR ? this.enrichQuote(quoteR) : null
+    if (!quote) return fail('获取行情失败', t0)
 
-    const quoteRaw = quoteR
-    const quote = quoteRaw ? this.enrichQuote(quoteRaw) : null
-    const profileRow = enrichDetailProfileFromQuote(
-      instrumentQueryData<Array<Record<string, unknown>>>(profileR)?.[0] ?? null,
-      quote as Record<string, unknown> | null,
-    )
-    const shareholderBase = shareholdersR.data?.[0] as import('./stock-detail-normalize.js').StockDetailShareholderView | null ?? null
-    const shareholders = enrichShareholderView(shareholderBase, {
-      price: quote?.price ?? null,
-      circulatingMarketCap: (quote as Record<string, unknown> | null)?.circulatingMarketCap as number | null
-        ?? (profileRow?.circulatingMarketCap as number | null | undefined)
-        ?? null,
-      holderHistory: holderHistoryR.data ?? [],
-    })
-    const financialHistory = financialAllR.data ?? []
-    const financial = financialHistory.find(row => row.reportType === 'annual')
-      ?? financialHistory[0]
-      ?? null
     const name = this.resolveStockName(
       code,
       cnRef.exchange ?? null,
-      quote?.name,
-      profileRow?.name as string | undefined,
-      profileRow?.orgName as string | undefined,
+      quote.name,
     )
 
     return ok({
       code: buildInstrumentNamespace(cnRef),
       name,
       quote,
-      profile: profileRow,
-      financial,
-      financialHistory,
-      news: newsR.data ?? [],
-      dividends: dividendR.data ?? [],
-      moneyFlow: moneyFlowR.data ?? [],
-      shareholders,
-    }, `${name}(${code}) 详情`, t0)
+      profile: null,
+      financial: null,
+      financialHistory: [],
+      news: [],
+      dividends: [],
+      moneyFlow: [],
+      shareholders: null,
+    }, `${name}(${code}) 行情`, t0)
   }
 
   private mergeQuoteWithLocal(
@@ -3673,121 +3579,44 @@ export class ResearchHub {
     const snapshotR = await this.de.queryInstrumentData(ref, 'snapshot')
     const snap = instrumentQueryData<Record<string, unknown>>(snapshotR)
 
-    const [
-      profileR,
-      noticeR,
-      articleR,
-      financialR,
-      dividendR,
-      shareholderR,
-      quoteR,
-    ] = await Promise.all([
-      this.stockDetailOptional(
-        this.de.queryInstrumentData(ref, 'profile').then(r => {
-          const data = instrumentQueryData<Array<Record<string, unknown>>>(r)
-          return { success: r.success && !!(data?.length), data }
-        }),
-      ),
-      this.stockDetailOptional(
-        this.de.queryInstrumentData(ref, 'notices', { page: 1, pageSize: 30 }).then(r => {
-          const data = instrumentQueryData<NewsItem[]>(r)
-          return { success: r.success && !!(data?.length), data }
-        }),
-      ),
-      this.stockDetailOptional(
-        this.de.queryInstrumentData(ref, 'news', { page: 1, pageSize: 30 }).then(r => {
-          const data = instrumentQueryData<NewsItem[]>(r)
-          return { success: r.success && !!(data?.length), data }
-        }),
-      ),
-      this.stockDetailOptional(
-        this.de.queryInstrumentData(ref, 'financials', { reportDate: '', reportType: 'annual' }).then(r => {
-          const data = instrumentQueryData<Array<Record<string, unknown>>>(r)
-          return { success: r.success && !!(data?.length), data }
-        }),
-      ),
-      market === 'HK'
-        ? this.stockDetailOptional(
-          this.de.queryInstrumentData(ref, 'dividend', { page: 1, pageSize: 10 }).then(r => {
-            const data = instrumentQueryData<Array<Record<string, unknown>>>(r)
-            return { success: r.success && !!(data?.length), data }
-          }),
-        )
-        : Promise.resolve({ success: false as const, data: null as Array<Record<string, unknown>> | null }),
-      market === 'US'
-        ? this.stockDetailOptional(
-          this.de.queryInstrumentData(ref, 'shareholders', { page: 1 }).then(r => {
-            const data = instrumentQueryData<Array<Record<string, unknown>>>(r)
-            return { success: r.success && !!(data?.length), data }
-          }),
-        )
-        : Promise.resolve({ success: false as const, data: null as Array<Record<string, unknown>> | null }),
-      this.stockDetailOptional(
-        (async () => {
-          const engineR = await this.de.queryInstrumentData(ref, 'realtime')
-          const row = instrumentQueryData<import('@opptrix/shared').StockRealtime[]>(engineR)?.[0]
-          if (row) return { success: true as const, data: [row as unknown as Record<string, unknown>] }
-          return { success: false as const, data: null as Record<string, unknown>[] | null }
-        })(),
-      ),
-    ])
+    const quoteR = await this.stockDetailOptional(
+      (async () => {
+        const engineR = await this.de.queryInstrumentData(ref, 'realtime')
+        const row = instrumentQueryData<import('@opptrix/shared').StockRealtime[]>(engineR)?.[0]
+        if (row) return { success: true as const, data: [row as unknown as Record<string, unknown>] }
+        return { success: false as const, data: null as Record<string, unknown>[] | null }
+      })(),
+    )
 
-    const profileRaw = profileR.data?.[0] ?? null
-    const profileSource = profileRaw
-      ?? (snap?.profile as Record<string, unknown> | null)
-      ?? null
-    const profile = profileSource
-      ? normalizeCrossMarketProfile(market, symbol, profileSource)
+    const snapProfile = snap?.profile as Record<string, unknown> | null
+    const profile = snapProfile
+      ? normalizeCrossMarketProfile(market, symbol, snapProfile)
       : null
 
-    const notices = normalizeCrossMarketNoticesFromNews(symbol, noticeR.data ?? null)
-    const articles = normalizeCrossMarketArticlesFromNews(symbol, articleR.data ?? null)
     const quote = mergeCrossMarketQuote(
       (snap?.quote ?? null) as Record<string, unknown> | null,
       quoteR.data?.[0] ?? null,
     )
 
-    const financialRows = financialR.data ?? []
-    const financialHistory = financialRows.length
-      ? normalizeCrossMarketFinancialHistory(symbol, financialRows)
-      : market === 'US'
-        ? normalizeUsFinancialHistory(symbol, null)
-        : normalizeHkFinancialHistory(symbol, null, null)
-
-    const hkDividendRows = dividendR.data ?? null
-    const dividends = market === 'HK'
-      ? (() => {
-        const fromStandard = normalizeCrossMarketDividends(symbol, hkDividendRows)
-        if (fromStandard.length) return fromStandard
-        return normalizeHkDividends(symbol, hkDividendRows?.[0] ?? null)
-      })()
-      : []
-
-    const shareholders = market === 'US'
-      ? normalizeCrossMarketShareholdersFromRows(symbol, shareholderR.data ?? null)
-        ?? normalizeUsShareholders(symbol, shareholderR.data?.[0] ?? null)
-      : null
-
     const payload = buildCrossMarketDetailPayload(market, symbol, snap ?? null, {
       profile,
       quote,
-      notices,
-      articles,
-      financialHistory,
-      dividends,
-      shareholders,
+      notices: [],
+      articles: [],
+      financialHistory: [],
+      dividends: [],
+      shareholders: null,
       reviewProspect: null,
       relatedStocks: [],
       seniorTrades: [],
       tradingDistribution: null,
     })
 
-    if (!payload.quote && !payload.profile && !(payload.recentKlines as unknown[])?.length
-      && !notices.length && !articles.length) {
+    if (!payload.quote && !(payload.recentKlines as unknown[])?.length) {
       return fail(`${market === 'US' ? '美股' : '港股'}详情获取失败`, t0)
     }
 
-    return ok(payload, `${market === 'US' ? '美股' : '港股'}详情`, t0)
+    return ok(payload, `${market === 'US' ? '美股' : '港股'}行情`, t0)
   }
 
   private async usSnapshot(symbol: string, t0: number) {

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -3733,9 +3733,12 @@ export class ResearchHub {
     ])
 
     const profileRaw = profileR.data?.[0] ?? null
-    const profile = profileRaw
-      ? normalizeCrossMarketProfile(market, symbol, profileRaw)
-      : (snap?.profile as Record<string, unknown> | null) ?? null
+    const profileSource = profileRaw
+      ?? (snap?.profile as Record<string, unknown> | null)
+      ?? null
+    const profile = profileSource
+      ? normalizeCrossMarketProfile(market, symbol, profileSource)
+      : null
 
     const notices = normalizeCrossMarketNoticesFromNews(symbol, noticeR.data ?? null)
     const articles = normalizeCrossMarketArticlesFromNews(symbol, articleR.data ?? null)

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -13,6 +13,10 @@ import { MarketDataEngine, computeIndicators, computeLatestChipProfile, computeC
   isCrossMarketTradingDay,
   isHkFdaysPayload,
   minuteKlinesToIntradayItems,
+  resolveCrossMarketKlineEngineQuery,
+  crossMarketFiveDayMinuteCount,
+  crossMarketIntradayMinuteCount,
+  resampleOhlcKlines,
 } from '@opptrix/a-stock-layer'
 import { resolveProvidersDir } from '@opptrix/shared'
 import type { IntradayTrendFetchResult, IntradayTrendSession } from '@opptrix/a-stock-layer'
@@ -1626,9 +1630,11 @@ export class ResearchHub {
       case '15m': return 320
       case '30m': return 240
       case '60m': return 240
-      case '5day': return 5
+      case '5day': return crossMarketFiveDayMinuteCount(2000)
       case 'weekly': return 160
-      case 'monthly': return 80
+      case 'monthly': return 120
+      case 'quarterly': return 80
+      case 'yearly': return 40
       case 'year1': return 260
       case 'year3': return 780
       case 'year5': return 1300
@@ -1641,7 +1647,9 @@ export class ResearchHub {
       case 'year5': return 1300
       case 'year3': return 780
       case 'year1': return 260
-      case '5day': return 5
+      case 'quarterly': return 120
+      case 'yearly': return 60
+      case '5day': return crossMarketFiveDayMinuteCount(2000)
       default: return 800
     }
   }
@@ -1657,9 +1665,10 @@ export class ResearchHub {
     opts: { count?: number; startDate?: string; endDate?: string },
   ) {
     const ref = { market, assetClass: 'EQUITY' as const, symbol }
+    const resolved = resolveCrossMarketKlineEngineQuery(period, opts.count ?? 120)
     return this.de.queryInstrumentData(ref, 'kline', {
-      count: opts.count ?? 120,
-      period,
+      count: resolved.count,
+      period: resolved.enginePeriod,
       startDate: opts.startDate,
       endDate: opts.endDate,
     })
@@ -1714,6 +1723,9 @@ export class ResearchHub {
         klines: data,
         hasMore: data.length >= Math.min(step, safeCount) && safeCount < mergeCap,
       }
+    }
+    if (period === 'quarterly' || period === 'yearly') {
+      return await this.fetchCrossMarketQuarterlyYearlyResampleFallback(market, symbol, period, safeCount)
     }
     return null
   }
@@ -1791,6 +1803,58 @@ export class ResearchHub {
     }
   }
 
+  private async fetchCnQuarterlyYearlyResampleFallback(
+    code: string,
+    period: 'quarterly' | 'yearly',
+    safeCount: number,
+    exchange: StockMarket,
+  ): Promise<{ klines: import('@opptrix/shared').StockKline[]; hasMore: boolean } | null> {
+    const factor = period === 'quarterly' ? 3 : 12
+    const monthlyCount = Math.min(Math.max(safeCount * factor, 80), 800)
+    let monthlyR = await this.queryCnKline(code, {
+      period: 'monthly',
+      count: monthlyCount,
+      exchange,
+    })
+    let monthly = instrumentQueryData<import('@opptrix/shared').StockKline[]>(monthlyR) ?? []
+    if (!monthly.length && inferCnAssetClass(normalizeCode(code)) === 'INDEX') {
+      monthlyR = await this.queryCnKline(code, {
+        period: 'monthly',
+        count: Math.max(monthlyCount, 120),
+        exchange,
+      })
+      monthly = instrumentQueryData<import('@opptrix/shared').StockKline[]>(monthlyR) ?? []
+    }
+    if (!monthlyR.success || !monthly.length) return null
+    const resampled = resampleOhlcKlines(monthly, period)
+    const klines = resampled.slice(-Math.min(safeCount, 800))
+    if (!klines.length) return null
+    return {
+      klines,
+      hasMore: resampled.length >= safeCount && monthlyCount < 800,
+    }
+  }
+
+  private async fetchCrossMarketQuarterlyYearlyResampleFallback(
+    market: 'US' | 'HK',
+    symbol: string,
+    period: 'quarterly' | 'yearly',
+    safeCount: number,
+  ): Promise<{ klines: StockKline[]; hasMore: boolean } | null> {
+    const factor = period === 'quarterly' ? 3 : 12
+    const monthlyCount = Math.min(Math.max(safeCount * factor, 80), 800)
+    const monthlyR = await this.queryCrossMarketKline(market, symbol, 'monthly', { count: monthlyCount })
+    const monthly = instrumentQueryData<StockKline[]>(monthlyR) ?? []
+    if (!monthlyR.success || !monthly.length) return null
+    const resampled = resampleOhlcKlines(monthly, period)
+    const klines = resampled.slice(-Math.min(safeCount, 800))
+    if (!klines.length) return null
+    return {
+      klines,
+      hasMore: resampled.length >= safeCount && monthlyCount < 800,
+    }
+  }
+
   private async fetchChartKlines(
     code: string,
     period: string,
@@ -1803,12 +1867,15 @@ export class ResearchHub {
       return this.fetchMinuteChartKlines(code, period, safeCount, before, tail, stockMarket)
     }
 
-    const klinePeriod = period === 'daily' ? 'daily' : period
+    const exchange = stockMarket
+    const klinePeriod = period === 'year1' || period === 'year3' || period === 'year5'
+      ? 'daily'
+      : (period === 'daily' ? 'daily' : period)
+
     const isIndex = inferCnAssetClass(normalizeCode(code)) === 'INDEX'
     const requestCount = isIndex && klinePeriod !== 'daily'
       ? Math.max(safeCount, 80)
       : safeCount
-    const exchange = stockMarket
     if (before) {
       const step = 200
       const endDay = this.dayBefore(before.slice(0, 10))
@@ -1842,7 +1909,15 @@ export class ResearchHub {
           hasMore: older.length >= step,
         }
       }
-      if (inferCnAssetClass(normalizeCode(code)) === 'INDEX') return null
+      if (inferCnAssetClass(normalizeCode(code)) === 'INDEX') {
+        if (period === 'quarterly' || period === 'yearly') {
+          return await this.fetchCnQuarterlyYearlyResampleFallback(code, period, safeCount, exchange)
+        }
+        return null
+      }
+      if (period === 'quarterly' || period === 'yearly') {
+        return await this.fetchCnQuarterlyYearlyResampleFallback(code, period, safeCount, exchange)
+      }
       return null
     }
 
@@ -1865,6 +1940,9 @@ export class ResearchHub {
         klines: klineData,
         hasMore: klineData.length >= safeCount && safeCount < 800,
       }
+    }
+    if (period === 'quarterly' || period === 'yearly') {
+      return await this.fetchCnQuarterlyYearlyResampleFallback(code, period, safeCount, exchange)
     }
     return null
   }
@@ -1889,7 +1967,7 @@ export class ResearchHub {
         }
         : normalized,
     )
-    const cap = this.isMinutePeriod(period) ? this.minuteMaxBars(period) : 800
+    const cap = this.isMinutePeriod(period) ? this.minuteMaxBars(period) : this.crossMarketMaxBars(period)
     const safeCount = Math.max(20, Math.min(count || this.defaultChartCount(period), cap))
     const stockMarket = this.resolveStockMarket(normalized, explicitMarket, cnRef)
     const quoteR = await this.stockRealtime(cnRef, explicitMarket)
@@ -1952,6 +2030,52 @@ export class ResearchHub {
         bars: this.sortChartBars(bars),
         indicators: [],
       }, `${name} 分时 ${session.sessionDate} ${bars.length} 点`, t0)
+    }
+
+    if (period === '5day') {
+      const trendR = await this.de.fetchIntradaySessions(code, 5, stockMarket)
+      const trendData = trendR.success
+        ? trendR.data as IntradayTrendFetchResult
+        : null
+      const sessions = trendData?.sessions ?? []
+      if (!sessions.length) {
+        return ok({
+          code: normalized,
+          name,
+          period,
+          preClose,
+          sessionDate: null,
+          isTradingDay: false,
+          bars: [],
+          indicators: [],
+        }, `${name} 暂无五日数据`, t0)
+      }
+
+      const today = cnTodayString()
+      const latestSession = sessions.at(-1)
+      const isLiveSession = latestSession?.sessionDate === today && shouldPreferTodayIntraday()
+      const bars = this.sortChartBars(
+        sessions.flatMap(session => session.bars.map(bar => ({
+          time: bar.time,
+          price: bar.price,
+          volume: bar.volume,
+          amount: bar.amount,
+          avgPrice: bar.avgPrice,
+        }))),
+      )
+
+      return ok({
+        code: normalized,
+        name,
+        period,
+        preClose,
+        sessionDate: latestSession?.sessionDate ?? null,
+        isTradingDay: isLiveSession,
+        hasMore: false,
+        chart_time_zone: 'Asia/Shanghai',
+        bars,
+        indicators: [],
+      }, `${name} 五日 ${bars.length} 点`, t0)
     }
 
     const fetched = await this.fetchChartKlines(normalized, period, safeCount, before, tail, stockMarket)
@@ -3400,21 +3524,21 @@ export class ResearchHub {
     const chartTimeZone = crossMarketChartTimeZone(market)
 
     if (period === 'intraday') {
-      const r = await this.de.queryInstrumentData(ref, 'kline', { count: safeCount, period })
-      if (!r.success) {
-        return fail(instrumentQueryError(r, `${market === 'US' ? '美股' : '港股'} K 线获取失败`), t0)
+      const minuteCount = crossMarketIntradayMinuteCount(safeCount)
+      const minuteR = await this.de.queryInstrumentData(ref, 'kline', { count: minuteCount, period: 'intraday' })
+      if (!minuteR.success) {
+        return fail(instrumentQueryError(minuteR, `${market === 'US' ? '美股' : '港股'} K 线获取失败`), t0)
       }
-      let items = instrumentQueryData<Record<string, unknown>[]>(r) ?? []
+      const minuteKlines = instrumentQueryData<StockKline[]>(minuteR) ?? []
       const qR = await this.de.queryInstrumentData(ref, 'realtime')
       const quote = instrumentQueryData<Record<string, unknown>[]>(qR)?.[0]
       preClose = quote?.preClose != null ? Number(quote.preClose) : null
       if (preClose == null || !Number.isFinite(preClose)) {
         preClose = quote?.pre_close != null ? Number(quote.pre_close) : null
       }
-      const minuteKlines = this.mapCrossMarketKlineItems(items, symbol)
       sessionDate = intradaySessionDateFromKlines(minuteKlines)
       isTradingDay = sessionDate ? isCrossMarketTradingDay(market, sessionDate) : false
-      items = minuteKlines.length ? minuteKlinesToIntradayItems(market, minuteKlines) : []
+      const items = minuteKlines.length ? minuteKlinesToIntradayItems(market, minuteKlines) : []
       return ok(
         {
           symbol,
@@ -3435,7 +3559,8 @@ export class ResearchHub {
     }
 
     if (period === '5day') {
-      const r = await this.de.queryInstrumentData(ref, 'kline', { count: safeCount, period })
+      const fiveCount = crossMarketFiveDayMinuteCount(safeCount)
+      const r = await this.de.queryInstrumentData(ref, 'kline', { count: fiveCount, period: '5day' })
       if (!r.success) {
         return fail(instrumentQueryError(r, `${market === 'US' ? '美股' : '港股'} K 线获取失败`), t0)
       }
@@ -3467,7 +3592,32 @@ export class ResearchHub {
         )
       }
 
-      const klines = items.length ? this.mapCrossMarketKlineItems(items, symbol) : []
+      const minuteKlines = items.length
+        ? this.mapCrossMarketKlineItems(items, symbol)
+        : []
+      if (minuteKlines.length) {
+        const fdaysItems = minuteKlinesToIntradayItems(market, minuteKlines)
+        const latestDay = intradaySessionDateFromKlines(minuteKlines)
+        return ok(
+          {
+            symbol,
+            period,
+            items: fdaysItems,
+            indicators: [],
+            count: fdaysItems.length,
+            preClose,
+            pre_close: preClose,
+            session_date: latestDay,
+            is_trading_day: latestDay ? isCrossMarketTradingDay(market, latestDay) : false,
+            hasMore: false,
+            chart_time_zone: chartTimeZone,
+          },
+          `五日 ${fdaysItems.length} 点`,
+          t0,
+        )
+      }
+
+      const klines = minuteKlines
       const indicators = klines.length ? this.mapCrossMarketChartIndicators(symbol, klines) : []
       return ok(
         {

--- a/packages/research-hub/src/instrument-router.ts
+++ b/packages/research-hub/src/instrument-router.ts
@@ -7,6 +7,7 @@ import {
   instrumentRefsFromList,
   normalizeInstrumentChart,
   normalizeInstrumentSnapshot,
+  canonicalSymbolForMarket,
   parseInstrumentRef,
   quoteFromProviderRow,
   resolveInstrumentCapabilities,
@@ -85,14 +86,20 @@ function wrapChart(ref: InstrumentRef, period: string, resp: ResearchResult): Re
   return { ...resp, data: chart }
 }
 
+function quoteRowMatchesRef(row: Record<string, unknown>, ref: InstrumentRef): boolean {
+  const code = String(row.code ?? '')
+  if (!code) return false
+  if (code === ref.symbol) return true
+  return canonicalSymbolForMarket(ref.market, code) === ref.symbol
+}
+
 /** Match a quote row to ref by symbol (+ exchange). Never trust sparse/filtered array index. */
 function findQuoteRowForRef(
   rows: Record<string, unknown>[],
   ref: InstrumentRef,
 ): Record<string, unknown> | undefined {
   return rows.find(r => {
-    const code = String(r.code ?? '')
-    if (code !== ref.symbol) return false
+    if (!quoteRowMatchesRef(r, ref)) return false
     if (!ref.exchange || r.exchange == null || r.exchange === '') return true
     return String(r.exchange).toUpperCase() === ref.exchange.toUpperCase()
   })

--- a/packages/shared/src/application-api.ts
+++ b/packages/shared/src/application-api.ts
@@ -114,6 +114,10 @@ export interface UnifiedInstrumentQuote {
   week52_low?: number | null
   /** 报价币种（如 USD、HKD） */
   currency?: string | null
+  /** 交易时段（美股盘前/盘中/盘后） */
+  quote_session?: string | null
+  /** 交易时段用户文案（如「盘中」） */
+  session_label?: string | null
 }
 
 /**

--- a/packages/shared/src/instrument-response.ts
+++ b/packages/shared/src/instrument-response.ts
@@ -154,6 +154,8 @@ export function quoteFromProviderRow(
     week52_high: num(row.week52High ?? row.week52_high),
     week52_low: num(row.week52Low ?? row.week52_low),
     currency: str(row.currency) || null,
+    quote_session: str(row.quoteSession ?? row.quote_session) || null,
+    session_label: str(row.sessionLabel ?? row.session_label) || null,
   }
 }
 

--- a/packages/shared/src/instrument-symbol.ts
+++ b/packages/shared/src/instrument-symbol.ts
@@ -320,7 +320,7 @@ export function parseInstrumentNamespace(raw: string): InstrumentRef | null {
     })
   }
 
-  const hk = /^HK:(\d{5})$/i.exec(text)
+  const hk = /^HK:(?:HK\.)?(\d{1,5})$/i.exec(text)
   if (hk) {
     return normalizeInstrumentRef({
       market: 'HK',

--- a/tests/instrument-standardization.test.mjs
+++ b/tests/instrument-standardization.test.mjs
@@ -9,6 +9,7 @@ import {
   normalizeInstrumentRef,
   canonicalHkSymbol,
   instrumentRefLabel,
+  parseInstrumentNamespace,
 } from '../packages/shared/dist/instrument-symbol.js'
 import { instrumentRefKey } from '../packages/shared/dist/instrument-ref.js'
 import {
@@ -19,6 +20,8 @@ import {
 import {
   resolveInstrumentQueryPlan,
 } from '../packages/a-stock-layer/dist/core/instrument-query.js'
+import { parseTickflowSymbol } from '../packages/a-stock-layer/dist/providers/tickflow/api/symbols.js'
+import { stockIndexItemToInstrumentRef } from '../packages/a-stock-layer/dist/providers/stockindex/normalize.js'
 
 test('resolveInstrumentFromParams — legacy code and explicit market', () => {
   const cn = resolveInstrumentFromParams({ code: '600519' })
@@ -227,11 +230,37 @@ test('Engine resolveInstrumentQueryPlan CN instrument_search uses registry', () 
 test('canonical symbol normalization across markets', () => {
   assert.equal(canonicalHkSymbol('700'), '00700')
   assert.equal(canonicalHkSymbol('0700'), '00700')
+  assert.equal(canonicalHkSymbol('2'), '00002')
   const hk = normalizeInstrumentRef({ market: 'HK', assetClass: 'EQUITY', symbol: '700' })
   assert.equal(hk.symbol, '00700')
   assert.equal(instrumentRefLabel(hk), 'HK:00700')
+  const hk2 = normalizeInstrumentRef({ market: 'HK', assetClass: 'EQUITY', symbol: '00002' })
+  assert.equal(instrumentRefLabel(hk2), 'HK:00002')
   const cn = normalizeInstrumentRef({ market: 'CN', assetClass: 'EQUITY', symbol: '519' })
   assert.equal(cn.symbol, '000519')
+})
+
+test('parseInstrumentNamespace accepts HK:HK.00002 StockIndex id', () => {
+  const ref = parseInstrumentNamespace('HK:HK.00002')
+  assert.equal(ref?.market, 'HK')
+  assert.equal(ref?.symbol, '00002')
+  assert.equal(instrumentRefLabel(ref), 'HK:00002')
+})
+
+test('parseTickflowSymbol keeps HK leading zeros', () => {
+  assert.equal(parseTickflowSymbol('00002.HK').code, '00002')
+  assert.equal(parseTickflowSymbol('00700.HK').code, '00700')
+})
+
+test('stockIndexItemToInstrumentRef resolves HK:HK.00002 instrumentId', () => {
+  const ref = stockIndexItemToInstrumentRef({
+    market: 'HK',
+    code: '00002',
+    instrumentId: 'HK:HK.00002',
+    nameCn: '中电控股',
+  })
+  assert.equal(ref?.market, 'HK')
+  assert.equal(ref?.symbol, '00002')
 })
 
 test('instrumentRefKey uses stock-index namespace without assetClass', () => {

--- a/tests/tickflow-kline-period.test.mjs
+++ b/tests/tickflow-kline-period.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { resolveTickflowKlineQuery, BROKER_CHART_PERIOD_TO_TICKFLOW } from '../packages/a-stock-layer/dist/providers/tickflow/normalize/klines.js'
+import {
+  resolveCrossMarketKlineEngineQuery,
+  crossMarketFiveDayMinuteCount,
+} from '../packages/a-stock-layer/dist/utils/cross-market-kline.js'
+
+test('resolveTickflowKlineQuery maps intraday to klines period 1m', () => {
+  const q = resolveTickflowKlineQuery('intraday', 100)
+  assert.ok(q)
+  assert.equal(q.tfPeriod, '1m')
+  assert.equal(q.count, 400)
+})
+
+test('resolveTickflowKlineQuery maps 5day to klines period 1m', () => {
+  const q = resolveTickflowKlineQuery('5day', 5)
+  assert.ok(q)
+  assert.equal(q.tfPeriod, '1m')
+  assert.equal(q.count, 2000)
+})
+
+test('resolveTickflowKlineQuery maps year periods to daily bars', () => {
+  const y1 = resolveTickflowKlineQuery('year1', 10)
+  assert.ok(y1)
+  assert.equal(y1.tfPeriod, '1d')
+  assert.equal(y1.count, 260)
+
+  const y3 = resolveTickflowKlineQuery('year3', 10)
+  assert.ok(y3)
+  assert.equal(y3.count, 780)
+
+  const y5 = resolveTickflowKlineQuery('year5', 10)
+  assert.ok(y5)
+  assert.equal(y5.count, 1300)
+})
+
+test('BROKER_CHART_PERIOD_TO_TICKFLOW aligns UI with TickFlow klines period', () => {
+  for (const [ui, tf] of Object.entries(BROKER_CHART_PERIOD_TO_TICKFLOW)) {
+    const q = resolveTickflowKlineQuery(ui, 60)
+    assert.ok(q, ui)
+    assert.equal(q.tfPeriod, tf, `${ui} → ${tf}`)
+    assert.equal(q.count, 60)
+  }
+})
+
+test('resolveTickflowKlineQuery keeps weekly/monthly/quarterly/yearly', () => {
+  assert.equal(resolveTickflowKlineQuery('weekly', 120)?.tfPeriod, '1w')
+  assert.equal(resolveTickflowKlineQuery('monthly', 80)?.tfPeriod, '1M')
+  assert.equal(resolveTickflowKlineQuery('quarterly', 40)?.tfPeriod, '1Q')
+  assert.equal(resolveTickflowKlineQuery('yearly', 20)?.tfPeriod, '1Y')
+  assert.equal(resolveTickflowKlineQuery('daily', 60)?.tfPeriod, '1d')
+})
+
+test('resolveCrossMarketKlineEngineQuery aligns UI periods', () => {
+  const intraday = resolveCrossMarketKlineEngineQuery('intraday', 50)
+  assert.equal(intraday.enginePeriod, 'intraday')
+  assert.equal(intraday.intradayLine, true)
+
+  const five = resolveCrossMarketKlineEngineQuery('5day', 5)
+  assert.equal(five.enginePeriod, '5day')
+  assert.equal(five.count, crossMarketFiveDayMinuteCount(5))
+  assert.equal(five.intradayLine, true)
+
+  const quarterly = resolveCrossMarketKlineEngineQuery('quarterly', 40)
+  assert.equal(quarterly.enginePeriod, 'quarterly')
+  assert.equal(quarterly.count, 40)
+  assert.equal(quarterly.intradayLine, false)
+
+  const yearly = resolveCrossMarketKlineEngineQuery('yearly', 20)
+  assert.equal(yearly.enginePeriod, 'yearly')
+  assert.equal(yearly.count, 20)
+  assert.equal(yearly.intradayLine, false)
+})

--- a/tests/tickflow-openapi-wiring.test.mjs
+++ b/tests/tickflow-openapi-wiring.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * TickFlow OpenAPI 静态接线审计 — 无需 API Key。
+ * 对照 https://api.tickflow.org/openapi.json 的 19 path / 21 操作。
+ */
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { TickflowClient } from '../packages/a-stock-layer/dist/providers/tickflow/api/client.js'
+import { TickflowDriver } from '../packages/a-stock-layer/dist/providers/tickflow/driver.js'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..')
+const clientSrc = readFileSync(
+  join(root, 'packages/a-stock-layer/src/providers/tickflow/api/client.ts'),
+  'utf8',
+)
+const extensionsSrc = readFileSync(
+  join(root, 'packages/a-stock-layer/src/providers/tickflow/markets/extensions.ts'),
+  'utf8',
+)
+const handlerSrc = readFileSync(
+  join(root, 'packages/a-stock-layer/src/providers/tickflow/markets/handler.ts'),
+  'utf8',
+)
+const commonSrc = readFileSync(
+  join(root, 'packages/a-stock-layer/src/providers/tickflow/markets/common.ts'),
+  'utf8',
+)
+
+/** OpenAPI path → TickflowClient 方法 */
+const OPENAPI_TO_CLIENT = [
+  { path: 'GET /v1/exchanges', method: 'getExchanges' },
+  { path: 'GET /v1/quotes', method: 'getQuotes' },
+  { path: 'POST /v1/quotes', method: 'postQuotes' },
+  { path: 'GET /v1/depth', method: 'getDepth' },
+  { path: 'GET /v1/depth/batch', method: 'getDepthBatch' },
+  { path: 'GET /v1/klines', method: 'getKlines' },
+  { path: 'GET /v1/klines/batch', method: 'getKlinesBatch' },
+  { path: 'GET /v1/klines/intraday', method: 'getKlinesIntraday' },
+  { path: 'GET /v1/klines/intraday/batch', method: 'getKlinesIntradayBatch' },
+  { path: 'GET /v1/klines/ex-factors', method: 'getKlinesExFactors' },
+  { path: 'GET /v1/instruments', method: 'getInstruments' },
+  { path: 'POST /v1/instruments', method: 'postInstruments' },
+  { path: 'GET /v1/exchanges/{exchange}/instruments', method: 'getExchangeInstruments' },
+  { path: 'GET /v1/universes', method: 'getUniverses' },
+  { path: 'GET /v1/universes/{id}', method: 'getUniverse' },
+  { path: 'POST /v1/universes/batch', method: 'postUniversesBatch' },
+  { path: 'GET /v1/financials/income', method: 'getFinancialsIncome' },
+  { path: 'GET /v1/financials/balance-sheet', method: 'getFinancialsBalanceSheet' },
+  { path: 'GET /v1/financials/cash-flow', method: 'getFinancialsCashFlow' },
+  { path: 'GET /v1/financials/metrics', method: 'getFinancialsMetrics' },
+  { path: 'GET /v1/financials/shares', method: 'getFinancialsShares' },
+]
+
+const HANDLER_WIRING = [
+  { path: 'GET /v1/quotes', needle: 'getQuotes', files: [handlerSrc, commonSrc] },
+  { path: 'POST /v1/quotes', needle: 'postQuotes', files: [handlerSrc] },
+  { path: 'GET /v1/klines', needle: 'getKlines', files: [commonSrc] },
+  { path: 'GET /v1/depth', needle: 'getDepth', files: [commonSrc] },
+  { path: 'GET /v1/instruments', needle: 'getInstruments', files: [commonSrc] },
+  { path: 'POST /v1/instruments', needle: 'postInstruments', files: [commonSrc] },
+  { path: 'GET /v1/exchanges/{exchange}/instruments', needle: 'getExchangeInstruments', files: [commonSrc] },
+  { path: 'GET /v1/universes/{id}', needle: 'getUniverse', files: [commonSrc, extensionsSrc] },
+  { path: 'GET /v1/financials/metrics', needle: 'getFinancialsMetrics', files: [commonSrc] },
+]
+
+const EXTENSION_WIRING = [
+  { path: 'GET /v1/depth/batch', method: 'tfDepthBatch', needle: 'getDepthBatch' },
+  { path: 'GET /v1/universes', method: 'tfListUniverses', needle: 'getUniverses' },
+  { path: 'GET /v1/universes/{id}', method: 'tfGetUniverse', needle: 'getUniverse' },
+  { path: 'POST /v1/universes/batch', method: 'tfUniverseBatch', needle: 'postUniversesBatch' },
+  { path: 'GET /v1/klines/ex-factors', method: 'tfExFactors', needle: 'getKlinesExFactors' },
+  { path: 'GET /v1/klines/batch', method: 'tfKlinesBatch', needle: 'getKlinesBatch' },
+  { path: 'GET /v1/quotes (universes)', method: 'tfQuotesUniverses', needle: 'getQuotes({ universes' },
+  { path: 'GET /v1/klines/intraday', method: 'tfKlinesIntraday', needle: 'getKlinesIntraday' },
+  { path: 'GET /v1/klines/intraday/batch', method: 'tfIntradayBatch', needle: 'getKlinesIntradayBatch' },
+]
+
+test('TickflowClient implements all OpenAPI client methods', () => {
+  const proto = TickflowClient.prototype
+  for (const { path, method } of OPENAPI_TO_CLIENT) {
+    assert.equal(typeof proto[method], 'function', `${path} → client.${method}`)
+    assert.match(clientSrc, new RegExp(`\\b${method}\\(`), `client.ts defines ${method}`)
+  }
+  assert.equal(OPENAPI_TO_CLIENT.length, 21)
+})
+
+test('standard handlers wire quotes and klines endpoints', () => {
+  for (const { path, needle, files } of HANDLER_WIRING) {
+    const hit = files.some(src => src.includes(needle))
+    assert.ok(hit, `${path} should reference ${needle} in handler/common`)
+  }
+  assert.match(handlerSrc, /getQuotes/, 'realtime uses GET /v1/quotes')
+  assert.match(handlerSrc, /postQuotes/, 'batchRealtime uses POST /v1/quotes')
+})
+
+test('extension methods wire remaining OpenAPI paths', () => {
+  for (const { path, method, needle } of EXTENSION_WIRING) {
+    assert.match(extensionsSrc, new RegExp(`\\b${method}\\b`), `${path} → ${method}`)
+    assert.ok(extensionsSrc.includes(needle), `${method} calls ${needle}`)
+  }
+})
+
+test('TickflowDriver exposes extension methods on prototype', () => {
+  const proto = TickflowDriver.prototype
+  for (const { method } of EXTENSION_WIRING) {
+    assert.equal(typeof proto[method], 'function', `TickflowDriver.${method}`)
+  }
+  assert.equal(typeof proto.fetchDepth, 'function', 'fetchDepth on common handler')
+  assert.equal(typeof proto.realtime, 'function', 'realtime STOCK_REALTIME')
+  assert.equal(typeof proto.kline, 'function', 'kline STOCK_KLINE')
+})

--- a/tests/tickflow-us-symbol-routing.test.mjs
+++ b/tests/tickflow-us-symbol-routing.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { inferMarketFromSymbol } from '../packages/a-stock-layer/dist/core/instrument.js'
+import { toTickflowSymbol } from '../packages/a-stock-layer/dist/providers/tickflow/api/symbols.js'
+import { mapTickflowQuote } from '../packages/a-stock-layer/dist/providers/tickflow/normalize/quotes.js'
+
+test('inferMarketFromSymbol treats AAPL as US not crypto', () => {
+  assert.equal(inferMarketFromSymbol('AAPL'), 'US')
+})
+
+test('toTickflowSymbol maps bare US ticker to AAPL.US', () => {
+  assert.equal(toTickflowSymbol('AAPL'), 'AAPL.US')
+})
+
+test('mapTickflowQuote maps US session label and valuation fields from ext', () => {
+  const row = mapTickflowQuote({
+    symbol: 'AAPL.US',
+    last_price: 190,
+    prev_close: 188,
+    open: 189,
+    high: 191,
+    low: 188.5,
+    volume: 1_000_000,
+    amount: 190_000_000,
+    session: 'regular',
+    ext: {
+      name: 'Apple Inc.',
+      change_pct: 0.01,
+      pe: 28.5,
+      market_cap: 3e12,
+      week52_high: 200,
+      week52_low: 150,
+      currency: 'USD',
+    },
+  })
+  assert.ok(row)
+  assert.equal(row.code, 'AAPL')
+  assert.equal(row.name, 'Apple Inc.')
+  assert.equal(row.sessionLabel, '盘中')
+  assert.equal(row.pe, 28.5)
+  assert.equal(row.marketCap, 3e12)
+  assert.equal(row.week52High, 200)
+  assert.equal(row.currency, 'USD')
+})


### PR DESCRIPTION
## Summary
- Align cross-market chart periods with broker standard (日/周/月/季/年) and TickFlow `GET /v1/klines` period params (1d/1w/1M/1Q/1Y)
- Fix HK symbol handling: parse StockIndex `HK:HK.*` ids, preserve 5-digit codes from TickFlow quotes, restore detail/snapshot loading
- Hub quarterly/yearly paths with TickFlow native periods and monthly resample fallback

## Test plan
- [x] `npm run check:ui`
- [x] `npm run build -w @opptrix/shared -w @opptrix/a-stock-layer -w @opptrix/research-hub`
- [x] `node --test tests/instrument-standardization.test.mjs`
- [x] `node --test tests/tickflow-kline-period.test.mjs`

Made with [Cursor](https://cursor.com)