### PR TITLE
feat(market): CN hot board and market dynamics fetch optimizations

### DIFF
--- a/apps/desktop/electron/updater.cjs
+++ b/apps/desktop/electron/updater.cjs
@@ -693,6 +693,8 @@ module.exports = {
   initUpdater,
   registerUpdaterIpc,
   resumePendingUpdateOnStartup,
+  tryQuickPendingUpdateOnStartup,
+  tryDeferredPendingUpdateOnStartup,
   isUpdateReady,
   installPendingUpdate,
 }

--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -303,13 +303,34 @@ export const research = {
   marketRegime: (scope: 'cn' | 'us' = 'cn') =>
     apiCall<import('../types/schemas').MarketRegimeData>('market_regime', { profile_scope: scope }),
 
-  marketDynamics: (opts?: { market?: 'cn' | 'us' | 'hk' }) =>
+  marketDynamics: (opts?: { market?: 'cn' | 'us' | 'hk'; refresh?: boolean }) =>
     apiCall<import('../types/schemas').MarketDynamicsData>(
       'market_dynamics',
-      { market: opts?.market ?? 'cn' },
+      { market: opts?.market ?? 'cn', ...(opts?.refresh ? { refresh: true } : {}) },
       undefined,
       35000,
     ),
+
+  cnMarketSpecial: (params: {
+    kind: 'skyrocket' | 'hot_stock' | 'hot_history' | string
+    date?: string
+    code?: string
+    start?: string
+    end?: string
+  }) =>
+    apiCall<{
+      kind: string
+      items: Record<string, unknown>[]
+      count: number
+      source?: string
+    }>('cn_market_special', params, undefined, 25000),
+
+  tradeCalendar: (year?: number) =>
+    apiCall<{
+      year: number
+      items: Array<{ date: string; isTradeDay?: boolean }>
+      count: number
+    }>('trade_calendar', { year: year ?? new Date().getFullYear() }, undefined, 20000),
 
   indexConstituents: (indexCode: string, opts?: { withQuotes?: boolean; quoteLimit?: number }) =>
     apiCall<import('../types/schemas').IndexConstituentsData>(

--- a/client-ui/src/pages/market-dynamics/CnHotBoardPanel.tsx
+++ b/client-ui/src/pages/market-dynamics/CnHotBoardPanel.tsx
@@ -1,0 +1,239 @@
+import { useMemo, useState } from 'react'
+import { Input, Spinner, Text, makeStyles } from '@fluentui/react-components'
+import type { MarketHotItem } from '../../types/schemas'
+import CnDashboardFlexPanel from './CnDashboardFlexPanel'
+import CnInsightSplitView from './CnInsightSplitView'
+import type { CnInsightStockPick } from './cnInsightStockUtils'
+import { CnInsightListPad, CnInsightStockRow } from './cnInsightListStyles'
+import { CnInsightListSkeleton } from './cnDashboardSkeletons'
+import { hotBoardRowMeta } from './cnHotBoardUtils'
+import { useCnHotBoardHistory } from './useCnHotBoardHistory'
+import { opptrixCssVars } from '../../theme/tokens'
+
+type HotBoardTab = 'skyrocket' | 'hot' | 'history'
+
+const TAB_ITEMS: { value: HotBoardTab; label: string }[] = [
+  { value: 'skyrocket', label: '飙升榜' },
+  { value: 'hot', label: '热股榜' },
+  { value: 'history', label: '历史排行' },
+]
+
+const useStyles = makeStyles({
+  body: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  dateRow: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    padding: '8px 12px 0',
+  },
+  dateLabel: {
+    fontSize: 'var(--opptrix-font-xs)',
+    fontWeight: 600,
+    color: opptrixCssVars.textTertiary,
+    whiteSpace: 'nowrap',
+  },
+  dateInput: {
+    flex: 1,
+    minWidth: 0,
+    maxWidth: '160px',
+  },
+  dateHint: {
+    fontSize: '10px',
+    color: opptrixCssVars.textTertiary,
+    whiteSpace: 'nowrap',
+  },
+  scroll: {
+    flex: 1,
+    minHeight: 0,
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  loading: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '8px',
+    color: opptrixCssVars.textTertiary,
+    fontSize: 'var(--opptrix-font-sm)',
+  },
+  empty: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '6px',
+    padding: '20px 14px',
+    textAlign: 'center',
+    color: opptrixCssVars.textTertiary,
+    fontSize: 'var(--opptrix-font-sm)',
+    lineHeight: 1.55,
+  },
+})
+
+type Props = {
+  skyrocket?: MarketHotItem[]
+  hotStocks?: MarketHotItem[]
+  loading?: boolean
+  emotionSource?: 'tonghuashun' | null
+}
+
+function HotBoardList({
+  items,
+  emptyTitle,
+  emptyHint,
+}: {
+  items: MarketHotItem[]
+  emptyTitle: string
+  emptyHint: string
+}) {
+  const s = useStyles()
+  if (!items.length) {
+    return (
+      <div className={s.empty}>
+        <div>{emptyTitle}</div>
+        <div>{emptyHint}</div>
+      </div>
+    )
+  }
+  return (
+    <CnInsightListPad fill>
+      {items.map(item => (
+        <CnInsightStockRow
+          key={item.code}
+          code={item.code}
+          name={item.name}
+          meta={hotBoardRowMeta(item)}
+          price={item.price}
+          changePct={item.change_pct}
+          changeAmt={item.change_amt}
+        />
+      ))}
+    </CnInsightListPad>
+  )
+}
+
+export default function CnHotBoardPanel({
+  skyrocket = [],
+  hotStocks = [],
+  loading = false,
+  emotionSource,
+}: Props) {
+  const s = useStyles()
+  const [tab, setTab] = useState<HotBoardTab>('skyrocket')
+  const [selected, setSelected] = useState<CnInsightStockPick | null>(null)
+  const history = useCnHotBoardHistory(tab === 'history')
+
+  const activeItems = useMemo(() => {
+    if (tab === 'skyrocket') return skyrocket
+    if (tab === 'hot') return hotStocks
+    return history.items
+  }, [tab, skyrocket, hotStocks, history.items])
+
+  const subtitle = useMemo(() => {
+    if (emotionSource !== 'tonghuashun' && tab !== 'history') {
+      return '配置高级行情源后可查看热榜'
+    }
+    if (tab === 'history' && history.queryDate) {
+      return `查询日 ${history.queryDate} · 日榜 Top30 · 收盘涨跌`
+    }
+    return '同花顺日榜 · Top30'
+  }, [emotionSource, tab, history.queryDate])
+
+  const listLoading = tab === 'history'
+    ? history.loading && !history.items.length
+    : loading && !activeItems.length
+
+  const renderList = () => {
+    if (listLoading) {
+      return <CnInsightListSkeleton fill />
+    }
+    if (tab === 'history' && history.error && !history.items.length) {
+      return (
+        <div className={s.empty}>
+          <div>{history.error}</div>
+          <div>请选择其他交易日重试</div>
+        </div>
+      )
+    }
+    if (tab === 'skyrocket') {
+      return (
+        <HotBoardList
+          items={skyrocket}
+          emptyTitle="暂无飙升榜"
+          emptyHint={emotionSource === 'tonghuashun'
+            ? '交易时段内将自动更新'
+            : '请在设置中启用同花顺行情源'}
+        />
+      )
+    }
+    if (tab === 'hot') {
+      return (
+        <HotBoardList
+          items={hotStocks}
+          emptyTitle="暂无热股榜"
+          emptyHint={emotionSource === 'tonghuashun'
+            ? '交易时段内将自动更新'
+            : '请在设置中启用同花顺行情源'}
+        />
+      )
+    }
+    return (
+      <HotBoardList
+        items={history.items}
+        emptyTitle={history.error || '暂无历史排行'}
+        emptyHint="非交易日已自动对齐至最近一个交易日"
+      />
+    )
+  }
+
+  return (
+    <CnDashboardFlexPanel
+      title="同花顺热榜"
+      subtitle={subtitle}
+      fill
+      tabConfig={{
+        tabs: TAB_ITEMS,
+        value: tab,
+        onChange: next => {
+          setTab(next)
+          setSelected(null)
+        },
+        ariaLabel: '同花顺热榜',
+      }}
+    >
+      <div className={s.body}>
+        {tab === 'history' ? (
+          <div className={s.dateRow}>
+            <Text className={s.dateLabel}>日期</Text>
+            <Input
+              className={s.dateInput}
+              type="date"
+              size="small"
+              value={history.pickerDate ?? ''}
+              onChange={(_e, data) => {
+                if (data.value) history.onPickerChange(data.value)
+              }}
+            />
+            {history.loading ? <Spinner size="tiny" /> : null}
+            {history.queryDate && history.pickerDate !== history.queryDate ? (
+              <span className={s.dateHint}>已对齐交易日</span>
+            ) : null}
+          </div>
+        ) : null}
+        <CnInsightSplitView selected={selected} onSelect={setSelected}>
+          {renderList()}
+        </CnInsightSplitView>
+      </div>
+    </CnDashboardFlexPanel>
+  )
+}

