### PR TITLE
feat(desktop): bootloader hook chain for startup and shutdown

### DIFF
--- a/apps/desktop/electron/bootloader-register.cjs
+++ b/apps/desktop/electron/bootloader-register.cjs
@@ -1,0 +1,100 @@
+/**
+ * Register desktop boot / shutdown hooks (wired from main.cjs).
+ * @param {ReturnType<import('./bootloader.cjs').createBootloader>} boot
+ * @param {object} deps
+ */
+'use strict'
+
+const { SIDECAR_GRACEFUL_MS } = require('./sidecar-supervisor.cjs')
+
+/**
+ * @param {ReturnType<import('./bootloader.cjs').createBootloader>} boot
+ * @param {{
+ *   initResolvedPorts: () => Promise<boolean>
+ *   tryQuickPendingUpdate: () => Promise<boolean>
+ *   tryDeferredPendingUpdate: () => Promise<void>
+ *   startSidecarHealthWatchdog: () => void
+ *   startScheduleReconcilePoll: () => void
+ *   initUpdater: () => void
+ *   maybeBootstrapOfflineModelDownloads: () => void
+ *   requestNotificationPermission: () => void
+ *   stopScheduleReconcilePoll: () => void
+ *   stopSidecarAndWait: (ms?: number) => Promise<void>
+ *   disposeTranslation: () => Promise<void> | void
+ *   destroyTray: () => void
+ *   intentionalSidecarStopRef: { current: boolean }
+ *   stopSidecarSupervision: () => void
+ * }} deps
+ */
+function registerDesktopBootloader(boot, deps) {
+  boot.clear()
+
+  boot.registerBootCritical(
+    'resolve-ports',
+    async () => {
+      const ok = await deps.initResolvedPorts()
+      if (!ok) {
+        throw new Error('无法解析本地 API 端口')
+      }
+    },
+    { timeoutMs: 20_000, required: true },
+  )
+
+  boot.registerBootCritical(
+    'pending-update-quick',
+    async (ctx) => {
+      const installing = await deps.tryQuickPendingUpdate()
+      if (installing) {
+        ctx.quittingForUpdate = true
+      }
+    },
+    { timeoutMs: 8_000, required: false },
+  )
+
+  boot.registerBootDeferred('sidecar-health-watchdog', async () => {
+    deps.startSidecarHealthWatchdog()
+  })
+
+  boot.registerBootDeferred('schedule-reconcile', async () => {
+    deps.startScheduleReconcilePoll()
+  })
+
+  boot.registerBootDeferred('updater-init', async () => {
+    deps.initUpdater()
+  })
+
+  boot.registerBootDeferred('translation-bootstrap', async () => {
+    deps.maybeBootstrapOfflineModelDownloads()
+  })
+
+  boot.registerBootDeferred('notification-permission', async () => {
+    deps.requestNotificationPermission()
+  })
+
+  boot.registerBootDeferred('pending-update-deferred', async () => {
+    await deps.tryDeferredPendingUpdate()
+  })
+
+  // Registration order = shutdown reverse (LIFO).
+  boot.registerShutdown('tray', async () => {
+    deps.destroyTray()
+  }, { timeoutMs: 2_000 })
+
+  boot.registerShutdown('translation', async () => {
+    await deps.disposeTranslation()
+  }, { timeoutMs: 4_000 })
+
+  boot.registerShutdown('sidecar', async () => {
+    deps.intentionalSidecarStopRef.current = true
+    deps.stopSidecarSupervision()
+    await deps.stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
+  }, { timeoutMs: SIDECAR_GRACEFUL_MS + 3_000 })
+
+  boot.registerShutdown('schedule-poll', async () => {
+    deps.stopScheduleReconcilePoll()
+  }, { timeoutMs: 2_000 })
+}
+
+module.exports = {
+  registerDesktopBootloader,
+}

