### PR TITLE
feat(settings): add system and per-provider LLM proxy settings

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -35,6 +35,7 @@
     "@opptrix/research-hub": "*",
     "@opptrix/search-hub": "*",
     "@opptrix/schedule": "*",
+    "@opptrix/shared": "*",
     "@opptrix/stock-eval": "*",
     "@opptrix/user-store": "*",
     "fastify": "^5.11.3",

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -3,6 +3,13 @@ import path from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import { getModelsDevCatalog, resolveModelsDevProviderMeta } from '@opptrix/agent'
+import {
+  normalizeProviderProxyMode,
+  resolveEffectiveProxyUrl,
+  validateProxyUrlInput,
+  type ProviderProxyMode,
+  type SystemProxySettings,
+} from '@opptrix/shared'
 import { getUserDataStore } from '@opptrix/user-store'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -16,7 +23,12 @@ export interface StoredProvider {
   base_url: string
   api_key: string
   models: string[]
+  /** inherit = system proxy; none = direct; custom = proxy_url */
+  proxy_mode?: ProviderProxyMode
+  proxy_url?: string
 }
+
+export type { ProviderProxyMode, SystemProxySettings }
 
 export interface LegacyLlmConfig {
   provider: string
@@ -30,6 +42,7 @@ export interface AppConfig {
   default_model?: string
   default_scorecard: string
   default_top_n: number
+  system_proxy?: SystemProxySettings
   /** @deprecated migrated to providers */
   llm?: LegacyLlmConfig
 }
@@ -178,6 +191,7 @@ export function loadConfig(): AppConfig {
     default_model: defaultModel,
     default_scorecard: file.default_scorecard ?? DEFAULTS.default_scorecard,
     default_top_n: file.default_top_n ?? DEFAULTS.default_top_n,
+    system_proxy: normalizeSystemProxy(file.system_proxy),
   }
 }
 
@@ -187,12 +201,14 @@ export function saveConfig(partial: Partial<AppConfig>): AppConfig {
     ...current,
     ...partial,
     providers: partial.providers ?? current.providers,
+    system_proxy: partial.system_proxy ?? current.system_proxy,
   }
   const toWrite = {
     providers: next.providers,
     default_model: next.default_model,
     default_scorecard: next.default_scorecard,
     default_top_n: next.default_top_n,
+    system_proxy: next.system_proxy,
   }
   getUserDataStore().setDocument(NAMESPACE, DOC_ID, toWrite)
   return next
@@ -215,21 +231,64 @@ export function publicConfig(cfg: AppConfig) {
       base_url: p.base_url,
       models: p.models,
       api_key_configured: !!p.api_key,
+      proxy_mode: normalizeProviderProxyMode(p.proxy_mode),
+      proxy_url: p.proxy_url?.trim() || undefined,
     })),
     available_models,
     default_model: cfg.default_model,
     default_scorecard: cfg.default_scorecard,
     default_top_n: cfg.default_top_n,
+    system_proxy: normalizeSystemProxy(cfg.system_proxy),
     llm_configured: cfg.providers.some(p => p.api_key && p.base_url && p.models.length > 0),
   }
 }
 