--- a/client-ui/src/pages/market-dynamics/CnMarketDynamicsView.tsx
+++ b/client-ui/src/pages/market-dynamics/CnMarketDynamicsView.tsx
@@ -8,6 +8,7 @@ import CnHeroIndexStrip from './CnHeroIndexStrip'
 import CnMarketChartPanel from './CnMarketChartPanel'
 import CnMarketInsightPanel, { type CnInsightTab } from './CnMarketInsightPanel'
 import CnSectorDiscoverGrid from './CnSectorDiscoverGrid'
+import CnHotBoardPanel from './CnHotBoardPanel'
 import { readCnIndexChartCode, writeCnIndexChartCode } from './cnIndexChartStorage'
 import { resolveIndexDisplayName } from './cnIndexFormat'
 import { chartCodeFromIndex } from './marketBoardUtils'
@@ -65,6 +66,23 @@ const useStyles = makeStyles({
   },
   sideCol: {
     minHeight: 0,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: CN_DASH.pageGap,
+    overflow: 'hidden',
+  },
+  sectorCol: {
+    flex: '1 1 45%',
+    minHeight: '200px',
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  hotBoardCol: {
+    flex: '1 1 55%',
+    minHeight: '280px',
     minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
@@ -224,13 +242,23 @@ export default function CnMarketDynamicsView({
         </div>
 
         <div className={s.sideCol}>
-          <CnSectorDiscoverGrid
-            sectors={sectorIndices}
-            selectedCode={selectedSectorCode}
-            loading={loading}
-            emptyHint={data?.cn_sector_hint}
-            onSelect={handleSectorSelect}
-          />
+          <div className={s.sectorCol}>
+            <CnSectorDiscoverGrid
+              sectors={sectorIndices}
+              selectedCode={selectedSectorCode}
+              loading={loading}
+              emptyHint={data?.cn_sector_hint}
+              onSelect={handleSectorSelect}
+            />
+          </div>
+          <div className={s.hotBoardCol}>
+            <CnHotBoardPanel
+              skyrocket={data?.cn_skyrocket}
+              hotStocks={data?.cn_hot_stocks}
+              loading={loading}
+              emotionSource={data?.cn_emotion_source ?? null}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/client-ui/src/pages/market-dynamics/CnSectorDiscoverGrid.tsx
+++ b/client-ui/src/pages/market-dynamics/CnSectorDiscoverGrid.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles({
     minHeight: 0,
     overflowY: 'auto',
     display: 'grid',
-    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
     gridAutoRows: 'min-content',
     alignContent: 'start',
     gap: '8px',

--- a/client-ui/src/pages/market-dynamics/cnDashboardSkeletons.tsx
+++ b/client-ui/src/pages/market-dynamics/cnDashboardSkeletons.tsx
@@ -150,7 +150,7 @@ const useSectorGridStyles = makeStyles({
     flex: 1,
     minHeight: 0,
     display: 'grid',
-    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+    gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
     gridAutoRows: 'min-content',
     alignContent: 'start',
     gap: '8px',

--- a/client-ui/src/pages/market-dynamics/cnHotBoardUtils.ts
+++ b/client-ui/src/pages/market-dynamics/cnHotBoardUtils.ts
@@ -1,0 +1,83 @@
+import type { MarketHotItem } from '../../types/schemas'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function bareCode(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  const dot = trimmed.indexOf('.')
+  return dot >= 0 ? trimmed.slice(0, dot) : trimmed
+}
+
+function numField(row: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const v = row[key]
+    if (typeof v === 'number' && Number.isFinite(v)) return v
+    if (typeof v === 'string' && v.trim()) {
+      const n = Number(v)
+      if (Number.isFinite(n)) return n
+    }
+  }
+  return null
+}
+
+function strField(row: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const v = row[key]
+    if (typeof v === 'string' && v.trim()) return v.trim()
+  }
+  return ''
+}
+
+/** Map Hub cn_market_special / market_dynamics raw rows → UI hot items. */
+export function mapCnHotBoardItems(raw: unknown): MarketHotItem[] {
+  const rows = Array.isArray(raw) ? raw : raw != null ? [raw] : []
+  const out: MarketHotItem[] = []
+  for (const row of rows) {
+    if (!isRecord(row)) continue
+    const code = bareCode(String(row.thscode ?? row.ticker ?? row.code ?? ''))
+    if (!code) continue
+    const name = strField(row, 'name', 'stock_name') || code
+    const heatRaw = row.heat ?? row.hot_value ?? row.hot_score ?? row.score
+    const heat = typeof heatRaw === 'number' && Number.isFinite(heatRaw)
+      ? heatRaw
+      : typeof heatRaw === 'string' && heatRaw.trim()
+        ? Number(heatRaw.trim()) || null
+        : null
+    out.push({
+      code,
+      name,
+      rank: numField(row, 'rank', 'hot_rank', 'order'),
+      heat,
+      rank_change: numField(row, 'rank_change', 'rankChange', 'rank_delta', 'change_rank'),
+      price: numField(row, 'price'),
+      change_pct: numField(row, 'change_pct', 'changePct', 'price_change_ratio_pct'),
+      change_amt: numField(row, 'change_amt', 'changeAmt'),
+    })
+  }
+  return out
+}
+
+export function formatHotRank(rank: number | null | undefined): string {
+  if (rank == null || !Number.isFinite(rank)) return '—'
+  return `#${Math.round(rank)}`
+}
+
+export function formatHotHeat(heat: number | null | undefined): string {
+  if (heat == null || !Number.isFinite(heat)) return ''
+  if (heat >= 10000) return `${(heat / 10000).toFixed(1)}万`
+  return String(Math.round(heat))
+}
+
+export function hotBoardRowMeta(item: MarketHotItem): string {
+  const parts: string[] = [item.code]
+  if (item.rank != null) parts.push(`#${Math.round(item.rank)}`)
+  const heatLabel = formatHotHeat(item.heat ?? null)
+  if (heatLabel) parts.push(`热度 ${heatLabel}`)
+  if (item.rank_change != null && item.rank_change !== 0) {
+    parts.push(item.rank_change > 0 ? `升 ${item.rank_change}` : `降 ${Math.abs(item.rank_change)}`)
+  }
+  return parts.join(' · ')
+}

--- a/client-ui/src/pages/market-dynamics/cnTradingDayUtils.ts
+++ b/client-ui/src/pages/market-dynamics/cnTradingDayUtils.ts
@@ -1,0 +1,69 @@
+import { research } from '../../api/client'
+
+const calendarCache = new Map<number, Set<string>>()
+
+/** Normalize API date to YYYY-MM-DD. */
+export function normalizeTradeDate(input: string): string | null {
+  const trimmed = input.trim()
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed
+  if (/^\d{8}$/.test(trimmed)) {
+    return `${trimmed.slice(0, 4)}-${trimmed.slice(4, 6)}-${trimmed.slice(6, 8)}`
+  }
+  return null
+}
+
+function todayYmd(): string {
+  const d = new Date()
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+async function loadTradingDaysForYear(year: number): Promise<Set<string>> {
+  const cached = calendarCache.get(year)
+  if (cached) return cached
+  const resp = await research.tradeCalendar(year)
+  const days = new Set<string>()
+  for (const row of resp.data?.items ?? []) {
+    if (row.isTradeDay === false) continue
+    const normalized = normalizeTradeDate(String(row.date ?? ''))
+    if (normalized) days.add(normalized)
+  }
+  calendarCache.set(year, days)
+  return days
+}
+
+async function tradingDaysAround(dateYmd: string): Promise<Set<string>> {
+  const year = Number(dateYmd.slice(0, 4))
+  const years = [year - 1, year, year + 1].filter(y => y >= 1990 && y <= 2100)
+  const merged = new Set<string>()
+  for (const y of years) {
+    const days = await loadTradingDaysForYear(y)
+    for (const d of days) merged.add(d)
+  }
+  return merged
+}
+
+/**
+ * Last A-share trading day on or before target (inclusive).
+ * Falls back to target when calendar unavailable.
+ */
+export async function resolveLastTradingDayOnOrBefore(targetYmd?: string): Promise<string> {
+  const target = normalizeTradeDate(targetYmd ?? '') ?? todayYmd()
+  try {
+    const days = await tradingDaysAround(target)
+    if (!days.size) return target
+    const sorted = [...days].filter(d => d <= target).sort()
+    if (sorted.length) return sorted[sorted.length - 1]!
+    const future = [...days].sort()
+    return future[0] ?? target
+  } catch {
+    return target
+  }
+}
+
+/** Default history query date: last trading day on or before today. */
+export async function defaultHotHistoryDate(): Promise<string> {
+  return resolveLastTradingDayOnOrBefore(todayYmd())
+}

--- a/client-ui/src/pages/market-dynamics/useCnHotBoardHistory.ts
+++ b/client-ui/src/pages/market-dynamics/useCnHotBoardHistory.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { research } from '../../api/client'
+import type { MarketHotItem } from '../../types/schemas'
+import { mapCnHotBoardItems } from './cnHotBoardUtils'
+import { defaultHotHistoryDate, normalizeTradeDate, resolveLastTradingDayOnOrBefore } from './cnTradingDayUtils'
+
+type State = {
+  items: MarketHotItem[]
+  queryDate: string | null
+  loading: boolean
+  error: string
+}
+
+export function useCnHotBoardHistory(enabled: boolean) {
+  const [state, setState] = useState<State>({
+    items: [],
+    queryDate: null,
+    loading: false,
+    error: '',
+  })
+  const [pickerDate, setPickerDate] = useState<string | null>(null)
+  const mountedRef = useRef(true)
+
+  const loadForDate = useCallback(async (rawDate: string) => {
+    const normalized = normalizeTradeDate(rawDate)
+    if (!normalized) {
+      setState(prev => ({ ...prev, error: '日期格式无效', loading: false }))
+      return
+    }
+    setState(prev => ({ ...prev, loading: true, error: '' }))
+    try {
+      const tradeDate = await resolveLastTradingDayOnOrBefore(normalized)
+      setPickerDate(tradeDate)
+      const resp = await research.cnMarketSpecial({ kind: 'hot_history', date: tradeDate })
+      if (!mountedRef.current) return
+      if (!resp.success) {
+        setState({
+          items: [],
+          queryDate: tradeDate,
+          loading: false,
+          error: resp.message || '暂时无法获取历史热股',
+        })
+        return
+      }
+      const items = mapCnHotBoardItems(resp.data?.items ?? [])
+      setState({
+        items,
+        queryDate: tradeDate,
+        loading: false,
+        error: items.length ? '' : '该日暂无热股排行',
+      })
+    } catch (e) {
+      if (!mountedRef.current) return
+      setState({
+        items: [],
+        queryDate: null,
+        loading: false,
+        error: e instanceof Error ? e.message : '加载失败',
+      })
+    }
+  }, [])
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) return
+    void (async () => {
+      const initial = await defaultHotHistoryDate()
+      await loadForDate(initial)
+    })()
+  }, [enabled, loadForDate])
+
+  const onPickerChange = useCallback((value: string) => {
+    void loadForDate(value)
+  }, [loadForDate])
+
+  return {
+    ...state,
+    pickerDate,
+    onPickerChange,
+    refresh: () => {
+      if (pickerDate) void loadForDate(pickerDate)
+    },
+  }
+}

--- a/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
+++ b/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
@@ -56,13 +56,16 @@ export function useMarketDynamics() {
   const [error, setError] = useState('')
   const mountedRef = useRef(true)
 
-  const load = useCallback(async (opts?: { silent?: boolean }) => {
+  const load = useCallback(async (opts?: { silent?: boolean; force?: boolean }) => {
     const silent = opts?.silent ?? false
     if (!silent) setLoading(true)
     else setRefreshing(true)
     setError('')
     try {
-      const resp = await research.marketDynamics({ market: 'cn' })
+      const resp = await research.marketDynamics({
+        market: 'cn',
+        ...(opts?.force ? { refresh: true } : {}),
+      })
       if (!mountedRef.current) return
       if (resp.success && resp.data) {
         setData({
@@ -99,6 +102,6 @@ export function useMarketDynamics() {
     refreshing,
     error,
     refreshedAt: data?.refreshed_at ?? null,
-    refresh: () => load({ silent: true }),
+    refresh: () => load({ silent: true, force: true }),
   }
 }

--- a/client-ui/src/types/schemas.ts
+++ b/client-ui/src/types/schemas.ts
@@ -433,6 +433,9 @@ export interface MarketHotItem {
   rank?: number | null
   heat?: number | null
   rank_change?: number | null
+  price?: number | null
+  change_pct?: number | null
+  change_amt?: number | null
 }
 
 export interface MarketLimitLadderBoard {

--- a/packages/a-stock-layer/src/providers/tonghuashun/custom-method-docs.ts
+++ b/packages/a-stock-layer/src/providers/tonghuashun/custom-method-docs.ts
@@ -167,6 +167,25 @@ export const TONGHUASHUN_METHOD_DOCS: Record<string, CustomMethodApiDoc> = {
     },
   ),
 
+  thsHotStockList: thsDoc(
+    'thsHotStockList',
+    'A 股热股榜单 Top30',
+    '/api/a-share/special-data/hot-stock-list',
+    [
+      {
+        name: 'period',
+        type: 'string',
+        description: '统计周期：day（日榜，默认）',
+        default: 'day',
+      },
+    ],
+    'Record<string, unknown>[] 热股行，含 source=tonghuashun',
+    {
+      example: '{"provider":"tonghuashun","method":"thsHotStockList","args":["day"]}',
+      usage: INVOKE('thsHotStockList', '["day"]'),
+    },
+  ),
+
   thsHotStockListHistory: thsDoc(
     'thsHotStockListHistory',
     '历史热股排行（按自然日）',

--- a/packages/agent/src/unified-mcp-tools.ts
+++ b/packages/agent/src/unified-mcp-tools.ts
@@ -436,7 +436,7 @@ export function buildUnifiedInstrumentTools(
         kind: {
           type: 'string',
           description:
-            'limit_up_ladder | skyrocket | hot_history | hot_rank_trend | anomaly_list | anomaly_stock | ths_index_list',
+            'limit_up_ladder | skyrocket | hot_stock | hot_history | hot_rank_trend | anomaly_list | anomaly_stock | ths_index_list',
         },
         code: { type: 'string', description: '个股代码（hot_rank_trend / anomaly_stock）' },
         codes: { type: 'string', description: 'anomaly_stock 多码时可逗号分隔' },

--- a/packages/research-hub/src/hub.ts
+++ b/packages/research-hub/src/hub.ts
@@ -127,7 +127,6 @@ import {
   normalizeShareholderPayload,
 } from './stock-detail-normalize.js'
 import {
-  mapCnAnomalyItems,
   mapCnHotStockItems,
   mapCnLimitBreakItems,
   mapCnLimitUpItems,
@@ -137,12 +136,15 @@ import {
 import {
   dedupeThsCatalogEntries,
   indexSnapshotRows,
+  majorCnIndexThscode,
+  mapMajorCnIndexQuote,
   mapThsIndexSnapshotToQuote,
   mergeConstituentQuoteRow,
   parseConstituentStockCode,
   parseThsIndexCatalogRow,
   rankSectorIndexQuotes,
   sortConstituentRowsByChangePct,
+  type ThsIndexCatalogEntry,
   type ThsSectorTag,
 } from './market-sector-map.js'
 import {
@@ -259,6 +261,25 @@ export class ResearchHub {
   private readonly stockNameCache = new Map<string, string>()
   /** 进程内最近一次成功报价 — live 失败时回退，避免关注列表部分无价 */
   private readonly lastInstrumentQuotes = new Map<string, Record<string, unknown>>()
+  /** 同花顺板块 catalog — 慢变数据，降 market_dynamics 轮询压力 */
+  private readonly thsSectorCatalogCache = new Map<
+    ThsSectorTag,
+    { fetchedAt: number; entries: ThsIndexCatalogEntry[] }
+  >()
+  /** 历史热榜档期涨跌 — 过去交易日永久、当日短 TTL */
+  private readonly cnHotHistoryQuoteCache = new Map<
+    string,
+    {
+      fetchedAt: number
+      quotes: Map<string, { price: number | null; change_pct: number | null; change_amt: number | null }>
+    }
+  >()
+  /** A 股 market_dynamics 短 TTL — 去重 30s 轮询内的重复 bulk */
+  private marketDynamicsCnCache: { at: number; payload: ResearchResult } | null = null
+
+  private static readonly THS_SECTOR_CATALOG_TTL_MS = 15 * 60 * 1000
+  private static readonly MARKET_DYNAMICS_CN_TTL_MS = 22_000
+  private static readonly HOT_HISTORY_TODAY_TTL_MS = 5 * 60 * 1000
 
   initMarketDataAutoSync(): void {
     this.notifyMarketDataUiReady()
@@ -915,6 +936,88 @@ export class ResearchHub {
     return /^\d{6}$/.test(digits) ? digits : ''
   }
 
+  private shiftCalendarYmd(ymd: string, deltaDays: number): string {
+    const d = new Date(`${ymd}T12:00:00.000Z`)
+    d.setUTCDate(d.getUTCDate() + deltaDays)
+    return d.toISOString().slice(0, 10)
+  }
+
+  /** 历史热榜：按 tradeDate 拉日线 close / changePct，不用实时 batch。 */
+  private hotHistoryQuoteCacheTtlMs(tradeDateYmd: string): number {
+    const today = cnTodayString()
+    return tradeDateYmd < today
+      ? Number.MAX_SAFE_INTEGER
+      : ResearchHub.HOT_HISTORY_TODAY_TTL_MS
+  }
+
+  private async fetchCnHistoricalDayQuoteMap(
+    codes: string[],
+    tradeDateYmd: string,
+  ): Promise<Map<string, { price: number | null; change_pct: number | null; change_amt: number | null }>> {
+    const map = new Map<string, { price: number | null; change_pct: number | null; change_amt: number | null }>()
+    const unique = [...new Set(codes.map(code => this.bareCnStockCode(code)).filter(Boolean))]
+    if (!unique.length || !/^\d{4}-\d{2}-\d{2}$/.test(tradeDateYmd)) return map
+
+    const ttlMs = this.hotHistoryQuoteCacheTtlMs(tradeDateYmd)
+    const cached = this.cnHotHistoryQuoteCache.get(tradeDateYmd)
+    if (cached && Date.now() - cached.fetchedAt < ttlMs) {
+      for (const code of unique) {
+        const quote = cached.quotes.get(code)
+        if (quote) map.set(code, quote)
+      }
+    }
+
+    const missing = unique.filter(code => !map.has(code))
+    if (!missing.length) return map
+
+    const startYmd = this.shiftCalendarYmd(tradeDateYmd, -20)
+    const CONCURRENCY = 6
+    const fetched = new Map<string, { price: number | null; change_pct: number | null; change_amt: number | null }>()
+    for (let i = 0; i < missing.length; i += CONCURRENCY) {
+      const chunk = missing.slice(i, i + CONCURRENCY)
+      await Promise.all(chunk.map(async (code) => {
+        try {
+          const ref = resolveCnInstrumentRef({
+            market: 'CN',
+            assetClass: 'EQUITY',
+            symbol: code,
+          })
+          const r = await this.de.queryInstrumentData(ref, 'kline', {
+            startDate: startYmd,
+            endDate: tradeDateYmd,
+            count: 25,
+          })
+          const bars = instrumentQueryData<StockKline[]>(r) ?? []
+          const bar = bars.find(b => b.date === tradeDateYmd)
+            ?? bars.filter(b => b.date <= tradeDateYmd).at(-1)
+          if (!bar) return
+          const price = typeof bar.close === 'number' && Number.isFinite(bar.close) ? bar.close : null
+          const change_pct = typeof bar.changePct === 'number' && Number.isFinite(bar.changePct)
+            ? bar.changePct
+            : null
+          fetched.set(code, {
+            price,
+            change_pct,
+            change_amt: this.quoteChangeAmt(undefined, price, change_pct),
+          })
+        } catch {
+          /* skip single symbol */
+        }
+      }))
+    }
+
+    const store = cached?.quotes ?? new Map()
+    for (const [code, quote] of fetched) {
+      store.set(code, quote)
+      map.set(code, quote)
+    }
+    this.cnHotHistoryQuoteCache.set(tradeDateYmd, {
+      fetchedAt: Date.now(),
+      quotes: store,
+    })
+    return map
+  }
+
   private async fetchCnStockQuoteMap(
     codes: string[],
   ): Promise<Map<string, { price: number | null; change_pct: number | null; change_amt: number | null }>> {
@@ -965,7 +1068,30 @@ export class ResearchHub {
   private async fetchCnIndexMarketItems(
     indices: Array<{ code: string; name?: string }>,
   ) {
-    const items = await Promise.all(indices.map(async entry => {
+    if (!indices.length) return []
+
+    const thscodes = indices.map(entry => majorCnIndexThscode(entry.code)).filter(Boolean)
+    const { rows } = await this.fetchThsIndexPriceSnapshots(thscodes)
+    const snapByThscode = new Map(
+      rows.map(row => [String(row.thscode ?? '').trim().toUpperCase(), row]),
+    )
+
+    return Promise.all(indices.map(async entry => {
+      const thscode = majorCnIndexThscode(entry.code).toUpperCase()
+      const snap = snapByThscode.get(thscode)
+      const resolvedName = this.resolveIndexQuoteName(
+        entry.name,
+        snap ? String(snap.index_name ?? snap.name ?? '') : undefined,
+        entry.code,
+      )
+      const fromSnap = mapMajorCnIndexQuote({ code: entry.code, name: resolvedName }, snap)
+      if (fromSnap.price != null) {
+        return {
+          ...fromSnap,
+          name: this.resolveIndexQuoteName(entry.name, fromSnap.name, entry.code),
+        }
+      }
+
       const ref = resolveCnInstrumentRef({
         market: 'CN',
         assetClass: 'INDEX',
@@ -1000,7 +1126,6 @@ export class ResearchHub {
         market,
       }
     }))
-    return items.filter((item): item is NonNullable<typeof item> => item != null)
   }
 
   private async fetchGlobalIndexProxyItems(
@@ -1067,9 +1192,37 @@ export class ResearchHub {
     }
   }
 
+  private async fetchThsSectorCatalog(
+    tag: ThsSectorTag,
+    cap: number,
+  ): Promise<{ entries: ThsIndexCatalogEntry[]; error?: string }> {
+    const cached = this.thsSectorCatalogCache.get(tag)
+    if (cached && Date.now() - cached.fetchedAt < ResearchHub.THS_SECTOR_CATALOG_TTL_MS) {
+      return { entries: cached.entries.slice(0, cap) }
+    }
+    try {
+      const r = await this.de.invokeCustomMethod('tonghuashun', 'thsIndexList', [tag])
+      if (!r.success) {
+        return { entries: [], error: r.error ?? '板块目录获取失败' }
+      }
+      if (!Array.isArray(r.data)) return { entries: [] }
+      const entries = r.data
+        .slice(0, cap)
+        .map(row => parseThsIndexCatalogRow(row as Record<string, unknown>, tag))
+        .filter((entry): entry is NonNullable<typeof entry> => entry != null)
+      this.thsSectorCatalogCache.set(tag, { fetchedAt: Date.now(), entries })
+      return { entries }
+    } catch (e) {
+      return {
+        entries: [],
+        error: e instanceof Error ? e.message : String(e),
+      }
+    }
+  }
+
   /**
    * 同花顺板块指数 — SDK 路由：
-   * 1) index.catalogThsIndexList(tag) → thsIndexList
+   * 1) index.catalogThsIndexList(tag) → thsIndexList（15min 进程缓存）
    * 2) index.pricesSnapshot(thscodes) → thsIndexPricesSnapshot（非 aShare.prices）
    */
   private async fetchCnThsSectorIndexItems(): Promise<{
@@ -1085,21 +1238,9 @@ export class ResearchHub {
 
     const catalogEntries = (
       await Promise.all(TAGS.map(async tag => {
-        try {
-          const r = await this.de.invokeCustomMethod('tonghuashun', 'thsIndexList', [tag])
-          if (!r.success) {
-            if (r.error) catalogErrors.push(r.error)
-            return []
-          }
-          if (!Array.isArray(r.data)) return []
-          return r.data
-            .slice(0, CATALOG_CAP)
-            .map(row => parseThsIndexCatalogRow(row as Record<string, unknown>, tag))
-            .filter((entry): entry is NonNullable<typeof entry> => entry != null)
-        } catch (e) {
-          catalogErrors.push(e instanceof Error ? e.message : String(e))
-          return []
-        }
+        const { entries, error } = await this.fetchThsSectorCatalog(tag, CATALOG_CAP)
+        if (error) catalogErrors.push(error)
+        return entries
       }))
     ).flat()
 
@@ -1163,7 +1304,18 @@ export class ResearchHub {
     const market = String(params.market ?? 'cn').trim().toLowerCase()
     if (market === 'us') return this.marketDynamicsUs(t0)
     if (market === 'hk') return this.marketDynamicsHk(t0)
-    return this.marketDynamicsCn(t0)
+    const force = params.force === true || params.refresh === true
+    if (!force) {
+      const cached = this.marketDynamicsCnCache
+      if (cached && Date.now() - cached.at < ResearchHub.MARKET_DYNAMICS_CN_TTL_MS) {
+        return cached.payload
+      }
+    }
+    const result = await this.marketDynamicsCn(t0)
+    if (result.success) {
+      this.marketDynamicsCnCache = { at: Date.now(), payload: result }
+    }
+    return result
   }
 
   private async fetchHkSectorBoardViaTickflow() {
@@ -1558,13 +1710,26 @@ export class ResearchHub {
       chartSymbol: '^HSI',
     }
 
-    const fetchEmotionLimitUp = async () => {
+    const fetchCnLimitUpdownPack = async () => {
       try {
         const r = await this.de.limitUpdown()
-        if (!r.success || !Array.isArray(r.data)) return []
-        return mapCnLimitUpItems(r.data)
+        if (!r.success || !Array.isArray(r.data)) {
+          return { gainers: [] as Array<{ code: string; name: string; price: number | null; change_pct: number | null; change_amt: number | null }>, losers: [] as Array<{ code: string; name: string; price: number | null; change_pct: number | null; change_amt: number | null }>, limitUp: [] as ReturnType<typeof mapCnLimitUpItems> }
+        }
+        const mapMover = (row: { code: string; name: string; changePct?: number | null; type: string }) => ({
+          code: row.code,
+          name: row.name,
+          price: null as number | null,
+          change_pct: row.changePct ?? null,
+          change_amt: null as number | null,
+        })
+        return {
+          gainers: r.data.filter(row => row.type === 'limit_up').slice(0, 30).map(mapMover),
+          losers: r.data.filter(row => row.type === 'limit_down').slice(0, 30).map(mapMover),
+          limitUp: mapCnLimitUpItems(r.data),
+        }
       } catch {
-        return []
+        return { gainers: [], losers: [], limitUp: [] }
       }
     }
 
@@ -1608,41 +1773,30 @@ export class ResearchHub {
       }
     }
 
-    const fetchAnomaly = async () => {
-      try {
-        const r = await this.de.invokeCustomMethod('tonghuashun', 'thsAnomalyAnalysisList', [])
-        if (!r.success) return []
-        return mapCnAnomalyItems(r.data)
-      } catch {
-        return []
-      }
-    }
-
     const [
       cnMajorCn,
       cnMajorHk,
       cnSectorPack,
-      cnMovers,
+      cnLimitUpdownPack,
       dragonR,
-      cnLimitUp,
       cnSkyrocket,
       cnLimitLadder,
       cnLimitBreak,
       cnHotStocks,
-      cnAnomaly,
     ] = await Promise.all([
       this.fetchCnIndexMarketItems(CN_MAJOR_CN),
       this.fetchGlobalIndexProxyItems([HK_HSI_PROXY]),
       this.fetchCnThsSectorIndexItems(),
-      this.fetchCnLimitMovers(),
+      fetchCnLimitUpdownPack(),
       this.de.dragonTiger(),
-      fetchEmotionLimitUp(),
       fetchEmotionSkyrocket(),
       fetchEmotionLadder(),
       fetchLimitBreak(),
       fetchHotStocks(),
-      fetchAnomaly(),
     ])
+
+    const cnMovers = { gainers: cnLimitUpdownPack.gainers, losers: cnLimitUpdownPack.losers }
+    const cnLimitUp = cnLimitUpdownPack.limitUp
 
     const cnMajor = [...cnMajorCn, ...cnMajorHk]
     const cnSectors = cnSectorPack.items
@@ -1672,6 +1826,8 @@ export class ResearchHub {
       ...cnLimitUp,
       ...cnLimitBreak,
       ...cnDragonTiger,
+      ...cnSkyrocket,
+      ...cnHotStocks,
       ...(cnLimitLadder?.boards.flatMap(board => board.items) ?? []),
     ].map(item => item.code)
     const cnStockQuoteMap = await this.fetchCnStockQuoteMap(quoteCodes)
@@ -1681,6 +1837,8 @@ export class ResearchHub {
     const cnLimitUpQuoted = cnLimitUp.map(item => this.applyCnStockQuote(item, cnStockQuoteMap))
     const cnLimitBreakQuoted = cnLimitBreak.map(item => this.applyCnStockQuote(item, cnStockQuoteMap))
     const cnDragonTigerQuoted = cnDragonTiger.map(item => this.applyCnStockQuote(item, cnStockQuoteMap))
+    const cnSkyrocketQuoted = cnSkyrocket.map(item => this.applyCnStockQuote(item, cnStockQuoteMap))
+    const cnHotStocksQuoted = cnHotStocks.map(item => this.applyCnStockQuote(item, cnStockQuoteMap))
     const cnLimitLadderQuoted = cnLimitLadder
       ? {
           ...cnLimitLadder,
@@ -1727,10 +1885,9 @@ export class ResearchHub {
     }
 
     const hasEmotionData = cnLimitUpQuoted.length > 0
-      || cnSkyrocket.length > 0
+      || cnSkyrocketQuoted.length > 0
       || cnLimitBreakQuoted.length > 0
-      || cnHotStocks.length > 0
-      || cnAnomaly.length > 0
+      || cnHotStocksQuoted.length > 0
       || (cnLimitLadderQuoted?.boards.length ?? 0) > 0
 
     return ok({
@@ -1743,9 +1900,8 @@ export class ResearchHub {
       cn_dragon_tiger_date: cnDragonTigerQuoted[0]?.date ?? null,
       cn_limit_up: cnLimitUpQuoted.length ? cnLimitUpQuoted : undefined,
       cn_limit_break: cnLimitBreakQuoted.length ? cnLimitBreakQuoted : undefined,
-      cn_skyrocket: cnSkyrocket.length ? cnSkyrocket : undefined,
-      cn_hot_stocks: cnHotStocks.length ? cnHotStocks : undefined,
-      cn_anomaly: cnAnomaly.length ? cnAnomaly : undefined,
+      cn_skyrocket: cnSkyrocketQuoted.length ? cnSkyrocketQuoted : undefined,
+      cn_hot_stocks: cnHotStocksQuoted.length ? cnHotStocksQuoted : undefined,
       cn_limit_ladder: cnLimitLadderQuoted,
       cn_emotion_source: hasEmotionData ? 'tonghuashun' as const : null,
       cn_sector_status: cnSectorPack.status,
@@ -4165,6 +4321,10 @@ export class ResearchHub {
         method: 'thsSkyrocketList',
         args: p => [String(p.period ?? 'day')],
       },
+      hot_stock: {
+        method: 'thsHotStockList',
+        args: () => ['day'],
+      },
       hot_history: {
         method: 'thsHotStockListHistory',
         args: p => {
@@ -4204,7 +4364,7 @@ export class ResearchHub {
     const spec = kindMap[kind]
     if (!spec) {
       return fail(
-        'kind 必填且须为：limit_up_ladder | skyrocket | hot_history | hot_rank_trend | anomaly_list | anomaly_stock | ths_index_list（成分股用 get_index_constituents；财务指标用 get_instrument_financial_indicators）',
+        'kind 必填且须为：limit_up_ladder | skyrocket | hot_stock | hot_history | hot_rank_trend | anomaly_list | anomaly_stock | ths_index_list（成分股用 get_index_constituents；财务指标用 get_instrument_financial_indicators）',
         t0,
       )
     }
@@ -4222,13 +4382,30 @@ export class ResearchHub {
     }
     const raw = r.data
     const rows = Array.isArray(raw) ? raw : raw != null ? [raw] : []
+    const LIVE_HOT_QUOTE_KINDS = new Set(['skyrocket', 'hot_stock'])
+    let items: unknown[] = rows
+    const tradeDate = String(params.date ?? '').trim().slice(0, 10)
+    if (kind === 'hot_history') {
+      const mapped = mapCnSkyrocketItems(rows)
+      const quoteMap = /^\d{4}-\d{2}-\d{2}$/.test(tradeDate)
+        ? await this.fetchCnHistoricalDayQuoteMap(mapped.map(item => item.code), tradeDate)
+        : new Map()
+      items = mapped.map(item => this.applyCnStockQuote(item, quoteMap))
+    } else if (LIVE_HOT_QUOTE_KINDS.has(kind)) {
+      const mapped = mapCnSkyrocketItems(rows)
+      const quoteMap = await this.fetchCnStockQuoteMap(mapped.map(item => item.code))
+      items = mapped.map(item => this.applyCnStockQuote(item, quoteMap))
+    }
     return ok(
       {
         kind,
-        items: rows,
-        count: rows.length,
+        items,
+        count: items.length,
         source: 'tonghuashun',
         provider_method: spec.method,
+        ...(kind === 'hot_history' && /^\d{4}-\d{2}-\d{2}$/.test(tradeDate)
+          ? { as_of_date: tradeDate, quote_basis: 'historical_close' as const }
+          : {}),
         hint: '须启用同花顺（富耀）Provider；申万/板块目录用 get_sector_list；指数成分用 get_index_constituents；财务指标用 get_instrument_financial_indicators',
       },
       `${kind} ${rows.length} 条`,

--- a/packages/research-hub/src/market-sector-map.ts
+++ b/packages/research-hub/src/market-sector-map.ts
@@ -76,6 +76,50 @@ export function indexSnapshotRows(raw: unknown): Record<string, unknown>[] {
   return []
 }
 
+/** A 股宽基指数 thscode（000300 → 000300.SH，399006 → 399006.SZ） */
+export function majorCnIndexThscode(code: string): string {
+  const raw = String(code ?? '').trim()
+  if (!raw) return ''
+  if (raw.includes('.')) return raw.toUpperCase()
+  const digits = raw.replace(/\D/g, '').padStart(6, '0').slice(-6)
+  if (digits.startsWith('399') || digits.startsWith('88')) {
+    return `${digits}.${digits.startsWith('399') ? 'SZ' : 'TI'}`
+  }
+  return `${digits}.SH`
+}
+
+export function mapMajorCnIndexQuote(
+  entry: { code: string; name: string },
+  snap: Record<string, unknown> | undefined,
+): {
+  code: string
+  name: string
+  price: number | null
+  change_pct: number | null
+  change_amt: number | null
+  market: string
+} {
+  const market = entry.code.startsWith('399') ? 'SZ' : 'SH'
+  if (!snap) {
+    return {
+      code: entry.code,
+      name: entry.name,
+      price: null,
+      change_pct: null,
+      change_amt: null,
+      market,
+    }
+  }
+  return {
+    code: entry.code,
+    name: entry.name,
+    price: safeFloat(snap.last_price),
+    change_pct: safeFloat(snap.price_change_ratio_pct),
+    change_amt: safeFloat(snap.price_change),
+    market,
+  }
+}
+
 /** 从指数成份行解析 A 股标的代码（6 位），供 batchRealtime 对齐 */
 export function parseConstituentStockCode(row: Record<string, unknown>): string {
   const thscode = String(row.thscode ?? row.stock_code ?? '').trim()

--- a/tests/cn-hot-board.test.mjs
+++ b/tests/cn-hot-board.test.mjs
@@ -1,0 +1,157 @@
+/**
+ * A-share last trading day resolution (client-ui mirror for unit tests).
+ */
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+function normalizeTradeDate(input) {
+  const trimmed = input.trim()
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed
+  if (/^\d{8}$/.test(trimmed)) {
+    return `${trimmed.slice(0, 4)}-${trimmed.slice(4, 6)}-${trimmed.slice(6, 8)}`
+  }
+  return null
+}
+
+function resolveLastTradingDayOnOrBeforeSync(target, days) {
+  if (!days.size) return target
+  const sorted = [...days].filter(d => d <= target).sort()
+  if (sorted.length) return sorted[sorted.length - 1]
+  return [...days].sort()[0] ?? target
+}
+
+describe('cnTradingDayUtils contract', () => {
+  it('normalizeTradeDate accepts yyyy-MM-dd and yyyyMMdd', () => {
+    assert.equal(normalizeTradeDate('2026-08-28'), '2026-08-28')
+    assert.equal(normalizeTradeDate('20260828'), '2026-08-28')
+    assert.equal(normalizeTradeDate('bad'), null)
+  })
+
+  it('resolveLastTradingDayOnOrBefore picks latest trading day on or before target', () => {
+    const days = new Set(['2026-08-25', '2026-08-26', '2026-08-27', '2026-08-28'])
+    assert.equal(
+      resolveLastTradingDayOnOrBeforeSync('2026-08-28', days),
+      '2026-08-28',
+    )
+    assert.equal(
+      resolveLastTradingDayOnOrBeforeSync('2026-08-29', days),
+      '2026-08-28',
+    )
+    assert.equal(
+      resolveLastTradingDayOnOrBeforeSync('2026-08-24', days),
+      '2026-08-25',
+    )
+  })
+})
+
+describe('CnHotBoardPanel wiring', () => {
+  it('CnMarketDynamicsView mounts CnHotBoardPanel in side column', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../client-ui/src/pages/market-dynamics/CnMarketDynamicsView.tsx'),
+      'utf8',
+    )
+    assert.match(src, /CnHotBoardPanel/)
+    assert.match(src, /cn_hot_stocks/)
+    assert.match(src, /cn_skyrocket/)
+  })
+})
+
+describe('hub cn_market_special hot_stock', () => {
+  it('registers hot_stock kind', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    assert.match(src, /hot_stock:/)
+    assert.match(src, /thsHotStockList/)
+  })
+
+  it('enriches live hot board kinds with realtime quotes', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    assert.match(src, /LIVE_HOT_QUOTE_KINDS/)
+    assert.match(src, /fetchCnStockQuoteMap\(mapped\.map/)
+    assert.match(src, /applyCnStockQuote\(item, quoteMap\)/)
+  })
+
+  it('enriches hot_history with historical day kline quotes', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    assert.match(src, /kind === 'hot_history'/)
+    assert.match(src, /fetchCnHistoricalDayQuoteMap/)
+    assert.match(src, /quote_basis: 'historical_close'/)
+  })
+
+  it('market_dynamics merges limitUpdown into single fetch', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    assert.match(src, /fetchCnLimitUpdownPack/)
+    assert.doesNotMatch(
+      src.slice(src.indexOf('private async marketDynamicsCn')),
+      /fetchEmotionLimitUp/,
+    )
+  })
+
+  it('market_dynamics skips bulk cn_anomaly fetch', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    const start = src.indexOf('private async marketDynamicsCn')
+    const end = src.indexOf('private async marketRegime', start)
+    const body = end > start ? src.slice(start, end) : src.slice(start)
+    assert.doesNotMatch(body, /fetchAnomaly/)
+    assert.doesNotMatch(body, /thsAnomalyAnalysisList/)
+    assert.doesNotMatch(body, /cn_anomaly:/)
+  })
+
+  it('major indices use batch thsIndexPricesSnapshot', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    assert.match(src, /majorCnIndexThscode/)
+    assert.match(src, /fetchThsIndexPriceSnapshots\(thscodes\)/)
+  })
+
+  it('sector catalog and market dynamics use hub TTL caches', () => {
+    const src = fs.readFileSync(
+      path.join(here, '../packages/research-hub/src/hub.ts'),
+      'utf8',
+    )
+    assert.match(src, /thsSectorCatalogCache/)
+    assert.match(src, /THS_SECTOR_CATALOG_TTL_MS/)
+    assert.match(src, /marketDynamicsCnCache/)
+    assert.match(src, /cnHotHistoryQuoteCache/)
+  })
+})
+
+describe('majorCnIndexThscode', () => {
+  function majorCnIndexThscode(code) {
+    const raw = String(code ?? '').trim()
+    if (!raw) return ''
+    if (raw.includes('.')) return raw.toUpperCase()
+    const digits = raw.replace(/\D/g, '').padStart(6, '0').slice(-6)
+    if (digits.startsWith('399') || digits.startsWith('88')) {
+      return `${digits}.${digits.startsWith('399') ? 'SZ' : 'TI'}`
+    }
+    return `${digits}.SH`
+  }
+
+  it('maps major CN index codes to thscode', () => {
+    assert.equal(majorCnIndexThscode('000001'), '000001.SH')
+    assert.equal(majorCnIndexThscode('399006'), '399006.SZ')
+    assert.equal(majorCnIndexThscode('000300'), '000300.SH')
+  })
+})

--- a/tests/desktop-bootloader.test.mjs
+++ b/tests/desktop-bootloader.test.mjs
@@ -150,6 +150,15 @@ describe('main.cjs bootloader wiring', () => {
     assert.match(mainCjs, /runShutdownChain\('window-all-closed'\)/)
     assert.match(mainCjs, /runShutdownChain\('update-install'\)/)
   })
+
+  it('updater.cjs exports quick/deferred startup helpers', () => {
+    const updaterCjs = fs.readFileSync(
+      path.join(here, '../apps/desktop/electron/updater.cjs'),
+      'utf8',
+    )
+    assert.match(updaterCjs, /tryQuickPendingUpdateOnStartup,/)
+    assert.match(updaterCjs, /tryDeferredPendingUpdateOnStartup,/)
+  })
 })
 
 describe('bootloader-register hooks', () => {


### PR DESCRIPTION
## Summary
- Add A-share Tonghuashun hot-board sidebar (skyrocket, daily hot, history tab with as-of close quotes and mini chart split view).
- Optimize `market_dynamics` Hub path: batch major index snapshots, merge limitUpdown fetch, drop unused bulk anomaly, add catalog/history/bulk TTL caches, and manual refresh bypass.
- Fix desktop updater exports for quick/deferred startup hooks; sector discover grid uses 3 columns per row.

## Test plan
- [x] `npm run check:ui`
- [x] `node --test tests/cn-hot-board.test.mjs`
- [x] `node --test tests/desktop-bootloader.test.mjs`
- [ ] Open CN market dynamics: hot board tabs, history date picker shows close-based change
- [ ] Manual refresh bypasses 22s Hub cache; 30s poll uses cache


Made with [Cursor](https://cursor.com)