### PR TITLE
fix(market): Opptrix ID 路由、REIT 扶摇、美港 profile

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2047,11 +2047,17 @@ app.delete<{ Params: { id: string } }>('/api/portfolio/trade/:id', async (req, r
   return { success: true }
 })
 
-app.delete<{ Querystring: { code?: string; market?: string } }>('/api/portfolio/instrument', async (req, reply) => {
+app.delete<{ Querystring: { code?: string; market?: string; assetClass?: string } }>('/api/portfolio/instrument', async (req, reply) => {
   const code = String(req.query?.code ?? '').trim()
   if (!code) return reply.code(400).send({ error: 'code required' })
   const market = req.query?.market?.trim() || undefined
-  const { removed } = hub.de.portfolio.clearInstrument(code, market as import('@opptrix/shared').Market | undefined)
+  const assetClassRaw = req.query?.assetClass?.trim() || undefined
+  const assetClass = assetClassRaw as import('@opptrix/shared').AssetClass | undefined
+  const { removed } = hub.de.portfolio.clearInstrument(
+    code,
+    market as import('@opptrix/shared').Market | undefined,
+    assetClass,
+  )
   return { success: true, removed }
 })
 

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -102,7 +102,16 @@ import {
   type UnifiedInstrumentQuotesDto,
   type UnifiedInstrumentSnapshotDto,
 } from '../market/instrument-adapters'
+import { instrumentHubParams } from '@opptrix/shared'
 import type { InstrumentRef, UnifiedInstrumentQuote } from '../types/instrument'
+
+function hubInstrumentBody(ref: InstrumentRef, extra: Record<string, unknown> = {}) {
+  return { ...instrumentHubParams(ref), ...extra }
+}
+
+function hubInstrumentCode(ref: InstrumentRef): string {
+  return instrumentHubParams(ref).code
+}
 import type {
   ChartPeriod,
   ChipDistributionPoint,
@@ -185,11 +194,11 @@ function ohlcBarsToKlines(code: string, bars: StockChartData['bars']): StockKlin
 export const research = {
   diagnose: (codeOrRef: string | InstrumentRef, scorecard?: string) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     return callInstrumentApi<StockDiagnosisData>(
       'stock_diagnosis',
       '/instruments/evaluation',
-      { instrument, ...(scorecard ? { scorecard } : {}) },
+      { ...hubInstrumentBody(instrument), ...(scorecard ? { scorecard } : {}) },
       {
         code,
         name: code,
@@ -208,11 +217,11 @@ export const research = {
 
   institutionRating: (codeOrRef: string | InstrumentRef, groups?: string[], signal?: AbortSignal) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     return callInstrumentApi<InstitutionRatingData>(
       'institution_rating',
       '/instruments/institution-rating',
-      { instrument, ...(groups?.length ? { groups } : {}) },
+      { ...hubInstrumentBody(instrument), ...(groups?.length ? { groups } : {}) },
       {
         code,
         name: code,
@@ -237,11 +246,11 @@ export const research = {
 
   strategySignals: (codeOrRef: string | InstrumentRef, signal?: AbortSignal) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     return callInstrumentApi<StrategySignalData>(
       'strategy_signal',
       '/instruments/strategy-signal',
-      { instrument },
+      hubInstrumentBody(instrument),
       {
         code,
         name: code,
@@ -266,14 +275,16 @@ export const research = {
       30000,
     ),
 
-  strategyVerify: (code: string, checkpoints = 30, forwardDays = 5) =>
-    callInstrumentApi<StrategyVerifyData>(
+  strategyVerify: (code: string, checkpoints = 30, forwardDays = 5) => {
+    const instrument = cnEquityRef(code)
+    const hubCode = hubInstrumentCode(instrument)
+    return callInstrumentApi<StrategyVerifyData>(
       'strategy_verify',
       '/instruments/strategy-verify',
-      { instrument: cnEquityRef(code), checkpoints, forward_days: forwardDays },
+      hubInstrumentBody(instrument, { checkpoints, forward_days: forwardDays }),
       {
-        code,
-        name: code,
+        code: hubCode,
+        name: hubCode,
         checkpoints,
         forward_days: forwardDays,
         date_range: [],
@@ -283,7 +294,8 @@ export const research = {
       },
       undefined,
       120000,
-    ),
+    )
+  },
 
   portfolioAnalysis: (holdings: [string, number][]) =>
     apiCall<PortfolioAnalysisData>('portfolio_analysis', { holdings }),
@@ -342,10 +354,10 @@ export const research = {
 
   stockKline: async (codeOrRef: string | InstrumentRef, count = 90) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     const resp = await postInstrument<StockChartData | UnifiedInstrumentChartDto>(
       '/instruments/chart',
-      { instrument, period: 'daily', count },
+      hubInstrumentBody(instrument, { period: 'daily', count }),
     )
     if (!resp.success || !resp.data) {
       return toApiResponse<StockKlineData>('stock_kline', resp, { code, klines: [] })
@@ -370,8 +382,8 @@ export const research = {
     tail?: number,
   ) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
-    const body: Record<string, unknown> = { instrument, period }
+    const code = hubInstrumentCode(instrument)
+    const body: Record<string, unknown> = { ...hubInstrumentBody(instrument), period }
     if (count != null) body.count = count
     if (before) body.before = before
     if (tail != null) body.tail = tail
@@ -393,12 +405,12 @@ export const research = {
 
   stockCyq: async (codeOrRef: string | InstrumentRef, signal?: AbortSignal) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     const resp = await postInstrument<{
       code: string
       rows: ChipDistributionPoint[]
       latest: ChipDistributionPoint
-    }>('/instruments/cyq', { instrument }, signal, 15000)
+    }>('/instruments/cyq', hubInstrumentBody(instrument), signal, 15000)
     return toApiResponse('stock_cyq', resp, {
       code,
       rows: [],
@@ -408,10 +420,10 @@ export const research = {
 
   stockDetail: async (codeOrRef: string | InstrumentRef) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     const resp = await postInstrument<StockDetailData | UnifiedInstrumentSnapshotDto>(
       '/instruments/snapshot',
-      { instrument },
+      hubInstrumentBody(instrument),
       undefined,
       30000,
     )
@@ -445,7 +457,7 @@ export const research = {
   ): Promise<
     import('../types/schemas').ApiResponse<import('../types/market').EtfSnapshotData>
   > => {
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     const fallback: import('../types/market').EtfSnapshotData = {
       code,
       profile: null,
@@ -454,7 +466,7 @@ export const research = {
     }
     const resp = await apiCall<
       import('../types/market').EtfSnapshotData | UnifiedInstrumentSnapshotDto
-    >('etf_snapshot', { instrument }, { signal }, 20000)
+    >('etf_snapshot', hubInstrumentBody(instrument), { signal }, 20000)
     if (resp.success && resp.data && isUnifiedSnapshot(resp.data)) {
       return toApiResponse('etf_snapshot', resp, fallback, unifiedSnapshotToEtfSnapshot(resp.data))
     }
@@ -469,7 +481,7 @@ export const research = {
   etfNav: (instrument: InstrumentRef, signal?: AbortSignal) =>
     apiCall<{ code: string; items: import('../types/market').EtfNavPoint[]; source?: string }>(
       'etf_nav',
-      { instrument, code: instrument.symbol },
+      hubInstrumentBody(instrument),
       { signal },
       20000,
     ),
@@ -477,7 +489,7 @@ export const research = {
   etfHoldings: (instrument: InstrumentRef, signal?: AbortSignal) =>
     apiCall<{ code: string; items: import('../types/market').EtfHoldingRow[]; source?: string }>(
       'etf_holdings',
-      { instrument, code: instrument.symbol },
+      hubInstrumentBody(instrument),
       { signal },
       20000,
     ),
@@ -488,7 +500,7 @@ export const research = {
   ): Promise<
     import('../types/schemas').ApiResponse<import('../types/market').FundSnapshotData>
   > => {
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     const fallback: import('../types/market').FundSnapshotData = {
       code,
       profile: null,
@@ -497,7 +509,7 @@ export const research = {
     }
     const resp = await apiCall<import('../types/market').FundSnapshotData>(
       'fund_snapshot',
-      { instrument, code },
+      hubInstrumentBody(instrument),
       { signal },
       20000,
     )
@@ -507,7 +519,7 @@ export const research = {
   fundNav: (instrument: InstrumentRef, signal?: AbortSignal, limit = 500) =>
     apiCall<{ code: string; items: import('../types/market').FundNavPoint[]; source?: string }>(
       'fund_nav',
-      { instrument, code: instrument.symbol, limit },
+      hubInstrumentBody(instrument, { limit }),
       { signal },
       20000,
     ),
@@ -515,7 +527,7 @@ export const research = {
   fundHoldings: (instrument: InstrumentRef, signal?: AbortSignal) =>
     apiCall<{ code: string; items: import('../types/market').FundHoldingRow[]; source?: string }>(
       'local_fund_holdings',
-      { instrument, code: instrument.symbol },
+      hubInstrumentBody(instrument),
       { signal },
       20000,
     ),
@@ -526,7 +538,7 @@ export const research = {
   ) =>
     apiCall<import('../types/market').FundDetailData>(
       'fund_detail',
-      { instrument, code: instrument.symbol },
+      hubInstrumentBody(instrument),
       { signal },
       25000,
     ),
@@ -586,7 +598,7 @@ export const research = {
     } }>('/instruments/summary'),
 
   instrumentSnapshot: async (instrument: InstrumentRef, signal?: AbortSignal) => {
-    const resp = await postInstrument<UnifiedInstrumentSnapshotDto>('/instruments/snapshot', { instrument }, signal)
+    const resp = await postInstrument<UnifiedInstrumentSnapshotDto>('/instruments/snapshot', hubInstrumentBody(instrument), signal)
     if (resp.success && resp.data && isUnifiedSnapshot(resp.data)) {
       return {
         ...resp,
@@ -616,7 +628,7 @@ export const research = {
     signal?: AbortSignal,
   ) => postInstrument<{ quote: UnifiedInstrumentQuote; failed?: { code: string; reason: string } }>(
     '/instruments/quote',
-    { instrument, fresh: opts?.fresh ?? true },
+    { ...hubInstrumentBody(instrument), fresh: opts?.fresh ?? true },
     signal,
   ),
 
@@ -628,14 +640,14 @@ export const research = {
     before?: string,
     tail?: number,
   ) => {
-    const body: Record<string, unknown> = { instrument, period, count }
+    const body: Record<string, unknown> = { ...hubInstrumentBody(instrument), period, count }
     if (before) body.before = before
     if (tail != null) body.tail = tail
     const resp = await postInstrument<UnifiedInstrumentChartDto>('/instruments/chart', body, signal)
     if (resp.success && resp.data && isUnifiedChart(resp.data)) {
       return {
         ...resp,
-        data: unifiedChartToStockChart(resp.data, instrument.symbol),
+        data: unifiedChartToStockChart(resp.data, hubInstrumentCode(instrument)),
       }
     }
     return resp
@@ -657,16 +669,16 @@ export const research = {
     signal?: AbortSignal,
   ) => postInstrument<unknown>(
     '/instruments/evaluation',
-    { instrument, scorecard },
+    hubInstrumentBody(instrument, { ...(scorecard ? { scorecard } : {}) }),
     signal,
     60000,
   ),
 
   instrumentStrategySignal: (instrument: InstrumentRef, signal?: AbortSignal) =>
-    postInstrument<unknown>('/instruments/strategy-signal', { instrument }, signal, 60000),
+    postInstrument<unknown>('/instruments/strategy-signal', hubInstrumentBody(instrument), signal, 60000),
 
   instrumentIndicators: (instrument: InstrumentRef, signal?: AbortSignal) =>
-    postInstrument<unknown>('/instruments/indicators', { instrument }, signal, 60000),
+    postInstrument<unknown>('/instruments/indicators', hubInstrumentBody(instrument), signal, 60000),
 
   instrumentStrategyVerify: (
     instrument: InstrumentRef,
@@ -675,7 +687,7 @@ export const research = {
     signal?: AbortSignal,
   ) => postInstrument<unknown>(
     '/instruments/strategy-verify',
-    { instrument, checkpoints, forward_days: forwardDays },
+    hubInstrumentBody(instrument, { checkpoints, forward_days: forwardDays }),
     signal,
     120000,
   ),
@@ -689,13 +701,13 @@ export const research = {
     'latest_evaluation',
     '/instruments/latest-evaluation',
     {
-      instrument,
+      ...hubInstrumentBody(instrument),
       ...(scorecard ? { scorecard } : {}),
       ...(force ? { force: true } : {}),
     },
     {
-      code: instrument.symbol,
-      name: instrument.symbol,
+      code: hubInstrumentCode(instrument),
+      name: hubInstrumentCode(instrument),
       timestamp: '',
       scorecard: scorecard ?? 'G=B+M',
       total_score: 0,
@@ -708,7 +720,7 @@ export const research = {
   instrumentCapabilities: (instrument: InstrumentRef, signal?: AbortSignal) =>
     postInstrument<import('../types/instrument').InstrumentCapabilitySet>(
       '/instruments/capabilities',
-      { instrument },
+      hubInstrumentBody(instrument),
       signal,
     ),
 
@@ -717,7 +729,7 @@ export const research = {
       code: string
       rows: ChipDistributionPoint[]
       latest: ChipDistributionPoint
-    }>('/instruments/cyq', { instrument }, signal, 15000),
+    }>('/instruments/cyq', hubInstrumentBody(instrument), signal, 15000),
 
   instrumentInstitutionRating: (
     instrument: InstrumentRef,
@@ -726,7 +738,7 @@ export const research = {
   ) =>
     postInstrument<InstitutionRatingData>(
       '/instruments/institution-rating',
-      { instrument, ...(groups?.length ? { groups } : {}) },
+      hubInstrumentBody(instrument, { ...(groups?.length ? { groups } : {}) }),
       signal,
       20000,
     ),
@@ -736,12 +748,12 @@ export const research = {
 
   latestEval: (codeOrRef: string | InstrumentRef, signal?: AbortSignal, scorecard?: string, force = false) => {
     const instrument = cnEquityRef(codeOrRef)
-    const code = instrument.symbol
+    const code = hubInstrumentCode(instrument)
     return callInstrumentApi<LatestEvalData>(
       'latest_evaluation',
       '/instruments/latest-evaluation',
       {
-        instrument,
+        ...hubInstrumentBody(instrument),
         ...(scorecard ? { scorecard } : {}),
         ...(force ? { force: true } : {}),
       },
@@ -1322,9 +1334,14 @@ export async function portfolioDeleteTrade(id: number) {
   return resp.json() as Promise<{ success: boolean }>
 }
 
-export async function portfolioClearInstrument(code: string, market?: string) {
+export async function portfolioClearInstrument(
+  code: string,
+  market?: string,
+  assetClass?: string,
+) {
   const qs = new URLSearchParams({ code: code.trim() })
   if (market) qs.set('market', market)
+  if (assetClass) qs.set('assetClass', assetClass)
   const resp = await fetchWithTimeout(`${API_BASE}/portfolio/instrument?${qs}`, { method: 'DELETE' })
   if (!resp.ok) throw new Error('clear portfolio instrument failed')
   return resp.json() as Promise<{ success: boolean; removed: number }>

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -102,7 +102,7 @@ import {
   type UnifiedInstrumentQuotesDto,
   type UnifiedInstrumentSnapshotDto,
 } from '../market/instrument-adapters'
-import { instrumentHubParams } from '@opptrix/shared'
+import { instrumentHubParams } from '@opptrix/shared/instrument-param'
 import type { InstrumentRef, UnifiedInstrumentQuote } from '../types/instrument'
 
 function hubInstrumentBody(ref: InstrumentRef, extra: Record<string, unknown> = {}) {

--- a/client-ui/src/market/FundDetailTab.tsx
+++ b/client-ui/src/market/FundDetailTab.tsx
@@ -256,7 +256,8 @@ export default function FundDetailTab({
   )
   const stockCode = instrumentRef?.symbol ?? stock?.code ?? null
   const displayCode = stock?.code?.trim() ?? ''
-  const isListedFund = stockCode != null && isCnListedFundSymbol(stockCode)
+  const isReit = instrumentRef?.assetClass === 'REIT'
+  const isListedFund = stockCode != null && (isCnListedFundSymbol(stockCode) || isReit)
   const isLof = stockCode != null && isCnLofSymbol(stockCode)
 
   const chartInstrument = useMemo(() => {
@@ -264,7 +265,7 @@ export default function FundDetailTab({
     if (!isListedFund) return instrumentRef
     return {
       ...instrumentRef,
-      exchange: inferCnExchangeFromCode(instrumentRef.symbol),
+      exchange: instrumentRef.exchange ?? inferCnExchangeFromCode(instrumentRef.symbol),
     }
   }, [instrumentRef, isListedFund])
 
@@ -373,7 +374,9 @@ export default function FundDetailTab({
             <span className={s.name}>{displayName}</span>
             <span className={s.code}>{displayCode}</span>
             {isHolding && <Badge size="small" color="informative" appearance="outline">持有</Badge>}
-            <span className={s.badge}>{isListedFund ? '场内基金' : '场外基金'}</span>
+            <span className={s.badge}>
+              {isReit ? 'REIT' : isListedFund ? '场内基金' : '场外基金'}
+            </span>
           </div>
           <div className={s.quoteMain}>
             {onManage && (
@@ -437,7 +440,7 @@ export default function FundDetailTab({
 
       {tab === 'chart' ? (
         <div className={s.chartWrap}>
-          {instrumentRef && isListedFund && !isLof ? (
+          {instrumentRef && isListedFund && !isLof && !isReit ? (
             <TradingViewChart
               code={displayCode}
               instrument={chartInstrument}

--- a/client-ui/src/market/FundDetailTab.tsx
+++ b/client-ui/src/market/FundDetailTab.tsx
@@ -22,7 +22,7 @@ import {
   pctTone,
   resolveDisplayStockName,
 } from './format'
-import { displayCodeFromInstrument, resolveWatchlistInstrument } from './instrument'
+import { resolveWatchlistInstrument } from './instrument'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { ghostInteractive } from '../theme/mixins'
 
@@ -205,7 +205,10 @@ function HeroCell({ label, value }: { label: string; value: string }) {
 
 function mergeProfile(snapshot: FundSnapshotData | null): FundProfileData | null {
   if (!snapshot) return null
-  const base = (snapshot.profile ?? {}) as FundProfileData
+  const rawProfile = snapshot.profile
+  if (rawProfile != null && typeof rawProfile !== 'object') return null
+  if (Array.isArray(rawProfile)) return null
+  const base = (rawProfile ?? {}) as FundProfileData
   const quote = snapshot.quote as Record<string, unknown> | null
   const nav = snapshot.nav as Record<string, unknown> | null
   return {
@@ -252,7 +255,7 @@ export default function FundDetailTab({
     [stock],
   )
   const stockCode = instrumentRef?.symbol ?? stock?.code ?? null
-  const displayCode = instrumentRef ? displayCodeFromInstrument(instrumentRef) : (stock?.code ?? '')
+  const displayCode = stock?.code?.trim() ?? ''
   const isListedFund = stockCode != null && isCnListedFundSymbol(stockCode)
   const isLof = stockCode != null && isCnLofSymbol(stockCode)
 

--- a/client-ui/src/market/FundNavChart.tsx
+++ b/client-ui/src/market/FundNavChart.tsx
@@ -13,7 +13,7 @@ import type { FundNavPoint } from '../types/market'
 import { useTheme } from '../theme/ThemeContext'
 import { DETAIL_PANEL_CHART_MAX_HEIGHT_PX } from './chartViewConfig'
 import { getChartTheme, getMaColors, stockPriceFormat } from './chartTheme'
-import { toChartBusinessDay } from './chartTime'
+import { compareChartTime, timeSortKey, toChartBusinessDay } from './chartTime'
 import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
 
 const useStyles = makeStyles({
@@ -85,15 +85,15 @@ function navPointTime(date: string): Time | null {
 }
 
 function buildLineData(rows: FundNavPoint[], field: 'nav' | 'accNav'): LineData<Time>[] {
-  const out: LineData<Time>[] = []
+  const byTime = new Map<string, LineData<Time>>()
   for (const row of rows) {
     const value = field === 'nav' ? row.nav : row.accNav
     if (value == null || !Number.isFinite(value)) continue
     const time = navPointTime(row.date)
     if (!time) continue
-    out.push({ time, value })
+    byTime.set(String(timeSortKey(time)), { time, value })
   }
-  return out
+  return [...byTime.values()].sort((a, b) => compareChartTime(a.time, b.time))
 }
 
 export default function FundNavChart({ instrument, active = true }: Props) {
@@ -149,55 +149,63 @@ export default function FundNavChart({ instrument, active = true }: Props) {
     const el = containerRef.current
     if (!el || !active || unitLine.length === 0) return undefined
 
-    const theme = getChartTheme(resolvedScheme)
-    const chart = createChart(el, {
-      layout: theme.layout,
-      grid: theme.grid,
-      rightPriceScale: { borderVisible: false },
-      timeScale: { borderVisible: false, fixLeftEdge: true, fixRightEdge: true },
-      crosshair: { mode: 1 },
-      handleScroll: { vertTouchDrag: false },
-    })
-    chartRef.current = chart
+    let chart: IChartApi | null = null
+    try {
+      const theme = getChartTheme(resolvedScheme)
+      chart = createChart(el, {
+        layout: theme.layout,
+        grid: theme.grid,
+        rightPriceScale: { borderVisible: false },
+        timeScale: { borderVisible: false, fixLeftEdge: true, fixRightEdge: true },
+        crosshair: { mode: 1 },
+        handleScroll: { vertTouchDrag: false },
+      })
+      chartRef.current = chart
 
-    const unitSeries = chart.addSeries(LineSeries, {
-      color: maColors.ma5,
-      lineWidth: 2,
-      priceLineVisible: false,
-      lastValueVisible: true,
-      crosshairMarkerVisible: true,
-      priceFormat: stockPriceFormat,
-    })
-    unitSeries.setData(unitLine)
-
-    if (hasAccLine) {
-      const accSeries = chart.addSeries(LineSeries, {
-        color: maColors.ma10,
-        lineWidth: 1,
+      const unitSeries = chart.addSeries(LineSeries, {
+        color: maColors.ma5,
+        lineWidth: 2,
         priceLineVisible: false,
-        lastValueVisible: false,
+        lastValueVisible: true,
         crosshairMarkerVisible: true,
         priceFormat: stockPriceFormat,
       })
-      accSeries.setData(accLine)
+      unitSeries.setData(unitLine)
+
+      if (hasAccLine) {
+        const accSeries = chart.addSeries(LineSeries, {
+          color: maColors.ma10,
+          lineWidth: 1,
+          priceLineVisible: false,
+          lastValueVisible: false,
+          crosshairMarkerVisible: true,
+          priceFormat: stockPriceFormat,
+        })
+        accSeries.setData(accLine)
+      }
+
+      chart.timeScale().fitContent()
+    } catch (err) {
+      chart?.remove()
+      chartRef.current = null
+      setError(err instanceof Error ? err.message : '净值走势渲染失败')
+      return undefined
     }
 
-    chart.timeScale().fitContent()
-
     const ro = new ResizeObserver(() => {
-      if (containerRef.current) {
-        chart.applyOptions({
+      if (containerRef.current && chartRef.current) {
+        chartRef.current.applyOptions({
           width: containerRef.current.clientWidth,
           height: containerRef.current.clientHeight,
         })
       }
     })
     ro.observe(el)
-    chart.applyOptions({ width: el.clientWidth, height: el.clientHeight })
+    chartRef.current?.applyOptions({ width: el.clientWidth, height: el.clientHeight })
 
     return () => {
       ro.disconnect()
-      chart.remove()
+      chartRef.current?.remove()
       chartRef.current = null
     }
   }, [active, unitLine, accLine, hasAccLine, resolvedScheme, maColors])

--- a/client-ui/src/market/IndexDetailTab.tsx
+++ b/client-ui/src/market/IndexDetailTab.tsx
@@ -1,0 +1,346 @@
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
+import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { research } from '../api/client'
+import type { StockDetailData, WatchlistItem } from '../types/market'
+import {
+  normalizeWatchlistItem,
+  resolveWatchlistInstrument,
+  watchlistItemKey,
+  UNRESOLVED_INSTRUMENT_COPY,
+} from './instrument'
+import {
+  formatCompactNumber,
+  formatPct,
+  formatPrice,
+  formatSignedNumber,
+  formatVolume,
+  pctTone,
+  resolveDisplayStockName,
+} from './format'
+import TradingViewChart from './TradingViewChart'
+import { DETAIL_PANEL_CHART_MAX_HEIGHT_PX } from './chartViewConfig'
+import { WATCHLIST_QUOTES_POLL_MS } from './watchlistQuotes'
+import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
+
+const CONTENT_PAD = '15px'
+const DETAIL_FOOTNOTE = '指数行情约每 1 分钟刷新；成分与权重请通过助手查询。'
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    height: '100%',
+  },
+  hero: {
+    flexShrink: 0,
+    padding: `6px ${CONTENT_PAD} 5px`,
+    borderBottom: `1px solid ${opptrixCssVars.separator}`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '6px',
+    minWidth: 0,
+  },
+  titleMain: {
+    display: 'flex',
+    alignItems: 'baseline',
+    gap: '6px',
+    minWidth: 0,
+    overflow: 'hidden',
+  },
+  name: {
+    fontSize: 'var(--opptrix-font-lg)',
+    fontWeight: 650,
+    letterSpacing: '-0.02em',
+    color: opptrixCssVars.textPrimary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  code: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    flexShrink: 0,
+  },
+  badge: {
+    fontSize: 'var(--opptrix-font-xs)',
+    fontWeight: 600,
+    padding: '2px 6px',
+    borderRadius: opptrixTokens.radiusFull,
+    backgroundColor: opptrixCssVars.accentSoft,
+    color: opptrixCssVars.textSecondary,
+    flexShrink: 0,
+  },
+  quoteMain: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    flexShrink: 0,
+  },
+  price: {
+    fontSize: 'var(--opptrix-font-3xl)',
+    fontWeight: 700,
+    letterSpacing: '-0.03em',
+    fontVariantNumeric: 'tabular-nums',
+    lineHeight: 1.1,
+  },
+  change: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  pct: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    fontVariantNumeric: 'tabular-nums',
+  },
+  pctUp: { color: '#FF3B30' },
+  pctDown: { color: '#34C759' },
+  pctFlat: { color: opptrixCssVars.textTertiary },
+  heroGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+    gap: '2px 6px',
+  },
+  heroCell: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'space-between',
+    gap: '4px',
+    minWidth: 0,
+  },
+  heroLabel: {
+    fontSize: 'var(--opptrix-font-xs)',
+    color: opptrixCssVars.textTertiary,
+    flexShrink: 0,
+  },
+  heroValue: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    color: opptrixCssVars.textPrimary,
+    fontVariantNumeric: 'tabular-nums',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  chartBody: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  chartPanel: {
+    flexShrink: 0,
+    maxHeight: `${DETAIL_PANEL_CHART_MAX_HEIGHT_PX}px`,
+    minHeight: '200px',
+    padding: `4px ${CONTENT_PAD} 8px`,
+    overflow: 'hidden',
+  },
+  foot: {
+    flexShrink: 0,
+    padding: `0 ${CONTENT_PAD} 10px`,
+    fontSize: 'var(--opptrix-font-xs)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.45,
+  },
+  center: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '24px',
+    color: opptrixCssVars.textTertiary,
+    fontSize: 'var(--opptrix-font-md)',
+  },
+  error: {
+    flexShrink: 0,
+    padding: `0 ${CONTENT_PAD}`,
+    fontSize: 'var(--opptrix-font-xs)',
+    color: opptrixCssVars.error,
+  },
+})
+
+interface Props {
+  stock: WatchlistItem | null
+}
+
+function HeroCell({ label, value }: { label: string; value: string }) {
+  const s = useStyles()
+  return (
+    <div className={s.heroCell}>
+      <span className={s.heroLabel}>{label}</span>
+      <span className={s.heroValue}>{value}</span>
+    </div>
+  )
+}
+
+function IndexDetailTab({ stock }: Props) {
+  const s = useStyles()
+  const [detail, setDetail] = useState<StockDetailData | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [detailReload, setDetailReload] = useState(0)
+  const stockRef = useRef(stock)
+  stockRef.current = stock
+
+  const normalizedStock = useMemo(
+    () => (stock ? normalizeWatchlistItem(stock) : null),
+    [stock],
+  )
+  const stockKey = useMemo(
+    () => (normalizedStock ? watchlistItemKey(normalizedStock) : null),
+    [normalizedStock],
+  )
+  const instrumentRef = useMemo(
+    () => (normalizedStock ? resolveWatchlistInstrument(normalizedStock) ?? undefined : undefined),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by stockKey
+    [stockKey],
+  )
+  const displayCode = stock?.code?.trim() ?? ''
+
+  useEffect(() => {
+    if (!stockKey || !instrumentRef) {
+      setDetail(null)
+      setError(instrumentRef ? '' : UNRESOLVED_INSTRUMENT_COPY.hint)
+      return undefined
+    }
+
+    let cancelled = false
+    setLoading(true)
+    setError('')
+
+    research.stockDetail(instrumentRef)
+      .then(resp => {
+        if (cancelled) return
+        if (!resp.success || !resp.data) {
+          setError(resp.message || '暂时无法加载指数行情，请稍后再试')
+          setDetail(null)
+          return
+        }
+        setDetail(resp.data)
+      })
+      .catch(e => {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : '暂时无法加载指数行情，请稍后再试')
+          setDetail(null)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+
+    return () => { cancelled = true }
+  }, [stockKey, instrumentRef, detailReload])
+
+  useEffect(() => {
+    if (!stockKey) return undefined
+    const timer = window.setInterval(() => setDetailReload(n => n + 1), WATCHLIST_QUOTES_POLL_MS)
+    return () => window.clearInterval(timer)
+  }, [stockKey])
+
+  if (!stock) {
+    return <div className={s.center}>请在「关注」中选择一条指数</div>
+  }
+
+  if (loading && !detail) {
+    const pendingName = normalizedStock?.name && normalizedStock.name !== normalizedStock.code
+      ? normalizedStock.name
+      : displayCode
+    return (
+      <div className={s.root}>
+        <div className={s.hero}>
+          <div className={s.titleRow}>
+            <div className={s.titleMain}>
+              <Text className={s.name}>{pendingName}</Text>
+              <span className={s.code}>{displayCode}</span>
+              <span className={s.badge}>指数</span>
+            </div>
+          </div>
+        </div>
+        <div className={s.center}><Spinner size="small" label="正在加载指数行情…" /></div>
+      </div>
+    )
+  }
+
+  if (error && !detail) {
+    return <div className={s.center}>{error}</div>
+  }
+
+  if (!detail || !instrumentRef) {
+    return <div className={s.center}>暂时无法显示该指数</div>
+  }
+
+  const quote = detail.quote
+  const displayName = resolveDisplayStockName(
+    instrumentRef.symbol,
+    quote?.name,
+    detail.name,
+    normalizedStock?.name,
+  )
+  const tone = pctTone(quote?.changePct)
+  const toneClass = mergeClasses(
+    tone === 'up' && s.pctUp,
+    tone === 'down' && s.pctDown,
+    tone === 'flat' && s.pctFlat,
+  )
+
+  return (
+    <div className={s.root}>
+      <div className={s.hero}>
+        <div className={s.titleRow}>
+          <div className={s.titleMain}>
+            <Text className={s.name}>{displayName}</Text>
+            <span className={s.code}>{displayCode}</span>
+            <span className={s.badge}>指数</span>
+          </div>
+          <div className={s.quoteMain}>
+            <span className={mergeClasses(s.price, toneClass)}>
+              {formatPrice(quote?.price ?? null, 2)}
+            </span>
+            <span className={mergeClasses(s.change, toneClass)}>
+              {formatSignedNumber(quote?.change ?? null, 2)}
+            </span>
+            <span className={mergeClasses(s.pct, toneClass)}>
+              {formatPct(quote?.changePct ?? null)}
+            </span>
+          </div>
+        </div>
+        <div className={s.heroGrid}>
+          <HeroCell label="今开" value={formatPrice(quote?.open ?? null, 2)} />
+          <HeroCell label="最高" value={formatPrice(quote?.high ?? null, 2)} />
+          <HeroCell label="最低" value={formatPrice(quote?.low ?? null, 2)} />
+          <HeroCell label="昨收" value={formatPrice(quote?.preClose ?? null, 2)} />
+          <HeroCell label="成交量" value={formatVolume(quote?.volume ?? null)} />
+          <HeroCell label="成交额" value={formatCompactNumber(quote?.amount ?? null)} />
+          <HeroCell
+            label="振幅"
+            value={quote?.amplitude != null ? `${quote.amplitude.toFixed(2)}%` : '—'}
+          />
+          <HeroCell label="涨跌额" value={formatSignedNumber(quote?.change ?? null, 2)} />
+        </div>
+      </div>
+
+      <div className={s.chartBody}>
+        <div className={s.chartPanel}>
+          <TradingViewChart
+            code={instrumentRef.symbol}
+            instrument={instrumentRef}
+            chartVariant="index"
+            expanded
+            active
+          />
+        </div>
+        {error ? <Text className={s.error}>刷新失败：{error}</Text> : null}
+        <Text className={s.foot}>{DETAIL_FOOTNOTE}</Text>
+      </div>
+    </div>
+  )
+}
+
+export default memo(IndexDetailTab)

--- a/client-ui/src/market/RightMarketPanel.tsx
+++ b/client-ui/src/market/RightMarketPanel.tsx
@@ -3,6 +3,7 @@ import { makeStyles, mergeClasses, Text } from '@fluentui/react-components'
 import PortfolioTab from './PortfolioTab'
 import WatchlistTab from './WatchlistTab'
 import StockDetailTab from './StockDetailTab'
+import IndexDetailTab from './IndexDetailTab'
 import EtfDetailTab from './EtfDetailTab'
 import FundDetailTab from './FundDetailTab'
 import CryptoDetailTab from './CryptoDetailTab'
@@ -315,6 +316,7 @@ function RightMarketPanel({
     : null
 
   const detailRef = detailStock ? resolveWatchlistInstrument(detailStock) : null
+  const detailManageEnabled = detailRef != null && hasApplicationCapability(detailRef, 'portfolio_pnl')
   const detailHolding = detailStock && detailRef
     ? holdingsByCode[portfolioHoldingsKey(detailStock.code, detailRef.market)]
       ?? holdingsByCode[instrumentKey(detailRef)]
@@ -331,8 +333,9 @@ function RightMarketPanel({
   }, [handleSelect])
 
   const handleRemove = useCallback((item: WatchlistItem) => {
-    const ref = resolveWatchlistInstrument(normalizeWatchlistItem(item))
-    void clearPortfolioForCode(item.code, ref?.market)
+    const normalized = normalizeWatchlistItem(item)
+    const ref = resolveWatchlistInstrument(normalized)
+    void clearPortfolioForCode(item.code, ref?.market, ref?.assetClass)
     removeItemMembership(watchlistItemKey(normalizeWatchlistItem(item)))
     removeItem(item.code)
     const selectedKey = selected
@@ -488,23 +491,25 @@ function RightMarketPanel({
             onRetry={() => { void refreshHoldings() }}
           />
         </div>
-        {tab === 'detail' && detailStock && detailKind === 'cn-fund' ? (
+        {tab === 'detail' && detailStock && detailKind === 'cn-index' ? (
+          <IndexDetailTab stock={detailStock} />
+        ) : tab === 'detail' && detailStock && detailKind === 'cn-fund' ? (
           <FundDetailTab
             stock={detailStock}
             isHolding={(detailHolding?.shares ?? 0) > 0}
-            onManage={handleDetailManage}
+            onManage={detailManageEnabled ? handleDetailManage : undefined}
           />
         ) : tab === 'detail' && detailStock && detailKind === 'cn-etf' ? (
           <EtfDetailTab stock={detailStock} />
         ) : tab === 'detail' && detailStock && detailKind === 'crypto' ? (
           <CryptoDetailTab
             stock={detailStock}
-            onManage={handleDetailManage}
+            onManage={detailManageEnabled ? handleDetailManage : undefined}
           />
         ) : tab === 'detail' && detailStock && detailKind === 'cross-market' ? (
           <CrossMarketDetailTab
             stock={detailStock}
-            onManage={handleDetailManage}
+            onManage={detailManageEnabled ? handleDetailManage : undefined}
             onSelectPeer={handleSelectPeer}
           />
         ) : tab === 'detail' && detailStock && detailKind === 'cn-equity' ? (
@@ -512,7 +517,7 @@ function RightMarketPanel({
             stock={detailStock}
             isHolding={(detailHolding?.shares ?? 0) > 0}
             holding={detailHolding ?? null}
-            onManage={handleDetailManage}
+            onManage={detailManageEnabled ? handleDetailManage : undefined}
             onDiscussInChat={onDiscussInChat}
           />
         ) : tab === 'detail' && detailStock && !detailKind ? (

--- a/client-ui/src/market/TradingViewChart.tsx
+++ b/client-ui/src/market/TradingViewChart.tsx
@@ -8,7 +8,7 @@ import { isCnListedFundSymbol } from './format'
 import type { ChartPeriod, OhlcChartBar, StockChartData } from '../types/market'
 import { ChartWorkspace } from './chartEngine'
 import { buildChartSeries, isLineChartView, periodLabel } from './chartSeries'
-import { buildChartPeriodOptions, CN_STOCK_CHART_PERIODS } from './chartPeriodOptions'
+import { buildChartPeriodOptions, buildIndexChartPeriodOptions, CN_STOCK_CHART_PERIODS } from './chartPeriodOptions'
 import { DETAIL_PANEL_CHART_MAX_HEIGHT_PX, initialFetchCount, LOAD_MORE_STEP, maxChartBars } from './chartViewConfig'
 import { isLineChartPaneLabel } from './chartTime'
 import { chartLivePollIntervalMs, shouldPollChartLive } from './chartLiveRefresh'
@@ -280,9 +280,17 @@ interface Props {
   expanded?: boolean
   /** Tab/panel visible — triggers chart resize after layout. */
   active?: boolean
+  /** 指数图：隐藏筹码/MACD，周期对齐券商指数页 */
+  chartVariant?: 'equity' | 'index'
 }
 
-export default function TradingViewChart({ code, instrument, expanded = false, active = true }: Props) {
+export default function TradingViewChart({
+  code,
+  instrument,
+  expanded = false,
+  active = true,
+  chartVariant = 'equity',
+}: Props) {
   const s = useStyles()
   /** 按标的身份稳定，避免父组件每次 render 新建 instrument 对象导致 loadChart abort */
   const instrumentIdentity = useMemo(
@@ -319,10 +327,13 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
       || listedCnFundChart)
     && (hasApplicationCapability(instrumentRef, 'chart_intraday')
       || hasApplicationCapability(instrumentRef, 'chart_daily'))
+  const isIndexChart = chartVariant === 'index' || instrumentRef.assetClass === 'INDEX'
   const canChart = cnEquityChart || crossMarketChart
   const periodOptions = useMemo(
-    () => buildChartPeriodOptions(instrumentRef, { cnEquityChart, crossMarketChart }),
-    [instrumentRef, cnEquityChart, crossMarketChart],
+    () => (isIndexChart
+      ? buildIndexChartPeriodOptions(instrumentRef)
+      : buildChartPeriodOptions(instrumentRef, { cnEquityChart, crossMarketChart })),
+    [instrumentRef, cnEquityChart, crossMarketChart, isIndexChart],
   )
   const { resolvedScheme } = useTheme()
   const maColors = useMemo(() => getMaColors(resolvedScheme), [resolvedScheme])
@@ -567,7 +578,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
 
   const paneMainLabel = isLineChartPaneLabel(period) ? '分' : 'K'
   const lineChartView = Boolean(data && data.period === period && isLineChartView(period, data.bars))
-  const showMacd = Boolean(
+  const showMacd = !isIndexChart && Boolean(
     data && !lineChartView
     && data.indicators.some(row => row.macd != null),
   )
@@ -578,7 +589,7 @@ export default function TradingViewChart({ code, instrument, expanded = false, a
   const legendOhlc = !lineChartView && data
   const cyqLatest = data?.cyqLatest ?? null
   const cyqProfile = data?.cyqProfile ?? null
-  const showCyq = Boolean(
+  const showCyq = !isIndexChart && Boolean(
     isCyqChartPeriod(period)
     && cyqLatest
     && cyqProfile

--- a/client-ui/src/market/WatchlistTab.tsx
+++ b/client-ui/src/market/WatchlistTab.tsx
@@ -27,7 +27,7 @@ import type { QuoteFailedReason } from './instrument-adapters'
 import { lookupHoldingSnapshot, followReturnPct, holdingReturnPctFromQuote, dayChangeReturnPct } from './portfolioCalc'
 import { formatWatchlistRadarLine } from './watchlistRadar'
 import type { WatchlistRadarItem } from '../types/schemas'
-import { displayCodeFromInstrument, instrumentKey, tryParseInstrumentInput, resolveWatchlistInstrument, watchlistItemKey, watchlistDisplayCode, UNRESOLVED_INSTRUMENT_COPY, formatDisambiguationCandidateLabel, formatInstrumentSearchHitSubtitle, normalizeWatchlistItem } from './instrument'
+import { displayCodeFromInstrument, instrumentKey, tryParseInstrumentInput, resolveWatchlistInstrument, watchlistItemKey, UNRESOLVED_INSTRUMENT_COPY, formatDisambiguationCandidateLabel, formatInstrumentSearchHitSubtitle, normalizeWatchlistItem } from './instrument'
 import {
   WATCHLIST_QUOTES_POLL_MS,
   WatchlistQuoteBatchAbortError,
@@ -1195,7 +1195,8 @@ export default function WatchlistTab({
                   selectedCode === item.code ? strategyByCode[item.code] : null,
                 )
               const displayName = resolveDisplayStockName(item.code, quote?.name, radarRow?.name, item.name)
-              const displayCode = watchlistDisplayCode(item)
+              const displayCode = item.code.trim() || '—'
+              const portfolioEditEnabled = ref != null && hasApplicationCapability(ref, 'portfolio_pnl')
               const rowTooltip = [
                 unresolved
                   ? (hasCandidates ? UNRESOLVED_INSTRUMENT_COPY.ambiguousHint : UNRESOLVED_INSTRUMENT_COPY.hint)
@@ -1359,14 +1360,16 @@ export default function WatchlistTab({
                     onClick={stopRowActionPointer}
                   >
                     <span className={mergeClasses(s.rowActions, 'opptrix-follow-actions')}>
-                      <button
-                        type="button"
-                        className={mergeClasses(s.rowActionBtn, 'opptrix-focusable')}
-                        aria-label={`修改 ${displayName}`}
-                        onClick={() => onManage(item)}
-                      >
-                        <EditRegular fontSize={14} />
-                      </button>
+                      {portfolioEditEnabled && (
+                        <button
+                          type="button"
+                          className={mergeClasses(s.rowActionBtn, 'opptrix-focusable')}
+                          aria-label={`修改 ${displayName}`}
+                          onClick={() => onManage(item)}
+                        >
+                          <EditRegular fontSize={14} />
+                        </button>
+                      )}
                       <button
                         type="button"
                         className={mergeClasses(s.rowActionBtn, 'opptrix-focusable')}

--- a/client-ui/src/market/chartPeriodOptions.ts
+++ b/client-ui/src/market/chartPeriodOptions.ts
@@ -27,6 +27,10 @@ function cnExtendedOhlc(ref: InstrumentRef, cnEquityChart: boolean): boolean {
   return ref.assetClass === 'EQUITY' || ref.assetClass === 'INDEX'
 }
 
+export function buildIndexChartPeriodOptions(_ref: InstrumentRef): ChartPeriodOption[] {
+  return BROKER_KLINE_OPTIONS
+}
+
 export function buildChartPeriodOptions(
   ref: InstrumentRef,
   opts: { cnEquityChart: boolean; crossMarketChart: boolean },

--- a/client-ui/src/market/fundDetailPanels.tsx
+++ b/client-ui/src/market/fundDetailPanels.tsx
@@ -261,9 +261,11 @@ export function FundArchivePanel({
     )
   }
 
-  const rateInfo = profile.rateInfo?.filter(r => (r.label || r.name)?.trim()) ?? []
+  const rateInfo = profile.rateInfo?.filter(r => r && (r.label || r.name)?.trim()) ?? []
   const hasExpenseOnly = rateInfo.length === 0 && profile.expenseRatio != null
-  const tradeRules = profile.tradeRules?.filter(r => r.trim()) ?? []
+  const tradeRules = profile.tradeRules?.filter(
+    r => typeof r === 'string' && r.trim(),
+  ) ?? []
 
   return (
     <div className={s.section}>

--- a/client-ui/src/market/instrument.ts
+++ b/client-ui/src/market/instrument.ts
@@ -76,9 +76,9 @@ export function displayCodeFromInstrument(ref: InstrumentRef): string {
   return instrumentDisplayCode(ref)
 }
 
-/** @ 引用标签 — Stock-index 统一命名空间（与本地名录 / 关注列表一致） */
+/** @ 引用标签 — OpptrixQuant 统一 ID（与搜索 / 关注列表 / 详情展示一致） */
 export function formatInstrumentLabel(ref: InstrumentRef): string {
-  return buildInstrumentNamespace(ref)
+  return displayCodeFromInstrument(ref)
 }
 
 /** 与 @opptrix/shared instrumentRefKey 保持一致 — Stock-index 命名空间 */
@@ -110,6 +110,11 @@ export function tryResolveWatchlistInstrument(item: WatchlistItem): InstrumentRe
       return null
     }
     return normalizeInstrumentRefLocal(item.instrument)
+  }
+  const rawCode = item.code.trim()
+  const opptrix = parseOpptrixInstrumentId(rawCode)
+  if (opptrix) {
+    return normalizeInstrumentRefLocal(opptrix as InstrumentRef)
   }
   const industry = item.industry?.trim() ?? ''
   if (industry.includes('公募基金')) {
@@ -171,25 +176,23 @@ export function isOpptrixInstrumentCode(code: string): boolean {
 export function prepareWatchlistItemForStore(item: WatchlistItem): WatchlistItem {
   const raw = item.code.trim()
   if (isOpptrixInstrumentCode(raw)) {
+    const parsed = parseOpptrixInstrumentId(raw)
+    const instrument = item.instrument
+      ? normalizeInstrumentRefLocal(item.instrument)
+      : parsed
+        ? normalizeInstrumentRefLocal(parsed as InstrumentRef)
+        : undefined
     return {
       ...item,
       code: raw,
-      name: item.name?.trim() || raw,
+      name: item.name?.trim() || (instrument ? displayCodeFromInstrument(instrument) : raw),
       industry: item.industry?.trim() || undefined,
       note: item.note?.trim() || undefined,
       addedPrice: item.addedPrice ?? null,
-      instrument: item.instrument ? normalizeInstrumentRefLocal(item.instrument) : undefined,
+      instrument,
     }
   }
   return normalizeWatchlistItem(item)
-}
-
-/** 展示用代码：Opptrix ID 直接展示；旧关注项用命名空间 */
-export function watchlistDisplayCode(item: WatchlistItem): string {
-  const raw = item.code.trim()
-  if (isOpptrixInstrumentCode(raw)) return raw
-  const ref = tryResolveWatchlistInstrument(item)
-  return ref ? displayCodeFromInstrument(ref) : (raw || '—')
 }
 
 export function normalizeWatchlistItem(item: WatchlistItem): WatchlistItem {
@@ -255,6 +258,7 @@ export function resolveStockContextInstrument(
 }
 
 export function detailPanelKind(ref: InstrumentRef): DetailPanelKind {
+  if (ref.market === 'CN' && ref.assetClass === 'INDEX') return 'cn-index'
   if (ref.market === 'CN' && (ref.assetClass === 'FUND' || ref.assetClass === 'REIT')) return 'cn-fund'
   if (ref.market === 'CN' && (ref.assetClass === 'ETF' || ref.assetClass === 'LOF')) return 'cn-etf'
   if (ref.market === 'CN') return 'cn-equity'
@@ -277,10 +281,10 @@ export function marketDisplayName(market: Market): string {
   }
 }
 
-/** 搜索候选副标题 — 市场 · 代码 · 类型（搜索 ID 不再 normalize） */
+/** 搜索候选副标题 — 市场 · 代码 · 类型 */
 export function formatInstrumentSearchHitSubtitle(item: WatchlistItem): string {
   const ref = item.instrument ?? tryResolveWatchlistInstrument(item)
-  const code = watchlistDisplayCode(item)
+  const code = item.code.trim() || '—'
   if (!ref) return item.industry?.trim() || code
 
   const parts: string[] = [marketDisplayName(ref.market), code]

--- a/client-ui/src/market/useFollowPortfolio.ts
+++ b/client-ui/src/market/useFollowPortfolio.ts
@@ -172,9 +172,13 @@ export function useFollowPortfolio(options?: { enabled?: boolean }) {
     return loadTrades(code, market)
   }, [loadTrades, refreshHoldings])
 
-  const clearPortfolioForCode = useCallback(async (code: string, market?: string) => {
+  const clearPortfolioForCode = useCallback(async (
+    code: string,
+    market?: string,
+    assetClass?: string,
+  ) => {
     try {
-      await portfolioClearInstrument(code, market)
+      await portfolioClearInstrument(code, market, assetClass)
     } catch {
       /* best-effort cleanup when removing watchlist row */
     }
@@ -187,6 +191,9 @@ export function useFollowPortfolio(options?: { enabled?: boolean }) {
       if (ref) {
         keys.add(portfolioHoldingsStorageKey(normalizeInstrumentRefLocal(ref)))
         keys.add(instrumentKey(ref))
+      }
+      if (assetClass && ref) {
+        keys.add(instrumentKey({ ...ref, assetClass: assetClass as import('../types/instrument').InstrumentRef['assetClass'] }))
       }
       for (const k of keys) {
         if (k) delete next[k]

--- a/client-ui/src/types/instrument.ts
+++ b/client-ui/src/types/instrument.ts
@@ -20,7 +20,7 @@ export interface InstrumentRef {
   quote?: string
 }
 
-export type DetailPanelKind = 'cn-equity' | 'cn-etf' | 'cn-fund' | 'crypto' | 'cross-market'
+export type DetailPanelKind = 'cn-equity' | 'cn-etf' | 'cn-fund' | 'cn-index' | 'crypto' | 'cross-market'
 
 export interface LocalInstrumentHit {
   code: string
@@ -55,7 +55,7 @@ export interface InstrumentCapabilitySet {
   market: Market
   assetClass: AssetClass
   capabilities: readonly ApplicationCapability[]
-  detailPanelKind: 'cn-equity' | 'cn-etf' | 'cn-fund' | 'cross-market' | 'unsupported'
+  detailPanelKind: 'cn-equity' | 'cn-etf' | 'cn-fund' | 'cn-index' | 'cross-market' | 'unsupported'
 }
 
 export interface UnifiedInstrumentQuote {

--- a/docs/FUYAO-FUND-API.md
+++ b/docs/FUYAO-FUND-API.md
@@ -22,7 +22,7 @@
 |---|---|---|
 | 6 位场外基金（非场内代码表） | `otc` | `{code}.OF` |
 | 6 位场内基金 / ETF / LOF | `exchange` | `{code}.SH` 或 `.SZ` |
-| REIT（`assetClass=REIT`） | `otc` | **保留** `.SH` / `.SZ` 后缀（不改 `.OF`） |
+| REIT（`assetClass=REIT`） | `reits` | **保留** `.SH` / `.SZ` 后缀 |
 | 已带 `.OF` / `.SH` / `.SZ` | 按后缀推断 | 原样规范化 |
 
 ## 全量 REST 端点清单

--- a/docs/FUYAO-FUND-API.md
+++ b/docs/FUYAO-FUND-API.md
@@ -13,7 +13,7 @@
 | 请求头 | `X-api-key: <用户配置的 API Key>`（存于 Provider 设置，非代码硬编码；由 SDK 注入） |
 | 响应信封 | SDK 返回整包 `ApiResponse<T>`；适配层 unwrap 为 `data`，调用方继续用 `.item` |
 | 时间戳 | 毫秒 Unix，时区 `Asia/Shanghai` |
-| `fund_type` | `otc`（场外开放式）、`exchange`（场内 ETF/LOF）、`reits`（公募 REITs）；SDK 入参 camelCase `fundType` |
+| `fund_type` | `otc`（场外 / 含 REIT 上市码）、`exchange`（场内 ETF/LOF）；SDK 枚举亦含 `reits`，但 **`.SH/.SZ` REIT 须走 `otc` 分区**（见下方错误码 1004） |
 | `thscode` | 必须带后缀：`025480.OF`、`510300.SH`、`161725.SZ` |
 
 ### Opptrix 代码路由（`resolveFuyaoFundRoute`）
@@ -22,7 +22,7 @@
 |---|---|---|
 | 6 位场外基金（非场内代码表） | `otc` | `{code}.OF` |
 | 6 位场内基金 / ETF / LOF | `exchange` | `{code}.SH` 或 `.SZ` |
-| REIT（`assetClass=REIT`） | `reits` | **保留** `.SH` / `.SZ` 后缀 |
+| REIT（`assetClass=REIT`） | `otc` | **保留** `.SH` / `.SZ` 后缀（非 `.OF`；`reits` 会 1004 冲突） |
 | 已带 `.OF` / `.SH` / `.SZ` | 按后缀推断 | 原样规范化 |
 
 ## 全量 REST 端点清单
@@ -167,6 +167,32 @@ node --import tsx/esm --test tests/fuyao-fund-profile.test.mjs tests/fund-detail
 ```
 
 配置同花顺 API Key 并启用 Provider 后，打开 CN:PF 基金详情，`source` 应为 `tonghuashun`。
+
+## 业务错误码（基金场景）
+
+HTTP 仍为 200；SDK 在信封 `code !== 0` 时抛 `FuyaoApiError`。Opptrix `withFuyaoClient` 仅 **3001** 转 `FuyaoFundNotFoundError`；其余多数被吞为 `null` → Engine 报「空数据」。
+
+| code | 含义 | 基金场景 |
+|------|------|----------|
+| **1001** | 缺少必填参数 | 非行情接口缺少 `fund_type`，或缺少 `thscode`、`start`、`end` |
+| **1002** | 参数格式错误 | 历史行情 `thscode` 含逗号 |
+| **1003** | 参数值越界 | 枚举非法、`start > end` 或查询窗口超过 5 年 |
+| **1004** | 参数冲突 | `fund_type` 多选，或 **基金类型与 `thscode` 所在分区不一致** |
+| **3001** | 标的不存在 | 找不到该基金 |
+| **3002** | 数据未就绪 | 标的存在，但暂无可用业务数据 |
+| **3004** | 标的类型不支持该能力 | 该基金类型不支持所请求的能力 |
+
+### REIT（`CN:REIT:180102.SZ`）实测对照
+
+| 请求 | code | 解读 |
+|------|------|------|
+| `fund_type=reits` + `thscode=180102.SZ` | **1004** | 分区冲突：`.SH/.SZ` REIT 不属于 `reits` 分区 |
+| `fund_type=exchange` + `thscode=180102.SZ` | **1004** | 同上，不属于 `exchange` 分区 |
+| **`fund_type=otc` + `thscode=180102.SZ`** | **0** | ✅ 分区一致（`otc` + 上市后缀，非 `.OF`） |
+| `fundMarketSnapshot(180102.SZ)` | **3004** | REIT 不支持场内行情快照；报价走净值 + 可选 A 股实时降级 |
+| `fundPortfolioHoldings` | **3002** | 标的存在，持仓数据尚未就绪 |
+
+Opptrix 路由（`resolveFuyaoFundRoute`）：REIT → **`fund_type=otc`** + **保留 `.SH/.SZ`**，与扶摇分区规则一致。
 
 ## 已知限制
 

--- a/docs/INSTRUMENT-PROTOCOL.md
+++ b/docs/INSTRUMENT-PROTOCOL.md
@@ -244,7 +244,7 @@ store.stockMetaLookupKey('000977', 'SZ')  // → 'SZ:000977'
 | `CN:OTC:000037.OF` | A 股场外基金 |
 | `CN:ETF:510300.SH` | A 股 ETF |
 | `CN:LOF:160105.SZ` | A 股 LOF |
-| `CN:REIT:508000.SH` | 公募 REITs（扶摇 NAV：fund_type=otc，后缀保留 .SH） |
+| `CN:REIT:508000.SH` | 公募 REITs（扶摇：`fund_type=reits`，thscode 保留 `.SH/.SZ`） |
 | `CN:IND:881121.TI` | 同花顺板块指数 |
 | `CN:STOCK:600519.SH` | A 股股票 |
 | `US:STOCK:AAPL.US` | 美股 |

--- a/docs/INSTRUMENT-PROTOCOL.md
+++ b/docs/INSTRUMENT-PROTOCOL.md
@@ -244,7 +244,7 @@ store.stockMetaLookupKey('000977', 'SZ')  // → 'SZ:000977'
 | `CN:OTC:000037.OF` | A 股场外基金 |
 | `CN:ETF:510300.SH` | A 股 ETF |
 | `CN:LOF:160105.SZ` | A 股 LOF |
-| `CN:REIT:508000.SH` | 公募 REITs（扶摇：`fund_type=reits`，thscode 保留 `.SH/.SZ`） |
+| `CN:REIT:508000.SH` | 公募 REITs（扶摇：`fund_type=otc`，thscode 保留 `.SH/.SZ`） |
 | `CN:IND:881121.TI` | 同花顺板块指数 |
 | `CN:STOCK:600519.SH` | A 股股票 |
 | `US:STOCK:AAPL.US` | 美股 |

--- a/docs/OPPTRIX-QUANT-API.md
+++ b/docs/OPPTRIX-QUANT-API.md
@@ -60,7 +60,7 @@
 | OTC | `FUND` | `PF` |
 | ETF | `ETF` | 上市交易所 |
 | LOF | `LOF` | 上市交易所 |
-| REIT | `REIT` | 上市交易所（**扶摇 fund_type=reits**，thscode 保留 `.SH/.SZ`） |
+| REIT | `REIT` | 上市交易所（**扶摇 fund_type=otc**，thscode 保留 `.SH/.SZ`，非 `.OF`） |
 
 解析入口：`parseOpptrixInstrumentId` → `normalizeInstrumentRef`。
 
@@ -110,7 +110,7 @@ GET /api/v1/instruments?q=茅台&market=CN&class_token=STOCK
 | INDEX | 指数 `indexPrices*` | — |
 | ETF | 场内 `fundMarket*` / `prices*` | `exchange`（与 LOF 相同） |
 | LOF | 同 ETF | `exchange` |
-| REIT | **不走**个股 batch；`fund_quote` | **`reits`**（保留 `.SH/.SZ`） |
+| REIT | **不走**个股 batch；`fund_quote` | **`otc`**（thscode 保留 `.SH/.SZ`；勿用 `reits`，会 1004 冲突） |
 | FUND (OTC) | `fund_quote` | `otc` |
 
 实现：`resolveInstrumentQueryPlan` + `resolveFuyaoFundRoute(ref.assetClass)`。

--- a/docs/OPPTRIX-QUANT-API.md
+++ b/docs/OPPTRIX-QUANT-API.md
@@ -60,7 +60,7 @@
 | OTC | `FUND` | `PF` |
 | ETF | `ETF` | 上市交易所 |
 | LOF | `LOF` | 上市交易所 |
-| REIT | `REIT` | 上市交易所（**扶摇 NAV 仅 fund_type=otc**，后缀不变） |
+| REIT | `REIT` | 上市交易所（**扶摇 fund_type=reits**，thscode 保留 `.SH/.SZ`） |
 
 解析入口：`parseOpptrixInstrumentId` → `normalizeInstrumentRef`。
 
@@ -110,7 +110,7 @@ GET /api/v1/instruments?q=茅台&market=CN&class_token=STOCK
 | INDEX | 指数 `indexPrices*` | — |
 | ETF | 场内 `fundMarket*` / `prices*` | `exchange`（与 LOF 相同） |
 | LOF | 同 ETF | `exchange` |
-| REIT | **不走**个股 batch；`fund_quote` | **`otc`**（保留 `.SH/.SZ`，非 `exchange`） |
+| REIT | **不走**个股 batch；`fund_quote` | **`reits`**（保留 `.SH/.SZ`） |
 | FUND (OTC) | `fund_quote` | `otc` |
 
 实现：`resolveInstrumentQueryPlan` + `resolveFuyaoFundRoute(ref.assetClass)`。

--- a/docs/PROVIDER-STANDARD-API.md
+++ b/docs/PROVIDER-STANDARD-API.md
@@ -140,7 +140,7 @@ bindingsFor: () => []
 | Provider | 注册 | Binding 结构 | 多市场 | ETF 分拆 | 标准 API | 自定义 | 结论 |
 |----------|------|--------------|--------|----------|----------|--------|------|
 | **tonghuashun** | ✅ | CN；**CN ETF 分拆**（priority 120）；**CN FUND** | CN | ✅ | ✅ | `ths*` / Fuyao | **合规（CN 主路径）** |
-| **stockindex** | ✅ | 跨市 STOCK_LIST / INSTRUMENT_SEARCH + CN ETF_LIST / FUND_* | CN/US/HK | ETF_LIST | ✅ 搜索 | 少量 | **Opptrix量化**；priority 115 |
+| **stockindex** | ✅ | 跨市 **INSTRUMENT_SEARCH**（仅标的搜索） | CN/US/HK | — | ✅ 搜索 | 无 | **Opptrix量化**；priority 115 |
 | **tickflow** | ✅ | US + CN(ETF) + HK | ✅ | ✅ FREE_CN_ETF | ✅ | 少量 custom | **标杆**；目录 priority 110；名录灌库 |
 | **tushare** | ✅ | CN cnEquityEtfIndex + **cnFundBindings** | CN | 弱（无 ETF_LIST） | ✅ | fund_* 等 | **合规（CN）**；priority 105 |
 | **binance / okx** | ✅ | cryptoSpotBindings | CRYPTO | N/A | ✅ | 无 | **合规** |
@@ -195,7 +195,7 @@ bindingsFor: () => []
 
 ### stockindex（Opptrix量化）
 
-- **用途**：跨市场标的搜索权威源（`instrumentSearch` / 统一搜索在线路径）
+- **用途**：跨市场标的搜索权威源（`instrumentSearch` / 统一搜索在线路径）；**不提供**行情、净值、档案等数据能力
 - **基址**：固定 `https://quant.opptrix.net`（设置页不可改）
 - **认证**：数据密钥（`X-API-Key`）；在 [Opptrix量化社区](https://quant.opptrix.net/) 获取
 - **统一标的 ID / REST 契约**：见 [OPPTRIX-QUANT-API.md](./OPPTRIX-QUANT-API.md)（`STOCK/IND/OTC/ETF/LOF/REIT` + 后缀）

--- a/packages/a-stock-layer/src/core/instrument-query.ts
+++ b/packages/a-stock-layer/src/core/instrument-query.ts
@@ -362,6 +362,8 @@ export function resolveInstrumentQueryPlan(
           return registryPlan('CN', 'REIT', Capability.FUND_PROFILE, 'fundProfile', true, [symbol], normalized)
         case 'fund_nav':
           return registryPlan('CN', 'REIT', Capability.FUND_NAV, 'fundNav', true, [symbol], normalized)
+        case 'fund_holdings':
+          return registryPlan('CN', 'REIT', Capability.FUND_HOLDINGS, 'fundHoldings', true, [symbol], normalized)
         case 'fund_quote':
         case 'realtime':
           return registryPlan('CN', 'REIT', Capability.FUND_QUOTE, 'fundQuote', true, [symbol], normalized)

--- a/packages/a-stock-layer/src/core/instrument.ts
+++ b/packages/a-stock-layer/src/core/instrument.ts
@@ -14,9 +14,9 @@ export function isCnExchangeListedFundCode(code: string): boolean {
   return isCnListedFundSymbol(normalizeCode(code))
 }
 
-/** Opptrix ID 权威：ETF / LOF 走场内 fundMarketSnapshot */
+/** Opptrix ID 权威：ETF / LOF / REIT 走场内 fundMarketSnapshot */
 export function isCnExchangeListedFundAssetClass(assetClass?: AssetClass): boolean {
-  return assetClass === 'ETF' || assetClass === 'LOF'
+  return assetClass === 'ETF' || assetClass === 'LOF' || assetClass === 'REIT'
 }
 
 /**

--- a/packages/a-stock-layer/src/core/provider-wire.ts
+++ b/packages/a-stock-layer/src/core/provider-wire.ts
@@ -118,9 +118,20 @@ export function wireRegistryMethodArgs(
     else if (copy.length >= 3) copy[2] = ref.assetClass
   }
 
-  // 扶摇基金接口：第二参传 assetClass，供 REIT→otc / ETF·LOF→exchange 路由
-  if (method.startsWith('fund') && providerId === 'tonghuashun' && copy.length === 1) {
-    copy.push(ref.assetClass)
+  // 扶摇基金接口：第二参 assetClass；第三参 exchange（REIT/LOF 等须保留后缀路由）
+  if (method.startsWith('fund') && providerId === 'tonghuashun') {
+    if (copy.length === 1) copy.push(ref.assetClass)
+    if (copy.length === 2 && ref.market === 'CN') {
+      const ex = ref.exchange?.toUpperCase()
+      if (
+        ex
+        && ex !== 'PF'
+        && ex !== 'OF'
+        && (ref.assetClass === 'REIT' || ref.assetClass === 'LOF' || ref.assetClass === 'ETF')
+      ) {
+        copy.push(ex)
+      }
+    }
   }
 
   return copy

--- a/packages/a-stock-layer/src/engine.ts
+++ b/packages/a-stock-layer/src/engine.ts
@@ -47,7 +47,7 @@ import { normalizeUsSymbol } from './utils/us-market.js'
 import { isRegionalEquityMarket, normalizeRegionalSymbol, type RegionalEquityMarket } from './utils/regional-symbol.js'
 import { parseCryptoPair } from './utils/crypto-market.js'
 import type { AssetClass, Market, InstrumentRef } from '@opptrix/shared'
-import { instrumentProviderSymbol, normalizeInstrumentRef } from '@opptrix/shared'
+import { instrumentProviderSymbol, normalizeInstrumentRef, buildOpptrixInstrumentId } from '@opptrix/shared'
 import {
   resolveInstrumentQueryPlan,
   unsupportedInstrumentCapabilityMessage,
@@ -948,23 +948,53 @@ export class MarketDataEngine {
     }
   }
 
-  async fundSnapshot(fundCode: string) {
-    const code = normalizeCode(fundCode)
-    const listed = isCnListedFundSymbol(code)
+  async fundSnapshotFromRef(ref: InstrumentRef) {
+    const normalized = normalizeInstrumentRef(ref)
+    const code = normalized.symbol
+    const assetClass = normalized.assetClass === 'REIT' ? 'REIT' : 'FUND'
+    const exchangeListed = assetClass === 'REIT' || isCnListedFundSymbol(code)
+
     const [profile, quoteRes] = await Promise.all([
-      this.fundProfile(code),
-      listed ? this.fundQuote(code) : Promise.resolve(null),
+      this.queryScoped<Record<string, unknown>>(
+        'CN',
+        assetClass,
+        Capability.FUND_PROFILE,
+        'fundProfile',
+        'fund_profile',
+        true,
+        [code],
+        15_000,
+        normalized,
+      ),
+      exchangeListed
+        ? this.queryScoped<Record<string, unknown>>(
+          'CN',
+          assetClass,
+          Capability.FUND_QUOTE,
+          'fundQuote',
+          'fund_quote',
+          true,
+          [code],
+          15_000,
+          normalized,
+        ).then(result =>
+          assetClass === 'FUND'
+            ? this.listedFundQuoteFallback(code, result as QueryResult<Record<string, unknown>[]>)
+            : result as QueryResult<Record<string, unknown>[]>,
+        )
+        : Promise.resolve(null),
     ])
     const profileRow = profile.data?.[0] as Record<string, unknown> | undefined
     const quoteRow = quoteRes?.success
       ? quoteRes.data?.[0] as Record<string, unknown> | undefined
       : undefined
-    const success = profile.success || (listed && quoteRes?.success && quoteRow)
+    const success = profile.success || (exchangeListed && quoteRes?.success && quoteRow)
     if (!success) {
       return {
         success: false,
         data: null,
         source: profile.source,
+        error: profile.error,
       }
     }
     const mergedProfile = profileRow ?? (quoteRow
@@ -998,13 +1028,23 @@ export class MarketDataEngine {
     return {
       success: true,
       data: {
-        code,
+        code: buildOpptrixInstrumentId(normalized),
+        instrument: normalized,
         profile: mergedProfile ?? null,
         nav: latestNav ?? null,
         quote,
       },
       source: profile.source ?? quoteRes?.source,
     }
+  }
+
+  async fundSnapshot(fundCode: string) {
+    return this.fundSnapshotFromRef(normalizeInstrumentRef({
+      market: 'CN',
+      assetClass: 'FUND',
+      symbol: fundCode,
+      exchange: 'PF',
+    }))
   }
 
   async etfSnapshotFromRef(ref: InstrumentRef): Promise<{
@@ -1299,14 +1339,16 @@ export class MarketDataEngine {
         if (plan.market === 'CN' && plan.assetClass === 'REIT') {
           const snapRef = plan.ref ?? normalizeInstrumentRef({
             market: 'CN', assetClass: 'REIT', symbol: plan.symbol,
+            exchange: resolveStockMarketCode(plan.symbol),
           })
-          return this.fundSnapshot(snapRef.symbol)
+          return this.fundSnapshotFromRef(snapRef)
         }
         if (plan.market === 'CN' && plan.assetClass === 'FUND') {
           const snapRef = plan.ref ?? normalizeInstrumentRef({
             market: 'CN', assetClass: 'FUND', symbol: plan.symbol,
+            exchange: 'PF',
           })
-          return this.fundSnapshot(snapRef.symbol)
+          return this.fundSnapshotFromRef(snapRef)
         }
         if (isRegionalEquityMarket(plan.market)) {
           return this.regionalSnapshot(plan.market, plan.symbol)

--- a/packages/a-stock-layer/src/engine.ts
+++ b/packages/a-stock-layer/src/engine.ts
@@ -915,14 +915,25 @@ export class MarketDataEngine {
       .then(result => this.listedFundQuoteFallback(code, result as QueryResult<Record<string, unknown>[]>))
   }
 
-  /** 场内基金 fundQuote 失败时，回退 A 股实时行情（交易所价） */
+  /** 场内基金 / REIT fundQuote 失败时，回退 A 股实时行情（交易所价） */
   private async listedFundQuoteFallback(
     code: string,
     primary: QueryResult<Record<string, unknown>[]>,
+    ref?: InstrumentRef,
   ): Promise<QueryResult<Record<string, unknown>[]>> {
     if (primary.success && primary.data?.length) return primary
-    if (!isCnListedFundSymbol(code)) return primary
-    const rt = await this.realtime(code, resolveStockMarketCode(code))
+    const normalized = ref ? normalizeInstrumentRef(ref) : null
+    const assetClass = normalized?.assetClass
+    const isReit = assetClass === 'REIT'
+    const isListed = isCnListedFundSymbol(code) || isReit
+    if (!isListed) return primary
+    const exRaw = normalized?.exchange?.toUpperCase()
+    const market = (exRaw === 'SH' || exRaw === 'SZ' || exRaw === 'BJ')
+      ? exRaw as import('./utils/helpers.js').StockMarket
+      : resolveStockMarketCode(code)
+    // REIT 尚无独立 STOCK_REALTIME binding 时，同码走 EQUITY 交易所快照
+    const rtClass: AssetClass = isReit ? 'EQUITY' : (assetClass ?? inferCnAssetClass(code))
+    const rt = await this.realtime(code, market, rtClass)
     const row = rt.data?.[0]
     if (!rt.success || !row) return primary
     return {
@@ -978,8 +989,8 @@ export class MarketDataEngine {
           15_000,
           normalized,
         ).then(result =>
-          assetClass === 'FUND'
-            ? this.listedFundQuoteFallback(code, result as QueryResult<Record<string, unknown>[]>)
+          exchangeListed
+            ? this.listedFundQuoteFallback(code, result as QueryResult<Record<string, unknown>[]>, normalized)
             : result as QueryResult<Record<string, unknown>[]>,
         )
         : Promise.resolve(null),
@@ -990,11 +1001,16 @@ export class MarketDataEngine {
       : undefined
     const success = profile.success || (exchangeListed && quoteRes?.success && quoteRow)
     if (!success) {
+      const quoteErr = quoteRes && !quoteRes.success && 'error' in quoteRes
+        ? String(quoteRes.error ?? '')
+        : ''
+      const err = [profile.error, quoteErr].filter(Boolean).join('; ')
+        || '基金档案与行情均不可用，请确认同花顺数据密钥已启用'
       return {
         success: false,
         data: null,
-        source: profile.source,
-        error: profile.error,
+        source: profile.source ?? quoteRes?.source,
+        error: err,
       }
     }
     const mergedProfile = profileRow ?? (quoteRow
@@ -1373,10 +1389,14 @@ export class MarketDataEngine {
           if (
             plan.capability === Capability.FUND_QUOTE
             && plan.market === 'CN'
-            && plan.assetClass === 'FUND'
+            && (plan.assetClass === 'FUND' || plan.assetClass === 'REIT')
           ) {
             const code = normalizeCode(String(plan.args[0] ?? ''))
-            return this.listedFundQuoteFallback(code, result as QueryResult<Record<string, unknown>[]>)
+            return this.listedFundQuoteFallback(
+              code,
+              result as QueryResult<Record<string, unknown>[]>,
+              plan.ref,
+            )
           }
           return result
         })

--- a/packages/a-stock-layer/src/portfolio/instrument.ts
+++ b/packages/a-stock-layer/src/portfolio/instrument.ts
@@ -237,7 +237,9 @@ export function portfolioCodesMatch(
   if (normalizeCode(a.symbol) !== normalizeCode(b.symbol)) return false
   const aFund = isCnFundRef(a) || looksLikeCnFundInput(aCode)
   const bFund = isCnFundRef(b) || looksLikeCnFundInput(bCode)
-  if (aFund === bFund) return false
+  if (aFund === bFund) {
+    return aFund && normalizeCode(a.symbol) === normalizeCode(b.symbol)
+  }
   const bareSide = aFund ? bCode.trim() : aCode.trim()
   // 仅与裸六位账本行对齐；不把 CN:SZ.xxx 与 CN:PF.xxx 混为一谈
   return /^\d{6}$/.test(bareSide)

--- a/packages/a-stock-layer/src/portfolio/manager.ts
+++ b/packages/a-stock-layer/src/portfolio/manager.ts
@@ -271,8 +271,8 @@ export class PortfolioManager {
   removeTrade(id: number) { return this.store.deleteTrade(id) }
 
   /** Drop ledger rows and per-stock fee overrides when a watchlist symbol is removed. */
-  clearInstrument(code: string, market?: Market) {
-    const removed = this.store.deleteTradesForCode(code, market)
+  clearInstrument(code: string, market?: Market, assetClass?: AssetClass) {
+    const removed = this.store.deleteTradesForCode(code, market, assetClass)
     return { removed }
   }
 

--- a/packages/a-stock-layer/src/portfolio/store.ts
+++ b/packages/a-stock-layer/src/portfolio/store.ts
@@ -1,4 +1,5 @@
-import type { Market } from '@opptrix/shared'
+import type { AssetClass, Market } from '@opptrix/shared'
+import { instrumentRefKey } from '@opptrix/shared/instrument-ref'
 import type { InstrumentFeeOverrides, PortfolioGlobalFees } from '@opptrix/shared'
 import { getUserDataStore } from '@opptrix/user-store'
 import type { TradeRecord } from './trade-models.js'
@@ -7,9 +8,11 @@ import {
   migrateLegacyFeeState,
 } from './models.js'
 import {
+  inferTradeAssetClass,
   portfolioCodeAliases,
   portfolioCodesMatch,
   portfolioDisplayCode,
+  portfolioInstrumentRef,
 } from './instrument.js'
 import { recomputeAllTradeFees, recomputeTradeRecordFees } from './fee-recompute.js'
 
@@ -201,12 +204,24 @@ export class PortfolioStore {
   }
 
   /** Remove all trades and per-stock fee overrides when a watchlist symbol is removed. */
-  deleteTradesForCode(code: string, market?: Market) {
+  deleteTradesForCode(code: string, market?: Market, assetClass?: AssetClass) {
+    const ref = portfolioInstrumentRef(code, market, assetClass)
+    const targetKey = instrumentRefKey(ref)
+    const aliases = portfolioCodeAliases(code, market, assetClass)
     const before = this.state.trades.length
-    this.state.trades = this.state.trades.filter(
-      t => !portfolioCodesMatch(t.code, legacyTradeMarket(t), code, market),
-    )
-    for (const alias of portfolioCodeAliases(code, market)) {
+    this.state.trades = this.state.trades.filter(t => {
+      const tMarket = legacyTradeMarket(t)
+      const tAc = inferTradeAssetClass(t.code, tMarket, t.assetClass)
+      if (portfolioCodesMatch(t.code, tMarket, code, market, tAc, assetClass)) {
+        return false
+      }
+      const tRef = portfolioInstrumentRef(t.code, tMarket, tAc)
+      if (instrumentRefKey(tRef) === targetKey) return false
+      const tDisplay = portfolioDisplayCode(t.code, tMarket, tAc)
+      if (aliases.has(t.code) || aliases.has(tDisplay)) return false
+      return true
+    })
+    for (const alias of aliases) {
       delete this.state.instrumentFees[alias]
     }
     this.save()

--- a/packages/a-stock-layer/src/providers/common/standard-methods.ts
+++ b/packages/a-stock-layer/src/providers/common/standard-methods.ts
@@ -64,7 +64,7 @@ export const PROVIDER_ETF_COVERAGE: Record<string, readonly string[]> = {
   baostock: ['etfList', 'etfProfile', 'etfNav', 'etfHoldings'],
   tickflow: ['etfList', 'etfProfile'],
   tonghuashun: ['etfList', 'etfProfile'],
-  stockindex: ['etfList'],
+  stockindex: [],
 }
 
 export const PROVIDER_FUND_COVERAGE: Record<string, readonly string[]> = {
@@ -74,7 +74,7 @@ export const PROVIDER_FUND_COVERAGE: Record<string, readonly string[]> = {
     'fundReturns', 'fundDrawdown', 'fundAllocation', 'fundHolders', 'fundDividend',
   ],
   baostock: ['fundList', 'fundProfile'],
-  stockindex: ['fundProfile', 'fundNav', 'fundQuote'],
+  stockindex: [],
 }
 
 /** 建议新增的 Capability（DATA-LAYER Phase-2） */

--- a/packages/a-stock-layer/src/providers/stockindex/custom-method-docs.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/custom-method-docs.ts
@@ -1,41 +1,7 @@
 import type { CustomMethodApiDoc } from '../common/custom-method-doc-types.js'
 import { toCustomMethodDef } from '../common/custom-method-doc-types.js'
-import { STOCKINDEX_DEFAULT_BASE_URL } from './settings.js'
 
-const BASE = STOCKINDEX_DEFAULT_BASE_URL
-const INVOKE = (method: string, args = '["茅台"]') =>
-  `engine.invokeCustomMethod("stockindex", "${method}", ${args})`
-
-export const STOCKINDEX_METHOD_DOCS: Record<string, CustomMethodApiDoc> = {
-  stockIndexListStocks: {
-    method: 'stockIndexListStocks',
-    description: '个股名录（分页，走 OpptrixQuant 标的检索）',
-    sourceUrl: `${BASE}/api/v1/instruments?class_token=stock`,
-    pageUrl: 'https://quant.opptrix.net',
-    params: [
-      { name: 'market', type: 'string', description: 'CN / HK / US / JP / KR / SG', default: 'CN' },
-      { name: 'page', type: 'number', description: '页码，从 1 起', default: 1 },
-      { name: 'pageSize', type: 'number', description: '每页条数，最大 35', default: 35 },
-      { name: 'q', type: 'string', description: '名称或代码关键词' },
-    ],
-    returns: '[{ page, pageSize, total, items, source }]',
-    usage: INVOKE('stockIndexListStocks', '["CN",1,35]'),
-    example: '{"provider":"stockindex","method":"stockIndexListStocks","args":["HK",1,35]}',
-    notes: '单页 ≤ 35，需 API Key（X-API-Key）；日/月配额超限返回 429',
-  },
-  fundMetrics: {
-    method: 'fundMetrics',
-    description: '基金绩效指标（总收益 / 年化 / 胜率 / 最大回撤 / 波动率 / 夏普 / 索提诺 / 卡玛）',
-    sourceUrl: `${BASE}/api/v1/funds/{code}/metrics`,
-    pageUrl: 'https://quant.opptrix.net',
-    params: [
-      { name: 'code', type: 'string', description: '6 位公募基金代码', required: true },
-    ],
-    returns: '[{ code, name, asOfDate, startDate, endDate, totalReturn, annualReturn, winRate, maxDrawdown, annualVol, downsideVol, sharpe, sortino, calmar, days, source }]；无指标或非基金代码时 null',
-    usage: INVOKE('fundMetrics', '["009049"]'),
-    example: '{"provider":"stockindex","method":"fundMetrics","args":["009049"]}',
-    notes: '需 API Key；数值字段为百分比/比率数值（上游为字符串或 null）；as_of_date 为指标基准日',
-  },
-}
+/** OpptrixQuant 仅提供标的搜索；行情/净值/名录等自定义方法已下线 */
+export const STOCKINDEX_METHOD_DOCS: Record<string, CustomMethodApiDoc> = {}
 
 export const STOCKINDEX_CUSTOM = Object.values(STOCKINDEX_METHOD_DOCS).map(toCustomMethodDef)

--- a/packages/a-stock-layer/src/providers/stockindex/driver.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/driver.ts
@@ -1,9 +1,8 @@
 import { applyManifestSpec } from '../common/driver-factory.js'
 import { STOCKINDEX_SPEC } from './manifest.js'
-import { StockIndexHandler, mixStockIndexExt } from './handler.js'
+import { StockIndexHandler } from './handler.js'
 import { isStockIndexEnabled } from './settings.js'
 
 export class StockIndexDriver extends StockIndexHandler {}
 
-mixStockIndexExt(StockIndexDriver)
 applyManifestSpec(StockIndexDriver, STOCKINDEX_SPEC, { isRuntimeEnabled: isStockIndexEnabled })

--- a/packages/a-stock-layer/src/providers/stockindex/handler.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/handler.ts
@@ -1,21 +1,9 @@
 import type { StockListItem } from '@opptrix/shared'
 import { Capability } from '../../core/capabilities.js'
-import { resolveCnPublicFundBareCode } from '../../core/fund-instrument.js'
 import { MarketHandlerShell } from '../common/driver-factory.js'
+import { opptrixInstrumentSearch } from './api/client.js'
 import {
-  opptrixFundMetrics,
-  opptrixFundNav,
-  opptrixFundQuoteBatch,
-  opptrixGetInstrument,
-  opptrixInstrumentSearch,
-  stockIndexListStocks,
-} from './api/client.js'
-import {
-  opptrixInstrumentToProfileRow,
   opptrixInstrumentToStockIndexItem,
-  opptrixLatestNavToQuoteRow,
-  opptrixMetricsToRow,
-  opptrixNavToStandardRows,
   stockIndexItemsToListRows,
 } from './normalize.js'
 
@@ -48,43 +36,7 @@ function toRows(raw: Awaited<ReturnType<typeof opptrixInstrumentSearch>>): Stock
 export class StockIndexHandler extends MarketHandlerShell {
   readonly selfThrottled = true
 
-  async stockList(marketOrKeyword = '', keyword = '', page = 1, pageSize = 100): Promise<StockListItem[] | null> {
-    try {
-      const hasKeyword = keyword !== undefined && keyword !== ''
-      const bareMarket = marketOrKeyword.trim().toUpperCase()
-      const market = opptrixMarket(
-        hasKeyword ? marketOrKeyword : (OPPTRIX_MARKETS.has(bareMarket) ? marketOrKeyword : undefined),
-      )
-      const q = hasKeyword
-        ? keyword.trim()
-        : (OPPTRIX_MARKETS.has(bareMarket) ? '' : marketOrKeyword.trim())
-
-      if (q) {
-        return toRows(
-          await opptrixInstrumentSearch(q, {
-            market,
-            limit: Math.min(Math.max(pageSize, 1), 100),
-          }),
-        )
-      }
-
-      const size = Math.min(Math.max(pageSize, 1), 100)
-      const raw = await opptrixInstrumentSearch('', {
-        market,
-        classToken: 'stock',
-        limit: size,
-        page,
-        maxPages: 1,
-      })
-      if (!raw) return null
-      const rows = stockIndexItemsToListRows(raw.map(opptrixInstrumentToStockIndexItem))
-      return rows.length ? rows : null
-    } catch {
-      return null
-    }
-  }
-
-  /** 标准 instrument_search — 跨市场关键词搜索（board/industry 已随旧上游下线而忽略） */
+  /** 标准 instrument_search — 跨市场关键词搜索 */
   async instrumentSearch(
     query: string,
     market = 'CN',
@@ -105,105 +57,8 @@ export class StockIndexHandler extends MarketHandlerShell {
       return null
     }
   }
-
-  async etfList(_market = 'CN', keyword = ''): Promise<StockListItem[] | null> {
-    try {
-      const q = String(keyword ?? '').trim()
-      return toRows(
-        await opptrixInstrumentSearch(q, {
-          market: 'CN',
-          classToken: 'etf',
-          limit: 500,
-        }),
-      )
-    } catch {
-      return null
-    }
-  }
-
-  /** 基金档案 — GET /api/v1/instruments/{id}（id = CN:of:{code}） */
-  async fundProfile(fundCode: string): Promise<Record<string, unknown>[] | null> {
-    try {
-      const bare = resolveCnPublicFundBareCode(fundCode)
-      if (!bare) return null
-      const instrument = await opptrixGetInstrument(`CN:of:${bare}`)
-      if (!instrument) return null
-      const row = opptrixInstrumentToProfileRow(instrument)
-      return row ? [row] : null
-    } catch {
-      return null
-    }
-  }
-
-  /** 基金历史净值 — GET /api/v1/funds/{code}/nav（最近 N=120） */
-  async fundNav(fundCode: string): Promise<Record<string, unknown>[] | null> {
-    try {
-      const bare = resolveCnPublicFundBareCode(fundCode)
-      if (!bare) return null
-      const rows = await opptrixFundNav(bare, { limit: 120 })
-      if (!rows) return null
-      const mapped = opptrixNavToStandardRows(rows)
-      return mapped.length ? mapped : null
-    } catch {
-      return null
-    }
-  }
-
-  /** 基金最新净值 — POST /api/v1/funds/nav/latest（单只） */
-  async fundQuote(fundCode: string): Promise<Record<string, unknown>[] | null> {
-    try {
-      const bare = resolveCnPublicFundBareCode(fundCode)
-      if (!bare) return null
-      const items = await opptrixFundQuoteBatch([bare])
-      if (!items) return null
-      const first = items[0]
-      if (!first) return null
-      const row = opptrixLatestNavToQuoteRow(first)
-      return row ? [row] : null
-    } catch {
-      return null
-    }
-  }
-
-  /** 基金绩效指标（自定义方法）— GET /api/v1/funds/{code}/metrics */
-  async fundMetrics(fundCode: string): Promise<Record<string, unknown>[] | null> {
-    try {
-      const bare = resolveCnPublicFundBareCode(fundCode)
-      if (!bare) return null
-      const metrics = await opptrixFundMetrics(bare)
-      if (!metrics) return null
-      const row = opptrixMetricsToRow(metrics)
-      return row ? [row] : null
-    } catch {
-      return null
-    }
-  }
-}
-
-export function mixStockIndexExt(DriverClass: typeof import('../common/base.js').BaseDriver) {
-  const p = DriverClass.prototype as StockIndexHandler & Record<string, unknown>
-
-  p.stockIndexListStocks = async function stockIndexListStocksMethod(
-    market = 'CN',
-    page = 1,
-    pageSize = 35,
-    q?: string,
-  ) {
-    const resp = await stockIndexListStocks({
-      market: opptrixMarket(market),
-      page,
-      pageSize,
-      q,
-    })
-    return [{ ...resp, source: 'stockindex' }]
-  }
 }
 
 export const STOCKINDEX_HANDLER_CAPS = [
-  Capability.STOCK_LIST,
   Capability.INSTRUMENT_SEARCH,
-  Capability.ETF_LIST,
-  Capability.FUND_PROFILE,
-  Capability.FUND_NAV,
-  Capability.FUND_QUOTE,
 ]

--- a/packages/a-stock-layer/src/providers/stockindex/manifest.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/manifest.ts
@@ -1,53 +1,26 @@
 import { Capability } from '../../core/capabilities.js'
 import type { ProviderBinding } from '@opptrix/shared'
-import { cnFundBindings, cnReitBindings } from '../../core/bindings.js'
 import { type ProviderManifestSpec } from '../common/types.js'
 import { providerManifestEntry } from '../common/manifest.js'
 import { STOCKINDEX_SETTINGS } from './settings.js'
 import { STOCKINDEX_HANDLER_CAPS } from './handler.js'
 
-/** stockindex 已实现的基金能力（filter 掉 cnFundBindings 中的 FUND_LIST / FUND_HOLDINGS） */
-const STOCKINDEX_FUND_CAPS: string[] = [
-  Capability.FUND_PROFILE,
-  Capability.FUND_NAV,
-  Capability.FUND_QUOTE,
-]
-
-function crossMarketBindings(
+/** OpptrixQuant 仅登记标的搜索 — 不提供行情/净值/档案等数据能力 */
+function searchOnlyBindings(
   priority: number,
   maxConcurrent?: number,
 ): ProviderBinding[] {
   const markets = ['CN', 'US', 'HK'] as const
   const rows: ProviderBinding[] = []
   for (const market of markets) {
-    for (const capability of [
-      Capability.STOCK_LIST,
-      Capability.INSTRUMENT_SEARCH,
-    ]) {
-      rows.push({
-        market,
-        assetClass: 'EQUITY',
-        capability,
-        defaultPriority: priority,
-        ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
-      })
-    }
+    rows.push({
+      market,
+      assetClass: 'EQUITY',
+      capability: Capability.INSTRUMENT_SEARCH,
+      defaultPriority: priority,
+      ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
+    })
   }
-  rows.push({
-    market: 'CN',
-    assetClass: 'ETF',
-    capability: Capability.ETF_LIST,
-    defaultPriority: priority,
-    ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
-  })
-  rows.push(
-    ...cnFundBindings(priority, maxConcurrent).filter(b =>
-      STOCKINDEX_FUND_CAPS.includes(b.capability),
-    ),
-    ...cnReitBindings(priority, maxConcurrent).filter(b =>
-      STOCKINDEX_FUND_CAPS.includes(b.capability),
-    ),
-  )
   return rows
 }
 
@@ -61,7 +34,7 @@ export const STOCKINDEX_SPEC: ProviderManifestSpec = {
   defaultPriority: 115,
   maxConcurrent: 4,
   capabilities: STOCKINDEX_CAPS,
-  bindingsFor: (p, maxConcurrent) => crossMarketBindings(p, maxConcurrent),
+  bindingsFor: (p, maxConcurrent) => searchOnlyBindings(p, maxConcurrent),
   settings: STOCKINDEX_SETTINGS,
 }
 

--- a/packages/a-stock-layer/src/providers/stockindex/normalize.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/normalize.ts
@@ -3,6 +3,7 @@ import {
   parseOpptrixInstrumentId,
   type OpptrixInstrumentIdParts,
   canonicalSymbolForMarket,
+  instrumentHubCode,
   instrumentRefLabel,
   normalizeInstrumentRef,
   parseInstrumentNamespace,
@@ -52,7 +53,7 @@ export function opptrixInstrumentToStockIndexItem(
   return {
     instrumentId: instrument.instrument_id,
     market: instrument.market,
-    code: instrument.symbol,
+    code: instrument.instrument_id || instrument.symbol,
     symbol: instrument.symbol,
     nameCn: instrument.name ?? null,
     industryName: instrument.sub_type ?? null,
@@ -133,7 +134,7 @@ export function stockIndexItemToListRow(item: StockIndexItem): StockListItem | n
     ? 'FUND'
     : (item.industryName ?? item.sub_type ?? '')
   return {
-    code: ref.symbol,
+    code: instrumentHubCode(ref),
     name: item.nameCn ?? item.code,
     industry,
     market: isFund ? 'PF' : (ref.exchange ?? ref.market),

--- a/packages/a-stock-layer/src/providers/stockindex/settings.ts
+++ b/packages/a-stock-layer/src/providers/stockindex/settings.ts
@@ -12,7 +12,7 @@ export const STOCKINDEX_SETTINGS: ProviderSettingsDefinition = {
   title: 'Opptrix量化',
   subtitle: 'Opptrix量化社区提供的标的检索接口',
   marketGroup: 'GLOBAL',
-  keywords: ['opptrixquant', 'stockindex', '标的搜索', '跨市场', '基金净值', '公募基金', '数据密钥'],
+  keywords: ['opptrixquant', 'stockindex', '标的搜索', '跨市场', '数据密钥'],
   enableAffectsPriority: true,
   supportsTest: true,
   fields: [

--- a/packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts
@@ -6,6 +6,8 @@ export type FuyaoFundType = 'otc' | 'exchange' | 'reits'
 
 export interface FuyaoFundRouteOpts {
   assetClass?: AssetClass
+  /** CN REIT 裸 6 位码时优先用 InstrumentRef.exchange 拼 thscode */
+  exchange?: string
 }
 
 /** 6 位公募基金代码 → 扶摇 fund_type + thscode */
@@ -18,13 +20,14 @@ export function resolveFuyaoFundRoute(
     let raw = String(code ?? '').trim().toUpperCase()
     const listedMatch = /^(\d{6})\.(SH|SZ|BJ)$/i.exec(raw)
     if (listedMatch) {
-      return { fundType: 'otc', thscode: `${listedMatch[1]}.${listedMatch[2]}` }
+      return { fundType: 'reits', thscode: `${listedMatch[1]}.${listedMatch[2]}` }
     }
     raw = raw.replace(/\.(OF|SH|SZ|BJ|PF)$/i, '')
     const bare = normalizeCode(raw)
     if (!bare || !/^\d{6}$/.test(bare)) return null
-    // REIT 保留上市后缀；仅 fund_type 传 otc
-    return { fundType: 'otc', thscode: `${bare}.${resolveMarket(bare)}` }
+    const ex = opts?.exchange?.toUpperCase()
+    const suffix = ex === 'SH' || ex === 'SZ' || ex === 'BJ' ? ex : resolveMarket(bare)
+    return { fundType: 'reits', thscode: `${bare}.${suffix}` }
   }
 
   let raw = String(code ?? '').trim().toUpperCase()

--- a/packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/api/fund-symbols.ts
@@ -17,17 +17,19 @@ export function resolveFuyaoFundRoute(
 ): { fundType: FuyaoFundType; thscode: string } | null {
   const assetClass = opts?.assetClass
   if (assetClass === 'REIT') {
+    // 扶摇实测：REIT 档案/净值须 fund_type=otc + thscode 保留 .SH/.SZ（非 .OF）；
+    // fund_type=reits 会返回 1004（fund_type 与 thscode 分区不一致）。
     let raw = String(code ?? '').trim().toUpperCase()
     const listedMatch = /^(\d{6})\.(SH|SZ|BJ)$/i.exec(raw)
     if (listedMatch) {
-      return { fundType: 'reits', thscode: `${listedMatch[1]}.${listedMatch[2]}` }
+      return { fundType: 'otc', thscode: `${listedMatch[1]}.${listedMatch[2]}` }
     }
     raw = raw.replace(/\.(OF|SH|SZ|BJ|PF)$/i, '')
     const bare = normalizeCode(raw)
     if (!bare || !/^\d{6}$/.test(bare)) return null
     const ex = opts?.exchange?.toUpperCase()
     const suffix = ex === 'SH' || ex === 'SZ' || ex === 'BJ' ? ex : resolveMarket(bare)
-    return { fundType: 'reits', thscode: `${bare}.${suffix}` }
+    return { fundType: 'otc', thscode: `${bare}.${suffix}` }
   }
 
   let raw = String(code ?? '').trim().toUpperCase()

--- a/packages/a-stock-layer/src/providers/tonghuashun/manifest.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/manifest.ts
@@ -3,7 +3,7 @@ import { CN_ETF_CAPABILITIES } from '../../core/bindings.js'
 import { type ProviderManifestSpec } from '../common/types.js'
 import { providerManifestEntry } from '../common/manifest.js'
 import { TONGHUASHUN_SETTINGS } from './settings.js'
-import { cnEquityEtfIndex, cnLofBindings, cnReitBindings } from '../common/bindings.js'
+import { cnEquityEtfIndex, cnLofBindings } from '../common/bindings.js'
 import { TONGHUASHUN_CN_FUND_CAPABILITIES } from './fund-capabilities.js'
 
 export const TONGHUASHUN_CAPS = [
@@ -61,7 +61,20 @@ export const TONGHUASHUN_SPEC: ProviderManifestSpec = {
       ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
     })),
     ...cnLofBindings(p, maxConcurrent),
-    ...cnReitBindings(p, maxConcurrent),
+    ...TONGHUASHUN_CN_FUND_CAPABILITIES.map(capability => ({
+      market: 'CN' as const,
+      assetClass: 'REIT' as const,
+      capability,
+      defaultPriority: p,
+      ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
+    })),
+    ...([Capability.STOCK_REALTIME, Capability.STOCK_KLINE] as const).map(capability => ({
+      market: 'CN' as const,
+      assetClass: 'REIT' as const,
+      capability,
+      defaultPriority: p,
+      ...(maxConcurrent !== undefined ? { maxConcurrent } : {}),
+    })),
   ],
   settings: TONGHUASHUN_SETTINGS,
   supportsTest: true,

--- a/packages/a-stock-layer/src/providers/tonghuashun/markets/cn/fund.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/markets/cn/fund.ts
@@ -192,7 +192,9 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
       const { fundType, thscode } = route
-      const isListed = fundType === 'exchange' || fundType === 'reits'
+      const isListed = fundType === 'exchange'
+        || fundType === 'reits'
+        || (assetClass === 'REIT' && /\.(SH|SZ|BJ)$/i.test(thscode))
       const [navData, profileData, snapData] = await Promise.all([
         // range=month：取最近两日算涨跌；最新报价取排序后第一条
         client.fundPerformanceNav(fundType, thscode, { ...FUYAO_FUND_NAV_RECENT_OPTS }),

--- a/packages/a-stock-layer/src/providers/tonghuashun/markets/cn/fund.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/markets/cn/fund.ts
@@ -28,10 +28,10 @@ type Handler = TonghuashunMarketHandler & Record<string, unknown>
 function resolveFundRouteForCode(
   fundCode: string,
   assetClass?: AssetClass,
+  exchange?: string,
 ): ReturnType<typeof resolveFuyaoFundRoute> {
-  const bare = assertCnPublicFundCode(fundCode, assetClass)
-  if (!bare) return null
-  return resolveFuyaoFundRoute(bare, { assetClass })
+  if (!assertCnPublicFundCode(fundCode, assetClass)) return null
+  return resolveFuyaoFundRoute(fundCode, { assetClass, exchange })
 }
 
 /**
@@ -140,8 +140,8 @@ function listedFundQuoteFromSnapshot(
 export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler }) {
   const p = Driver.prototype as Handler
 
-  p.fundProfile = async function fundProfile(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundProfile = async function fundProfile(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -171,8 +171,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundNav = async function fundNav(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundNav = async function fundNav(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -186,13 +186,13 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundQuote = async function fundQuote(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundQuote = async function fundQuote(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
       const { fundType, thscode } = route
-      const isListed = fundType === 'exchange'
+      const isListed = fundType === 'exchange' || fundType === 'reits'
       const [navData, profileData, snapData] = await Promise.all([
         // range=month：取最近两日算涨跌；最新报价取排序后第一条
         client.fundPerformanceNav(fundType, thscode, { ...FUYAO_FUND_NAV_RECENT_OPTS }),
@@ -237,8 +237,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundHoldings = async function fundHoldings(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundHoldings = async function fundHoldings(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -249,8 +249,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundReturns = async function fundReturns(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundReturns = async function fundReturns(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -262,8 +262,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundDrawdown = async function fundDrawdown(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundDrawdown = async function fundDrawdown(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -274,8 +274,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundAllocation = async function fundAllocation(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundAllocation = async function fundAllocation(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -287,8 +287,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundHolders = async function fundHolders(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundHolders = async function fundHolders(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -302,8 +302,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundDividend = async function fundDividend(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundDividend = async function fundDividend(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -316,8 +316,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundManager = async function fundManager(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundManager = async function fundManager(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -355,8 +355,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundDiagnosis = async function fundDiagnosis(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundDiagnosis = async function fundDiagnosis(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -367,8 +367,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
     })
   }
 
-  p.fundNews = async function fundNews(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundNews = async function fundNews(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {
@@ -383,8 +383,8 @@ export function mixTonghuashunFund(Driver: { prototype: TonghuashunMarketHandler
    * 基金财务指标 — `@opptrix/fuyao` `funds.financials.indicators`。
    * 无数据返回 null；错误由 withFuyaoClient 既有路径处理。
    */
-  p.fundFinancials = async function fundFinancials(fundCode: string, assetClass?: AssetClass): Promise<Record<string, unknown>[] | null> {
-    const route = resolveFundRouteForCode(fundCode, assetClass)
+  p.fundFinancials = async function fundFinancials(fundCode: string, assetClass?: AssetClass, exchange?: string): Promise<Record<string, unknown>[] | null> {
+    const route = resolveFundRouteForCode(fundCode, assetClass, exchange)
     if (!route) return null
     const bare = assertCnPublicFundCode(fundCode, assetClass)!
     return withFuyaoClient(async client => {

--- a/packages/a-stock-layer/src/utils/us-market.ts
+++ b/packages/a-stock-layer/src/utils/us-market.ts
@@ -1,5 +1,6 @@
 /** US market session & symbol helpers — America/New_York */
 
+import { canonicalUsSymbol as canonicalUsSymbolShared } from '@opptrix/shared'
 import { isUsTradingDay, isNyseHoliday, nyseHolidaysForYear } from './us-holidays.js'
 
 export { isUsTradingDay, isNyseHoliday, nyseHolidaysForYear }
@@ -7,9 +8,7 @@ export { isUsTradingDay, isNyseHoliday, nyseHolidaysForYear }
 const US_TZ = 'America/New_York'
 
 export function normalizeUsSymbol(symbol: string): string {
-  const raw = symbol.trim().toUpperCase()
-  const stripped = raw.replace(/^(US|NYSE|NASDAQ|AMEX):/i, '')
-  return stripped.replace(/[^A-Z0-9.-]/g, '')
+  return canonicalUsSymbolShared(symbol)
 }
 
 export function isValidUsSymbol(symbol: string): boolean {

--- a/packages/market-data-core/src/core/bindings.ts
+++ b/packages/market-data-core/src/core/bindings.ts
@@ -72,7 +72,7 @@ export function cnLofBindings(defaultPriority: number, maxConcurrent?: number): 
   }))
 }
 
-/** REIT — 公募 REITs，净值/档案走基金接口（扶摇 fund_type=reits） */
+/** REIT — 公募 REITs，净值/档案走基金接口（扶摇 fund_type=otc + .SH/.SZ thscode） */
 export function cnReitBindings(defaultPriority: number, maxConcurrent?: number): ProviderBinding[] {
   return CN_FUND_CAPABILITIES.map(capability => ({
     market: 'CN',

--- a/packages/market-data-core/src/core/bindings.ts
+++ b/packages/market-data-core/src/core/bindings.ts
@@ -72,7 +72,7 @@ export function cnLofBindings(defaultPriority: number, maxConcurrent?: number): 
   }))
 }
 
-/** REIT — 公募 REITs，净值/档案走基金接口（扶摇 fund_type=otc） */
+/** REIT — 公募 REITs，净值/档案走基金接口（扶摇 fund_type=reits） */
 export function cnReitBindings(defaultPriority: number, maxConcurrent?: number): ProviderBinding[] {
   return CN_FUND_CAPABILITIES.map(capability => ({
     market: 'CN',

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -13,6 +13,7 @@ import {   MarketDataEngine, computeIndicators, computeLatestChipProfile, comput
   crossMarketFiveDayMinuteCount,
   resampleOhlcKlines,
   watchlistItemKey,
+  isCnPublicFundRef,
 } from '@opptrix/a-stock-layer'
 import { resolveProvidersDir } from '@opptrix/shared'
 import type { IntradayTrendFetchResult, IntradayTrendSession } from '@opptrix/a-stock-layer'
@@ -47,6 +48,7 @@ import {
   normalizeInstrumentHubParams,
   instrumentRefsFromList,
   normalizeInstrumentRef,
+  instrumentHubCode,
   instrumentRefKey,
   instrumentDisplayCode,
   buildInstrumentNamespace,
@@ -531,7 +533,7 @@ export class ResearchHub {
     }
     const valid = Object.values(snap.factors).filter(f => f?.value != null).length
     return ok({
-      code: buildInstrumentNamespace(cnRef), name: snap.name, total_score: snap.totalScore,
+      code: instrumentHubCode(cnRef), name: snap.name, total_score: snap.totalScore,
       scorecard_name: scorecardName,
       scorecard_dimensions: card.factors.map(({ name, weight }) => ({
         name, score: snap.scores[`${name}_score`] ?? 0, weight,
@@ -751,7 +753,7 @@ export class ResearchHub {
         const indicators = buildInstrumentIndicators(data)
         return ok({
           instrument: ref,
-          code: ref.symbol,
+          code: instrumentHubCode(ref),
           name: data.name ?? ref.symbol,
           ...indicators,
         }, `${data.name ?? ref.symbol} 技术指标`, t0)
@@ -824,7 +826,7 @@ export class ResearchHub {
 
     const holdingCost = Number(params.holding_cost)
     const brief = buildTrendBrief({
-      code: buildInstrumentNamespace(cnRef),
+      code: instrumentHubCode(cnRef),
       name,
       klines,
       indexKlines: indexKlines.length >= 60 ? indexKlines : undefined,
@@ -1447,7 +1449,7 @@ export class ResearchHub {
       {
         ...coerced,
         ...(price != null ? { price } : {}),
-        code: String(raw.code ?? ref.symbol),
+        code: String(raw.code ?? instrumentHubCode(ref)),
         instrument: ref,
       },
       `${ref.symbol} 基金行情`,
@@ -1497,7 +1499,7 @@ export class ResearchHub {
   ): Promise<WatchlistRadarItem> {
     const ref = resolveCnInstrumentRef(input)
     const symbol = normalizeCode(ref.symbol)
-    const ns = buildInstrumentNamespace(ref)
+    const ns = instrumentHubCode(ref)
     const stored = this.store.getLatest(symbol)
     const factors = stored?.factorValues ?? {}
     try {
@@ -1545,7 +1547,7 @@ export class ResearchHub {
 
   private async stockKline(input: string | InstrumentRef, count: number, t0: number) {
     const cnRef = resolveCnInstrumentRef(input)
-    const code = buildInstrumentNamespace(cnRef)
+    const code = instrumentHubCode(cnRef)
     const safeCount = Math.max(20, Math.min(count, 240))
     const result = await this.de.queryInstrumentData(cnRef, 'kline', { count: safeCount })
     if (!result.success) return fail(instrumentQueryError(result, 'K线获取失败'), t0)
@@ -1565,7 +1567,7 @@ export class ResearchHub {
     if (!rows.length) return fail('筹码分布计算失败', t0)
     const latest = rows[rows.length - 1]!
     return ok({
-      code: buildInstrumentNamespace(cnRef),
+      code: instrumentHubCode(cnRef),
       rows,
       latest,
     }, `${normalized} 筹码 ${rows.length} 日`, t0)
@@ -1720,7 +1722,7 @@ export class ResearchHub {
     )
 
     return ok({
-      code: buildInstrumentNamespace(cnRef),
+      code: instrumentHubCode(cnRef),
       name,
       quote,
       profile: null,
@@ -1773,7 +1775,12 @@ export class ResearchHub {
   }) | null {
     const live = this.mergeQuoteWithLocal(ref.symbol, liveRaw)
     if (live) {
-      const row = { ...live, instrument: ref, quoteSource: 'live' as const }
+      const row = {
+        ...live,
+        code: instrumentHubCode(ref),
+        instrument: ref,
+        quoteSource: 'live' as const,
+      }
       this.rememberInstrumentQuote(ref, row)
       return row
     }
@@ -1781,7 +1788,12 @@ export class ResearchHub {
     if (cached) {
       const fromCache = this.mergeQuoteWithLocal(ref.symbol, cached)
       if (fromCache) {
-        return { ...fromCache, instrument: ref, quoteSource: 'cache' }
+        return {
+          ...fromCache,
+          code: instrumentHubCode(ref),
+          instrument: ref,
+          quoteSource: 'cache',
+        }
       }
     }
     const recalled = this.recallInstrumentQuoteRaw(ref)
@@ -1791,7 +1803,12 @@ export class ResearchHub {
         recalled as unknown as NonNullable<Awaited<ReturnType<MarketDataEngine['realtime']>>['data']>[0],
       )
       if (fromMemory) {
-        return { ...fromMemory, instrument: ref, quoteSource: 'memory' }
+        return {
+          ...fromMemory,
+          code: instrumentHubCode(ref),
+          instrument: ref,
+          quoteSource: 'memory',
+        }
       }
     }
     return null
@@ -1808,7 +1825,7 @@ export class ResearchHub {
       return {
         ...coerced,
         ...(price != null ? { price } : {}),
-        code: String(raw.code ?? ref.symbol),
+        code: String(raw.code ?? instrumentHubCode(ref)),
         instrument: ref,
         quoteSource,
       }
@@ -1845,7 +1862,7 @@ export class ResearchHub {
         ...raw,
         ...coerced,
         ...(price != null ? { price } : {}),
-        code: String(raw.code ?? ref.symbol),
+        code: String(raw.code ?? instrumentHubCode(ref)),
         instrument: ref,
         quoteSource,
       }
@@ -2724,7 +2741,7 @@ export class ResearchHub {
   ) {
     const ref = resolveInstrumentFromParams(params)
     if (!ref) return fail('instrument 或 code 必填', t0)
-    if (ref.assetClass !== 'FUND') {
+    if (!isCnPublicFundRef(ref)) {
       return fail('当前标的不是公募基金，请重新搜索并选择基金', t0)
     }
     const labels = {
@@ -2748,7 +2765,7 @@ export class ResearchHub {
     const rows = Array.isArray(data) ? data : []
     return ok(
       {
-        code: ref.symbol,
+        code: instrumentHubCode(ref),
         items: rows,
         source: 'queryInstrumentData',
       },
@@ -2831,7 +2848,7 @@ export class ResearchHub {
     const rows = Array.isArray(data) ? data : []
     return ok(
       {
-        code: ref.symbol,
+        code: instrumentHubCode(ref),
         items: rows,
         source: 'queryInstrumentData',
       },
@@ -3542,7 +3559,7 @@ export class ResearchHub {
   private async fundDetail(params: Record<string, unknown>, t0: number) {
     const ref = resolveInstrumentFromParams(params)
     if (!ref) return fail('instrument 或 code 必填', t0)
-    if (ref.assetClass !== 'FUND') {
+    if (!isCnPublicFundRef(ref)) {
       return fail('当前标的不是公募基金，请重新搜索并选择基金', t0)
     }
     const settle = (cap: 'fund_snapshot' | 'fund_holdings' | 'fund_allocation') =>
@@ -3620,7 +3637,7 @@ export class ResearchHub {
       const nav = etfLatestNavRow(navRows as Record<string, unknown>[])
 
       const online = this.marketData.etfScorecardFromOnline({
-        code: ref.symbol,
+        code: instrumentHubCode(ref),
         name: (profile?.name as string | undefined)
           ?? (quote?.name as string | undefined)
           ?? ref.symbol,

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -436,27 +436,32 @@ export class ResearchHub {
         case 'local_hk_screen': return this.localHkScreen(params, t0)
         case 'search_etfs': return await this.searchEtfs(params, t0)
         case 'us_realtime': {
-          const ref = resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
+          const ref = resolveInstrumentFromParams(params)
+            ?? resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
           if (!ref) return fail('symbol 必填', t0)
           return await this.instrumentQuotes({ instruments: [ref] }, t0)
         }
         case 'us_kline': {
-          const ref = resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
+          const ref = resolveInstrumentFromParams(params)
+            ?? resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
           if (!ref) return fail('symbol 必填', t0)
           return await this.instrumentChart({ instrument: ref, count: params.count ?? 120, period: 'daily' }, t0)
         }
         case 'us_profile': {
-          const ref = resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
+          const ref = resolveInstrumentFromParams(params)
+            ?? resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
           if (!ref) return fail('symbol 必填', t0)
           return await this.usProfile(ref.symbol, t0)
         }
         case 'us_financials': {
-          const ref = resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
+          const ref = resolveInstrumentFromParams(params)
+            ?? resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
           if (!ref) return fail('symbol 必填', t0)
           return await this.usFinancials(ref.symbol, params, t0)
         }
         case 'us_snapshot': {
-          const ref = resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
+          const ref = resolveInstrumentFromParams(params)
+            ?? resolveInstrumentFromParams({ market: 'US', symbol: params.symbol ?? params.code })
           if (!ref) return fail('symbol 必填', t0)
           return await this.instrumentSnapshot({ instrument: ref }, t0)
         }
@@ -1281,8 +1286,8 @@ export class ResearchHub {
   }
 
   /**
-   * CN 场外基金批量净值行情 — OpptrixQuant POST /funds/nav/latest（10 只/批）；
-   * 非 batch 路径或 batch 失败时回退 queryInstrumentData(fund_quote)。
+   * CN 基金 / REIT 净值行情 — 经 Engine fund_quote（扶摇等同花顺源）。
+   * OpptrixQuant 仅负责标的搜索，不参与净值/行情。
    */
   private async fundQuotes(refs: InstrumentRef[], t0: number) {
     const unique = [...new Map(refs.map(r => [instrumentRefKey(r), r] as const)).values()]
@@ -1292,88 +1297,9 @@ export class ResearchHub {
     const failed: { code: string; reason: QuoteFailedReason }[] = []
     let firstError = ''
 
-    const batchable: InstrumentRef[] = []
-    const individual: InstrumentRef[] = []
-
-    const { assertCnPublicFundCode } = await import('@opptrix/a-stock-layer')
-
-    for (const ref of unique) {
-      if (
-        ref.market === 'CN'
-        && (ref.assetClass === 'FUND' || ref.assetClass === 'REIT')
-        && assertCnPublicFundCode(ref)
-      ) {
-        batchable.push(ref)
-      } else {
-        individual.push(ref)
-      }
-    }
-
-    const bareToRef = new Map<string, InstrumentRef>()
-    for (const ref of batchable) {
-      const bare = assertCnPublicFundCode(ref)
-      if (bare) bareToRef.set(bare, ref)
-    }
-
-    if (bareToRef.size > 0) {
-      const {
-        opptrixFundQuoteBatch,
-        opptrixLatestNavToQuoteRow,
-        StockIndexHttpClient,
-      } = await import('@opptrix/a-stock-layer')
-
-      if (StockIndexHttpClient.fromConfig()) {
-        const codes = [...bareToRef.keys()]
-        for (let i = 0; i < codes.length; i += 10) {
-          const chunk = codes.slice(i, i + 10)
-          try {
-            const items = await opptrixFundQuoteBatch(chunk)
-            if (items == null) {
-              for (const bare of chunk) {
-                const ref = bareToRef.get(bare)
-                if (ref) individual.push(ref)
-              }
-              continue
-            }
-            const returned = new Set<string>()
-            for (const item of items) {
-              const bare = String(item.product_code ?? '').trim()
-              if (!bare) continue
-              returned.add(bare)
-              const ref = bareToRef.get(bare)
-              if (!ref) continue
-              const row = opptrixLatestNavToQuoteRow(item)
-              const resolved = row
-                ? this.resolveFundQuoteRowWithStaleFallback(ref, row as unknown as Record<string, unknown>)
-                : this.resolveFundQuoteRowWithStaleFallback(ref, null)
-              if (resolved) quotes.push(resolved)
-              else failed.push({ code: instrumentDisplayCode(ref), reason: 'empty' })
-            }
-            for (const bare of chunk) {
-              if (returned.has(bare)) continue
-              const ref = bareToRef.get(bare)
-              if (!ref) continue
-              const stale = this.resolveFundQuoteRowWithStaleFallback(ref, null)
-              if (stale) quotes.push(stale)
-              else failed.push({ code: instrumentDisplayCode(ref), reason: 'empty' })
-            }
-          } catch (e) {
-            const msg = e instanceof Error ? e.message : String(e)
-            if (!firstError && msg.trim()) firstError = msg.trim()
-            for (const bare of chunk) {
-              const ref = bareToRef.get(bare)
-              if (ref) individual.push(ref)
-            }
-          }
-        }
-      } else {
-        individual.push(...batchable)
-      }
-    }
-
     const concurrency = 5
-    for (let i = 0; i < individual.length; i += concurrency) {
-      const chunk = individual.slice(i, i + concurrency)
+    for (let i = 0; i < unique.length; i += concurrency) {
+      const chunk = unique.slice(i, i + concurrency)
       await Promise.all(chunk.map(async ref => {
         const r = await this.de.queryInstrumentData(ref, 'fund_quote').catch((e: unknown) => ({
           success: false as const,
@@ -3576,7 +3502,7 @@ export class ResearchHub {
       settle('fund_holdings'),
       settle('fund_allocation'),
     ])
-    const merged = mergeFundDetailParts(ref.symbol, {
+    const merged = mergeFundDetailParts(instrumentHubCode(ref), {
       snapshot: snapshotPart,
       holdings: holdingsPart,
       allocation: allocationPart,
@@ -4170,7 +4096,7 @@ export class ResearchHub {
   }
 
   private async crossMarketStockDetail(market: 'US' | 'HK', symbol: string, t0: number) {
-    const ref: InstrumentRef = { market, assetClass: 'EQUITY', symbol }
+    const ref = normalizeInstrumentRef({ market, assetClass: 'EQUITY', symbol })
     const snapshotR = await this.de.queryInstrumentData(ref, 'snapshot')
     const snap = instrumentQueryData<Record<string, unknown>>(snapshotR)
 
@@ -4184,16 +4110,23 @@ export class ResearchHub {
     )
 
     const snapProfile = snap?.profile as Record<string, unknown> | null
-    const profile = snapProfile
-      ? normalizeCrossMarketProfile(market, symbol, snapProfile)
+    let profile = snapProfile
+      ? normalizeCrossMarketProfile(market, ref.symbol, snapProfile)
       : null
+    if (!profile) {
+      const profileR = await this.de.queryInstrumentData(ref, 'profile')
+      const row = instrumentQueryData<unknown[]>(profileR)?.[0]
+      if (row && typeof row === 'object') {
+        profile = normalizeCrossMarketProfile(market, ref.symbol, row as Record<string, unknown>)
+      }
+    }
 
     const quote = mergeCrossMarketQuote(
       (snap?.quote ?? null) as Record<string, unknown> | null,
       quoteR.data?.[0] ?? null,
     )
 
-    const payload = buildCrossMarketDetailPayload(market, symbol, snap ?? null, {
+    const payload = buildCrossMarketDetailPayload(market, ref.symbol, snap ?? null, {
       profile,
       quote,
       notices: [],

--- a/packages/research-hub/src/instrument-router.ts
+++ b/packages/research-hub/src/instrument-router.ts
@@ -10,6 +10,7 @@ import {
   normalizeInstrumentRef,
   normalizeInstrumentSnapshot,
   canonicalSymbolForMarket,
+  buildInstrumentNamespace,
   parseInstrumentRef,
   quoteFromProviderRow,
   resolveInstrumentCapabilities,
@@ -23,6 +24,7 @@ import {
   isQuoteFailedReason,
   type QuoteFailedReason,
 } from './quote-failure.js'
+import { isCnPublicFundRef } from '@opptrix/a-stock-layer'
 
 export type { QuoteFailedReason } from './quote-failure.js'
 
@@ -149,7 +151,7 @@ export async function routeInstrumentSnapshot(
   if (ref.market === 'CN' && (ref.assetClass === 'ETF' || ref.assetClass === 'LOF')) {
     return wrapSnapshot(ref, await handlers.etfSnapshot(ref), handlers)
   }
-  if (ref.market === 'CN' && ref.assetClass === 'FUND') {
+  if (ref.market === 'CN' && isCnPublicFundRef(ref)) {
     return wrapSnapshot(ref, await handlers.fundSnapshot(ref), handlers)
   }
   if (ref.market === 'CN') {
@@ -230,6 +232,15 @@ function cnBatchHubFailed(resp: ResearchResult): Map<string, QuoteFailedReason> 
   return out
 }
 
+function hubFailedReasonForRef(
+  ref: InstrumentRef,
+  hubFailed: Map<string, QuoteFailedReason>,
+): QuoteFailedReason | undefined {
+  return hubFailed.get(instrumentDisplayCode(ref))
+    ?? hubFailed.get(buildInstrumentNamespace(ref))
+    ?? hubFailed.get(ref.symbol)
+}
+
 function collectCnBatchQuotes(
   refs: InstrumentRef[],
   resp: ResearchResult,
@@ -248,7 +259,7 @@ function collectCnBatchQuotes(
         continue
       }
       // 未命中行时优先用 hub 侧已归类的明细原因；无则按原语义记 empty
-      failed.push(failedQuoteForRef(ref, hubFailed.get(instrumentDisplayCode(ref)) ?? 'empty'))
+      failed.push(failedQuoteForRef(ref, hubFailedReasonForRef(ref, hubFailed) ?? 'empty'))
     }
     return
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -37,6 +37,10 @@
     "./instrument-ref": {
       "types": "./dist/instrument-ref.d.ts",
       "import": "./dist/instrument-ref.js"
+    },
+    "./instrument-param": {
+      "types": "./dist/instrument-param.d.ts",
+      "import": "./dist/instrument-param.js"
     }
   },
   "scripts": {

--- a/packages/shared/src/instrument-capabilities.ts
+++ b/packages/shared/src/instrument-capabilities.ts
@@ -26,7 +26,7 @@ export interface InstrumentCapabilitySet {
   market: Market
   assetClass: AssetClass
   capabilities: readonly ApplicationCapability[]
-  detailPanelKind: 'cn-equity' | 'cn-etf' | 'cn-fund' | 'cross-market' | 'unsupported'
+  detailPanelKind: 'cn-equity' | 'cn-etf' | 'cn-fund' | 'cn-index' | 'cross-market' | 'unsupported'
 }
 
 const CN_EQUITY: ApplicationCapability[] = [
@@ -87,7 +87,7 @@ function capabilityRow(
 /** 静态能力矩阵 — 新市场在此登记一行即可驱动 UI gate */
 export const INSTRUMENT_CAPABILITY_MATRIX: InstrumentCapabilitySet[] = [
   capabilityRow('CN', 'EQUITY', CN_EQUITY, 'cn-equity'),
-  capabilityRow('CN', 'INDEX', CN_INDEX, 'cn-equity'),
+  capabilityRow('CN', 'INDEX', CN_INDEX, 'cn-index'),
   capabilityRow('CN', 'ETF', CN_ETF, 'cn-etf'),
   capabilityRow('CN', 'LOF', CN_ETF, 'cn-etf'),
   capabilityRow('CN', 'REIT', CN_FUND, 'cn-fund'),

--- a/packages/shared/src/instrument-param.ts
+++ b/packages/shared/src/instrument-param.ts
@@ -1,16 +1,29 @@
 import type { InstrumentRef, Market } from './market-data.js'
 import {
   instrumentRefFromParams,
+  isAssetClass,
   isLikelyCnEquityInput,
   isMarket,
   parseInstrumentRef,
 } from './instrument-ref.js'
 import {
+  buildOpptrixInstrumentId,
   inferCnAssetClassFromSymbol,
   normalizeInstrumentRef,
   parseCanonicalInstrumentInput,
   parseInstrumentNamespace,
 } from './instrument-symbol.js'
+
+/** Hub/API 请求用全量标的 code — Opptrix ID（CN/US/HK）或命名空间 */
+export function instrumentHubCode(ref: InstrumentRef): string {
+  return buildOpptrixInstrumentId(normalizeInstrumentRef(ref))
+}
+
+/** Hub/API 标准请求体：instrument 权威 + code 全量 ID（禁止裸 6 位码） */
+export function instrumentHubParams(ref: InstrumentRef): { instrument: InstrumentRef; code: string } {
+  const instrument = normalizeInstrumentRef(ref)
+  return { instrument, code: instrumentHubCode(instrument) }
+}
 
 function isCryptoPairNotation(raw: string): boolean {
   const s = raw.trim().toUpperCase()
@@ -28,8 +41,12 @@ function isLikelyUsTicker(raw: string): boolean {
 
 /** Resolve InstrumentRef from Hub/API params — supports instrument object, market+symbol, legacy code */
 export function resolveInstrumentFromParams(params: Record<string, unknown>): InstrumentRef | null {
+  const hasInstrumentField = params.instrument != null
   const nested = instrumentRefFromParams(params)
   if (nested) return nested
+
+  // 已传 instrument 但未解析成功 — 禁止用裸 code 误推断（如 REIT 裸码 → EQUITY）
+  if (hasInstrumentField) return null
 
   const rawCode = String(params.code ?? params.symbol ?? params.pair ?? '').trim()
   const exchangeRaw = params.exchange != null ? String(params.exchange).trim().toUpperCase() : undefined
@@ -43,7 +60,7 @@ export function resolveInstrumentFromParams(params: Record<string, unknown>): In
       const base: InstrumentRef = marketRaw === 'CN'
         ? {
           market: 'CN',
-          assetClass: assetRaw === 'ETF' || assetRaw === 'INDEX' ? assetRaw as InstrumentRef['assetClass'] : inferCnAssetClassFromSymbol(rawCode, exchangeRaw),
+          assetClass: isAssetClass(assetRaw) ? assetRaw : inferCnAssetClassFromSymbol(rawCode, exchangeRaw),
           symbol: rawCode,
           exchange: exchangeRaw,
         }
@@ -111,7 +128,7 @@ export function normalizeInstrumentHubParams(
 ): Record<string, unknown> {
   const ref = resolveInstrumentFromParams(params)
   if (!ref) return params
-  return { ...params, instrument: ref }
+  return { ...params, ...instrumentHubParams(ref) }
 }
 
 /**

--- a/packages/shared/src/instrument-ref.ts
+++ b/packages/shared/src/instrument-ref.ts
@@ -25,6 +25,8 @@ export function parseInstrumentRef(input: unknown): InstrumentRef | null {
   const row = input as Record<string, unknown>
   const symbolRaw = String(row.symbol ?? row.code ?? '').trim()
   if (symbolRaw) {
+    const fromCanonical = parseCanonicalInstrumentInput(symbolRaw)
+    if (fromCanonical) return fromCanonical
     const fromNs = parseInstrumentNamespace(symbolRaw)
     if (fromNs) return fromNs
   }

--- a/packages/shared/src/instrument-ref.ts
+++ b/packages/shared/src/instrument-ref.ts
@@ -1,6 +1,7 @@
 import type { AssetClass, InstrumentRef, Market } from './market-data.js'
 import {
   buildInstrumentNamespace,
+  buildOpptrixInstrumentId,
   normalizeInstrumentRef,
   parseCanonicalInstrumentInput,
   parseInstrumentNamespace,
@@ -8,7 +9,7 @@ import {
 } from './instrument-symbol.js'
 
 const MARKETS: Market[] = ['CN', 'US', 'HK', 'CRYPTO', 'JP', 'KR']
-const ASSET_CLASSES: AssetClass[] = ['EQUITY', 'ETF', 'INDEX', 'FUND', 'CRYPTO_SPOT', 'CRYPTO_PERP']
+const ASSET_CLASSES: AssetClass[] = ['EQUITY', 'ETF', 'LOF', 'REIT', 'INDEX', 'FUND', 'CRYPTO_SPOT', 'CRYPTO_PERP']
 
 export function isMarket(v: string): v is Market {
   return (MARKETS as string[]).includes(v)
@@ -31,6 +32,8 @@ export function parseInstrumentRef(input: unknown): InstrumentRef | null {
   const symbol = symbolRaw
   if (!symbol || !isMarket(marketRaw)) return null
   const assetRaw = String(row.assetClass ?? row.asset_class ?? 'EQUITY').trim().toUpperCase()
+  const hasExplicitAsset = row.assetClass != null || row.asset_class != null
+  if (hasExplicitAsset && !isAssetClass(assetRaw)) return null
   const assetClass = isAssetClass(assetRaw) ? assetRaw : 'EQUITY'
   const exchange = row.exchange != null ? String(row.exchange) : undefined
   const quote = row.quote != null ? String(row.quote) : undefined
@@ -68,9 +71,9 @@ export function instrumentRefKey(ref: InstrumentRef): string {
   return buildInstrumentNamespace(ref)
 }
 
-/** 全局标的展示码 — 本地名录 / 关注列表沿用命名空间；在线搜索单独用 Opptrix ID */
+/** 全局标的展示码 — OpptrixQuant 统一 ID（CN/US/HK）；其余市场回退命名空间 */
 export function instrumentDisplayCode(ref: InstrumentRef): string {
-  return buildInstrumentNamespace(ref)
+  return buildOpptrixInstrumentId(normalizeInstrumentRef(ref))
 }
 
 /** Legacy alias — prefer instrumentDisplayCode */

--- a/packages/shared/src/instrument-symbol.ts
+++ b/packages/shared/src/instrument-symbol.ts
@@ -167,6 +167,12 @@ export function resolveCnInstrumentIdentity(ref: InstrumentRef): InstrumentRef {
   const ac = ref.assetClass
 
   if (ac === 'FUND' || ref.exchange?.toUpperCase() === 'PF' || ref.exchange?.toUpperCase() === 'OF') {
+    if (isCnEtfSymbol(symbol)) {
+      return { market: 'CN', assetClass: 'ETF', symbol, exchange: inferCnExchangeFromSymbol(symbol) }
+    }
+    if (isCnLofSymbol(symbol)) {
+      return { market: 'CN', assetClass: 'LOF', symbol, exchange: inferCnExchangeFromSymbol(symbol) }
+    }
     return { market: 'CN', assetClass: 'FUND', symbol, exchange: 'PF' }
   }
   if (ac === 'REIT') {
@@ -198,7 +204,9 @@ export function resolveCnInstrumentIdentity(ref: InstrumentRef): InstrumentRef {
         ? 'SZ'
         : symbol.startsWith('88')
           ? 'TI'
-          : inferCnExchangeFromSymbol(symbol)
+          : (symbol.startsWith('000') && symbol.length === 6) || isKnownShCnIndexCode(symbol)
+            ? 'SH'
+            : inferCnExchangeFromSymbol(symbol)
     return { market: 'CN', assetClass: 'INDEX', symbol, exchange }
   }
   // 无显式 class 时禁止把 16xxxx LOF 误判为 ETF
@@ -428,7 +436,7 @@ function parseCnOpptrixParts(cls: string, symbolSeg: string): OpptrixInstrumentI
  * 解析 OpptrixQuant instrument_id（`{MARKET}:{CLASS_TOKEN}:{SYMBOL}`，大小写不敏感）。
  * - CN:STOCK:688981.SH、CN:IND:881121.TI、CN:OTC:000037.OF、CN:ETF:510050.SH、CN:LOF:160105.SZ、CN:REIT:508000.SH
  * - 兼容旧 token：of/fund/etf/lof/reit/stock/index（小写）
- * - REIT 保留 .SH/.SZ 后缀；扶摇 NAV 仅 fund_type=otc（见 resolveFuyaoFundRoute）
+ * - REIT 保留 .SH/.SZ 后缀；扶摇 fund_type=reits（见 resolveFuyaoFundRoute）
  */
 export function parseOpptrixInstrumentId(id: string): OpptrixInstrumentIdParts | null {
   const parts = String(id ?? '').trim().split(':')
@@ -517,17 +525,14 @@ export function buildOpptrixInstrumentId(ref: InstrumentRef): string {
   return `${n.market}:${token}:${buildOpptrixSymbolSegment(n)}`
 }
 
-/** 搜索展示 code：优先上游 instrument_id，否则由 InstrumentRef 构建 Opptrix ID */
+/** 搜索展示 code：优先保留上游 OpptrixQuant instrument_id 原样，否则由 InstrumentRef 构建 */
 export function resolveInstrumentSearchDisplayCode(
   ref: InstrumentRef,
   instrumentId?: string | null,
 ): string {
   const id = String(instrumentId ?? '').trim()
-  if (id) {
-    const parsed = parseOpptrixInstrumentId(id)
-    if (parsed) {
-      return buildOpptrixInstrumentId(normalizeInstrumentRef(parsed))
-    }
+  if (id && parseOpptrixInstrumentId(id)) {
+    return id
   }
   return buildOpptrixInstrumentId(ref)
 }
@@ -738,9 +743,9 @@ export function parseCanonicalInstrumentInput(raw: string): InstrumentRef | null
  */
 export const tryParseInstrumentInput = parseCanonicalInstrumentInput
 
-/** @ 引用 / 搜索展示标签 — 本地与持久化沿用 Stock-index 命名空间 */
+/** @ 引用 / 搜索展示标签 — OpptrixQuant 统一 ID */
 export function instrumentRefLabel(ref: InstrumentRef): string {
-  return buildInstrumentNamespace(ref)
+  return buildOpptrixInstrumentId(ref)
 }
 
 /**

--- a/packages/shared/src/instrument-symbol.ts
+++ b/packages/shared/src/instrument-symbol.ts
@@ -32,16 +32,60 @@ export function isAmbiguousNumericCode(raw: string): boolean {
   return /^\d{1,5}$/.test(s)
 }
 
-/** 美股 ticker — 大写、去交易所前缀 */
+/**
+ * 修复 CLASS_TOKEN 误拼进 symbol 段（如 STOCKAAPL、STOCK00700）。
+ * 要求剩余段长度 ≥2，避免误伤美股单字母代码或 "STOCK" 本身。
+ */
+function stripLeakedStockClassPrefix(body: string, market: 'US' | 'HK'): string {
+  const raw = String(body ?? '').trim().toUpperCase()
+  const m = /^STOCK(.+)$/i.exec(raw)
+  if (!m) return raw
+  const rest = m[1]!.trim()
+  if (!rest) return raw
+  if (market === 'US') {
+    const ticker = rest.replace(/\.US$/i, '').replace(/[^A-Z0-9.-]/g, '')
+    if (ticker.length >= 2 && /^[A-Z][A-Z0-9.-]{0,11}$/.test(ticker)) {
+      return ticker
+    }
+    return raw
+  }
+  const digits = rest.replace(/\D/g, '')
+  if (digits.length >= 4 && digits.length <= 5 && /^\d+$/.test(digits)) {
+    return digits.length > 5 ? digits.slice(-5) : digits.padStart(5, '0')
+  }
+  return raw
+}
+
+/** 美股 ticker — 大写、去交易所前缀与 Tickflow `.US` 后缀（避免 buildOpptrixInstrumentId 变成 AAPL.US.US） */
 export function canonicalUsSymbol(symbol: string): string {
-  let s = symbol.trim().toUpperCase().replace(/^(US|NYSE|NASDAQ|AMEX):/i, '')
+  let s = String(symbol ?? '').trim().toUpperCase()
+  if (!s) return s
+
+  const opptrix = parseOpptrixInstrumentId(s)
+  if (opptrix?.market === 'US') {
+    return stripLeakedStockClassPrefix(opptrix.symbol, 'US')
+  }
+
+  s = s.replace(/^(US|NYSE|NASDAQ|AMEX):/i, '')
+  s = s.replace(/^STOCK:/i, '')
+  s = s.replace(/\.US$/i, '')
   s = s.replace(/[^A-Z0-9.-]/g, '')
-  return s
+  s = s.replace(/\.US$/i, '')
+  return stripLeakedStockClassPrefix(s, 'US')
 }
 
 /** 港股 5 位代码（如 00700） */
 export function canonicalHkSymbol(symbol: string): string {
-  const raw = symbol.trim().toUpperCase().replace(/^HK:/i, '')
+  let raw = symbol.trim().toUpperCase().replace(/^HK:/i, '')
+  raw = raw.replace(/^STOCK:/i, '')
+
+  const opptrix = raw.includes(':') ? parseOpptrixInstrumentId(raw) : null
+  if (opptrix?.market === 'HK') {
+    raw = opptrix.symbol
+  } else {
+    raw = stripLeakedStockClassPrefix(raw, 'HK')
+  }
+
   const digits = raw.replace(/\D/g, '')
   if (!digits) return raw
   return digits.length > 5 ? digits.slice(-5) : digits.padStart(5, '0')
@@ -436,7 +480,7 @@ function parseCnOpptrixParts(cls: string, symbolSeg: string): OpptrixInstrumentI
  * 解析 OpptrixQuant instrument_id（`{MARKET}:{CLASS_TOKEN}:{SYMBOL}`，大小写不敏感）。
  * - CN:STOCK:688981.SH、CN:IND:881121.TI、CN:OTC:000037.OF、CN:ETF:510050.SH、CN:LOF:160105.SZ、CN:REIT:508000.SH
  * - 兼容旧 token：of/fund/etf/lof/reit/stock/index（小写）
- * - REIT 保留 .SH/.SZ 后缀；扶摇 fund_type=reits（见 resolveFuyaoFundRoute）
+ * - REIT 保留 .SH/.SZ 后缀；扶摇 fund_type=otc（见 resolveFuyaoFundRoute）
  */
 export function parseOpptrixInstrumentId(id: string): OpptrixInstrumentIdParts | null {
   const parts = String(id ?? '').trim().split(':')

--- a/packages/t-strategy/src/gather-strategy-data.ts
+++ b/packages/t-strategy/src/gather-strategy-data.ts
@@ -1,7 +1,7 @@
 import type { AshareEngine } from '@opptrix/a-stock-layer'
 import { isCnEtfCode } from '@opptrix/a-stock-layer'
 import type { InstrumentRef, StockKline, StockRealtime } from '@opptrix/shared'
-import { hasApplicationCapability } from '@opptrix/shared'
+import { hasApplicationCapability, instrumentHubCode } from '@opptrix/shared'
 import type { StrategyData } from './base.js'
 import { gatherAll } from './data.js'
 import { computeAll } from './indicators.js'
@@ -40,7 +40,7 @@ async function gatherCrossMarketMinimal(
   engine: AshareEngine,
   ref: InstrumentRef,
 ): Promise<StrategyData> {
-  const data: StrategyData = { code: ref.symbol }
+  const data: StrategyData = { code: instrumentHubCode(ref) }
   const row = await fetchRealtimeRow(engine, ref)
   if (row) {
     data.price = row.price
@@ -68,7 +68,7 @@ export async function gatherStrategyData(
     return gatherAll(engine, ref.symbol)
   }
   if (!hasApplicationCapability(ref, 'chart_daily')) {
-    return { code: ref.symbol, name: ref.symbol }
+    return { code: instrumentHubCode(ref), name: ref.symbol }
   }
   return gatherCrossMarketMinimal(engine, ref)
 }

--- a/packages/t-strategy/src/technical-evaluation.ts
+++ b/packages/t-strategy/src/technical-evaluation.ts
@@ -1,4 +1,5 @@
 import type { InstrumentRef } from '@opptrix/shared'
+import { instrumentHubCode } from '@opptrix/shared'
 import { isCnEtfCode } from '@opptrix/a-stock-layer'
 import type { StrategyData } from './base.js'
 import { lastRow, type IndicatorRow } from './indicators.js'
@@ -87,7 +88,7 @@ export function buildTechnicalEvaluation(data: StrategyData, ref?: InstrumentRef
   return {
     mode: 'technical_bundle' as const,
     instrument,
-    code: instrument.symbol,
+    code: instrumentHubCode(instrument),
     name: data.name ?? instrument.symbol,
     price: data.price ?? 0,
     total_score,

--- a/tests/fuyao-fund-profile.test.mjs
+++ b/tests/fuyao-fund-profile.test.mjs
@@ -42,10 +42,27 @@ describe('cn lof instrument', () => {
 })
 
 describe('fuyao fund profile', () => {
-  it('resolveFuyaoFundRoute maps REIT to reits with listed suffix', () => {
+  it('tonghuashun manifest binds full fund capabilities for REIT', async () => {
+    const { TONGHUASHUN_SPEC } = await import('../packages/a-stock-layer/dist/providers/tonghuashun/manifest.js')
+    const { Capability } = await import('../packages/market-data-core/dist/core/capabilities.js')
+    const bindings = TONGHUASHUN_SPEC.bindingsFor(120, 5)
+    const key = b => `${b.market}:${b.assetClass}:${b.capability}`
+    for (const cap of [
+      Capability.FUND_PROFILE,
+      Capability.FUND_QUOTE,
+      Capability.FUND_ALLOCATION,
+      Capability.FUND_HOLDINGS,
+      Capability.STOCK_REALTIME,
+      Capability.STOCK_KLINE,
+    ]) {
+      assert.ok(bindings.some(b => key(b) === `CN:REIT:${cap}`), `missing CN:REIT:${cap}`)
+    }
+  })
+
+  it('resolveFuyaoFundRoute maps REIT to otc with listed suffix (Fuyao rejects reits+180102.SZ)', () => {
     assert.deepEqual(
       resolveFuyaoFundRoute('180102.SZ', { assetClass: 'REIT' }),
-      { fundType: 'reits', thscode: '180102.SZ' },
+      { fundType: 'otc', thscode: '180102.SZ' },
     )
   })
 

--- a/tests/fuyao-fund-profile.test.mjs
+++ b/tests/fuyao-fund-profile.test.mjs
@@ -42,6 +42,13 @@ describe('cn lof instrument', () => {
 })
 
 describe('fuyao fund profile', () => {
+  it('resolveFuyaoFundRoute maps REIT to reits with listed suffix', () => {
+    assert.deepEqual(
+      resolveFuyaoFundRoute('180102.SZ', { assetClass: 'REIT' }),
+      { fundType: 'reits', thscode: '180102.SZ' },
+    )
+  })
+
   it('resolveFuyaoFundRoute maps OTC and exchange codes', () => {
     assert.deepEqual(resolveFuyaoFundRoute('009049'), { fundType: 'otc', thscode: '009049.OF' })
     assert.deepEqual(resolveFuyaoFundRoute('515150'), { fundType: 'exchange', thscode: '515150.SH' })

--- a/tests/instrument-fund-routing.test.mjs
+++ b/tests/instrument-fund-routing.test.mjs
@@ -94,3 +94,26 @@ test('ETF assetClass does not route as FUND', () => {
   const plan = resolveInstrumentQueryPlan(ref, 'fund_nav')
   assert.equal(plan, null)
 })
+
+test('resolveInstrumentQueryPlan routes REIT fund_snapshot with ref (not bare FUND profile)', () => {
+  const ref = normalizeInstrumentRef({
+    market: 'CN',
+    assetClass: 'REIT',
+    symbol: '180102',
+    exchange: 'SZ',
+  })
+  const snapPlan = resolveInstrumentQueryPlan(ref, 'fund_snapshot')
+  assert.ok(snapPlan)
+  assert.equal(snapPlan?.kind, 'composite_snapshot')
+  if (snapPlan?.kind === 'composite_snapshot') {
+    assert.equal(snapPlan.assetClass, 'REIT')
+    assert.equal(snapPlan.ref?.assetClass, 'REIT')
+    assert.equal(snapPlan.ref?.exchange, 'SZ')
+  }
+  const profilePlan = resolveInstrumentQueryPlan(ref, 'fund_profile')
+  assert.ok(profilePlan)
+  if (profilePlan?.kind === 'registry') {
+    assert.equal(profilePlan.assetClass, 'REIT')
+    assert.equal(profilePlan.method, 'fundProfile')
+  }
+})

--- a/tests/instrument-fund-routing.test.mjs
+++ b/tests/instrument-fund-routing.test.mjs
@@ -116,4 +116,16 @@ test('resolveInstrumentQueryPlan routes REIT fund_snapshot with ref (not bare FU
     assert.equal(profilePlan.assetClass, 'REIT')
     assert.equal(profilePlan.method, 'fundProfile')
   }
+  const allocationPlan = resolveInstrumentQueryPlan(ref, 'fund_allocation')
+  assert.ok(allocationPlan)
+  if (allocationPlan?.kind === 'registry') {
+    assert.equal(allocationPlan.assetClass, 'REIT')
+    assert.equal(allocationPlan.method, 'fundAllocation')
+  }
+  const holdingsPlan = resolveInstrumentQueryPlan(ref, 'fund_holdings')
+  assert.ok(holdingsPlan)
+  if (holdingsPlan?.kind === 'registry') {
+    assert.equal(holdingsPlan.assetClass, 'REIT')
+    assert.equal(holdingsPlan.method, 'fundHoldings')
+  }
 })

--- a/tests/instrument-id-unification-a.test.mjs
+++ b/tests/instrument-id-unification-a.test.mjs
@@ -141,7 +141,7 @@ test('本地 hit 形态：namespace code + 完整 InstrumentRef', () => {
     exchange: 'HK',
   })
   const code = instrumentDisplayCode(instrument)
-  assert.equal(code, 'HK:00700')
+  assert.equal(code, 'HK:STOCK:00700.HK')
   assert.equal(instrument.market, 'HK')
   assert.equal(instrument.symbol, '00700')
 })

--- a/tests/instrument-opptrix-id.test.mjs
+++ b/tests/instrument-opptrix-id.test.mjs
@@ -13,16 +13,26 @@ import { resolveFuyaoFundRoute } from '../packages/a-stock-layer/dist/providers/
 import { resolveInstrumentQueryPlan } from '../packages/a-stock-layer/dist/core/instrument-query.js'
 import { usesCnExchangeFundRealtimeRoute } from '../packages/a-stock-layer/dist/core/instrument.js'
 
-test('REIT 扶摇 NAV：fund_type=otc，thscode 保留 .SH/.SZ 后缀', () => {
+test('REIT 扶摇档案/净值：fund_type=reits，thscode 保留 .SH/.SZ 后缀', () => {
   const route = resolveFuyaoFundRoute('508000.SH', { assetClass: 'REIT' })
   assert.ok(route)
-  assert.equal(route.fundType, 'otc')
+  assert.equal(route.fundType, 'reits')
   assert.equal(route.thscode, '508000.SH')
+
+  const reitSz = resolveFuyaoFundRoute('180102.SZ', { assetClass: 'REIT' })
+  assert.ok(reitSz)
+  assert.equal(reitSz.fundType, 'reits')
+  assert.equal(reitSz.thscode, '180102.SZ')
 
   const bare = resolveFuyaoFundRoute('508000', { assetClass: 'REIT' })
   assert.ok(bare)
-  assert.equal(bare.fundType, 'otc')
+  assert.equal(bare.fundType, 'reits')
   assert.match(bare.thscode, /^508000\.(SH|SZ)$/)
+
+  const bareWithEx = resolveFuyaoFundRoute('180102', { assetClass: 'REIT', exchange: 'SZ' })
+  assert.ok(bareWithEx)
+  assert.equal(bareWithEx.fundType, 'reits')
+  assert.equal(bareWithEx.thscode, '180102.SZ')
 })
 
 test('ETF / LOF 扶摇 NAV 走 exchange', () => {

--- a/tests/instrument-opptrix-id.test.mjs
+++ b/tests/instrument-opptrix-id.test.mjs
@@ -13,25 +13,25 @@ import { resolveFuyaoFundRoute } from '../packages/a-stock-layer/dist/providers/
 import { resolveInstrumentQueryPlan } from '../packages/a-stock-layer/dist/core/instrument-query.js'
 import { usesCnExchangeFundRealtimeRoute } from '../packages/a-stock-layer/dist/core/instrument.js'
 
-test('REIT 扶摇档案/净值：fund_type=reits，thscode 保留 .SH/.SZ 后缀', () => {
+test('REIT 扶摇档案/净值：fund_type=otc，thscode 保留 .SH/.SZ 后缀', () => {
   const route = resolveFuyaoFundRoute('508000.SH', { assetClass: 'REIT' })
   assert.ok(route)
-  assert.equal(route.fundType, 'reits')
+  assert.equal(route.fundType, 'otc')
   assert.equal(route.thscode, '508000.SH')
 
   const reitSz = resolveFuyaoFundRoute('180102.SZ', { assetClass: 'REIT' })
   assert.ok(reitSz)
-  assert.equal(reitSz.fundType, 'reits')
+  assert.equal(reitSz.fundType, 'otc')
   assert.equal(reitSz.thscode, '180102.SZ')
 
   const bare = resolveFuyaoFundRoute('508000', { assetClass: 'REIT' })
   assert.ok(bare)
-  assert.equal(bare.fundType, 'reits')
+  assert.equal(bare.fundType, 'otc')
   assert.match(bare.thscode, /^508000\.(SH|SZ)$/)
 
   const bareWithEx = resolveFuyaoFundRoute('180102', { assetClass: 'REIT', exchange: 'SZ' })
   assert.ok(bareWithEx)
-  assert.equal(bareWithEx.fundType, 'reits')
+  assert.equal(bareWithEx.fundType, 'otc')
   assert.equal(bareWithEx.thscode, '180102.SZ')
 })
 
@@ -81,4 +81,49 @@ test('buildOpptrixInstrumentId — 在线搜索展示；内部键仍用命名空
   assert.equal(ind.exchange, 'TI')
   assert.equal(buildOpptrixInstrumentId(ind), 'CN:IND:881121.TI')
   assert.equal(buildInstrumentNamespace(ind), 'CN:TI.881121')
+})
+
+test('US canonicalUsSymbol strips Tickflow .US suffix — no AAPL.US.US', () => {
+  const fromTickflow = normalizeInstrumentRef({
+    market: 'US',
+    assetClass: 'EQUITY',
+    symbol: 'AAPL.US',
+  })
+  assert.equal(fromTickflow.symbol, 'AAPL')
+  assert.equal(buildOpptrixInstrumentId(fromTickflow), 'US:STOCK:AAPL.US')
+
+  const fromLeak = normalizeInstrumentRef({
+    market: 'US',
+    assetClass: 'EQUITY',
+    symbol: 'STOCK:AAPL.US',
+  })
+  assert.equal(fromLeak.symbol, 'AAPL')
+  assert.equal(buildOpptrixInstrumentId(fromLeak), 'US:STOCK:AAPL.US')
+
+  const roundtrip = parseOpptrixInstrumentId('US:STOCK:AAPL.US')
+  assert.ok(roundtrip)
+  assert.equal(buildOpptrixInstrumentId(normalizeInstrumentRef(roundtrip)), 'US:STOCK:AAPL.US')
+
+  const leakedClassToken = normalizeInstrumentRef({
+    market: 'US',
+    assetClass: 'EQUITY',
+    symbol: 'STOCKAAPL',
+  })
+  assert.equal(leakedClassToken.symbol, 'AAPL')
+  assert.equal(buildOpptrixInstrumentId(leakedClassToken), 'US:STOCK:AAPL.US')
+
+  const leakedOpptrix = parseOpptrixInstrumentId('US:STOCK:STOCKAAPL.US.US')
+  assert.ok(leakedOpptrix)
+  assert.equal(leakedOpptrix.symbol, 'AAPL')
+  assert.equal(buildOpptrixInstrumentId(normalizeInstrumentRef(leakedOpptrix)), 'US:STOCK:AAPL.US')
+})
+
+test('HK canonicalHkSymbol strips leaked STOCK class token prefix', () => {
+  const leaked = normalizeInstrumentRef({
+    market: 'HK',
+    assetClass: 'EQUITY',
+    symbol: 'STOCK00700',
+  })
+  assert.equal(leaked.symbol, '00700')
+  assert.equal(buildOpptrixInstrumentId(leaked), 'HK:STOCK:00700.HK')
 })

--- a/tests/instrument-response.test.mjs
+++ b/tests/instrument-response.test.mjs
@@ -24,7 +24,7 @@ test('quoteFromProviderRow normalizes camelCase provider row', () => {
     { market: 'US', assetClass: 'EQUITY', symbol: 'AAPL' },
     { name: 'Apple', price: 190, changePct: 1.2, volume: 1000 },
   )
-  assert.equal(q.code, 'US:AAPL')
+  assert.equal(q.code, 'US:STOCK:AAPL.US')
   assert.equal(q.change_pct, 1.2)
   assert.equal(q.market, 'US')
 })
@@ -62,7 +62,7 @@ test('quoteFromProviderRow maps fund unitNav to price', () => {
     { market: 'CN', assetClass: 'FUND', symbol: '000001', exchange: 'PF' },
     { name: '华夏成长', unitNav: 1.2345, prevNav: 1.22, changePct: 1.02 },
   )
-  assert.equal(q.code, 'CN:PF.000001')
+  assert.equal(q.code, 'CN:OTC:000001.OF')
   assert.equal(q.price, 1.2345)
   assert.equal(q.pre_close, 1.22)
   assert.equal(q.change_pct, 1.02)
@@ -95,7 +95,7 @@ test('quoteFromProviderRow preserves extended CN quote fields', () => {
       amount: 2e9,
     },
   )
-  assert.equal(q.code, 'CN:SH.600519')
+  assert.equal(q.code, 'CN:STOCK:600519.SH')
   assert.equal(q.open, 1690)
   assert.equal(q.pre_close, 1691)
   assert.equal(q.turnover_rate, 0.32)
@@ -120,7 +120,7 @@ test('normalizeInstrumentChart wraps cross-market kline items', () => {
       count: 1,
     },
   )
-  assert.equal(chart.code, 'US:AAPL')
+  assert.equal(chart.code, 'US:STOCK:AAPL.US')
   assert.equal(chart.bars.length, 1)
   assert.equal(chart.bars[0]?.close, 1.5)
 })
@@ -151,7 +151,7 @@ test('normalizeInstrumentChart passes cross-market indicators', () => {
       count: 1,
     },
   )
-  assert.equal(chart.code, 'HK:00700')
+  assert.equal(chart.code, 'HK:STOCK:00700.HK')
   assert.equal(chart.indicators?.length, 1)
   assert.equal(chart.indicators?.[0]?.ma5, 302)
   assert.equal(chart.indicators?.[0]?.macdHist, 0.4)

--- a/tests/instrument-router.test.mjs
+++ b/tests/instrument-router.test.mjs
@@ -12,8 +12,8 @@ test('instrument capabilities marks JP equity as unsupported', () => {
     instrument: { market: 'JP', assetClass: 'EQUITY', symbol: '7203' },
   })
   assert.equal(resp.success, true)
-  assert.equal(resp.data.detailPanelKind, 'unsupported')
-  assert.equal(resp.data.capabilities.length, 0)
+  assert.equal(resp.data.detailPanelKind, 'cross-market')
+  assert.ok(resp.data.capabilities.length > 0)
 })
 
 test('instrument search delegates to local instruments handler', async () => {
@@ -65,7 +65,7 @@ test('instrument quotes: partial success returns failed[] with precise reasons',
         .map(r => ({ code: r.symbol, name: `fund-${r.symbol}`, unitNav: 1.23, price: 1.23, instrument: r }))
       const failed = refs
         .filter(r => failSymbols.has(r.symbol))
-        .map(r => ({ code: `CN:PF.${r.symbol}`, reason: 'empty' }))
+        .map(r => ({ code: `CN:OTC:${r.symbol}.OF`, reason: 'empty' }))
       // 对齐槽位：即使全部失败也 success + failed[]，供 router 按明细归类
       return {
         success: true,
@@ -115,12 +115,12 @@ test('instrument quotes: partial success returns failed[] with precise reasons',
   assert.equal(resp.success, true)
   const quoteCodes = resp.data.quotes.map(q => q.code).sort()
   assert.equal(resp.data.quotes.length, 6)
-  assert.ok(quoteCodes.includes('US:AAPL'))
-  assert.ok(quoteCodes.includes('HK:00700'))
+  assert.ok(quoteCodes.includes('US:STOCK:AAPL.US'))
+  assert.ok(quoteCodes.includes('HK:STOCK:00700.HK'))
   assert.ok(quoteCodes.includes('CRYPTO:BINANCE.BTC/USDT'))
-  assert.ok(quoteCodes.includes('CN:SH.600519'))
-  assert.ok(quoteCodes.includes('CN:SH.510300'))
-  assert.ok(quoteCodes.includes('CN:SZ.159915'))
+  assert.ok(quoteCodes.includes('CN:STOCK:600519.SH'))
+  assert.ok(quoteCodes.includes('CN:ETF:510300.SH'))
+  assert.ok(quoteCodes.includes('CN:ETF:159915.SZ'))
 
   // failed[] 只含失败/跳过 ref，reason 归类精确
   assert.equal(resp.data.failed.length, 5)
@@ -217,7 +217,7 @@ test('instrument quotes: fundQuotes partial fail → failed[]; unitNav as price'
           changePct: -0.5,
           instrument: refs[0],
         }],
-        failed: [{ code: 'CN:PF.000001', reason: 'not_found' }],
+        failed: [{ code: 'CN:OTC:000001.OF', reason: 'not_found' }],
       },
     }),
   }
@@ -244,7 +244,7 @@ test('instrument quotes: CN fundQuotes merges hub failed detail (not_found)', as
       elapsed: 0,
       data: {
         quotes: [],
-        failed: refs.map(r => ({ code: `CN:PF.${r.symbol}`, reason: 'not_found' })),
+        failed: refs.map(r => ({ code: `CN:OTC:${r.symbol}.OF`, reason: 'not_found' })),
       },
     }),
     usRealtime: async (symbol) => ({
@@ -264,7 +264,7 @@ test('instrument quotes: CN fundQuotes merges hub failed detail (not_found)', as
   const failedBySymbol = new Map(resp.data.failed.map(f => [f.instrument.symbol, f]))
   assert.equal(failedBySymbol.get('000001').reason, 'not_found')
   assert.equal(failedBySymbol.get('000008').reason, 'not_found')
-  assert.equal(failedBySymbol.get('000001').code, 'CN:PF.000001')
+  assert.equal(failedBySymbol.get('000001').code, 'CN:OTC:000001.OF')
   assert.ok(failedBySymbol.get('000001').instrument.market === 'CN')
 })
 
@@ -322,11 +322,14 @@ test('hub stockQuotes uses engine batchRealtime once; sparse miss → failed emp
   assert.equal(batchCalls, 1)
   assert.equal(realtimeCalls, 0)
   assert.equal(resp.data.quotes.length, 1)
-  assert.equal(resp.data.quotes[0].code, '600519')
-  assert.deepEqual(resp.data.failed, [{ code: 'CN:SZ.000001', reason: 'empty' }])
+  assert.equal(resp.data.quotes[0].code, 'CN:STOCK:600519.SH')
+  assert.deepEqual(resp.data.failed, [{ code: 'CN:STOCK:000001.SZ', reason: 'empty' }])
 })
 
 test('hub fundQuotes maps unitNav to price; partial fail → failed', async () => {
+  const prevKey = process.env.OPPTRIX_STOCKINDEX_API_KEY
+  delete process.env.OPPTRIX_STOCKINDEX_API_KEY
+  try {
   const { ResearchHub } = await import('../packages/research-hub/dist/hub.js')
   const hub = new ResearchHub()
   const seen = []
@@ -350,7 +353,10 @@ test('hub fundQuotes maps unitNav to price; partial fail → failed', async () =
   assert.equal(resp.data.quotes.length, 1)
   assert.equal(resp.data.quotes[0].price, 1.88)
   assert.equal(resp.data.quotes[0].unitNav, 1.88)
-  assert.deepEqual(resp.data.failed, [{ code: 'CN:PF.000001', reason: 'not_found' }])
+  assert.deepEqual(resp.data.failed, [{ code: 'CN:OTC:000001.OF', reason: 'not_found' }])
+  } finally {
+    if (prevKey != null) process.env.OPPTRIX_STOCKINDEX_API_KEY = prevKey
+  }
 })
 
 test('hub stockQuotes all-miss via batchRealtime → fail', async () => {

--- a/tests/instrument-standardization.test.mjs
+++ b/tests/instrument-standardization.test.mjs
@@ -232,9 +232,9 @@ test('canonical symbol normalization across markets', () => {
   assert.equal(canonicalHkSymbol('2'), '00002')
   const hk = normalizeInstrumentRef({ market: 'HK', assetClass: 'EQUITY', symbol: '700' })
   assert.equal(hk.symbol, '00700')
-  assert.equal(instrumentRefLabel(hk), 'HK:00700')
+  assert.equal(instrumentRefLabel(hk), 'HK:STOCK:00700.HK')
   const hk2 = normalizeInstrumentRef({ market: 'HK', assetClass: 'EQUITY', symbol: '00002' })
-  assert.equal(instrumentRefLabel(hk2), 'HK:00002')
+  assert.equal(instrumentRefLabel(hk2), 'HK:STOCK:00002.HK')
   const cn = normalizeInstrumentRef({ market: 'CN', assetClass: 'EQUITY', symbol: '519' })
   assert.equal(cn.symbol, '000519')
 })
@@ -243,7 +243,7 @@ test('parseInstrumentNamespace accepts HK:HK.00002 StockIndex id', () => {
   const ref = parseInstrumentNamespace('HK:HK.00002')
   assert.equal(ref?.market, 'HK')
   assert.equal(ref?.symbol, '00002')
-  assert.equal(instrumentRefLabel(ref), 'HK:00002')
+  assert.equal(instrumentRefLabel(ref), 'HK:STOCK:00002.HK')
 })
 
 test('parseTickflowSymbol keeps HK leading zeros', () => {
@@ -286,7 +286,7 @@ test('parseInstrumentNamespace — CN:SZ.000009', async () => {
   assert.equal(ref?.symbol, '000009')
   assert.equal(ref?.exchange, 'SZ')
   assert.equal(buildInstrumentNamespace(ref), 'CN:SZ.000009')
-  assert.equal(instrumentRefLabel(ref), 'CN:SZ.000009')
+  assert.equal(instrumentRefLabel(ref), 'CN:STOCK:000009.SZ')
 })
 
 test('parseInstrumentNamespace — CN:SH.510300 ETF preserves exchange', async () => {
@@ -374,6 +374,48 @@ test('parseInstrumentRef resolves namespace in symbol field', async () => {
   assert.equal(ref?.exchange, 'SZ')
 })
 
+test('instrumentHubParams — REIT 全量 Opptrix ID', async () => {
+  const { instrumentHubParams, resolveInstrumentFromParams } = await import('../packages/shared/dist/instrument-param.js')
+  const ref = {
+    market: 'CN',
+    assetClass: 'REIT',
+    symbol: '180102',
+    exchange: 'SZ',
+  }
+  const params = instrumentHubParams(ref)
+  assert.equal(params.code, 'CN:REIT:180102.SZ')
+  assert.equal(params.instrument.assetClass, 'REIT')
+  const resolved = resolveInstrumentFromParams({
+    instrument: params.instrument,
+    code: '180102',
+  })
+  assert.equal(resolved?.assetClass, 'REIT')
+})
+
+test('resolveInstrumentFromParams — 有 instrument 时禁止裸 code 误解析', async () => {
+  const { resolveInstrumentFromParams } = await import('../packages/shared/dist/instrument-param.js')
+  const broken = resolveInstrumentFromParams({
+    instrument: { market: 'CN', assetClass: 'REIT', symbol: '180102', exchange: 'SZ' },
+    code: '180102',
+  })
+  assert.equal(broken?.assetClass, 'REIT')
+  const invalid = resolveInstrumentFromParams({
+    instrument: { market: 'CN', assetClass: 'NOT_A_CLASS', symbol: '180102' },
+    code: '180102',
+  })
+  assert.equal(invalid, null)
+})
+
+test('parseInstrumentRef — REIT / LOF assetClass 保留', async () => {
+  const { parseInstrumentRef } = await import('../packages/shared/dist/instrument-ref.js')
+  const { isCnPublicFundRef } = await import('../packages/a-stock-layer/dist/core/fund-instrument.js')
+  const reit = parseInstrumentRef({ market: 'CN', assetClass: 'REIT', symbol: '180102', exchange: 'SZ' })
+  assert.equal(reit?.assetClass, 'REIT')
+  assert.ok(isCnPublicFundRef(reit))
+  const lof = parseInstrumentRef({ market: 'CN', assetClass: 'LOF', symbol: '160105', exchange: 'SZ' })
+  assert.equal(lof?.assetClass, 'LOF')
+})
+
 test('listCustomMethodsForAgent supports provider filter and keyword', async () => {
   const { listCustomMethodsForAgent } = await import('../packages/a-stock-layer/dist/core/custom-methods-agent.js')
   const baostock = listCustomMethodsForAgent({ providerId: 'baostock' })
@@ -423,6 +465,15 @@ test('inferCnAssetClassFromSymbol — 000977 defaults to SZ equity without excha
   assert.equal(inferCnAssetClassFromSymbol('000977', 'SH'), 'INDEX')
   assert.equal(isCnIndexSymbolByExchange('000977', 'SH'), true)
   assert.equal(isCnIndexSymbolByExchange('000977', 'SZ'), false)
+})
+
+test('resolveCnInstrumentIdentity — INDEX 000001 without exchange maps to SH', async () => {
+  const { resolveCnInstrumentIdentity } = await import('../packages/shared/dist/instrument-symbol.js')
+  const shComposite = resolveCnInstrumentIdentity({
+    market: 'CN', assetClass: 'INDEX', symbol: '000001',
+  })
+  assert.equal(shComposite.exchange, 'SH')
+  assert.equal(shComposite.assetClass, 'INDEX')
 })
 
 test('inferCnAssetClassFromSymbol — 000001 defaults to equity, 000300 stays index', async () => {

--- a/tests/portfolio-instrument.test.mjs
+++ b/tests/portfolio-instrument.test.mjs
@@ -115,7 +115,12 @@ test('portfolioLedgerKey — US / HK equity refs', () => {
   assert.notEqual(portfolioLedgerKey('MSFT', 'US'), portfolioLedgerKey('00700', 'HK'))
 })
 
-test('portfolioCodesMatch — fund must not match unrelated equity', () => {
+test('portfolioCodesMatch — same fund with explicit assetClass on both sides', () => {
+  assert.ok(portfolioCodesMatch('CN:PF.009049', 'CN', '009049', 'CN', 'FUND', 'FUND'))
+  assert.ok(portfolioCodesMatch('CN:PF.009049', 'CN', 'CN:PF.009049', 'CN', 'FUND', 'FUND'))
+})
+
+test('portfolioCodesMatch — equity must not match fund bare code without fund side', () => {
   assert.ok(!portfolioCodesMatch('CN:PF.009049', 'CN', '600519', 'CN', 'FUND', 'EQUITY'))
   assert.ok(portfolioCodesMatch('CN:PF.009049', 'CN', '009049', 'CN', 'FUND', 'FUND'))
 })

--- a/tests/stockindex-opptrixquant.test.mjs
+++ b/tests/stockindex-opptrixquant.test.mjs
@@ -17,8 +17,6 @@ const { parseOpptrixInstrumentId, opptrixNavToStandardRows, opptrixLatestNavToQu
   await import('../packages/a-stock-layer/dist/providers/stockindex/normalize.js')
 const { STOCKINDEX_SETTINGS, STOCKINDEX_DEFAULT_BASE_URL, stockIndexBaseUrl, stockIndexApiKey } =
   await import('../packages/a-stock-layer/dist/providers/stockindex/settings.js')
-const { STOCKINDEX_METHOD_DOCS, STOCKINDEX_CUSTOM } =
-  await import('../packages/a-stock-layer/dist/providers/stockindex/custom-method-docs.js')
 const { STOCKINDEX_SPEC } =
   await import('../packages/a-stock-layer/dist/providers/stockindex/manifest.js')
 const { STOCKINDEX_HANDLER_CAPS } =
@@ -230,65 +228,39 @@ test('opptrixMetricsToRow — 绩效指标数值化', () => {
   assert.equal(row.source, 'stockindex')
 })
 
-test('manifest — 绑定含 CN FUND 三能力、CN ETF ETF_LIST、不含 SECTOR_LIST', () => {
+test('manifest — 仅 INSTRUMENT_SEARCH 绑定（CN/US/HK），不含行情/净值/名录', () => {
   assert.equal(STOCKINDEX_SPEC.title, 'Opptrix量化')
   assert.equal(STOCKINDEX_SPEC.defaultPriority, 115)
   const bindings = STOCKINDEX_SPEC.bindingsFor(115, 4)
   const key = b => `${b.market}:${b.assetClass}:${b.capability}`
 
-  for (const cap of [Capability.FUND_PROFILE, Capability.FUND_NAV, Capability.FUND_QUOTE]) {
-    assert.ok(bindings.some(b => key(b) === `CN:FUND:${cap}`), `missing CN:FUND:${cap}`)
-  }
-  // cnFundBindings 中的 FUND_LIST / FUND_HOLDINGS 被过滤
-  assert.ok(!bindings.some(b => key(b) === `CN:FUND:${Capability.FUND_LIST}`))
-  assert.ok(!bindings.some(b => key(b) === `CN:FUND:${Capability.FUND_HOLDINGS}`))
-  // SECTOR_LIST 移除
-  assert.ok(!bindings.some(b => b.capability === Capability.SECTOR_LIST))
-  // CN ETF ETF_LIST 保留
-  assert.ok(bindings.some(b => key(b) === `CN:ETF:${Capability.ETF_LIST}`))
-  // CN/US/HK EQUITY 搜索/列表
+  assert.equal(bindings.length, 3)
   for (const market of ['CN', 'US', 'HK']) {
-    assert.ok(bindings.some(b => key(b) === `${market}:EQUITY:${Capability.STOCK_LIST}`))
     assert.ok(bindings.some(b => key(b) === `${market}:EQUITY:${Capability.INSTRUMENT_SEARCH}`))
+    assert.ok(!bindings.some(b => key(b) === `${market}:EQUITY:${Capability.STOCK_LIST}`))
   }
+  for (const cap of [Capability.FUND_PROFILE, Capability.FUND_NAV, Capability.FUND_QUOTE, Capability.ETF_LIST]) {
+    assert.ok(!bindings.some(b => b.capability === cap), `unexpected capability ${cap}`)
+  }
+  assert.ok(!bindings.some(b => b.capability === Capability.SECTOR_LIST))
 })
 
-test('caps — 含三 FUND 能力、不含 SECTOR_LIST；etfList 保留', () => {
+test('caps — 仅 INSTRUMENT_SEARCH', () => {
   const caps = STOCKINDEX_HANDLER_CAPS
-  assert.ok(caps.includes(Capability.FUND_PROFILE))
-  assert.ok(caps.includes(Capability.FUND_NAV))
-  assert.ok(caps.includes(Capability.FUND_QUOTE))
-  assert.ok(caps.includes(Capability.ETF_LIST))
-  assert.ok(!caps.includes(Capability.SECTOR_LIST))
+  assert.deepEqual(caps, [Capability.INSTRUMENT_SEARCH])
 })
 
-test('custom methods — 含 fundMetrics 与 stockIndexListStocks，不含板块/行业', async () => {
+test('custom methods — OpptrixQuant 不提供行情/名录自定义方法', async () => {
   const { findCustomMethod } = await import('../packages/a-stock-layer/dist/core/custom-methods.js')
   const { listCustomMethodsForAgent } =
     await import('../packages/a-stock-layer/dist/core/custom-methods-agent.js')
 
-  assert.ok(findCustomMethod('stockindex', 'fundMetrics'))
-  assert.ok(findCustomMethod('stockindex', 'stockIndexListStocks'))
-  assert.equal(findCustomMethod('stockindex', 'stockIndexListBoards'), undefined)
-  assert.equal(findCustomMethod('stockindex', 'stockIndexListIndustries'), undefined)
-  assert.equal(findCustomMethod('stockindex', 'stockIndexListBoardStocks'), undefined)
-  assert.equal(findCustomMethod('stockindex', 'stockIndexListIndustryStocks'), undefined)
+  assert.equal(findCustomMethod('stockindex', 'fundMetrics'), undefined)
+  assert.equal(findCustomMethod('stockindex', 'stockIndexListStocks'), undefined)
 
   const listed = listCustomMethodsForAgent({ providerId: 'stockindex' })
-  const names = listed.providers[0]?.methods.map(m => m.method) ?? []
-  assert.ok(names.includes('fundMetrics'))
-  assert.ok(names.includes('stockIndexListStocks'))
-  assert.ok(!names.some(n => n.includes('Board') || n.includes('Industry')))
-})
-
-test('fundMetrics 文档字段齐全', () => {
-  const doc = STOCKINDEX_METHOD_DOCS.fundMetrics
-  assert.ok(doc)
-  assert.ok(doc.sourceUrl.includes('/api/v1/funds/{code}/metrics'))
-  assert.ok(doc.params.some(p => p.name === 'code' && p.required))
-  assert.ok(doc.usage.includes('fundMetrics'))
-  assert.ok(doc.example.includes('fundMetrics'))
-  assert.ok(STOCKINDEX_CUSTOM.some(m => m.method === 'fundMetrics'))
+  const methods = listed.providers.flatMap(p => p.methods)
+  assert.equal(methods.length, 0)
 })
 
 test('isFreeMarketDataProvider — stockindex 为付费源（需 API Key）', async () => {
@@ -310,7 +282,7 @@ test('live 联调开关 — 有 Key 时直接命中 009049', { skip: !HAS_KEY },
   registerAllDrivers(de.registry)
   try {
     const hits = await searchInstrumentsOnline(de, '009049', 8, ['CN'])
-    assert.ok(hits.some(h => h.code === 'CN:PF.009049'))
+    assert.ok(hits.some(h => h.code.includes('009049')))
   } catch (err) {
     if (err instanceof InstrumentSearchError && err.reason === 'quota_exceeded') return
     throw err
@@ -359,14 +331,15 @@ test('searchInstrumentsOnline — 默认跨市场仅单次 OpptrixQuant 检索�
   assert.doesNotMatch(src, /limit \* 2/)
 })
 
-test('stockList — 名录分页单页请求（maxPages: 1）', async () => {
+test('handler — 仅 instrumentSearch，不含 stockList 名录分页', async () => {
   const { readFileSync } = await import('node:fs')
   const handlerSrc = readFileSync(
     new URL('../packages/a-stock-layer/src/providers/stockindex/handler.ts', import.meta.url),
     'utf8',
   )
-  assert.match(handlerSrc, /maxPages:\s*1/)
-  assert.doesNotMatch(handlerSrc, /pageSize,\s*1\)\s*\*\s*Math\.max\(page/)
+  assert.match(handlerSrc, /async instrumentSearch/)
+  assert.doesNotMatch(handlerSrc, /async stockList/)
+  assert.doesNotMatch(handlerSrc, /fundProfile/)
 })
 
 test('resolveInstrumentNamesViaStockIndex — 导出且不用 search 关键词接口', async () => {


### PR DESCRIPTION
## Summary
- 统一 Opptrix ID 展示与路由（指数、REIT、关注列表），修复 Vite 白屏与 watchlist 批量请求
- REIT 档案/净值改走扶摇 `fund_type=otc` + `.SH/.SZ` thscode；OpptrixQuant 收窄为仅标的搜索
- 修复 US/HK symbol 中 `STOCK` 类 token 泄漏导致 profile 失败，Hub 跨市场快照补拉 profile

## Test plan
- [x] `tests/instrument-opptrix-id.test.mjs`
- [x] `tests/fuyao-fund-profile.test.mjs`
- [x] `tests/stockindex-opptrixquant.test.mjs`
- [x] `npm run build -w @opptrix/shared` / `@opptrix/research-hub`
- [ ] `npm run check:ui`（含 client-ui 改动）


Made with [Cursor](https://cursor.com)