### PR TITLE
feat(market-dynamics): keep A-share dashboard and offline yfinance

### DIFF
--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -303,7 +303,7 @@ export const research = {
   marketRegime: (scope: 'cn' | 'us' = 'cn') =>
     apiCall<import('../types/schemas').MarketRegimeData>('market_regime', { profile_scope: scope }),
 
-  marketDynamics: (opts?: { market?: 'cn' | 'us' }) =>
+  marketDynamics: (opts?: { market?: 'cn' | 'us' | 'hk' }) =>
     apiCall<import('../types/schemas').MarketDynamicsData>(
       'market_dynamics',
       { market: opts?.market ?? 'cn' },

--- a/client-ui/src/desktop/DesktopWindowChrome.tsx
+++ b/client-ui/src/desktop/DesktopWindowChrome.tsx
@@ -44,6 +44,7 @@ import {
   desktopTitleLeft,
   desktopTitleMaxWidth,
   desktopToolbarLeft,
+  desktopChromeToolbarReserve,
   type DesktopViewMode,
 } from './layout'
 import ChromeToolButton from './ChromeToolButton'
@@ -357,6 +358,8 @@ export default function DesktopWindowChrome({
     rightPanelWidth,
   )
 
+  const standaloneDragLeft = dragLeftInset
+
   const handleSidebarPointer = () => {
     if (sidebarHoverReveal) {
       if (!sidebarOpen) onRevealSidebar?.()
@@ -411,7 +414,7 @@ export default function DesktopWindowChrome({
           <div
             className={s.drag}
             style={{
-              left: `${dragLeftInset}px`,
+              left: `${standaloneDragLeft}px`,
               right: 0,
               ...dragRightClip,
               ...(dragRightClip.right != null

--- a/client-ui/src/pages/market-dynamics/CnInsightSplitView.tsx
+++ b/client-ui/src/pages/market-dynamics/CnInsightSplitView.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { makeStyles, mergeClasses } from '@fluentui/react-components'
 import TradingViewChart from '../../market/TradingViewChart'
 import { opptrixCssVars } from '../../theme/tokens'
+import type { InstrumentRef } from '../../types/instrument'
 import { CnInsightStockSelectProvider } from './cnInsightStockContext'
 import type { CnInsightStockPick } from './cnInsightStockUtils'
 import { cnInsightChartInputCode, cnInsightInstrumentFromCode } from './cnInsightStockUtils'
@@ -68,23 +69,29 @@ type Props = {
   selected: CnInsightStockPick | null
   onSelect: (pick: CnInsightStockPick | null) => void
   children: React.ReactNode
+  instrumentFromCode?: (code: string) => InstrumentRef
+  chartInputCode?: (ref: InstrumentRef) => string
 }
 
 function ChartPane({
   stock,
   onClose,
+  instrumentFromCode,
+  chartInputCodeFn,
 }: {
   stock: CnInsightStockPick
   onClose: () => void
+  instrumentFromCode: (code: string) => InstrumentRef
+  chartInputCodeFn: (ref: InstrumentRef) => string
 }) {
   const s = useStyles()
   const instrument = useMemo(
-    () => cnInsightInstrumentFromCode(stock.code),
-    [stock.code],
+    () => instrumentFromCode(stock.code),
+    [instrumentFromCode, stock.code],
   )
   const chartInputCode = useMemo(
-    () => cnInsightChartInputCode(instrument),
-    [instrument],
+    () => chartInputCodeFn(instrument),
+    [chartInputCodeFn, instrument],
   )
 
   return (
@@ -109,6 +116,8 @@ export default function CnInsightSplitView({
   selected,
   onSelect,
   children,
+  instrumentFromCode = cnInsightInstrumentFromCode,
+  chartInputCode: chartInputCodeFn = cnInsightChartInputCode,
 }: Props) {
   const s = useStyles()
   const split = selected != null
@@ -121,7 +130,12 @@ export default function CnInsightSplitView({
         </div>
         <div className={mergeClasses(s.chartPane, split && s.chartPaneOpen)}>
           {selected ? (
-            <ChartPane stock={selected} onClose={() => onSelect(null)} />
+            <ChartPane
+              stock={selected}
+              onClose={() => onSelect(null)}
+              instrumentFromCode={instrumentFromCode}
+              chartInputCodeFn={chartInputCodeFn}
+            />
           ) : null}
         </div>
       </div>

--- a/client-ui/src/pages/market-dynamics/MarketDynamicsHeader.tsx
+++ b/client-ui/src/pages/market-dynamics/MarketDynamicsHeader.tsx
@@ -36,12 +36,19 @@ const useStyles = makeStyles({
     height: '40px',
     padding: '0 12px',
   },
+  titleTabs: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: '28px',
+    position: 'relative',
+    zIndex: 1,
+  },
   title: {
-    paddingLeft: '3px',
-    fontSize: 'var(--opptrix-font-sm)',
+    fontSize: 'var(--opptrix-font-md)',
     fontWeight: 650,
     color: opptrixCssVars.textPrimary,
-    flexShrink: 0,
+    lineHeight: 1.2,
     whiteSpace: 'nowrap',
   },
   spacer: {
@@ -133,7 +140,9 @@ export default function MarketDynamicsHeader({
         paddingRight: electronChrome ? `${paddingRight}px` : undefined,
       }}
     >
-      <Text className={s.title}>A股</Text>
+      <div className={mergeClasses(s.titleTabs, 'opptrix-panel-title-no-drag')}>
+        <Text className={s.title}>市场动态</Text>
+      </div>
       <div
         className={mergeClasses(s.spacer, electronChrome && dragRegionClassName)}
         aria-hidden

--- a/client-ui/src/pages/market-dynamics/MarketDynamicsPage.tsx
+++ b/client-ui/src/pages/market-dynamics/MarketDynamicsPage.tsx
@@ -45,17 +45,20 @@ type Props = {
 
 function MarketDynamicsContent({ electronChrome = false, chromeToolbarReserve = 0 }: Props) {
   const s = useStyles()
-  const { data, loading, refreshing, error, refreshedAt, refresh } = useMarketDynamics('cn')
-  const insights = useMarketInsights('cn')
+  const { data, loading, refreshing, error, refresh } = useMarketDynamics()
+  const insights = useMarketInsights()
 
-  const updatedLabel = refreshedAt ? formatCnDateTime(refreshedAt) : null
+  const panelData = data?.market === 'cn' ? data : null
+  const panelLoading = loading || (data != null && data.market !== 'cn')
+
+  const updatedLabel = panelData?.refreshed_at ? formatCnDateTime(panelData.refreshed_at) : null
   const statusLabel = refreshing
     ? '刷新中…'
     : updatedLabel
       ? `更新 ${updatedLabel}`
       : '尚未刷新'
 
-  const hasData = Boolean(data?.sections.length || data?.us_indices?.length)
+  const hasData = Boolean(panelData?.sections.length)
 
   const handleRefresh = () => {
     void refresh()
@@ -75,8 +78,8 @@ function MarketDynamicsContent({ electronChrome = false, chromeToolbarReserve = 
       {error && <div className={s.errorBanner}>{error}</div>}
       <div className={s.content}>
         <CnMarketDynamicsView
-          data={data}
-          loading={loading && !hasData}
+          data={panelData}
+          loading={panelLoading && !hasData}
           articles={insights.articles}
           insightsLoading={insights.loading}
         />

--- a/client-ui/src/pages/market-dynamics/marketBoardUtils.ts
+++ b/client-ui/src/pages/market-dynamics/marketBoardUtils.ts
@@ -66,7 +66,18 @@ export function indexInstrumentFromQuote(
   const chartSym = item.chart_symbol?.trim()
 
   if (chartSym && (mkt === 'HK' || mkt === 'US')) {
-    return { market: mkt as 'HK' | 'US', assetClass: 'INDEX', symbol: chartSym }
+    const isHkIndex = mkt === 'HK' && (
+      chartSym.startsWith('^')
+        || chartSym.toUpperCase() === 'HSTECH.HK'
+        || ['HSI', 'HSCE', 'HSTECH'].includes((item.code ?? '').trim().toUpperCase())
+    )
+    return {
+      market: mkt as 'HK' | 'US',
+      assetClass: mkt === 'HK'
+        ? (isHkIndex ? 'INDEX' : 'EQUITY')
+        : 'INDEX',
+      symbol: chartSym,
+    }
   }
 
   const symbol = indexChartCodeFromQuote(item)

--- a/client-ui/src/pages/market-dynamics/marketDynamicsStorage.ts
+++ b/client-ui/src/pages/market-dynamics/marketDynamicsStorage.ts
@@ -1,9 +1,26 @@
+/** A 股市场动态 — 港股/美股面板已暂时下线 */
 export type MarketDynamicsTab = 'cn'
 
+const STORAGE_KEY = 'opptrix-market-dynamics-tab'
+
 export function readMarketDynamicsTab(): MarketDynamicsTab {
+  if (typeof window === 'undefined') return 'cn'
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)?.trim().toLowerCase()
+    if (raw === 'hk' || raw === 'us') {
+      localStorage.setItem(STORAGE_KEY, 'cn')
+    }
+  } catch {
+    /* ignore */
+  }
   return 'cn'
 }
 
 export function writeMarketDynamicsTab(_tab: MarketDynamicsTab): void {
-  /* 暂仅 A 股看板；忽略历史 localStorage */
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, 'cn')
+  } catch {
+    /* ignore */
+  }
 }

--- a/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
+++ b/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
@@ -1,12 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { news, research } from '../../api/client'
 import type { FeedArticle, MarketDynamicsData } from '../../types/schemas'
-import type { MarketDynamicsTab } from './marketDynamicsStorage'
 
 const NEWS_REFRESH_MS = 60_000
 const MARKET_REFRESH_MS = 30_000
 
-export function useMarketInsights(market: MarketDynamicsTab = 'cn') {
+function filterCnArticles(articles: FeedArticle[]): FeedArticle[] {
+  return articles.filter(article => {
+    const text = `${article.title} ${article.source_title ?? ''}`.toLowerCase()
+    return /a股|沪深|上证|深证|创业板|科创板|北交所|cn\b|china/i.test(text)
+      || !/美股|nasdaq|nyse|港股|恒生|crypto|btc/i.test(text)
+  })
+}
+
+export function useMarketInsights() {
   const [articles, setArticles] = useState<FeedArticle[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
@@ -19,12 +26,7 @@ export function useMarketInsights(market: MarketDynamicsTab = 'cn') {
       const feedResp = await news.getFeed({ limit: 24 }).catch(() => null)
       if (!mountedRef.current) return
       if (feedResp?.articles) {
-        const filtered = feedResp.articles.filter(article => {
-          const text = `${article.title} ${article.source_title ?? ''}`.toLowerCase()
-          return /a股|沪深|上证|深证|创业板|科创板|北交所|cn\b|china/i.test(text)
-            || !/美股|nasdaq|nyse|港股|恒生|crypto|btc/i.test(text)
-        })
-        setArticles(filtered.slice(0, 12))
+        setArticles(filterCnArticles(feedResp.articles).slice(0, 12))
       }
     } catch (e) {
       if (!mountedRef.current) return
@@ -32,7 +34,7 @@ export function useMarketInsights(market: MarketDynamicsTab = 'cn') {
     } finally {
       if (mountedRef.current) setLoading(false)
     }
-  }, [market])
+  }, [])
 
   useEffect(() => {
     mountedRef.current = true
@@ -47,7 +49,7 @@ export function useMarketInsights(market: MarketDynamicsTab = 'cn') {
   return { articles, loading, error, refresh: () => load({ silent: true }) }
 }
 
-export function useMarketDynamics(market: MarketDynamicsTab = 'cn') {
+export function useMarketDynamics() {
   const [data, setData] = useState<MarketDynamicsData | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -60,10 +62,13 @@ export function useMarketDynamics(market: MarketDynamicsTab = 'cn') {
     else setRefreshing(true)
     setError('')
     try {
-      const resp = await research.marketDynamics({ market })
+      const resp = await research.marketDynamics({ market: 'cn' })
       if (!mountedRef.current) return
       if (resp.success && resp.data) {
-        setData(resp.data)
+        setData({
+          ...resp.data,
+          market: resp.data.market ?? 'cn',
+        })
       } else {
         setError(resp.message || '暂时无法获取市场数据')
       }
@@ -76,7 +81,7 @@ export function useMarketDynamics(market: MarketDynamicsTab = 'cn') {
         setRefreshing(false)
       }
     }
-  }, [market])
+  }, [])
 
   useEffect(() => {
     mountedRef.current = true

--- a/client-ui/src/types/schemas.ts
+++ b/client-ui/src/types/schemas.ts
@@ -400,6 +400,7 @@ export interface MarketStockMover {
   price: number | null
   change_pct: number | null
   change_amt?: number | null
+  rank?: number | null
 }
 
 export interface MarketDragonTigerItem {
@@ -461,7 +462,7 @@ export interface MarketAnomalyItem {
 }
 
 export interface MarketDynamicsData {
-  market?: 'cn' | 'us'
+  market?: 'cn' | 'us' | 'hk'
   refreshed_at: string
   sections: MarketDynamicsSection[]
   cn_gainers?: MarketStockMover[]
@@ -482,6 +483,12 @@ export interface MarketDynamicsData {
   us_losers?: MarketStockMover[]
   us_trending?: MarketStockMover[]
   us_trending_jp?: MarketStockMover[]
+  hk_indices?: MarketIndexQuote[]
+  hk_gainers?: MarketStockMover[]
+  hk_losers?: MarketStockMover[]
+  hk_trending?: MarketStockMover[]
+  hk_sector_status?: 'ok' | 'empty' | 'error'
+  hk_sector_hint?: string
 }
 
 export interface StockSearchItem {

--- a/packages/a-stock-layer/src/engine.ts
+++ b/packages/a-stock-layer/src/engine.ts
@@ -1220,13 +1220,20 @@ export class MarketDataEngine {
     const normalized = market === 'US'
       ? symbols.map(s => normalizeUsSymbol(s))
       : symbols
+    const marketsMap = Object.fromEntries(
+      normalized.flatMap(code => {
+        const key = code.trim()
+        const padded = market === 'HK' ? key.padStart(5, '0') : key
+        return [[key, market], [padded, market], [key.toUpperCase(), market]]
+      }),
+    )
     return this.qScoped(
       market,
       'EQUITY',
       Capability.STOCK_REALTIME,
       'batchRealtime',
       false,
-      normalized,
+      [normalized, marketsMap],
     )
   }
 

--- a/packages/a-stock-layer/src/providers/manifests.ts
+++ b/packages/a-stock-layer/src/providers/manifests.ts
@@ -5,7 +5,6 @@ import { BINANCE_MANIFEST } from './binance/manifest.js'
 import { OKX_MANIFEST } from './okx/manifest.js'
 import { TONGHUASHUN_MANIFEST } from './tonghuashun/manifest.js'
 import { STOCKINDEX_MANIFEST } from './stockindex/manifest.js'
-import { YFINANCE_MANIFEST } from './yfinance/manifest.js'
 import { getManifestRegistry } from './manifest-registry.js'
 
 export { TUSHARE_SETTINGS } from './tushare/settings.js'
@@ -19,7 +18,7 @@ export { TONGHUASHUN_SETTINGS } from './tonghuashun/settings.js'
 export { STOCKINDEX_SETTINGS } from './stockindex/settings.js'
 export { YFINANCE_SETTINGS } from './yfinance/settings.js'
 
-/** Static built-in manifests — baostock / zzshare 暂时下线，不进目录 */
+/** Static built-in manifests — baostock / zzshare / yfinance 暂时下线，不进目录 */
 export const BUILTIN_PROVIDER_MANIFESTS: ProviderManifest[] = [
   TUSHARE_MANIFEST,
   TICKFLOW_MANIFEST,
@@ -27,7 +26,6 @@ export const BUILTIN_PROVIDER_MANIFESTS: ProviderManifest[] = [
   OKX_MANIFEST,
   TONGHUASHUN_MANIFEST,
   STOCKINDEX_MANIFEST,
-  YFINANCE_MANIFEST,
 ]
 
 /** Live manifest list (built-in + installed). Prefer listProviderManifests(). */

--- a/packages/a-stock-layer/src/providers/register.ts
+++ b/packages/a-stock-layer/src/providers/register.ts
@@ -5,9 +5,8 @@ import { BinanceDriver } from './binance/driver.js'
 import { OkxDriver } from './okx/driver.js'
 import { TonghuashunDriver } from './tonghuashun/driver.js'
 import { StockIndexDriver } from './stockindex/driver.js'
-import { YfinanceDriver } from './yfinance/driver.js'
 
-/** Register built-in data providers. baostock / zzshare 暂时下线（源码保留，可本地 new 测限流）。 */
+/** Register built-in data providers. baostock / zzshare / yfinance 暂时下线（源码保留，可本地 new 测）。 */
 export function registerAllDrivers(registry: DriverRegistry) {
   const drivers = [
     new TushareDriver(),
@@ -16,7 +15,6 @@ export function registerAllDrivers(registry: DriverRegistry) {
     new OkxDriver(),
     new TonghuashunDriver(),
     new StockIndexDriver(),
-    new YfinanceDriver(),
   ]
   for (const d of drivers) registry.register(d)
   return drivers.length
@@ -29,8 +27,10 @@ export {
   OkxDriver,
   TonghuashunDriver,
   StockIndexDriver,
-  YfinanceDriver,
 }
+
+/** 源码保留；生产 registerAllDrivers 不再注册。 */
+export { YfinanceDriver } from './yfinance/driver.js'
 
 /** 源码保留；生产 registerAllDrivers 不再注册。测试限流等可手动 new。 */
 export { BaostockDriver } from './baostock/driver.js'

--- a/packages/a-stock-layer/src/providers/yfinance/client.ts
+++ b/packages/a-stock-layer/src/providers/yfinance/client.ts
@@ -13,8 +13,9 @@ import type { ChartResultArray } from 'yahoo-finance2/modules/chart'
 import type { Quote, QuoteOptions } from 'yahoo-finance2/modules/quote'
 import { sleep } from '../../utils/http-shared.js'
 import {
-  YFINANCE_QUERY_HOST,
+  yfinanceFetchHeaders,
   yfinanceMaxRetries,
+  yfinanceQueryHost,
   yfinanceQueueIntervalMs,
   yfinanceQuoteCombineDebounceMs,
   yfinanceQuoteCombineMaxSymbols,
@@ -35,9 +36,22 @@ function isRetriableYahooError(err: unknown): boolean {
 }
 
 function createYahooFinanceClient(): YahooFinanceClient {
+  const browserHeaders = yfinanceFetchHeaders()
+  const browserFetch: typeof fetch = (input, init) => {
+    const headers = new Headers(init?.headers)
+    for (const [key, value] of Object.entries(browserHeaders)) {
+      headers.set(key, value)
+    }
+    return fetch(input, { ...init, headers })
+  }
+
   return new YahooFinance({
     suppressNotices: ['yahooSurvey'],
-    YF_QUERY_HOST: YFINANCE_QUERY_HOST,
+    YF_QUERY_HOST: yfinanceQueryHost(),
+    fetch: browserFetch,
+    fetchOptions: {
+      headers: browserHeaders,
+    },
     queue: {
       concurrency: 1,
       interval: yfinanceQueueIntervalMs(),

--- a/packages/a-stock-layer/src/providers/yfinance/handler.ts
+++ b/packages/a-stock-layer/src/providers/yfinance/handler.ts
@@ -12,6 +12,7 @@ import {
   resolveYfinanceGlobalIndex,
 } from './symbols.js'
 import { listYfinanceSectorBoards } from './sectors.js'
+import { normalizeCode } from '../../utils/helpers.js'
 import {
   mapChartQuotesToIndexKlines,
   mapChartQuotesToKlines,
@@ -41,7 +42,7 @@ function periodStartDate(period: ChartInterval, count: number): Date {
 
 function marketFromTicker(ticker: string): Market {
   const upper = ticker.toUpperCase()
-  if (upper === '^HSI' || upper.endsWith('.HK')) return 'HK'
+  if (upper === '^HSI' || upper === '^HSCE' || upper === 'HSTECH.HK' || upper.endsWith('.HK')) return 'HK'
   if (upper === '^N225' || upper.endsWith('.T')) return 'JP'
   if (upper === '^KS11' || upper.endsWith('.KS')) return 'KR'
   if (upper.endsWith('.SS') || upper.endsWith('.SZ')) return 'CN'
@@ -58,6 +59,30 @@ function asYahooQuote(quote: unknown): Parameters<typeof mapQuoteToGlobalIndex>[
 
 function asQuoteSummary(summary: unknown): Parameters<typeof mapQuoteSummaryToProfile>[1] {
   return summary as Parameters<typeof mapQuoteSummaryToProfile>[1]
+}
+
+function resolveBatchQuoteMarket(
+  code: string,
+  markets?: Record<string, Market | undefined>,
+): Market {
+  const raw = code.trim()
+  const candidates = [
+    raw,
+    raw.toUpperCase(),
+    normalizeCode(raw),
+    raw.padStart(5, '0'),
+    normalizeCode(raw).padStart(5, '0'),
+  ]
+  for (const key of candidates) {
+    const hit = markets?.[key]
+    if (hit) return hit
+  }
+  if (raw.endsWith('.HK') || raw.toUpperCase() === 'HSTECH.HK' || /^\d{4,5}$/.test(normalizeCode(raw))) {
+    return 'HK'
+  }
+  if (raw.endsWith('.T')) return 'JP'
+  if (raw.endsWith('.KS')) return 'KR'
+  return 'US'
 }
 
 export class YfinanceMarketHandler extends MarketHandlerShell {
@@ -126,7 +151,7 @@ export class YfinanceMarketHandler extends MarketHandlerShell {
   ): Promise<import('@opptrix/shared').StockRealtime[] | null> {
     if (!codes.length) return null
     const pairs = codes.map(code => {
-      const mkt = markets?.[code] ?? markets?.[code.trim().toUpperCase()] ?? 'US'
+      const mkt = resolveBatchQuoteMarket(code, markets)
       const ticker = resolveYahooEquityTicker(mkt, code)
       return ticker ? { code, mkt, ticker } : null
     }).filter((row): row is { code: string; mkt: Market; ticker: string } => row != null)

--- a/packages/a-stock-layer/src/providers/yfinance/normalize.ts
+++ b/packages/a-stock-layer/src/providers/yfinance/normalize.ts
@@ -1,6 +1,7 @@
 import type { StockKline, StockRealtime } from '@opptrix/shared'
 import type { GlobalIndex, IndexKline, StockProfile } from '../../core/schema.js'
 import type { YfinanceGlobalIndex } from './symbols.js'
+import { displayCodeFromYahooTicker } from './symbols.js'
 
 function n(v: unknown): number | null {
   if (v == null || v === '') return null
@@ -192,7 +193,7 @@ export function mapQuoteSummaryToProfile(
 }
 
 export function mapSectorQuoteRow(
-  board: { code: string; name: string; market: string; tag?: string },
+  board: { code: string; name: string; market: string; tag?: string; yahoo?: string },
   quote: YahooQuote,
 ): Record<string, unknown> {
   return {
@@ -202,7 +203,7 @@ export function mapSectorQuoteRow(
     sector_tag: board.tag ?? 'sector',
     price: n(quote.regularMarketPrice),
     change_pct: pct(quote.regularMarketChangePercent),
-    chart_symbol: board.code,
+    chart_symbol: board.yahoo ?? board.code,
   }
 }
 
@@ -220,8 +221,12 @@ export function mapScreenerQuoteToMover(
   quote: ScreenerQuoteLike,
   market: string,
 ): Record<string, unknown> {
-  const code = String(quote.symbol ?? '').trim()
-  if (!code) return {}
+  const ticker = String(quote.symbol ?? '').trim()
+  if (!ticker) return {}
+  const mkt = market.toUpperCase()
+  const code = mkt === 'HK' || mkt === 'JP' || mkt === 'KR'
+    ? displayCodeFromYahooTicker(ticker, mkt as import('@opptrix/shared').Market)
+    : ticker
   const name = String(quote.shortName ?? quote.displayName ?? quote.longName ?? code)
   const price = n(quote.regularMarketPrice)
   const changePct = pct(quote.regularMarketChangePercent)
@@ -237,7 +242,7 @@ export function mapScreenerQuoteToMover(
     change_pct: changePct,
     change_amt: changeAmt,
     market,
-    chart_symbol: code,
+    chart_symbol: ticker,
   }
 }
 

--- a/packages/a-stock-layer/src/providers/yfinance/settings.ts
+++ b/packages/a-stock-layer/src/providers/yfinance/settings.ts
@@ -11,8 +11,36 @@ export const YFINANCE_SETTINGS = enabledOnlySettings(
   },
 )
 
-/** Yahoo Finance API 主机 — 与 yahoo-finance2 默认一致 */
+/** Yahoo Finance API 主机 — 与 yahoo-finance2 默认一致；可通过环境变量覆盖 */
+export function yfinanceQueryHost(): string {
+  const fromEnv = process.env.OPPTRIX_YFINANCE_QUERY_HOST?.trim()
+  return fromEnv || 'query2.finance.yahoo.com'
+}
+
+/** @deprecated 使用 yfinanceQueryHost() */
 export const YFINANCE_QUERY_HOST = 'query2.finance.yahoo.com'
+
+/**
+ * 桌面 Chrome UA — Yahoo 会拒绝 `compatible; yahoo-finance2/x` 等非浏览器标识（crumb 403）。
+ * 可通过 OPPTRIX_YFINANCE_USER_AGENT 覆盖（例如与本地浏览器 DevTools 一致）。
+ */
+export const YFINANCE_DEFAULT_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+export function yfinanceUserAgent(): string {
+  const fromEnv = process.env.OPPTRIX_YFINANCE_USER_AGENT?.trim()
+  return fromEnv || YFINANCE_DEFAULT_USER_AGENT
+}
+
+/** yahoo-finance2 全局 fetchOptions.headers — crumb / quote / screener 共用 */
+export function yfinanceFetchHeaders(): Record<string, string> {
+  return {
+    'User-Agent': yfinanceUserAgent(),
+    Accept: '*/*',
+    'Accept-Language': 'en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7',
+    'Accept-Encoding': 'gzip, deflate, br',
+  }
+}
 
 /** 同 host 两次请求最小间隔（ms），对齐全仓 hostnameLimiter 默认 1s */
 const DEFAULT_QUEUE_INTERVAL_MS = 1000

--- a/packages/a-stock-layer/src/providers/yfinance/symbols.ts
+++ b/packages/a-stock-layer/src/providers/yfinance/symbols.ts
@@ -16,6 +16,8 @@ export const YFINANCE_GLOBAL_INDICES: YfinanceGlobalIndex[] = [
   { outCode: 'IXIC', yahoo: '^IXIC', name: '纳斯达克', market: 'US' },
   { outCode: 'DJI', yahoo: '^DJI', name: '道琼斯', market: 'US' },
   { outCode: 'HSI', yahoo: '^HSI', name: '恒生指数', market: 'HK' },
+  { outCode: 'HSCE', yahoo: '^HSCE', name: '恒生国企', market: 'HK' },
+  { outCode: 'HSTECH', yahoo: 'HSTECH.HK', name: '恒生科技', market: 'HK' },
   { outCode: 'N225', yahoo: '^N225', name: '日经225', market: 'JP' },
   { outCode: 'KOSPI', yahoo: '^KS11', name: '韩国综合', market: 'KR' },
   { outCode: 'FTSE', yahoo: '^FTSE', name: '富时100', market: 'UK' },
@@ -39,6 +41,13 @@ const ALIAS_TO_OUT: Record<string, string> = {
   '^dji': 'DJI',
   hsi: 'HSI',
   '^hsi': 'HSI',
+  hsce: 'HSCE',
+  '^hsce': 'HSCE',
+  hscei: 'HSCE',
+  '^hscei': 'HSCE',
+  hstech: 'HSTECH',
+  '^hstech': 'HSTECH',
+  'hstech.hk': 'HSTECH',
   n225: 'N225',
   nikkei: 'N225',
   '^n225': 'N225',
@@ -95,6 +104,8 @@ export function resolveYahooIndexTicker(
   }
   if (mkt === 'HK') {
     if (raw.toUpperCase() === 'HSI') return '^HSI'
+    if (raw.toUpperCase() === 'HSCE' || raw.toUpperCase() === 'HSCEI') return '^HSCE'
+    if (raw.toUpperCase() === 'HSTECH') return 'HSTECH.HK'
     const hk = normalizeCode(raw)
     if (/^\d{4,5}$/.test(hk)) return `${hk}.HK`
     return raw.includes('.') ? raw : `${raw}.HK`

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -60,6 +60,7 @@ import {
   type InstrumentRef,
   type InstrumentHubCapability,
 } from '@opptrix/shared'
+import { canonicalHkSymbol } from '@opptrix/shared/instrument-symbol'
 import {
   quickAssess,
   verifyStrategy,
@@ -1009,11 +1010,17 @@ export class ResearchHub {
       displayName: string
       location: string
       chartSymbol?: string
+      etfFallback?: import('@opptrix/shared').InstrumentRef
     }>,
   ) {
     const items = await Promise.all(proxies.map(async proxy => {
       const r = await this.de.queryInstrumentData(proxy.ref, 'realtime')
-      const row = instrumentQueryData<import('@opptrix/shared').StockRealtime[]>(r)?.[0]
+      const indexRow = instrumentQueryData<import('@opptrix/shared').StockRealtime[]>(r)?.[0]
+      let fallbackRow: import('@opptrix/shared').StockRealtime | undefined
+      if ((!indexRow || indexRow.price == null) && proxy.etfFallback) {
+        const fbR = await this.de.queryInstrumentData(proxy.etfFallback, 'realtime')
+        fallbackRow = instrumentQueryData<import('@opptrix/shared').StockRealtime[]>(fbR)?.[0]
+      }
       const base = {
         code: proxy.outCode,
         name: proxy.displayName,
@@ -1023,9 +1030,14 @@ export class ResearchHub {
         location: proxy.location,
         chart_symbol: proxy.chartSymbol ?? proxy.ref.symbol,
       }
+      const row = indexRow ?? fallbackRow
       if (!row) return base
-      const price = typeof row.price === 'number' ? row.price : null
-      const changePct = typeof row.changePct === 'number' ? row.changePct : null
+      const price = typeof indexRow?.price === 'number' ? indexRow.price : null
+      const changePct = typeof indexRow?.changePct === 'number'
+        ? indexRow.changePct
+        : typeof fallbackRow?.changePct === 'number'
+          ? fallbackRow.changePct
+          : null
       return {
         ...base,
         price,
@@ -1150,7 +1162,209 @@ export class ResearchHub {
   private async marketDynamics(t0: number, params: Record<string, unknown> = {}) {
     const market = String(params.market ?? 'cn').trim().toLowerCase()
     if (market === 'us') return this.marketDynamicsUs(t0)
+    if (market === 'hk') return this.marketDynamicsHk(t0)
     return this.marketDynamicsCn(t0)
+  }
+
+  private async fetchHkSectorBoardViaTickflow() {
+    const boards = [
+      { code: '2828', name: '恒生中国企业', chartSymbol: '2828.HK' },
+      { code: '3067', name: '恒生科技', chartSymbol: '3067.HK' },
+      { code: '2800', name: '盈富基金', chartSymbol: '2800.HK' },
+      { code: '3033', name: '南方恒生科技', chartSymbol: '3033.HK' },
+    ]
+    const batch = await this.de.batchRealtimeByMarket('HK', boards.map(b => b.code))
+    if (!batch.success || !batch.data?.length) return []
+    return boards.flatMap(board => {
+      const row = (batch.data as Record<string, unknown>[]).find(item => {
+        const code = String(item.code ?? '').trim().padStart(5, '0')
+        return code === board.code.padStart(5, '0')
+      })
+      if (!row) return []
+      return [{
+        code: board.code,
+        name: board.name,
+        price: typeof row.price === 'number' ? row.price : null,
+        change_pct: typeof row.changePct === 'number' ? row.changePct : null,
+        change_amt: null as number | null,
+        market: 'HK' as const,
+        location: '香港',
+        chart_symbol: board.chartSymbol,
+        sector_tag: 'sector',
+      }]
+    })
+  }
+
+  private async fetchHkMoversViaTickflow(limit = 12) {
+    const watch = [
+      '00700', '09988', '01810', '03690', '00941', '01299', '02318', '01398',
+      '00883', '01024', '09999', '09618', '02382', '02628', '00005', '00011',
+      '00388', '02269', '02020', '06618', '01211', '02313', '01928', '00939',
+    ]
+    const chunkSize = 4
+    const merged: Record<string, unknown>[] = []
+    for (let i = 0; i < watch.length; i += chunkSize) {
+      const part = watch.slice(i, i + chunkSize)
+      const batch = await this.de.batchRealtimeByMarket('HK', part)
+      if (batch.success && batch.data?.length) {
+        merged.push(...(batch.data as Record<string, unknown>[]))
+      }
+    }
+    if (!merged.length) return { gainers: [], losers: [] }
+    const rows = merged
+      .map(row => {
+        const code = String(row.code ?? '').trim().padStart(5, '0')
+        const name = String(row.name ?? code).trim()
+        const changePct = typeof row.changePct === 'number' ? row.changePct : null
+        if (!code || changePct == null) return null
+        return {
+          code,
+          name,
+          price: typeof row.price === 'number' ? row.price : null,
+          change_pct: changePct,
+          change_amt: typeof row.change === 'number' ? row.change : null,
+        }
+      })
+      .filter((row): row is NonNullable<typeof row> => row != null)
+      .sort((a, b) => (b.change_pct ?? 0) - (a.change_pct ?? 0))
+    return {
+      gainers: rows.filter(r => (r.change_pct ?? 0) > 0).slice(0, limit),
+      losers: rows.filter(r => (r.change_pct ?? 0) < 0).slice(-limit).reverse(),
+    }
+  }
+
+  private async marketDynamicsHk(t0: number) {
+    const hkYahooEquityTicker = (code: string) => {
+      const hk = canonicalHkSymbol(code.replace(/\.HK$/i, ''))
+      const yahoo = hk.length > 4 ? hk.slice(-4) : hk
+      return `${yahoo}.HK`
+    }
+    const hkMoverChartSymbol = (code: string, chartFromRow?: unknown) => {
+      const chart = String(chartFromRow ?? '').trim()
+      if (chart && (chart.includes('.') || chart.startsWith('^'))) return chart
+      return hkYahooEquityTicker(code)
+    }
+
+    const HK_CORE_INDICES = [
+      {
+        ref: { market: 'HK', assetClass: 'INDEX', symbol: '^HSI' } as import('@opptrix/shared').InstrumentRef,
+        etfFallback: { market: 'HK', assetClass: 'EQUITY', symbol: '2800' } as import('@opptrix/shared').InstrumentRef,
+        outCode: 'HSI', displayName: '恒生指数', chartSymbol: '^HSI', location: '香港',
+      },
+      {
+        ref: { market: 'HK', assetClass: 'INDEX', symbol: '^HSCE' } as import('@opptrix/shared').InstrumentRef,
+        etfFallback: { market: 'HK', assetClass: 'EQUITY', symbol: '2828' } as import('@opptrix/shared').InstrumentRef,
+        outCode: 'HSCE', displayName: '恒生国企', chartSymbol: '^HSCE', location: '香港',
+      },
+      {
+        ref: { market: 'HK', assetClass: 'INDEX', symbol: '^HSTECH' } as import('@opptrix/shared').InstrumentRef,
+        etfFallback: { market: 'HK', assetClass: 'EQUITY', symbol: '3067' } as import('@opptrix/shared').InstrumentRef,
+        outCode: 'HSTECH', displayName: '恒生科技', chartSymbol: 'HSTECH.HK', location: '香港',
+      },
+    ]
+
+    const [
+      hkItems,
+      hkSectors,
+      moversFallback,
+    ] = await Promise.all([
+      this.fetchGlobalIndexProxyItems(
+        HK_CORE_INDICES.map(row => ({
+          ref: row.ref,
+          etfFallback: row.etfFallback,
+          outCode: row.outCode,
+          displayName: row.displayName,
+          location: row.location,
+          chartSymbol: row.chartSymbol,
+        })),
+      ).then(items => items.map((item, idx) => ({
+        ...item,
+        chart_symbol: HK_CORE_INDICES[idx]?.chartSymbol ?? item.code,
+      }))),
+      this.fetchHkSectorBoardViaTickflow(),
+      this.fetchHkMoversViaTickflow(12),
+    ])
+
+    const hkGainers = moversFallback.gainers
+    const hkLosers = moversFallback.losers
+    const hkTrending: Array<{
+      code: string
+      name: string
+      price: number | null
+      change_pct: number | null
+      change_amt: number | null
+      rank?: number
+    }> = []
+
+    const sections = hkItems.length ? [{
+      id: 'hk_major',
+      title: '港股主要指数',
+      hint: '恒生系列宽基指数实时报价',
+      items: hkItems,
+    }] : []
+
+    if (hkSectors.length) {
+      sections.push({
+        id: 'hk_sectors',
+        title: '港股板块',
+        hint: '代表性 ETF 板块涨跌',
+        items: hkSectors,
+      })
+    }
+
+    if (hkGainers.length) {
+      sections.push({
+        id: 'hk_gainers',
+        title: '港股涨幅榜',
+        hint: '当日涨幅领先个股',
+        items: hkGainers.map(row => ({
+          ...row,
+          market: 'HK',
+          location: '香港',
+          chart_symbol: hkMoverChartSymbol(row.code, row.code),
+        })),
+      })
+    }
+
+    if (hkLosers.length) {
+      sections.push({
+        id: 'hk_losers',
+        title: '港股跌幅榜',
+        hint: '当日跌幅靠前个股',
+        items: hkLosers.map(row => ({
+          ...row,
+          market: 'HK',
+          location: '香港',
+          chart_symbol: hkMoverChartSymbol(row.code, row.code),
+        })),
+      })
+    }
+
+    if (hkTrending.length) {
+      sections.push({
+        id: 'hk_trending',
+        title: '港股热门',
+        hint: '当前讨论与关注度较高的标的',
+        items: hkTrending.map(row => ({
+          ...row,
+          market: 'HK',
+          location: '香港',
+          chart_symbol: hkMoverChartSymbol(row.code, row.code),
+        })),
+      })
+    }
+
+    return ok({
+      market: 'hk' as const,
+      refreshed_at: new Date().toISOString(),
+      sections,
+      hk_indices: hkItems,
+      hk_gainers: hkGainers,
+      hk_losers: hkLosers,
+      hk_trending: hkTrending,
+      hk_sector_status: hkSectors.length ? 'ok' as const : 'empty' as const,
+      hk_sector_hint: hkSectors.length ? undefined : '板块数据待更新，请稍后刷新',
+    }, '港股市场动态', t0)
   }
 
   private async marketDynamicsUs(t0: number) {
@@ -1169,16 +1383,9 @@ export class ResearchHub {
       FCHI: { location: '法国', chartSymbol: '^FCHI' },
     }
 
-    const usSectorRef = { market: 'US', assetClass: 'EQUITY', symbol: 'AAPL' } as import('@opptrix/shared').InstrumentRef
-
     const [
       usItems,
       asiaItems,
-      usSectorR,
-      gainersR,
-      losersR,
-      trendingUsR,
-      trendingJpR,
       globalR,
     ] = await Promise.all([
       this.fetchGlobalIndexProxyItems(
@@ -1204,11 +1411,6 @@ export class ResearchHub {
         ...item,
         chart_symbol: ASIA_CORE_INDICES[idx]?.chartSymbol ?? item.code,
       }))),
-      this.de.queryInstrumentData(usSectorRef, 'sector_list', { plateType: 'boards:US' }),
-      this.de.invokeCustomMethod('yfinance', 'yfScreener', ['day_gainers', 12, 'US']),
-      this.de.invokeCustomMethod('yfinance', 'yfScreener', ['day_losers', 12, 'US']),
-      this.de.invokeCustomMethod('yfinance', 'yfTrendingSymbols', ['US', 10]),
-      this.de.invokeCustomMethod('yfinance', 'yfTrendingSymbols', ['JP', 8]),
       this.de.globalIndex(''),
     ])
 
@@ -1228,43 +1430,29 @@ export class ResearchHub {
         }
       })
 
-    const usSectors = (instrumentQueryData<Array<Record<string, unknown>>>(usSectorR) ?? [])
-      .map(row => ({
-        code: String(row.code ?? '').trim(),
-        name: String(row.name ?? row.code ?? '').trim(),
-        price: typeof row.price === 'number' ? row.price : null,
-        change_pct: typeof row.change_pct === 'number' ? row.change_pct : null,
-        change_amt: null as number | null,
-        market: 'US' as const,
-        location: '美国',
-        chart_symbol: String(row.chart_symbol ?? row.code ?? '').trim() || String(row.code ?? '').trim(),
-        sector_tag: String(row.sector_tag ?? 'sector'),
-      }))
-      .filter(item => item.code && item.name)
+    const usSectors: Array<{
+      code: string
+      name: string
+      price: number | null
+      change_pct: number | null
+      change_amt: number | null
+      market: 'US'
+      location: string
+      chart_symbol: string
+      sector_tag: string
+    }> = []
 
-    const mapUsMovers = (r: { success: boolean; data?: unknown }) => {
-      if (!r.success || !Array.isArray(r.data)) return []
-      return r.data
-        .map(row => {
-          const rec = row as Record<string, unknown>
-          const code = String(rec.code ?? '').trim()
-          const name = String(rec.name ?? code).trim()
-          if (!code || !name) return null
-          return {
-            code,
-            name,
-            price: typeof rec.price === 'number' ? rec.price : null,
-            change_pct: typeof rec.change_pct === 'number' ? rec.change_pct : null,
-            change_amt: typeof rec.change_amt === 'number' ? rec.change_amt : null,
-          }
-        })
-        .filter((row): row is NonNullable<typeof row> => row != null)
-    }
-
-    const usGainers = mapUsMovers(gainersR)
-    const usLosers = mapUsMovers(losersR)
-    const usTrending = mapUsMovers(trendingUsR)
-    const usTrendingJp = mapUsMovers(trendingJpR)
+    const emptyUsMovers: Array<{
+      code: string
+      name: string
+      price: number | null
+      change_pct: number | null
+      change_amt: number | null
+    }> = []
+    const usGainers = emptyUsMovers
+    const usLosers = emptyUsMovers
+    const usTrending = emptyUsMovers
+    const usTrendingJp = emptyUsMovers
 
     const allIndices = [...usItems, ...asiaItems, ...euItems]
 

--- a/packages/shared/src/provider-settings.ts
+++ b/packages/shared/src/provider-settings.ts
@@ -291,5 +291,5 @@ export const REMOVED_SCRAPING_PROVIDER_IDS = [
 ] as const
 
 /** 暂时下线的内置源（源码保留，便于以后加回；启动时 purge 用户配置） */
-export const REMOVED_TEMP_PROVIDER_IDS = ['baostock', 'zzshare'] as const
+export const REMOVED_TEMP_PROVIDER_IDS = ['baostock', 'zzshare', 'yfinance'] as const
 

--- a/tests/provider-priority-order.test.mjs
+++ b/tests/provider-priority-order.test.mjs
@@ -80,14 +80,14 @@ describe('provider-priority-order', () => {
     const tickflow = row({
       providerId: 'tickflow',
       title: 'TickFlow',
-      sortOrder: 20,
+      sortOrder: 30,
       requiresApiKey: false,
       manifestDefaultPriority: 110,
     })
     const tushare = row({
       providerId: 'tushare',
       title: 'Tushare',
-      sortOrder: 30,
+      sortOrder: 40,
       manifestDefaultPriority: 105,
     })
     // 新加源无 sortOrder，不得甩到最后

--- a/tests/yfinance-provider.test.mjs
+++ b/tests/yfinance-provider.test.mjs
@@ -9,6 +9,9 @@ test('resolveYfinanceGlobalIndex maps aliases to Yahoo tickers', async () => {
   assert.equal(resolveYfinanceGlobalIndex('^HSI')?.outCode, 'HSI')
   assert.equal(resolveYahooIndexTicker('US', 'SPX'), '^GSPC')
   assert.equal(resolveYahooIndexTicker('HK', 'HSI'), '^HSI')
+  assert.equal(resolveYahooIndexTicker('HK', 'HSCE'), '^HSCE')
+  assert.equal(resolveYahooIndexTicker('HK', 'HSTECH'), 'HSTECH.HK')
+  assert.equal(resolveYfinanceGlobalIndex('HSTECH')?.yahoo, 'HSTECH.HK')
   assert.equal(resolveYahooIndexTicker('JP', 'N225'), '^N225')
 })
 
@@ -18,6 +21,7 @@ test('resolveYahooEquityTicker maps regional stock codes', async () => {
   )
   assert.equal(resolveYahooEquityTicker('US', 'aapl'), 'AAPL')
   assert.equal(resolveYahooEquityTicker('HK', '00700'), '0700.HK')
+  assert.equal(resolveYahooEquityTicker('HK', '700'), '0700.HK')
   assert.equal(resolveYahooEquityTicker('JP', '7203'), '7203.T')
   assert.equal(resolveYahooEquityTicker('KR', '005930'), '005930.KS')
 })
@@ -73,6 +77,21 @@ test('mapScreenerQuoteToMover normalizes screener rows', async () => {
   assert.equal(row.change_pct, 2.5)
 })
 
+test('mapScreenerQuoteToMover normalizes HK screener rows', async () => {
+  const { mapScreenerQuoteToMover } = await import(
+    '../packages/a-stock-layer/dist/providers/yfinance/normalize.js'
+  )
+  const row = mapScreenerQuoteToMover({
+    symbol: '0700.HK',
+    shortName: 'Tencent',
+    regularMarketPrice: 400,
+    regularMarketChangePercent: 1.2,
+  }, 'HK')
+  assert.equal(row.code, '00700')
+  assert.equal(row.chart_symbol, '0700.HK')
+  assert.equal(row.market, 'HK')
+})
+
 test('yfinance custom methods are registered', async () => {
   const { findCustomMethod } = await import(
     '../packages/a-stock-layer/dist/core/custom-methods.js'
@@ -81,20 +100,14 @@ test('yfinance custom methods are registered', async () => {
   assert.ok(findCustomMethod('yfinance', 'yfTrendingSymbols'))
 })
 
-test('resolveInstrumentQueryPlan routes US INDEX kline to yfinance binding', async () => {
-  const { resolveInstrumentQueryPlan } = await import(
-    '../packages/a-stock-layer/dist/core/instrument-query.js'
+test('yfinanceFetchHeaders uses browser User-Agent not SDK identifier', async () => {
+  const { yfinanceFetchHeaders, yfinanceUserAgent, YFINANCE_DEFAULT_USER_AGENT } = await import(
+    '../packages/a-stock-layer/dist/providers/yfinance/settings.js'
   )
-  const plan = resolveInstrumentQueryPlan(
-    { market: 'US', assetClass: 'INDEX', symbol: '^GSPC' },
-    'kline',
-    { count: 120 },
-  )
-  assert.equal(plan?.kind, 'registry')
-  if (plan?.kind === 'registry') {
-    assert.equal(plan.market, 'US')
-    assert.equal(plan.assetClass, 'INDEX')
-    assert.equal(plan.method, 'indexKline')
-  }
+  const ua = yfinanceUserAgent()
+  assert.ok(ua.includes('Chrome') || ua.includes('Safari'))
+  assert.ok(!ua.includes('yahoo-finance2'))
+  assert.equal(yfinanceFetchHeaders()['User-Agent'], ua)
+  assert.ok(YFINANCE_DEFAULT_USER_AGENT.includes('AppleWebKit'))
 })
 


### PR DESCRIPTION
## Summary
- Remove HK/US market dynamics tabs from the UI; market dynamics is A-share only again.
- Unregister yfinance from the builtin provider stack and purge user config on startup; source remains for later re-enable.
- Extend Hub HK helpers with Tickflow fallbacks and harden yfinance client code kept in tree.

## Test plan
- [x] `npm run build:packages`
- [x] `npm run check:ui`
- [x] Provider/yfinance related unit tests
- [ ] Restart backend and confirm market dynamics shows A-share only
- [ ] Confirm yfinance no longer appears in data source settings


Made with [Cursor](https://cursor.com)