+function normalizeSystemProxy(raw: unknown): SystemProxySettings {
+  if (!raw || typeof raw !== 'object') return { enabled: false }
+  const rec = raw as Record<string, unknown>
+  const enabled = rec.enabled === true
+  const url = typeof rec.url === 'string' ? rec.url.trim() : undefined
+  return { enabled, ...(url ? { url } : {}) }
+}
+
+export function parseSystemProxyInput(raw: unknown): SystemProxySettings {
+  const base = normalizeSystemProxy(raw)
+  if (base.enabled && base.url) {
+    return { enabled: true, url: validateProxyUrlInput(base.url) ?? undefined }
+  }
+  if (base.enabled && !base.url?.trim()) {
+    throw new Error('启用系统代理时请填写代理地址')
+  }
+  return { enabled: false }
+}
+
+export function parseProviderProxyFields(body: {
+  proxy_mode?: unknown
+  proxy_url?: unknown
+}): Pick<StoredProvider, 'proxy_mode' | 'proxy_url'> {
+  const mode = normalizeProviderProxyMode(body.proxy_mode)
+  if (mode === 'custom') {
+    const url = validateProxyUrlInput(typeof body.proxy_url === 'string' ? body.proxy_url : '')
+    if (!url) throw new Error('自定义代理模式下请填写代理地址')
+    return { proxy_mode: 'custom', proxy_url: url }
+  }
+  if (mode === 'none') {
+    return { proxy_mode: 'none' }
+  }
+  return { proxy_mode: 'inherit' }
+}
+
 export function toAgentProviders(cfg: AppConfig) {
+  const system = cfg.system_proxy
   return cfg.providers.map(p => ({
     id: p.id,
     name: p.name,
     baseUrl: p.base_url,
     apiKey: p.api_key,
     models: p.models,
+    proxyUrl: resolveEffectiveProxyUrl(
+      { mode: normalizeProviderProxyMode(p.proxy_mode), url: p.proxy_url },
+      system,
+    ),
   }))
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,9 +9,11 @@ import { getWorkspaceService, assertAllowedShellArgv, getSessionSecretAccessStor
 import { getUserDataStore } from '@opptrix/user-store'
 import { ResearchHub } from '@opptrix/research-hub'
 import { listTemplates, REGISTRY } from '@opptrix/stock-eval'
+import { resolveEffectiveProxyUrl } from '@opptrix/shared'
 import {
   loadConfig, saveConfig, publicConfig, toAgentProviders,
-  resolveProviderPresets, type StoredProvider,
+  resolveProviderPresets, parseSystemProxyInput, parseProviderProxyFields,
+  type StoredProvider,
 } from './config.js'
 import { closeMarketDuckRuntime, getMarketDataService } from '@opptrix/market-data-store'
 import { registerStaticUi, shouldServeUi, isApiPath, resolveUiDist } from './static-ui.js'
@@ -959,14 +961,31 @@ app.get('/api/market-data/sync-state', async () => {
   }
 })
 
-app.patch<{ Body: { default_scorecard?: string; default_top_n?: number; default_model?: string } }>(
+app.patch<{ Body: {
+  default_scorecard?: string
+  default_top_n?: number
+  default_model?: string
+  system_proxy?: { enabled?: boolean; url?: string }
+} }>(
   '/api/config',
-  async (req) => {
+  async (req, reply) => {
     const b = req.body ?? {}
+    let system_proxy = cfg.system_proxy
+    if (b.system_proxy !== undefined) {
+      try {
+        system_proxy = parseSystemProxyInput(b.system_proxy)
+      } catch (e) {
+        return reply.code(400).send({
+          status: 'error',
+          error: e instanceof Error ? e.message : '系统代理配置无效',
+        })
+      }
+    }
     cfg = saveConfig({
       default_scorecard: b.default_scorecard,
       default_top_n: b.default_top_n,
       default_model: b.default_model,
+      system_proxy,
     })
     syncAgentProviders()
     return { status: 'saved', config: publicConfig(cfg) }
@@ -975,15 +994,31 @@ app.patch<{ Body: { default_scorecard?: string; default_top_n?: number; default_
 
 app.get('/api/providers/presets', async () => ({ presets: await resolveProviderPresets() }))
 
-app.post<{ Body: { base_url: string; api_key: string } }>(
+app.post<{ Body: {
+  base_url: string
+  api_key: string
+  proxy_mode?: string
+  proxy_url?: string
+} }>(
   '/api/providers/discover-models',
   async (req, reply) => {
-    const { base_url, api_key } = req.body ?? {}
+    const { base_url, api_key, proxy_mode, proxy_url } = req.body ?? {}
     if (!base_url?.trim() || !api_key?.trim()) {
       return reply.code(400).send({ error: 'base_url and api_key required' })
     }
+    let proxyUrl: string | undefined
     try {
-      const models = await fetchOpenAiModelList(base_url.trim(), api_key.trim())
+      const proxyFields = parseProviderProxyFields({ proxy_mode, proxy_url })
+      proxyUrl = resolveEffectiveProxyUrl(
+        { mode: proxyFields.proxy_mode, url: proxyFields.proxy_url },
+        cfg.system_proxy,
+      )
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '代理配置无效'
+      return reply.code(400).send({ error: msg })
+    }
+    try {
+      const models = await fetchOpenAiModelList(base_url.trim(), api_key.trim(), { proxyUrl })
       return { models }
     } catch (e) {
       const msg = e instanceof Error ? e.message : 'fetch models failed'
@@ -992,20 +1027,35 @@ app.post<{ Body: { base_url: string; api_key: string } }>(
   },
 )
 
-app.post<{ Body: { name: string; base_url: string; api_key: string; models: string[] } }>(
+app.post<{ Body: {
+  name: string
+  base_url: string
+  api_key: string
+  models: string[]
+  proxy_mode?: string
+  proxy_url?: string
+} }>(
   '/api/providers',
   async (req, reply) => {
-    const { name, base_url, api_key, models } = req.body ?? {}
+    const { name, base_url, api_key, models, proxy_mode, proxy_url } = req.body ?? {}
     if (!name?.trim() || !base_url?.trim() || !api_key?.trim()) {
       return reply.code(400).send({ error: 'name, base_url and api_key required' })
     }
     if (!models?.length) return reply.code(400).send({ error: '至少启用一个模型' })
+    let proxyFields: Pick<StoredProvider, 'proxy_mode' | 'proxy_url'> = { proxy_mode: 'inherit' }
+    try {
+      proxyFields = parseProviderProxyFields({ proxy_mode, proxy_url })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : '代理配置无效'
+      return reply.code(400).send({ error: msg })
+    }
     const provider: StoredProvider = {
       id: randomUUID(),
       name: name.trim(),
       base_url: base_url.trim(),
       api_key: api_key.trim(),
       models: [...new Set(models.map(m => m.trim()).filter(Boolean))],
+      ...proxyFields,
     }
     cfg = saveConfig({ providers: [...cfg.providers, provider] })
     if (!cfg.default_model) {
@@ -1023,6 +1073,21 @@ app.patch<{ Params: { id: string }; Body: Partial<StoredProvider> }>(
     if (idx < 0) return reply.code(404).send({ error: 'provider not found' })
     const b = req.body ?? {}
     const current = cfg.providers[idx]
+    let proxyFields: Pick<StoredProvider, 'proxy_mode' | 'proxy_url'> = {
+      proxy_mode: current.proxy_mode ?? 'inherit',
+      proxy_url: current.proxy_url,
+    }
+    if (b.proxy_mode !== undefined || b.proxy_url !== undefined) {
+      try {
+        proxyFields = parseProviderProxyFields({
+          proxy_mode: b.proxy_mode ?? current.proxy_mode,
+          proxy_url: b.proxy_url ?? current.proxy_url,
+        })
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : '代理配置无效'
+        return reply.code(400).send({ error: msg })
+      }
+    }
     const next: StoredProvider = {
       ...current,
       name: b.name?.trim() || current.name,
@@ -1031,6 +1096,7 @@ app.patch<{ Params: { id: string }; Body: Partial<StoredProvider> }>(
       models: b.models?.length
         ? [...new Set(b.models.map(m => m.trim()).filter(Boolean))]
         : current.models,
+      ...proxyFields,
     }
     if (!next.models.length) return reply.code(400).send({ error: '至少启用一个模型' })
     const providers = [...cfg.providers]

--- a/apps/server/src/translation-remote.ts
+++ b/apps/server/src/translation-remote.ts
@@ -1,4 +1,5 @@
 import { createProvider, chatMessageContentToText } from '@opptrix/agent'
+import { resolveEffectiveProxyUrl } from '@opptrix/shared'
 import type { NewsTranslationSettings } from '@opptrix/news-feed'
 import { loadConfig } from './config.js'
 import {
@@ -56,6 +57,10 @@ function resolveRemoteLlm(translation: NewsTranslationSettings) {
     temperature: 0.3,
     maxTokens: 2048,
     timeout: 120_000,
+    proxyUrl: resolveEffectiveProxyUrl(
+      { mode: provider.proxy_mode, url: provider.proxy_url },
+      cfg.system_proxy,
+    ),
   })
 }
 

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -1489,6 +1489,13 @@ export interface PublicProvider {
   base_url: string
   models: string[]
   api_key_configured: boolean
+  proxy_mode?: 'inherit' | 'none' | 'custom'
+  proxy_url?: string
+}
+
+export interface SystemProxySettings {
+  enabled: boolean
+  url?: string
 }
 
 export interface ProviderPreset {
@@ -1504,6 +1511,7 @@ export interface AppConfig {
   default_model?: string
   default_scorecard: string
   default_top_n: number
+  system_proxy?: SystemProxySettings
   llm_configured: boolean
 }
 
@@ -1517,6 +1525,7 @@ export async function patchConfig(payload: {
   default_scorecard?: string
   default_top_n?: number
   default_model?: string
+  system_proxy?: SystemProxySettings
 }) {
   return jsonFetch<{ status: string; config: AppConfig }>('/config', {
     method: 'PATCH',
@@ -1559,13 +1568,22 @@ export async function getProviderPresets() {
 /** 拉取模型列表：上游常需 10–30s，须长于默认 REQUEST_TIMEOUT */
 const DISCOVER_MODELS_TIMEOUT_MS = 45_000
 
-export async function discoverModels(base_url: string, api_key: string) {
+export async function discoverModels(
+  base_url: string,
+  api_key: string,
+  proxy?: { proxy_mode?: 'inherit' | 'none' | 'custom'; proxy_url?: string },
+) {
   return jsonFetch<{ models: string[] }>(
     '/providers/discover-models',
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ base_url, api_key }),
+      body: JSON.stringify({
+        base_url,
+        api_key,
+        ...(proxy?.proxy_mode ? { proxy_mode: proxy.proxy_mode } : {}),
+        ...(proxy?.proxy_url ? { proxy_url: proxy.proxy_url } : {}),
+      }),
     },
     DISCOVER_MODELS_TIMEOUT_MS,
   )
@@ -1576,6 +1594,8 @@ export async function createProvider(payload: {
   base_url: string
   api_key: string
   models: string[]
+  proxy_mode?: 'inherit' | 'none' | 'custom'
+  proxy_url?: string
 }) {
   return jsonFetch<{ status: string; provider: PublicProvider }>('/providers', {
     method: 'POST',
@@ -1589,6 +1609,8 @@ export async function updateProvider(id: string, payload: Partial<{
   base_url: string
   api_key: string
   models: string[]
+  proxy_mode: 'inherit' | 'none' | 'custom'
+  proxy_url: string
 }>) {
   return jsonFetch<{ status: string; provider: PublicProvider }>(`/providers/${id}`, {
     method: 'PATCH',

--- a/client-ui/src/pages/ProviderWizard.tsx
+++ b/client-ui/src/pages/ProviderWizard.tsx
@@ -11,6 +11,7 @@ import {
   type ProviderPreset, type PublicProvider,
 } from '../api/client'
 import { useSettingsToast } from './settings/SettingsToast'
+import { ProxySettingsFields, type ProviderProxyMode } from './settings/ProxySettingsFields'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { focusRing, ghostInteractive } from '../theme/mixins'
 
@@ -402,6 +403,8 @@ export default function ProviderWizard({
   const [discovering, setDiscovering] = useState(false)
   const [saving, setSaving] = useState(false)
   const [discoverHint, setDiscoverHint] = useState('')
+  const [proxyMode, setProxyMode] = useState<ProviderProxyMode>('inherit')
+  const [proxyUrl, setProxyUrl] = useState('')
 
   useEffect(() => {
     getProviderPresets()
@@ -422,6 +425,8 @@ export default function ProviderWizard({
     setCustomFormOpen(false)
     setSelectedPresetId(null)
     setDiscoverHint('')
+    setProxyMode(provider.proxy_mode ?? 'inherit')
+    setProxyUrl(provider.proxy_url ?? '')
   }, [provider])
 
   /** 扁平列表：返利置顶 → 其余中国 → 海外 → 自定义 */
@@ -465,6 +470,11 @@ export default function ProviderWizard({
     setStep(2)
   }
 
+  const proxyPayload = useMemo(() => ({
+    proxy_mode: proxyMode,
+    ...(proxyMode === 'custom' && proxyUrl.trim() ? { proxy_url: proxyUrl.trim() } : {}),
+  }), [proxyMode, proxyUrl])
+
   const runDiscover = async (): Promise<boolean> => {
     const url = baseUrl.trim()
     const key = apiKey.trim()
@@ -481,7 +491,7 @@ export default function ProviderWizard({
     setDiscovered([])
     setSelected(new Set())
     try {
-      const { models } = await discoverModels(url, key)
+      const { models } = await discoverModels(url, key, proxyPayload)
       setDiscovered(models)
       if (models.length) {
         if (isEdit && provider) {
@@ -562,6 +572,10 @@ export default function ProviderWizard({
       toast.showError('请至少勾选一个模型')
       return
     }
+    if (proxyMode === 'custom' && !proxyUrl.trim()) {
+      toast.showError('自定义代理模式下请填写代理地址')
+      return
+    }
     setSaving(true)
     try {
       if (isEdit && provider) {
@@ -570,6 +584,8 @@ export default function ProviderWizard({
           base_url: baseUrl.trim(),
           ...(apiKey.trim() ? { api_key: apiKey.trim() } : {}),
           models: [...selected],
+          proxy_mode: proxyMode,
+          ...(proxyMode === 'custom' ? { proxy_url: proxyUrl.trim() } : {}),
         })
       } else {
         await createProvider({
@@ -577,6 +593,8 @@ export default function ProviderWizard({
           base_url: baseUrl.trim(),
           api_key: apiKey.trim(),
           models: [...selected],
+          proxy_mode: proxyMode,
+          ...(proxyMode === 'custom' ? { proxy_url: proxyUrl.trim() } : {}),
         })
       }
       onDone()
@@ -785,6 +803,13 @@ export default function ProviderWizard({
                     autoComplete="off"
                   />
                 </OpptrixField>
+                <ProxySettingsFields
+                  scope="provider"
+                  mode={proxyMode}
+                  url={proxyUrl}
+                  onModeChange={setProxyMode}
+                  onUrlChange={setProxyUrl}
+                />
               </div>
             </>
           )}

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -26,6 +26,7 @@ import PythonEnvironmentSettingsSection from './settings/PythonEnvironmentSettin
 import SelfEvolveSettingsSection from './settings/SelfEvolveSettingsSection'
 import PortfolioFeeSettingsSection from './settings/PortfolioFeeSettingsSection'
 import AboutSettingsSection from './settings/AboutSettingsSection'
+import { SystemProxySettingsSection } from './settings/SystemProxySettingsSection'
 import { SettingsToastProvider, useSettingsToast } from './settings/SettingsToast'
 import {
   SettingsGroup, SettingsRow, SettingsEmptyState,
@@ -34,7 +35,7 @@ import {
 } from './settings/SettingsPrimitives'
 import {
   getConfig, patchConfig, deleteProvider, getHealth, news,
-  type AppConfig, type PublicProvider,
+  type AppConfig, type PublicProvider, type SystemProxySettings,
 } from '../api/client'
 import {
   applyFontScale, readFontScalePreference, writeFontScalePreference,
@@ -515,6 +516,11 @@ function SettingsPageView({
       })
   }, [scorecard, loading, onSaved, toast], SCORECARD_SAVE_MS, true)
 
+  const handleSystemProxySaved = useCallback((next: SystemProxySettings) => {
+    setConfig(prev => (prev ? { ...prev, system_proxy: next } : prev))
+    onSaved?.()
+  }, [onSaved])
+
   const openProviderWizard = useCallback((provider: PublicProvider | null = null) => {
     setEditingProvider(provider)
     setWizardOpen(true)
@@ -655,6 +661,14 @@ function SettingsPageView({
               <Text className={mergeClasses(s.saveHint, saveState !== 'idle' && s.saveHintActive)} block>
                 {saveHintText}
               </Text>
+            </div>
+
+            <div className={s.sectionBlock}>
+              <SettingsSectionLabel spaced>网络</SettingsSectionLabel>
+              <SystemProxySettingsSection
+                saved={config?.system_proxy}
+                onSaved={handleSystemProxySaved}
+              />
             </div>
 
             <div className={s.sectionBlock}>

--- a/client-ui/src/pages/settings/ProxySettingsFields.tsx
+++ b/client-ui/src/pages/settings/ProxySettingsFields.tsx
@@ -1,0 +1,87 @@
+import { makeStyles } from '@fluentui/react-components'
+import OpptrixField from '../../components/opptrix/OpptrixField'
+import OpptrixInput from '../../components/opptrix/OpptrixInput'
+import OpptrixSelect, { OpptrixOption } from '../../components/opptrix/OpptrixSelect'
+
+export type ProviderProxyMode = 'inherit' | 'none' | 'custom'
+
+const PROXY_MODE_OPTIONS: Array<{ value: ProviderProxyMode; label: string }> = [
+  { value: 'inherit', label: '跟随系统' },
+  { value: 'none', label: '直连（不走代理）' },
+  { value: 'custom', label: '自定义代理' },
+]
+
+function providerModeHint(mode: ProviderProxyMode): string | undefined {
+  if (mode === 'inherit') {
+    return '与「常规 → 网络」中的系统代理一致；系统未启用时自动直连。'
+  }
+  if (mode === 'none') {
+    return '始终直连此服务的 API 地址，不使用系统或自定义代理。'
+  }
+  return undefined
+}
+
+const CUSTOM_PROXY_HINT = '仅对本提供商生效'
+
+const SYSTEM_PROXY_HINT =
+  '支持 HTTP、HTTPS、SOCKS5，如 http://127.0.0.1:7890'
+
+const useStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '14px',
+  },
+})
+
+export function ProxySettingsFields({
+  mode,
+  url,
+  onModeChange,
+  onUrlChange,
+  scope,
+}: {
+  mode: ProviderProxyMode
+  url: string
+  onModeChange: (mode: ProviderProxyMode) => void
+  onUrlChange: (url: string) => void
+  /** provider = per-LLM; system = global fallback */
+  scope: 'provider' | 'system'
+}) {
+  const s = useStyles()
+  const showUrl = scope === 'system' || mode === 'custom'
+
+  return (
+    <div className={s.root}>
+      {scope === 'provider' ? (
+        <OpptrixField label="网络代理" hint={providerModeHint(mode)}>
+          <OpptrixSelect
+            value={PROXY_MODE_OPTIONS.find(o => o.value === mode)?.label ?? mode}
+            selectedOptions={[mode]}
+            onOptionSelect={(_, data) => {
+              const next = (data.optionValue ?? 'inherit') as ProviderProxyMode
+              onModeChange(next)
+            }}
+          >
+            {PROXY_MODE_OPTIONS.map(o => (
+              <OpptrixOption key={o.value} value={o.value}>{o.label}</OpptrixOption>
+            ))}
+          </OpptrixSelect>
+        </OpptrixField>
+      ) : null}
+      {showUrl ? (
+        <OpptrixField
+          label="代理地址"
+          hint={scope === 'system' ? SYSTEM_PROXY_HINT : CUSTOM_PROXY_HINT}
+        >
+          <OpptrixInput
+            value={url}
+            onChange={(_, d) => onUrlChange(d.value ?? '')}
+            placeholder="http://127.0.0.1:7890"
+            autoComplete="off"
+          />
+        </OpptrixField>
+      ) : null}
+    </div>
+  )
+}

--- a/client-ui/src/pages/settings/SystemProxySettingsSection.tsx
+++ b/client-ui/src/pages/settings/SystemProxySettingsSection.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  Input,
+  Switch,
+  Text,
+  makeStyles,
+  mergeClasses,
+} from '@fluentui/react-components'
+import { CheckmarkRegular, GlobeRegular } from '@fluentui/react-icons'
+import OpptrixButton from '../../components/opptrix/OpptrixButton'
+import { patchConfig, type SystemProxySettings } from '../../api/client'
+import { opptrixCssVars, opptrixTokens } from '../../theme/tokens'
+import { inputShellInteractive } from '../../theme/mixins'
+import {
+  SettingsGroup,
+  SettingsRow,
+  SettingsStaticBlock,
+} from './SettingsPrimitives'
+import { useSettingsToast } from './SettingsToast'
+
+const PROTOCOLS = ['HTTP', 'HTTPS', 'SOCKS5', 'SOCKS4'] as const
+
+const useStyles = makeStyles({
+  fieldBlock: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+  },
+  fieldLabel: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 500,
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.35,
+  },
+  protocolRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '6px',
+  },
+  protocolChip: {
+    fontSize: '11px',
+    fontWeight: 500,
+    letterSpacing: '0.02em',
+    color: opptrixCssVars.textTertiary,
+    padding: '2px 8px',
+    borderRadius: opptrixTokens.radiusFull,
+    border: `1px solid ${opptrixCssVars.separator}`,
+    backgroundColor: opptrixCssVars.canvasAlt,
+    lineHeight: 1.4,
+  },
+  activeCard: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '10px',
+    padding: '10px 12px',
+    borderRadius: opptrixTokens.radiusMd,
+    border: `1px solid color-mix(in srgb, ${opptrixCssVars.success} 28%, transparent)`,
+    backgroundColor: 'color-mix(in srgb, var(--opptrix-success) 6%, transparent)',
+  },
+  activeIcon: {
+    color: opptrixCssVars.success,
+    fontSize: '18px',
+    flexShrink: 0,
+    marginTop: '1px',
+  },
+  activeBody: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2px',
+  },
+  activeTitle: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontWeight: 600,
+    color: opptrixCssVars.textPrimary,
+    lineHeight: 1.35,
+  },
+  activeUrl: {
+    fontSize: 'var(--opptrix-font-sm)',
+    fontFamily: 'var(--opptrix-font-mono)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.45,
+    wordBreak: 'break-all',
+  },
+  validation: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.warning,
+    lineHeight: 1.45,
+  },
+  fieldHint: {
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.45,
+  },
+  panelFooter: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '12px',
+    flexWrap: 'wrap',
+  },
+  urlCombo: {
+    ...inputShellInteractive,
+    width: '100%',
+    minWidth: 0,
+    minHeight: '30px',
+    display: 'flex',
+    alignItems: 'stretch',
+    padding: 0,
+    overflow: 'hidden',
+    boxSizing: 'border-box',
+  },
+  urlInput: {
+    flex: '1 1 0',
+    minWidth: 0,
+    fontFamily: 'var(--opptrix-font-mono)',
+    fontSize: 'var(--opptrix-font-md)',
+    paddingLeft: '10px',
+  },
+  urlSegment: {
+    display: 'flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    borderLeft: `1px solid ${opptrixCssVars.separator}`,
+  },
+})
+
+function looksLikeProxyUrl(raw: string): boolean {
+  const u = raw.trim().toLowerCase()
+  return u.startsWith('http://')
+    || u.startsWith('https://')
+    || u.startsWith('socks5://')
+    || u.startsWith('socks4://')
+}
+
+/** Browser-safe mirror of @opptrix/shared/proxy-config (avoid shared barrel → node modules). */
+function maskProxyUrlForDisplay(url: string): string {
+  const trimmed = url.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.password || parsed.username) {
+      parsed.username = parsed.username ? '***' : ''
+      parsed.password = parsed.password ? '***' : ''
+    }
+    return parsed.toString()
+  } catch {
+    return trimmed.replace(/\/\/[^@/]+@/, '//***@')
+  }
+}
+
+export function SystemProxySettingsSection({
+  saved,
+  onSaved,
+}: {
+  saved: SystemProxySettings | undefined
+  onSaved: (next: SystemProxySettings) => void
+}) {
+  const s = useStyles()
+  const toast = useSettingsToast()
+  const [expanded, setExpanded] = useState(false)
+  const [draftUrl, setDraftUrl] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const enabled = saved?.enabled === true
+  const savedUrl = saved?.url?.trim() ?? ''
+
+  useEffect(() => {
+    if (!expanded) {
+      setDraftUrl(savedUrl)
+    }
+  }, [expanded, savedUrl])
+
+  const draftTrimmed = draftUrl.trim()
+  const urlValid = !draftTrimmed || looksLikeProxyUrl(draftTrimmed)
+  const urlChanged = draftTrimmed !== savedUrl
+  const showActiveCard = enabled && savedUrl && !urlChanged
+  const canSave = Boolean(draftTrimmed) && urlValid && !saving && (urlChanged || !enabled)
+
+  const rowDesc = (() => {
+    if (enabled && !expanded) {
+      return `已启用 · ${maskProxyUrlForDisplay(savedUrl)}`
+    }
+    if (expanded) {
+      return '填写代理地址后，点输入框右侧按钮保存'
+    }
+    return '为未单独配置的模型提供商提供默认出站代理'
+  })()
+
+  const persist = useCallback(async (next: SystemProxySettings) => {
+    setSaving(true)
+    try {
+      const resp = await patchConfig({ system_proxy: next })
+      const stored = resp.config.system_proxy ?? { enabled: false }
+      onSaved(stored)
+      setDraftUrl(stored.url ?? '')
+      toast.showSuccess(stored.enabled ? '系统代理已保存' : '系统代理已停用')
+    } catch (e) {
+      toast.showError(e instanceof Error ? e.message : '保存失败')
+    } finally {
+      setSaving(false)
+    }
+  }, [onSaved, toast])
+
+  const handleSwitchChange = (_: unknown, data: { checked: boolean }) => {
+    setExpanded(data.checked)
+  }
+
+  const handleSave = () => {
+    if (!draftTrimmed) {
+      toast.showError('请先填写代理地址')
+      return
+    }
+    if (!urlValid || !canSave) return
+    void persist({ enabled: true, url: draftTrimmed })
+  }
+
+  const handleDisable = () => {
+    if (!enabled || saving) return
+    void persist({ enabled: false, url: savedUrl || undefined })
+  }
+
+  return (
+    <SettingsGroup>
+      <SettingsRow
+        title="大模型网络代理"
+        desc={rowDesc}
+        last={!expanded}
+        control={(
+          <Switch
+            checked={expanded}
+            onChange={handleSwitchChange}
+            aria-label="展开或收起大模型网络代理设置"
+          />
+        )}
+      />
+
+      {expanded ? (
+        <SettingsStaticBlock>
+          {showActiveCard ? (
+            <div className={s.activeCard}>
+              <GlobeRegular className={s.activeIcon} />
+              <div className={s.activeBody}>
+                <Text className={s.activeTitle} block>当前生效</Text>
+                <Text className={s.activeUrl} block>
+                  {maskProxyUrlForDisplay(savedUrl)}
+                </Text>
+              </div>
+            </div>
+          ) : null}
+
+          <div className={s.fieldBlock}>
+            <Text className={s.fieldLabel} block>代理服务器</Text>
+            <div className={mergeClasses(s.urlCombo, 'opptrix-input-shell', 'opptrix-settings-inline-input', 'opptrix-credential-combo')}>
+              <Input
+                className={mergeClasses(s.urlInput, 'opptrix-settings-field-input')}
+                appearance="filled-darker"
+                size="small"
+                value={draftUrl}
+                placeholder="http://127.0.0.1:7890"
+                autoComplete="off"
+                disabled={saving}
+                onChange={(_, d) => setDraftUrl(d.value ?? '')}
+              />
+              <div className={s.urlSegment}>
+                <OpptrixButton
+                  variant="icon"
+                  aria-label="保存代理"
+                  icon={<CheckmarkRegular fontSize={14} />}
+                  disabled={!canSave}
+                  onClick={handleSave}
+                />
+              </div>
+            </div>
+            <div className={s.protocolRow} aria-hidden>
+              {PROTOCOLS.map(p => (
+                <span key={p} className={s.protocolChip}>{p}</span>
+              ))}
+            </div>
+            {!urlValid && draftTrimmed ? (
+              <Text className={s.validation} block>
+                请使用 http://、https://、socks5:// 或 socks4:// 开头
+              </Text>
+            ) : (
+              <div className={s.panelFooter}>
+                <Text className={s.fieldHint} block>
+                  保存后对所有「跟随系统」的模型提供商生效；可在「大模型」中单独覆盖。
+                </Text>
+                {enabled ? (
+                  <OpptrixButton
+                    variant="ghost"
+                    size="small"
+                    disabled={saving}
+                    onClick={handleDisable}
+                  >
+                    停用
+                  </OpptrixButton>
+                ) : null}
+              </div>
+            )}
+          </div>
+        </SettingsStaticBlock>
+      ) : null}
+    </SettingsGroup>
+  )
+}

--- a/client-ui/src/pages/settings/settingsSearchIndex.ts
+++ b/client-ui/src/pages/settings/settingsSearchIndex.ts
@@ -60,9 +60,10 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   { section: 'general', group: '外观', title: '提示音', desc: '对话完成或需要你确认时播放轻提示', keywords: ['提示音', '音效', '声音', 'sound', '通知音'] },
   { section: 'general', group: '偏好', title: '评分卡', desc: '因子评估默认使用的评分模板', keywords: ['scorecard', 'G=B+M', '因子'] },
   { section: 'general', group: '连接', title: '后端连接', desc: '检查 API 服务与 LLM 提供商配置', keywords: ['测试', 'health', '连接'] },
+  { section: 'general', group: '网络', title: '大模型系统代理', desc: '打开开关配置代理地址，在输入框旁保存', keywords: ['代理', 'proxy', 'socks', '网络'] },
 
   // 大模型
-  { section: 'models', title: '提供商', desc: '配置服务地址与密钥', keywords: ['大模型', 'LLM', 'OpenAI', '密钥', '提供商'] },
+  { section: 'models', title: '提供商', desc: '配置服务地址与密钥', keywords: ['大模型', 'LLM', 'OpenAI', '密钥', '提供商', '代理'] },
   { section: 'models', title: '添加提供商', keywords: ['新增', '添加', '大模型'] },
   { section: 'models', title: '编辑提供商', keywords: ['修改', '大模型'] },
   // 自进化

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,7 @@
         "@opptrix/research-hub": "*",
         "@opptrix/schedule": "*",
         "@opptrix/search-hub": "*",
+        "@opptrix/shared": "*",
         "@opptrix/stock-eval": "*",
         "@opptrix/user-store": "*",
         "fastify": "^5.11.3",
@@ -8569,6 +8570,18 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmmirror.com/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -10315,6 +10328,15 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
+      "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -10490,6 +10512,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmmirror.com/degenerator/-/degenerator-7.0.1.tgz",
+      "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "quickjs-wasi": "^2.2.0"
       }
     },
     "node_modules/delaunator": {
@@ -11302,6 +11341,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
     "node_modules/eslint": {
       "version": "9.39.5",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
@@ -11456,6 +11516,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmmirror.com/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -11486,7 +11559,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -11506,7 +11578,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -12574,6 +12645,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/get-uri/-/get-uri-8.0.1.tgz",
+      "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.3.1",
+        "data-uri-to-buffer": "8.0.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/github-from-package": {
@@ -16191,6 +16276,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/node-abi": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
@@ -17095,6 +17189,92 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pac-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "get-uri": "8.0.1",
+        "http-proxy-agent": "9.1.0",
+        "https-proxy-agent": "9.1.0",
+        "pac-resolver": "9.0.1",
+        "quickjs-wasi": "^2.2.0",
+        "socks-proxy-agent": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/pac-proxy-agent/node_modules/socks-proxy-agent": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/pac-resolver/-/pac-resolver-9.0.1.tgz",
+      "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "7.0.1",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "quickjs-wasi": "^2.2.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -17900,6 +18080,111 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-agent": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmmirror.com/proxy-agent/-/proxy-agent-8.0.2.tgz",
+      "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "9.1.0",
+        "https-proxy-agent": "9.1.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "9.1.0",
+        "proxy-from-env": "^2.0.0",
+        "socks-proxy-agent": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-agent/node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmmirror.com/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/http-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/socks-proxy-agent": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -17994,6 +18279,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/quickjs-wasi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
+      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
+      "license": "MIT"
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -19376,7 +19667,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -21840,7 +22131,10 @@
     },
     "packages/shared": {
       "name": "@opptrix/shared",
-      "version": "0.4.0"
+      "version": "0.4.0",
+      "dependencies": {
+        "proxy-agent": "^8.0.2"
+      }
     },
     "packages/stock-eval": {
       "name": "@opptrix/stock-eval",

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -58,6 +58,8 @@ export interface LlmConfig {
   temperature?: number
   maxTokens?: number
   timeout?: number
+  /** http(s):// or socks5:// — per-provider or system-resolved */
+  proxyUrl?: string
 }
 
 export interface ToolCall {
@@ -626,6 +628,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       },
       body: JSON.stringify(buildBody(stream)),
       signal: requestSignal,
+      ...(this.cfg.proxyUrl ? { proxyUrl: this.cfg.proxyUrl } : {}),
     })
 
     /** 上游拒收 tool_choice 时：先改 auto，再省略该字段后重试 */
@@ -772,7 +775,9 @@ export class OpenAiCompatibleProvider implements LlmProvider {
   }
 
   async listModels() {
-    return fetchOpenAiModelList(this.cfg.baseUrl, this.cfg.apiKey).catch(() => [])
+    return fetchOpenAiModelList(this.cfg.baseUrl, this.cfg.apiKey, {
+      proxyUrl: this.cfg.proxyUrl,
+    }).catch(() => [])
   }
 }
 
@@ -795,11 +800,16 @@ export function joinOpenAiCompatibleUrl(baseUrl: string, relativePath: string): 
 }
 
 /** OpenAI 兼容 GET {baseUrl}/models — 见 {@link joinOpenAiCompatibleUrl}。 */
-export async function fetchOpenAiModelList(baseUrl: string, apiKey: string): Promise<string[]> {
+export async function fetchOpenAiModelList(
+  baseUrl: string,
+  apiKey: string,
+  opts?: { proxyUrl?: string },
+): Promise<string[]> {
   const url = joinOpenAiCompatibleUrl(baseUrl, 'models')
   const resp = await outboundFetch(url, {
     headers: { Authorization: `Bearer ${apiKey}` },
     signal: AbortSignal.timeout(30_000),
+    ...(opts?.proxyUrl ? { proxyUrl: opts.proxyUrl } : {}),
   })
   if (!resp.ok) {
     const text = (await resp.text()).slice(0, 200)

--- a/packages/agent/src/llm/providers.ts
+++ b/packages/agent/src/llm/providers.ts
@@ -15,6 +15,8 @@ export interface ProviderProfile {
   baseUrl: string
   apiKey: string
   models: string[]
+  /** Resolved effective outbound proxy (provider overrides system). */
+  proxyUrl?: string
 }
 
 export interface AvailableModel {
@@ -129,6 +131,7 @@ export class ProviderRegistry {
       apiKey: p.apiKey,
       model,
       baseUrl: normalizeBaseUrl(p.baseUrl),
+      ...(p.proxyUrl ? { proxyUrl: p.proxyUrl } : {}),
     }
   }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -53,10 +53,18 @@
     "./builtin-skill-titles": {
       "types": "./dist/builtin-skill-titles.d.ts",
       "import": "./dist/builtin-skill-titles.js"
+    },
+    "./proxy-config": {
+      "types": "./dist/proxy-config.d.ts",
+      "import": "./dist/proxy-config.js"
     }
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -p tsconfig.json --watch"
+  },
+  "dependencies": {
+    "https-proxy-agent": "^7.0.6",
+    "socks-proxy-agent": "^8.0.5"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -54,7 +54,24 @@ export {
   type OutboundFamilyMode,
   type OutboundNetworkStatus,
 } from './outbound-network.js'
-export { outboundFetch, formatOutboundFetchError, isOutboundTimeoutError } from './outbound-fetch.js'
+export {
+  outboundFetch,
+  formatOutboundFetchError,
+  isOutboundTimeoutError,
+  resetOutboundProxyAgentCacheForTests,
+  type OutboundFetchInit,
+} from './outbound-fetch.js'
+export {
+  resolveEffectiveProxyUrl,
+  validateProxyUrlInput,
+  normalizeProxyUrlInput,
+  normalizeProviderProxyMode,
+  isValidProxyUrl,
+  maskProxyUrlForDisplay,
+  type ProviderProxyMode,
+  type SystemProxySettings,
+  type ProviderProxySettings,
+} from './proxy-config.js'
 export { ok, fail, elapsedSince } from './result.js'
 export {
   resolveUserDataRoot,

--- a/packages/shared/src/outbound-fetch.ts
+++ b/packages/shared/src/outbound-fetch.ts
@@ -1,6 +1,9 @@
 import http from 'node:http'
 import https from 'node:https'
+import type { Agent } from 'node:http'
 import { Readable } from 'node:stream'
+import { HttpsProxyAgent } from 'https-proxy-agent'
+import { SocksProxyAgent } from 'socks-proxy-agent'
 import {
   ensureOutboundNetworkReady,
   getConnectFamiliesForHost,
@@ -9,6 +12,31 @@ import {
   noteHostConnectSuccess,
   type OutboundConnectFamily,
 } from './outbound-network.js'
+import { isValidProxyUrl, normalizeProxyUrlInput } from './proxy-config.js'
+
+export type OutboundFetchInit = RequestInit & {
+  /** http(s):// or socks5:// / socks4:// — routes this request through a proxy */
+  proxyUrl?: string
+}
+
+const proxyAgentCache = new Map<string, Agent>()
+
+function proxyAgentFor(url: string): Agent {
+  let agent = proxyAgentCache.get(url)
+  if (!agent) {
+    const scheme = new URL(url).protocol.replace(':', '').toLowerCase()
+    agent = (scheme === 'socks5' || scheme === 'socks4')
+      ? new SocksProxyAgent(url)
+      : new HttpsProxyAgent(url)
+    proxyAgentCache.set(url, agent)
+  }
+  return agent
+}
+
+/** @internal tests only */
+export function resetOutboundProxyAgentCacheForTests(): void {
+  proxyAgentCache.clear()
+}
 
 function normalizeHeaders(headers?: RequestInit['headers']): Record<string, string> {
   if (!headers) return {}
@@ -60,6 +88,7 @@ function outboundFetchOnce(
   url: string,
   init: RequestInit,
   family: OutboundConnectFamily,
+  proxyUrl?: string,
 ): Promise<Response> {
   const parsed = new URL(url)
   const isHttps = parsed.protocol === 'https:'
@@ -67,6 +96,16 @@ function outboundFetchOnce(
   const method = init.method ?? 'GET'
   const headers = normalizeHeaders(init.headers)
   const payload = bodyBytes(init.body)
+  const agent = proxyUrl ? proxyAgentFor(proxyUrl) : undefined
+
+  const requestOptions: https.RequestOptions = {
+    hostname: parsed.hostname,
+    port: parsed.port || (isHttps ? 443 : 80),
+    path: `${parsed.pathname}${parsed.search}`,
+    method,
+    headers,
+    ...(agent ? { agent } : { family }),
+  }
 
   return new Promise((resolve, reject) => {
     const signal = init.signal
@@ -88,16 +127,8 @@ function outboundFetchOnce(
     }
 
     const req = lib.request(
-      {
-        hostname: parsed.hostname,
-        port: parsed.port || (isHttps ? 443 : 80),
-        path: `${parsed.pathname}${parsed.search}`,
-        method,
-        headers,
-        family,
-      },
+      requestOptions,
       (res) => {
-        // 响应头到达即 resolve，body 用可读流 — 禁止整包缓冲后再给调用方
         const webBody = Readable.toWeb(res) as ReadableStream<Uint8Array>
         settleResolve(new Response(webBody, {
           status: res.statusCode ?? 500,
@@ -108,14 +139,12 @@ function outboundFetchOnce(
     )
 
     req.on('error', (error) => {
-      // 已 resolve（流式读 body）后 destroy/abort 只影响 body，勿再 reject Promise
       settleReject(error)
     })
 
     const onAbort = () => {
       const reason = abortRejectReason(signal)
       req.destroy(reason)
-      // 尚未拿到响应头：以 abort reason 结束（含 TimeoutError，由 formatOutboundFetchError 转中文）
       settleReject(reason)
     }
     signal?.addEventListener('abort', onAbort, { once: true })
@@ -126,24 +155,34 @@ function outboundFetchOnce(
   })
 }
 
+function resolveProxyFromInit(init: OutboundFetchInit): string | undefined {
+  const raw = normalizeProxyUrlInput(init.proxyUrl)
+  if (!raw) return undefined
+  if (!isValidProxyUrl(raw)) return undefined
+  return raw
+}
+
 /**
  * Outbound HTTP(S) fetch: IPv4 first per host; retry IPv6 only after v4 connect/DNS failure.
  * 一旦响应头到达并开始流式 body，不再换栈重放。
+ * With `proxyUrl`, traffic routes through HTTP/HTTPS/SOCKS proxy (no dual-stack retry).
  */
-export async function outboundFetch(url: string, init: RequestInit = {}): Promise<Response> {
+export async function outboundFetch(url: string, init: OutboundFetchInit = {}): Promise<Response> {
   await ensureOutboundNetworkReady()
+  const { proxyUrl: proxyOpt, ...fetchInit } = init
+  const proxyUrl = resolveProxyFromInit({ ...fetchInit, proxyUrl: proxyOpt })
   const hostname = new URL(url).hostname
-  const families = getConnectFamiliesForHost(hostname)
+  const families: OutboundConnectFamily[] = proxyUrl ? [4] : getConnectFamiliesForHost(hostname)
 
   let lastError: unknown
   for (const family of families) {
     try {
-      const response = await outboundFetchOnce(url, init, family)
-      noteHostConnectSuccess(hostname, family)
+      const response = await outboundFetchOnce(url, fetchInit, family, proxyUrl)
+      if (!proxyUrl) noteHostConnectSuccess(hostname, family)
       return response
     } catch (error) {
-      if (init.signal?.aborted) throw error
-      if (!isOutboundConnectError(error)) throw error
+      if (fetchInit.signal?.aborted) throw error
+      if (proxyUrl || !isOutboundConnectError(error)) throw error
       noteHostConnectFailure(hostname, family)
       lastError = error
     }

--- a/packages/shared/src/proxy-config.ts
+++ b/packages/shared/src/proxy-config.ts
@@ -1,0 +1,86 @@
+/** Per-provider proxy mode; `inherit` falls back to system proxy when enabled. */
+export type ProviderProxyMode = 'inherit' | 'none' | 'custom'
+
+export interface SystemProxySettings {
+  enabled: boolean
+  /** http(s):// or socks5:// / socks4:// */
+  url?: string
+}
+
+export interface ProviderProxySettings {
+  mode?: ProviderProxyMode
+  url?: string
+}
+
+const PROXY_URL_RE = /^(https?|socks5|socks4):\/\/.+/i
+
+/** Trim; empty string → null. Does not validate scheme. */
+export function normalizeProxyUrlInput(raw: string | undefined | null): string | null {
+  const trimmed = (raw ?? '').trim()
+  return trimmed.length ? trimmed : null
+}
+
+/** Validate proxy URL for storage / outbound use. */
+export function isValidProxyUrl(url: string): boolean {
+  const u = normalizeProxyUrlInput(url)
+  if (!u) return false
+  try {
+    const parsed = new URL(u)
+    const scheme = parsed.protocol.replace(':', '').toLowerCase()
+    if (!['http', 'https', 'socks5', 'socks4'].includes(scheme)) return false
+    return Boolean(parsed.hostname)
+  } catch {
+    return PROXY_URL_RE.test(u)
+  }
+}
+
+export function validateProxyUrlInput(raw: string | undefined | null): string | null {
+  const u = normalizeProxyUrlInput(raw)
+  if (!u) return null
+  if (!isValidProxyUrl(u)) {
+    throw new Error('代理地址须以 http://、https://、socks5:// 或 socks4:// 开头')
+  }
+  return u
+}
+
+export function normalizeProviderProxyMode(mode: unknown): ProviderProxyMode {
+  if (mode === 'none' || mode === 'custom' || mode === 'inherit') return mode
+  return 'inherit'
+}
+
+/**
+ * Resolve outbound proxy for an LLM provider.
+ * Priority: provider custom > provider none (direct) > system > direct.
+ */
+export function resolveEffectiveProxyUrl(
+  provider: ProviderProxySettings | undefined | null,
+  system: SystemProxySettings | undefined | null,
+): string | undefined {
+  const mode = normalizeProviderProxyMode(provider?.mode)
+  if (mode === 'none') return undefined
+  if (mode === 'custom') {
+    const url = normalizeProxyUrlInput(provider?.url)
+    return url && isValidProxyUrl(url) ? url : undefined
+  }
+  if (system?.enabled) {
+    const url = normalizeProxyUrlInput(system.url)
+    if (url && isValidProxyUrl(url)) return url
+  }
+  return undefined
+}
+
+/** Mask credentials in proxy URL for logs / previews. */
+export function maskProxyUrlForDisplay(url: string): string {
+  const trimmed = url.trim()
+  if (!trimmed) return ''
+  try {
+    const parsed = new URL(trimmed)
+    if (parsed.password || parsed.username) {
+      parsed.username = parsed.username ? '***' : ''
+      parsed.password = parsed.password ? '***' : ''
+    }
+    return parsed.toString()
+  } catch {
+    return trimmed.replace(/\/\/[^@/]+@/, '//***@')
+  }
+}

--- a/tests/proxy-config.test.mjs
+++ b/tests/proxy-config.test.mjs
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  resolveEffectiveProxyUrl,
+  isValidProxyUrl,
+  validateProxyUrlInput,
+  normalizeProviderProxyMode,
+} from '@opptrix/shared'
+
+describe('proxy-config', () => {
+  it('validates http and socks proxy URLs', () => {
+    assert.equal(isValidProxyUrl('http://127.0.0.1:7890'), true)
+    assert.equal(isValidProxyUrl('https://proxy.local:8443'), true)
+    assert.equal(isValidProxyUrl('socks5://127.0.0.1:1080'), true)
+    assert.equal(isValidProxyUrl('socks4://127.0.0.1:1080'), true)
+    assert.equal(isValidProxyUrl('ftp://127.0.0.1:21'), false)
+    assert.equal(isValidProxyUrl('not-a-url'), false)
+  })
+
+  it('provider custom overrides system proxy', () => {
+    const system = { enabled: true, url: 'http://127.0.0.1:7890' }
+    const url = resolveEffectiveProxyUrl(
+      { mode: 'custom', url: 'socks5://127.0.0.1:1080' },
+      system,
+    )
+    assert.equal(url, 'socks5://127.0.0.1:1080')
+  })
+
+  it('provider none bypasses system proxy', () => {
+    const system = { enabled: true, url: 'http://127.0.0.1:7890' }
+    assert.equal(resolveEffectiveProxyUrl({ mode: 'none' }, system), undefined)
+  })
+
+  it('provider inherit uses system proxy when enabled', () => {
+    const system = { enabled: true, url: 'http://127.0.0.1:7890' }
+    assert.equal(
+      resolveEffectiveProxyUrl({ mode: 'inherit' }, system),
+      'http://127.0.0.1:7890',
+    )
+  })
+
+  it('falls back to direct when system disabled and provider inherits', () => {
+    assert.equal(
+      resolveEffectiveProxyUrl({ mode: 'inherit' }, { enabled: false }),
+      undefined,
+    )
+  })
+
+  it('normalizeProviderProxyMode defaults to inherit', () => {
+    assert.equal(normalizeProviderProxyMode(undefined), 'inherit')
+    assert.equal(normalizeProviderProxyMode('bogus'), 'inherit')
+  })
+
+  it('validateProxyUrlInput rejects invalid schemes', () => {
+    assert.throws(() => validateProxyUrlInput('ftp://x'), /代理地址/)
+  })
+})


### PR DESCRIPTION
## Summary
- Add system-level LLM proxy in Settings → General → Network with collapsible panel, switch-to-expand UX, and inline save on the address field.
- Add per-provider proxy mode (inherit system / direct / custom) in the provider wizard and wire proxy resolution through server, agent LLM calls, and remote translation.
- Introduce shared `proxy-config` helpers plus outbound fetch proxy agents; avoid importing `@opptrix/shared` barrel from client-ui to prevent browser bundle crashes.

## Test plan
- [x] `npm run build:packages`
- [x] `npm run check:ui`
- [x] `node --test tests/proxy-config.test.mjs`
- [ ] Configure system proxy in Settings → General → Network and verify LLM requests route correctly
- [ ] Override proxy per provider in model wizard (inherit / direct / custom)

Made with [Cursor](https://cursor.com)