--- a/apps/desktop/electron/bootloader.cjs
+++ b/apps/desktop/electron/bootloader.cjs
@@ -1,0 +1,160 @@
+/**
+ * Desktop boot / shutdown hook runner.
+ * Pure Node — no electron at module load.
+ *
+ * - Critical boot hooks: sequential, block UI until done (per-hook timeout).
+ * - Deferred boot hooks: fire-and-forget after shell ready; never block quit.
+ * - Shutdown hooks: sequential LIFO registration order, global deadline anti-deadlock.
+ */
+'use strict'
+
+/** Default per critical boot hook budget (sidecar cold start on Windows). */
+const BOOT_CRITICAL_DEFAULT_MS = 90_000
+
+/** Per deferred hook is not awaited; this is only for logging. */
+const BOOT_DEFERRED_LABEL = 'deferred'
+
+/** Must exceed SIDECAR_GRACEFUL_MS + SIDECAR_HARD_EXTRA_MS (~16.5s). */
+const SHUTDOWN_GLOBAL_MS = 20_000
+
+/** Single shutdown hook soft budget before skip. */
+const SHUTDOWN_HOOK_DEFAULT_MS = 16_000
+
+/**
+ * @param {Promise<unknown>} promise
+ * @param {number} ms
+ * @param {string} label
+ */
+function withTimeout(promise, ms, label) {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return Promise.resolve(promise)
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Hook timeout: ${label} (${ms}ms)`))
+    }, ms)
+    Promise.resolve(promise).then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+}
+
+/**
+ * @returns {{
+ *   registerBootCritical: (name: string, run: (ctx: object) => Promise<void> | void, opts?: { timeoutMs?: number, required?: boolean }) => void
+ *   registerBootDeferred: (name: string, run: (ctx: object) => Promise<void> | void) => void
+ *   registerShutdown: (name: string, run: (ctx: object) => Promise<void> | void, opts?: { timeoutMs?: number }) => void
+ *   runBootCritical: (ctx?: object) => Promise<void>
+ *   runBootDeferred: (ctx?: object) => void
+ *   runShutdown: (ctx?: object) => Promise<void>
+ *   clear: () => void
+ * }}
+ */
+function createBootloader() {
+  /** @type {Array<{ name: string, run: Function, timeoutMs: number, required: boolean }>} */
+  const bootCritical = []
+  /** @type {Array<{ name: string, run: Function }>} */
+  const bootDeferred = []
+  /** @type {Array<{ name: string, run: Function, timeoutMs: number }>} */
+  const shutdownHooks = []
+
+  return {
+    registerBootCritical(name, run, opts = {}) {
+      bootCritical.push({
+        name,
+        run,
+        timeoutMs: opts.timeoutMs ?? BOOT_CRITICAL_DEFAULT_MS,
+        required: opts.required !== false,
+      })
+    },
+
+    registerBootDeferred(name, run) {
+      bootDeferred.push({ name, run })
+    },
+
+    registerShutdown(name, run, opts = {}) {
+      shutdownHooks.push({
+        name,
+        run,
+        timeoutMs: opts.timeoutMs ?? SHUTDOWN_HOOK_DEFAULT_MS,
+      })
+    },
+
+    async runBootCritical(ctx = {}) {
+      for (const hook of bootCritical) {
+        const started = Date.now()
+        console.log(`[boot] critical → ${hook.name}`)
+        try {
+          await withTimeout(Promise.resolve().then(() => hook.run(ctx)), hook.timeoutMs, hook.name)
+          console.log(`[boot] critical ✓ ${hook.name} (${Date.now() - started}ms)`)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          console.error(`[boot] critical ✗ ${hook.name}: ${msg}`)
+          if (hook.required) {
+            throw err instanceof Error ? err : new Error(msg)
+          }
+        }
+      }
+    },
+
+    runBootDeferred(ctx = {}) {
+      for (const hook of bootDeferred) {
+        void Promise.resolve()
+          .then(() => hook.run(ctx))
+          .then(() => {
+            console.log(`[boot] ${BOOT_DEFERRED_LABEL} ✓ ${hook.name}`)
+          })
+          .catch((err) => {
+            const msg = err instanceof Error ? err.message : String(err)
+            console.warn(`[boot] ${BOOT_DEFERRED_LABEL} ✗ ${hook.name}: ${msg}`)
+          })
+      }
+    },
+
+    async runShutdown(ctx = {}) {
+      const deadline = Date.now() + SHUTDOWN_GLOBAL_MS
+      console.log('[shutdown] begin')
+      // LIFO — last registered runs first (UI-adjacent before infrastructure).
+      const chain = [...shutdownHooks].reverse()
+      for (const hook of chain) {
+        const remaining = deadline - Date.now()
+        if (remaining <= 0) {
+          console.warn(`[shutdown] global deadline (${SHUTDOWN_GLOBAL_MS}ms); skip ${hook.name}`)
+          break
+        }
+        const budget = Math.min(hook.timeoutMs, remaining)
+        const started = Date.now()
+        console.log(`[shutdown] → ${hook.name}`)
+        try {
+          await withTimeout(Promise.resolve().then(() => hook.run(ctx)), budget, hook.name)
+          console.log(`[shutdown] ✓ ${hook.name} (${Date.now() - started}ms)`)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          console.warn(`[shutdown] ✗ ${hook.name}: ${msg}`)
+        }
+      }
+      console.log('[shutdown] end')
+    },
+
+    clear() {
+      bootCritical.length = 0
+      bootDeferred.length = 0
+      shutdownHooks.length = 0
+    },
+  }
+}
+
+module.exports = {
+  createBootloader,
+  withTimeout,
+  BOOT_CRITICAL_DEFAULT_MS,
+  SHUTDOWN_GLOBAL_MS,
+  SHUTDOWN_HOOK_DEFAULT_MS,
+}

--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -10,6 +10,7 @@ const {
   waitForHealth: waitForSidecarHealth,
   stopChild,
   serverEntryPath,
+  sidecarHealthTimeoutMs,
 } = require('./os-schedule/sidecar-launch.cjs')
 const {
   SIDECAR_GRACEFUL_MS,
@@ -25,7 +26,7 @@ const { applyAppIcon, resolveAppIconPath } = require('./icon.cjs')
 const { configureAboutPanel, installApplicationMenu, listApplicationMenuTopItems, popupApplicationMenuAt } = require('./menu.cjs')
 const { hardenWebContents, mainWindowWebPreferences } = require('./security.cjs')
 const { clearMacAppQuarantine } = require('./clear-mac-quarantine.cjs')
-const { initUpdater, registerUpdaterIpc, resumePendingUpdateOnStartup, isUpdateReady, installPendingUpdate } = require('./updater.cjs')
+const { initUpdater, registerUpdaterIpc, tryQuickPendingUpdateOnStartup, tryDeferredPendingUpdateOnStartup, isUpdateReady, installPendingUpdate } = require('./updater.cjs')
 const {
   deliverProtocolUrl,
   findProtocolUrl,
@@ -70,8 +71,16 @@ const {
   resolveApiPort,
   resolveWebPort,
   logPortPlan,
+  forceReleaseApiPort,
 } = require('./resolve-ports.cjs')
+const { createBootloader } = require('./bootloader.cjs')
+const { registerDesktopBootloader } = require('./bootloader-register.cjs')
 const windowState = require('./window-state.cjs')
+
+/** Unified boot / shutdown hook runner (see bootloader-register.cjs). */
+const boot = createBootloader()
+let bootHooksRegistered = false
+let shutdownChainRunning = false
 
 const isDev = !app.isPackaged
 const launchArgs = parseLaunchArgs()
@@ -287,6 +296,58 @@ function stopSidecarSupervision() {
   }
 }
 
+function registerBootHooksIfNeeded() {
+  if (bootHooksRegistered) return
+  bootHooksRegistered = true
+  registerDesktopBootloader(boot, {
+    initResolvedPorts,
+    tryQuickPendingUpdate: async () => {
+      const quitting = await tryQuickPendingUpdateOnStartup({ version: VERSION })
+      return quitting
+    },
+    tryDeferredPendingUpdate: () => tryDeferredPendingUpdateOnStartup({ version: VERSION }),
+    startSidecarHealthWatchdog,
+    startScheduleReconcilePoll,
+    initUpdater: () => initUpdater({ version: VERSION }),
+    maybeBootstrapOfflineModelDownloads: () => {
+      void maybeBootstrapOfflineModelDownloads(repoRoot(), progress => {
+        for (const win of BrowserWindow.getAllWindows()) {
+          if (!win.isDestroyed()) {
+            win.webContents.send('translation-download-progress', progress)
+          }
+        }
+      })
+    },
+    requestNotificationPermission: () => {
+      if (app.isPackaged) void requestNotificationPermission()
+    },
+    stopScheduleReconcilePoll,
+    stopSidecarAndWait,
+    disposeTranslation,
+    destroyTray,
+    intentionalSidecarStopRef: {
+      get current() { return intentionalSidecarStop },
+      set current(v) { intentionalSidecarStop = v },
+    },
+    stopSidecarSupervision,
+  })
+}
+
+async function runShutdownChain(reason) {
+  if (shutdownChainRunning) return
+  shutdownChainRunning = true
+  app.isQuitting = true
+  intentionalSidecarStop = true
+  try {
+    registerBootHooksIfNeeded()
+    await boot.runShutdown({ reason })
+    sidecarQuitPrepared = true
+    serverProcess = null
+  } finally {
+    shutdownChainRunning = false
+  }
+}
+
 function spawnSidecar() {
   const root = repoRoot()
   const entry = serverEntryPath(root)
@@ -322,7 +383,7 @@ function spawnSidecar() {
   return serverProcess
 }
 
-async function waitForHealth(timeoutMs = 30_000) {
+async function waitForHealth(timeoutMs = sidecarHealthTimeoutMs(isDev)) {
   await waitForSidecarHealth(API_HOST, API_PORT, timeoutMs)
 }
 
@@ -705,9 +766,6 @@ function prepareForUpdateInstall() {
   app.isUpdating = true
   app.isQuitting = true
   prepareForUpdateInstallPromise = (async () => {
-    // 1) 停主进程内调度轮询，避免安装窗口期再 reconcile / 拉起 tick
-    stopScheduleReconcilePoll()
-    // 2) 卸掉 OS 级 tick（launchd / schtasks / systemd），防止第二实例顶上
     try {
       const paused = await pauseOsScheduleForUpdateInstall()
       if (!paused.ok) {
@@ -716,11 +774,7 @@ function prepareForUpdateInstall() {
     } catch (err) {
       console.warn('[updater] pause OS schedule tick failed:', err)
     }
-    // 3) 托盘会让进程在关窗后仍存活；安装前必须拆掉
-    destroyTray()
-    // 4) sidecar 可能正跑计划任务；宽限原生模块关闭后再强杀，再交给 ShipIt
-    await stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
-    sidecarQuitPrepared = true
+    await runShutdownChain('update-install')
     for (const win of BrowserWindow.getAllWindows()) {
       if (win.isDestroyed()) continue
       try {
@@ -731,7 +785,7 @@ function prepareForUpdateInstall() {
         /* ignore */
       }
     }
-    // 5) 强杀同 bundle / 安装目录残留（Helper、孤儿实例、sidecar 孙进程等），排除 self
+    // 强杀同 bundle / 安装目录残留（Helper、孤儿实例、sidecar 孙进程等），排除 self
     try {
       await killResidualAppProcessesForUpdate()
     } catch (err) {
@@ -751,13 +805,7 @@ async function quitApp() {
     return
   }
   if (app.isUpdating) return
-  app.isQuitting = true
-  intentionalSidecarStop = true
-  stopSidecarSupervision()
-  stopScheduleReconcilePoll()
-  destroyTray()
-  await stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
-  sidecarQuitPrepared = true
+  await runShutdownChain('quit-app')
   allowQuit = true
   for (const win of BrowserWindow.getAllWindows()) {
     if (win.isDestroyed()) continue
@@ -769,7 +817,6 @@ async function quitApp() {
     }
   }
   app.quit()
-  // Windows / Linux：托盘或 AppImage 更新后偶发不退；短超时强制 exit（更新路径另有 scheduleInstallExitGuards）
   if (process.platform === 'win32' || process.platform === 'linux') {
     setTimeout(() => {
       if (app.isUpdating) return
@@ -1046,16 +1093,15 @@ async function loadAppInMainWindow(win, { enforceMinSplash = true, sidecarAlread
   }
 }
 
-async function ensureSidecarReady() {
+async function ensureSidecarReadyOnce(timeoutMs) {
   if (isDev) {
-    await waitForHealth()
+    await waitForHealth(timeoutMs)
     return
   }
   if (apiPortMode === 'reuse') {
-    await waitForHealth()
+    await waitForHealth(timeoutMs)
     return
   }
-  // Spawn 前先 probe：托盘二次唤起 / second-instance 等场景下健康窗可 reuse，避免双开
   if (!serverProcess) {
     const healthy = await probeSidecarHealth(2500)
     if (healthy) {
@@ -1064,7 +1110,29 @@ async function ensureSidecarReady() {
     }
     spawnSidecar()
   }
-  await waitForHealth()
+  await waitForHealth(timeoutMs)
+}
+
+async function ensureSidecarReady() {
+  const timeoutMs = sidecarHealthTimeoutMs(isDev)
+  try {
+    await ensureSidecarReadyOnce(timeoutMs)
+  } catch (firstErr) {
+    if (isDev || apiPortMode === 'reuse') throw firstErr
+    console.warn(
+      '[sidecar] ensure failed; releasing port and retrying once:',
+      firstErr instanceof Error ? firstErr.message : firstErr,
+    )
+    await forceReleaseApiPort(Number(API_PORT), { maxPasses: 3 })
+    if (serverProcess) {
+      intentionalSidecarStop = true
+      await stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
+      intentionalSidecarStop = false
+    }
+    apiPortMode = 'use'
+    spawnSidecar()
+    await waitForHealth(timeoutMs)
+  }
 }
 
 async function bootstrapApp({ withSplash = true } = {}) {
@@ -1142,7 +1210,6 @@ async function bootstrapBackgroundApp() {
   await reconcileOsSchedule().catch((err) => {
     console.warn('[schedule] reconcile failed:', err instanceof Error ? err.message : err)
   })
-  startScheduleReconcilePoll()
 }
 
 /**
@@ -1150,13 +1217,7 @@ async function bootstrapBackgroundApp() {
  * 新注册的 OS tick 不再指向此路径（见 headless-tick.cjs）。
  */
 async function exitAfterEphemeralScheduleTick() {
-  app.isQuitting = true
-  intentionalSidecarStop = true
-  stopSidecarSupervision()
-  stopScheduleReconcilePoll()
-  destroyTray()
-  await stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
-  sidecarQuitPrepared = true
+  await runShutdownChain('schedule-tick-exit')
   allowQuit = true
   app.quit()
   if (process.platform === 'win32' || process.platform === 'linux') {
@@ -1210,7 +1271,6 @@ async function bootstrapForegroundApp({ withSplash = true } = {}) {
   await reconcileOsSchedule().catch((err) => {
     console.warn('[schedule] reconcile failed:', err instanceof Error ? err.message : err)
   })
-  startScheduleReconcilePoll()
   return true
 }
 
@@ -1644,16 +1704,18 @@ if (!gotTheLock) {
     setupDesktopChrome()
     registerWindowIpc()
 
-    const portsOk = await initResolvedPorts()
-    if (!portsOk) {
+    registerBootHooksIfNeeded()
+    /** @type {{ quittingForUpdate?: boolean }} */
+    const bootCtx = {}
+    try {
+      await boot.runBootCritical(bootCtx)
+    } catch (err) {
+      console.error('[boot] critical chain failed:', err instanceof Error ? err.message : err)
       app.quit()
       return
     }
-
-    if (app.isPackaged) {
-      const quittingForUpdate = await resumePendingUpdateOnStartup({ version: VERSION })
-      // true：已 destroy 窗口并进入 quitAndInstall；退出/恢复看门狗在 updater.triggerInstall
-      if (quittingForUpdate) return
+    if (bootCtx.quittingForUpdate) {
+      return
     }
 
     await continueDesktopBootstrap({
@@ -1715,20 +1777,7 @@ if (!gotTheLock) {
     if (launchUrl) deliverProtocolUrl(launchUrl)
     else flushPendingProtocolUrl()
 
-    if (app.isPackaged) {
-      void requestNotificationPermission()
-    }
-
-    // 本地翻译模型按需加载（首次 translate / 显式 preload），启动不占显存
-    void maybeBootstrapOfflineModelDownloads(repoRoot(), progress => {
-      for (const win of BrowserWindow.getAllWindows()) {
-        if (!win.isDestroyed()) {
-          win.webContents.send('translation-download-progress', progress)
-        }
-      }
-    })
-    initUpdater({ version: VERSION })
-    startSidecarHealthWatchdog()
+    boot.runBootDeferred({ background, withSplash })
     return true
   }
 
@@ -1747,61 +1796,33 @@ if (!gotTheLock) {
     // 更新安装中由 quitAndInstall 接管退出；勿抢先 app.quit()
     if (app.isUpdating) return
     if (app.isPackaged && hasTray()) return
-    // quitApp / before-quit 已在停 sidecar：勿双重 SIGKILL
     if (app.isQuitting) {
       if (allowQuit || sidecarQuitPrepared || !serverProcess) {
         app.quit()
       }
       return
     }
-    app.isQuitting = true
-    intentionalSidecarStop = true
-    stopSidecarSupervision()
-    void (async () => {
-      await stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
-      sidecarQuitPrepared = true
+    void runShutdownChain('window-all-closed').then(() => {
       allowQuit = true
       app.quit()
-    })()
+    })
   })
 
   app.on('before-quit', (event) => {
     app.isQuitting = true
-    intentionalSidecarStop = true
-    stopSidecarSupervision()
-    stopScheduleReconcilePoll()
-
     if (allowQuit || sidecarQuitPrepared) {
-      destroyTray()
       void disposeTranslation()
       return
     }
-
-    // quitApp 等路径已等过 sidecar（process 已 null）→ 直接放行
-    if (!serverProcess || serverProcess.killed || serverProcess.exitCode != null) {
-      serverProcess = null
-      sidecarQuitPrepared = true
-      destroyTray()
-      void disposeTranslation()
+    if (shutdownChainRunning) {
+      event.preventDefault()
       return
     }
-
-    // Cmd+Q：先宽限停 sidecar，再允许真正退出（避免硬杀原生模块导致 SIGABRT）
     event.preventDefault()
-    void (async () => {
-      try {
-        await stopSidecarAndWait(SIDECAR_GRACEFUL_MS)
-      } catch (err) {
-        console.warn(
-          '[sidecar] graceful stop on quit failed:',
-          err instanceof Error ? err.message : err,
-        )
-      }
-      sidecarQuitPrepared = true
+    void runShutdownChain('before-quit').then(() => {
       allowQuit = true
-      destroyTray()
       void disposeTranslation()
       app.quit()
-    })()
+    })
   })
 }

--- a/apps/desktop/electron/os-schedule/sidecar-launch.cjs
+++ b/apps/desktop/electron/os-schedule/sidecar-launch.cjs
@@ -176,7 +176,15 @@ function sleep(ms) {
  * @param {string | number} port
  * @param {number} [timeoutMs]
  */
-async function waitForHealth(host, port, timeoutMs = 30_000) {
+/** Packaged cold start (Windows AV / native modules) may exceed 30s. */
+const SIDECAR_HEALTH_TIMEOUT_DEV_MS = 30_000
+const SIDECAR_HEALTH_TIMEOUT_PACKAGED_MS = 60_000
+
+function sidecarHealthTimeoutMs(isDev) {
+  return isDev ? SIDECAR_HEALTH_TIMEOUT_DEV_MS : SIDECAR_HEALTH_TIMEOUT_PACKAGED_MS
+}
+
+async function waitForHealth(host, port, timeoutMs = SIDECAR_HEALTH_TIMEOUT_PACKAGED_MS) {
   const url = `http://${host}:${port}/api/health`
   const started = Date.now()
   while (Date.now() - started < timeoutMs) {
@@ -269,4 +277,7 @@ module.exports = {
   stopChildAndWait,
   SIDECAR_GRACEFUL_MS,
   SIDECAR_HARD_EXTRA_MS,
+  SIDECAR_HEALTH_TIMEOUT_DEV_MS,
+  SIDECAR_HEALTH_TIMEOUT_PACKAGED_MS,
+  sidecarHealthTimeoutMs,
 }

--- a/apps/desktop/electron/resolve-ports.cjs
+++ b/apps/desktop/electron/resolve-ports.cjs
@@ -3,7 +3,7 @@
  * Used by Electron main (production) and dev launch scripts.
  */
 const net = require('node:net')
-const { execSync } = require('node:child_process')
+const { execSync, spawnSync } = require('node:child_process')
 
 const API_HOST = '127.0.0.1'
 const DEFAULT_API_PORT = 8711
@@ -115,7 +115,9 @@ function getProcessCommand(pid) {
 
 function isOpptrixServerCommand(command) {
   if (!command) return false
-  return /apps[\\/]+server[\\/]+dist[\\/]+index\.js|@opptrix[\\/]+server|stock-research|opptrix/i.test(command)
+  return /apps[\\/]+server[\\/]+dist[\\/]+index\.js|runtime-stage[\\/].*index\.js|@opptrix[\\/]+server|stock-research|opptrix\.exe.*index\.js|ELECTRON_RUN_AS_NODE/i.test(
+    command,
+  )
 }
 
 function isOpptrixViteCommand(command) {
@@ -132,6 +134,37 @@ async function waitForPortFree(port, timeoutMs = 5000) {
   return !(await isPortListening(port))
 }
 
+/**
+ * Windows: taskkill /T kills child tree (sidecar under Opptrix.exe).
+ * @param {number} pid
+ * @param {boolean} [force]
+ */
+function killPidTree(pid, force = false) {
+  if (!Number.isFinite(pid) || pid <= 0 || pid === process.pid) return false
+  if (process.platform === 'win32') {
+    try {
+      const args = force
+        ? ['/F', '/T', '/PID', String(pid)]
+        : ['/PID', String(pid), '/T']
+      const result = spawnSync('taskkill', args, {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true,
+        timeout: 4000,
+      })
+      return result.status === 0 || /not found|no running instance|找不到/i.test(String(result.stderr ?? ''))
+    } catch {
+      return false
+    }
+  }
+  try {
+    process.kill(pid, force ? 'SIGKILL' : 'SIGTERM')
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function tryCleanupStaleListeners(port, { forWeb = false, aggressive = false } = {}) {
   const pids = getListenPids(port)
   let killed = false
@@ -141,33 +174,47 @@ async function tryCleanupStaleListeners(port, { forWeb = false, aggressive = fal
     const command = getProcessCommand(pid)
     const matches = forWeb ? isOpptrixViteCommand(command) : isOpptrixServerCommand(command)
     if (!matches && !aggressive) continue
-    try {
-      process.kill(pid, 'SIGTERM')
-      killed = true
-    } catch {
-      /* ignore */
-    }
+    if (killPidTree(pid, false)) killed = true
   }
 
   if (killed) {
-    const freed = await waitForPortFree(port, 4000)
+    const freed = await waitForPortFree(port, 5000)
     if (!freed) {
       for (const pid of getListenPids(port)) {
         if (pid === process.pid) continue
         const command = getProcessCommand(pid)
         const matches = forWeb ? isOpptrixViteCommand(command) : isOpptrixServerCommand(command)
         if (!matches && !aggressive) continue
-        try {
-          process.kill(pid, 'SIGKILL')
-          killed = true
-        } catch {
-          /* ignore */
-        }
+        if (killPidTree(pid, true)) killed = true
       }
-      await sleep(300)
+      await waitForPortFree(port, 3000)
     }
   }
   return killed
+}
+
+/**
+ * Aggressive multi-pass cleanup until port is free or health is Opptrix-ok.
+ * @param {number} port
+ * @param {{ maxPasses?: number, waitMs?: number }} [opts]
+ */
+async function forceReleaseApiPort(port, opts = {}) {
+  const maxPasses = opts.maxPasses ?? 3
+  const waitMs = opts.waitMs ?? 5000
+  let cleaned = false
+  for (let pass = 0; pass < maxPasses; pass++) {
+    const health = await probeOpptrixHealth(port)
+    if (health) return { released: false, reused: true, health, cleaned }
+    if (!(await isPortListening(port))) {
+      return { released: true, reused: false, cleaned }
+    }
+    cleaned = (await tryCleanupStaleListeners(port, { aggressive: true })) || cleaned
+    if (await waitForPortFree(port, waitMs)) {
+      return { released: true, reused: false, cleaned }
+    }
+    await sleep(200)
+  }
+  return { released: !(await isPortListening(port)), reused: false, cleaned }
 }
 
 /** Force-clean Opptrix API listeners on a port (SIGTERM → SIGKILL). */
@@ -206,10 +253,14 @@ async function resolveApiPort(opts = {}) {
     return { port: base, mode: 'use' }
   }
 
-  // 端口占用但 health 不通 — 多为 K 线导入等卡死的事件循环，视为僵尸 sidecar
+  // 端口占用但 health 不通 — 多为僵尸 sidecar；强制多轮清理（Win taskkill /T）
   const staleSidecar = !health
   if (allowCleanup) {
-    await tryCleanupStaleListeners(base, { aggressive: staleSidecar })
+    if (staleSidecar) {
+      await forceReleaseApiPort(base, { maxPasses: 3 })
+    } else {
+      await tryCleanupStaleListeners(base, { aggressive: false })
+    }
     if (!(await isPortListening(base))) {
       return { port: base, mode: 'use', cleaned: true }
     }
@@ -335,6 +386,7 @@ module.exports = {
   applyPortEnv,
   cleanupStaleApiListeners,
   describePortPlan,
+  forceReleaseApiPort,
   isPortListening,
   logPortPlan,
   probeOpptrixHealth,

--- a/apps/desktop/electron/updater.cjs
+++ b/apps/desktop/electron/updater.cjs
@@ -79,6 +79,10 @@ let installExitWatchdogScheduled = false
 const INSTALL_FORCE_EXIT_MS = 3_000
 const INSTALL_STALL_RECOVER_MS = 12_000
 
+/** Startup: do not block UI/bootstrap longer than this for hydrate + install. */
+const STARTUP_UPDATE_QUICK_MS = 6_000
+const STARTUP_UPDATE_DEFERRED_MS = 25_000
+
 function broadcast(channel, payload) {
   for (const win of BrowserWindow.getAllWindows()) {
     if (!win.isDestroyed()) {
@@ -460,10 +464,11 @@ function waitForHydratedUpdate(currentVersion, timeoutMs = 20_000) {
 }
 
 /**
- * 启动第一时间：若本地已有比当前版本新的待安装包，则跳过 UI/bootstrap，直接退出并安装。
- * 防循环：同一 pending 包在窗口期内失败次数有上限，超出后仅提示手动安装。
+ * 启动第一时间：若本地已有比当前版本新的待安装包，则尝试退出并安装。
+ * @param {{ version: string, hydrateTimeoutMs?: number }} opts
+ * @returns {Promise<boolean>} true = 已进入安装退出路径
  */
-async function resumePendingUpdateOnStartup({ version }) {
+async function resumePendingUpdateOnStartup({ version, hydrateTimeoutMs = 20_000 }) {
   if (!app.isPackaged || !autoUpdater || shouldSkipStartupResume()) {
     return false
   }
@@ -487,8 +492,9 @@ async function resumePendingUpdateOnStartup({ version }) {
   attachNativeBeforeQuitHook()
   bindAutoUpdaterEvents(version)
 
-  const hydratedVersion = await waitForHydratedUpdate(version)
+  const hydratedVersion = await waitForHydratedUpdate(version, hydrateTimeoutMs)
   if (!hydratedVersion || !isVersionNewer(hydratedVersion, version)) {
+    console.warn('[updater] startup resume: update not hydrated yet; deferring')
     return false
   }
 
@@ -496,6 +502,26 @@ async function resumePendingUpdateOnStartup({ version }) {
     targetVersion: hydratedVersion,
     cacheKey: pending.cacheKey,
     source: 'startup',
+  })
+}
+
+/** 短超时快速尝试（不阻塞 UI）；失败则 deferred 钩子再试。 */
+async function tryQuickPendingUpdateOnStartup({ version }) {
+  return resumePendingUpdateOnStartup({
+    version,
+    hydrateTimeoutMs: STARTUP_UPDATE_QUICK_MS,
+  })
+}
+
+/** UI 就绪后后台再试一次 pending 安装。 */
+async function tryDeferredPendingUpdateOnStartup({ version }) {
+  if (!app.isPackaged || !autoUpdater) return
+  const pending = readPendingDownloadFromDisk()
+  if (!pending?.version || !isVersionNewer(pending.version, version)) return
+  if (status.state === 'installing') return
+  await resumePendingUpdateOnStartup({
+    version,
+    hydrateTimeoutMs: STARTUP_UPDATE_DEFERRED_MS,
   })
 }
 

--- a/tests/desktop-bootloader.test.mjs
+++ b/tests/desktop-bootloader.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * Desktop bootloader hook runner — unit contracts (no Electron).
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createBootloader, withTimeout, SHUTDOWN_GLOBAL_MS } from '../apps/desktop/electron/bootloader.cjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainCjs = fs.readFileSync(path.join(here, '../apps/desktop/electron/main.cjs'), 'utf8')
+const registerCjs = fs.readFileSync(
+  path.join(here, '../apps/desktop/electron/bootloader-register.cjs'),
+  'utf8',
+)
+
+describe('bootloader withTimeout', () => {
+  it('resolves when promise completes within budget', async () => {
+    const value = await withTimeout(Promise.resolve(42), 500, 'fast')
+    assert.equal(value, 42)
+  })
+
+  it('rejects when promise exceeds budget', async () => {
+    await assert.rejects(
+      () =>
+        withTimeout(
+          new Promise((resolve) => setTimeout(() => resolve('late'), 80)),
+          20,
+          'slow-hook',
+        ),
+      /Hook timeout: slow-hook/,
+    )
+  })
+})
+
+describe('bootloader runBootCritical', () => {
+  it('continues optional hooks after failure', async () => {
+    const boot = createBootloader()
+    const log = []
+    boot.registerBootCritical('required-ok', async () => {
+      log.push('a')
+    })
+    boot.registerBootCritical(
+      'optional-fail',
+      async () => {
+        throw new Error('boom')
+      },
+      { required: false },
+    )
+    boot.registerBootCritical('after-optional', async () => {
+      log.push('b')
+    })
+    await boot.runBootCritical()
+    assert.deepEqual(log, ['a', 'b'])
+  })
+
+  it('throws on required hook failure', async () => {
+    const boot = createBootloader()
+    boot.registerBootCritical(
+      'must-fail',
+      async () => {
+        throw new Error('fatal')
+      },
+      { required: true },
+    )
+    await assert.rejects(() => boot.runBootCritical(), /fatal/)
+  })
+
+  it('passes ctx through critical chain', async () => {
+    const boot = createBootloader()
+    boot.registerBootCritical('set-flag', async (ctx) => {
+      ctx.quittingForUpdate = true
+    })
+    const ctx = {}
+    await boot.runBootCritical(ctx)
+    assert.equal(ctx.quittingForUpdate, true)
+  })
+})
+
+describe('bootloader runShutdown anti-deadlock', () => {
+  it('runs hooks LIFO and skips remaining after global deadline', async () => {
+    const boot = createBootloader()
+    const order = []
+    boot.registerShutdown('first-registered', async () => {
+      order.push('first-registered')
+    })
+    boot.registerShutdown('second', async () => {
+      order.push('second')
+      await new Promise((r) => setTimeout(r, 30))
+    })
+    boot.registerShutdown('third', async () => {
+      order.push('third')
+      await new Promise((r) => setTimeout(r, SHUTDOWN_GLOBAL_MS + 200))
+    })
+    const t0 = Date.now()
+    await boot.runShutdown()
+    assert.ok(Date.now() - t0 < SHUTDOWN_GLOBAL_MS + 500, 'shutdown must not hang past global deadline')
+    assert.deepEqual(order, ['third', 'second', 'first-registered'])
+  })
+
+  it('continues after a hook times out', async () => {
+    const boot = createBootloader()
+    const order = []
+    boot.registerShutdown(
+      'slow',
+      async () => {
+        order.push('slow-start')
+        await new Promise((r) => setTimeout(r, 200))
+        order.push('slow-end')
+      },
+      { timeoutMs: 30 },
+    )
+    boot.registerShutdown('fast', async () => {
+      order.push('fast')
+    })
+    await boot.runShutdown()
+    assert.deepEqual(order, ['fast', 'slow-start'])
+  })
+})
+
+describe('main.cjs bootloader wiring', () => {
+  it('whenReady runs critical boot before continueDesktopBootstrap', () => {
+    const whenReady = mainCjs.slice(mainCjs.indexOf('app.whenReady().then'))
+    assert.match(whenReady, /registerBootHooksIfNeeded\(\)/)
+    assert.match(whenReady, /await boot\.runBootCritical\(bootCtx\)/)
+    assert.match(whenReady, /bootCtx\.quittingForUpdate/)
+    assert.match(whenReady, /await continueDesktopBootstrap/)
+    const criticalAt = whenReady.indexOf('runBootCritical')
+    const bootstrapAt = whenReady.indexOf('continueDesktopBootstrap')
+    assert.ok(criticalAt < bootstrapAt)
+  })
+
+  it('continueDesktopBootstrap defers non-critical startup work', () => {
+    const start = mainCjs.indexOf('async function continueDesktopBootstrap(opts')
+    assert.ok(start >= 0, 'continueDesktopBootstrap missing')
+    const end = mainCjs.indexOf('recoverDesktopAfterUpdateStall = async', start)
+    assert.ok(end > start, 'continueDesktopBootstrap end marker missing')
+    const fn = mainCjs.slice(start, end)
+    assert.match(fn, /boot\.runBootDeferred/)
+    assert.doesNotMatch(fn, /void requestNotificationPermission\(\)/)
+    assert.doesNotMatch(fn, /void maybeBootstrapOfflineModelDownloads/)
+    assert.doesNotMatch(fn, /startSidecarHealthWatchdog\(\)/)
+  })
+
+  it('quit paths use unified runShutdownChain', () => {
+    assert.match(mainCjs, /async function runShutdownChain\(reason\)/)
+    assert.match(mainCjs, /await runShutdownChain\('quit-app'\)/)
+    assert.match(mainCjs, /runShutdownChain\('before-quit'\)/)
+    assert.match(mainCjs, /runShutdownChain\('window-all-closed'\)/)
+    assert.match(mainCjs, /runShutdownChain\('update-install'\)/)
+  })
+})
+
+describe('bootloader-register hooks', () => {
+  it('registers port resolve + quick update as critical', () => {
+    assert.match(registerCjs, /registerBootCritical\(\s*'resolve-ports'/)
+    assert.match(registerCjs, /registerBootCritical\(\s*'pending-update-quick'/)
+    assert.match(registerCjs, /ctx\.quittingForUpdate = true/)
+  })
+
+  it('registers deferred startup tasks', () => {
+    for (const name of [
+      'sidecar-health-watchdog',
+      'schedule-reconcile',
+      'updater-init',
+      'translation-bootstrap',
+      'notification-permission',
+      'pending-update-deferred',
+    ]) {
+      assert.match(registerCjs, new RegExp(`registerBootDeferred\\('${name}'`))
+    }
+  })
+
+  it('shutdown hooks run LIFO (schedule before sidecar before tray)', () => {
+    const trayAt = registerCjs.indexOf("registerShutdown('tray'")
+    const sidecarAt = registerCjs.indexOf("registerShutdown('sidecar'")
+    const scheduleAt = registerCjs.indexOf("registerShutdown('schedule-poll'")
+    assert.ok(trayAt < sidecarAt && sidecarAt < scheduleAt, 'registration order defines LIFO shutdown')
+  })
+})

--- a/tests/desktop-startup-accel.test.mjs
+++ b/tests/desktop-startup-accel.test.mjs
@@ -105,5 +105,7 @@ describe('desktop splash ∥ sidecar + reuse probe', () => {
     assert.ok(probeAt >= 0, 'probeSidecarHealth required before spawn')
     assert.ok(spawnAt > probeAt, 'probe must precede spawn')
     assert.match(body, /apiPortMode\s*=\s*['"]reuse['"]/)
+    assert.match(body, /forceReleaseApiPort/)
+    assert.match(body, /retrying once/)
   })
 })


### PR DESCRIPTION
## Summary
- Add unified bootloader hook runner with critical boot, deferred boot, and LIFO shutdown chains plus per-hook and global anti-deadlock timeouts.
- Wire desktop startup so port cleanup and quick pending updates run before UI, while watchdog/updater/translation/notification/deferred update run asynchronously after shell ready.
- Unify quit paths (tray, before-quit, window-all-closed, update install, schedule tick) through `runShutdownChain`, with stronger Windows port release and sidecar health retry.

## Test plan
- [x] `node --test tests/desktop-bootloader.test.mjs tests/desktop-startup-accel.test.mjs`
- [ ] Windows cold start with stale API port on 8711
- [ ] Pending update package with slow hydrate: UI should still appear, deferred install may retry
- [ ] Quit via tray / Cmd+Q / last window close completes within shutdown deadline


Made with [Cursor](https://cursor.com)