### PR TITLE
feat(network): global Opptrix outbound proxy from settings

### DIFF
--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { getModelsDevCatalog, resolveModelsDevProviderMeta } from '@opptrix/agent'
 import {
   normalizeProviderProxyMode,
-  resolveEffectiveProxyUrl,
+  resolveOutboundProxyInit,
   validateProxyUrlInput,
   type ProviderProxyMode,
   type SystemProxySettings,
@@ -23,7 +23,7 @@ export interface StoredProvider {
   base_url: string
   api_key: string
   models: string[]
-  /** inherit = system proxy; none = direct; custom = proxy_url */
+  /** inherit = global outbound proxy; none = direct; custom = proxy_url */
   proxy_mode?: ProviderProxyMode
   proxy_url?: string
 }
@@ -257,7 +257,7 @@ export function parseSystemProxyInput(raw: unknown): SystemProxySettings {
     return { enabled: true, url: validateProxyUrlInput(base.url) ?? undefined }
   }
   if (base.enabled && !base.url?.trim()) {
-    throw new Error('启用系统代理时请填写代理地址')
+    throw new Error('启用网络代理时请填写代理地址')
   }
   return { enabled: false }
 }
@@ -286,7 +286,7 @@ export function toAgentProviders(cfg: AppConfig) {
     baseUrl: p.base_url,
     apiKey: p.api_key,
     models: p.models,
-    proxyUrl: resolveEffectiveProxyUrl(
+    proxyUrl: resolveOutboundProxyInit(
       { mode: normalizeProviderProxyMode(p.proxy_mode), url: p.proxy_url },
       system,
     ),

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -9,7 +9,6 @@ import { getWorkspaceService, assertAllowedShellArgv, getSessionSecretAccessStor
 import { getUserDataStore } from '@opptrix/user-store'
 import { ResearchHub } from '@opptrix/research-hub'
 import { listTemplates, REGISTRY } from '@opptrix/stock-eval'
-import { resolveEffectiveProxyUrl } from '@opptrix/shared'
 import {
   loadConfig, saveConfig, publicConfig, toAgentProviders,
   resolveProviderPresets, parseSystemProxyInput, parseProviderProxyFields,
@@ -34,7 +33,15 @@ import {
 } from './stock-analysis-store.js'
 import { getStockPrep, startStockPrep } from './stock-prep-jobs.js'
 import { listDiscoverStrategiesPublic, getDiscoverStrategy, mcpToolCatalog } from '@opptrix/agent'
-import { isDiscoverStrategyProfile, listDiscoverProfileMeta, resolveOpptrixAppVersion, resolveProjectRoot, type DiscoverStrategyProfile } from '@opptrix/shared'
+import {
+  applySystemProxyAsDefault,
+  isDiscoverStrategyProfile,
+  listDiscoverProfileMeta,
+  resolveOpptrixAppVersion,
+  resolveOutboundProxyInit,
+  resolveProjectRoot,
+  type DiscoverStrategyProfile,
+} from '@opptrix/shared'
 import { registerNewsRoutes } from './news-routes.js'
 import { registerCommunityRoutes } from './community-routes.js'
 import { registerSandboxSettingsRoutes } from './sandbox-settings-routes.js'
@@ -88,6 +95,7 @@ const APP_VERSION = resolveOpptrixAppVersion()
 
 const hub = new ResearchHub()
 let cfg = loadConfig()
+applySystemProxyAsDefault(cfg.system_proxy)
 
 function syncAgentProviders() {
   agent.setProviders(toAgentProviders(cfg), cfg.default_model)
@@ -977,7 +985,7 @@ app.patch<{ Body: {
       } catch (e) {
         return reply.code(400).send({
           status: 'error',
-          error: e instanceof Error ? e.message : '系统代理配置无效',
+          error: e instanceof Error ? e.message : '网络代理配置无效',
         })
       }
     }
@@ -987,6 +995,7 @@ app.patch<{ Body: {
       default_model: b.default_model,
       system_proxy,
     })
+    applySystemProxyAsDefault(cfg.system_proxy)
     syncAgentProviders()
     return { status: 'saved', config: publicConfig(cfg) }
   },
@@ -1006,10 +1015,10 @@ app.post<{ Body: {
     if (!base_url?.trim() || !api_key?.trim()) {
       return reply.code(400).send({ error: 'base_url and api_key required' })
     }
-    let proxyUrl: string | undefined
+    let proxyUrl: string | false | undefined
     try {
       const proxyFields = parseProviderProxyFields({ proxy_mode, proxy_url })
-      proxyUrl = resolveEffectiveProxyUrl(
+      proxyUrl = resolveOutboundProxyInit(
         { mode: proxyFields.proxy_mode, url: proxyFields.proxy_url },
         cfg.system_proxy,
       )

--- a/apps/server/src/translation-remote.ts
+++ b/apps/server/src/translation-remote.ts
@@ -1,5 +1,5 @@
 import { createProvider, chatMessageContentToText } from '@opptrix/agent'
-import { resolveEffectiveProxyUrl } from '@opptrix/shared'
+import { resolveOutboundProxyInit } from '@opptrix/shared'
 import type { NewsTranslationSettings } from '@opptrix/news-feed'
 import { loadConfig } from './config.js'
 import {
@@ -57,7 +57,7 @@ function resolveRemoteLlm(translation: NewsTranslationSettings) {
     temperature: 0.3,
     maxTokens: 2048,
     timeout: 120_000,
-    proxyUrl: resolveEffectiveProxyUrl(
+    proxyUrl: resolveOutboundProxyInit(
       { mode: provider.proxy_mode, url: provider.proxy_url },
       cfg.system_proxy,
     ),

--- a/client-ui/src/pages/settings/ProxySettingsFields.tsx
+++ b/client-ui/src/pages/settings/ProxySettingsFields.tsx
@@ -6,17 +6,17 @@ import OpptrixSelect, { OpptrixOption } from '../../components/opptrix/OpptrixSe
 export type ProviderProxyMode = 'inherit' | 'none' | 'custom'
 
 const PROXY_MODE_OPTIONS: Array<{ value: ProviderProxyMode; label: string }> = [
-  { value: 'inherit', label: '跟随系统' },
+  { value: 'inherit', label: '跟随全局代理' },
   { value: 'none', label: '直连（不走代理）' },
   { value: 'custom', label: '自定义代理' },
 ]
 
 function providerModeHint(mode: ProviderProxyMode): string | undefined {
   if (mode === 'inherit') {
-    return '与「常规 → 网络」中的系统代理一致；系统未启用时自动直连。'
+    return '与「常规 → 网络代理」一致；未启用时自动直连。'
   }
   if (mode === 'none') {
-    return '始终直连此服务的 API 地址，不使用系统或自定义代理。'
+    return '始终直连，不使用全局或自定义代理。'
   }
   return undefined
 }

--- a/client-ui/src/pages/settings/SystemProxySettingsSection.tsx
+++ b/client-ui/src/pages/settings/SystemProxySettingsSection.tsx
@@ -185,7 +185,7 @@ export function SystemProxySettingsSection({
     if (expanded) {
       return '填写代理地址后，点输入框右侧按钮保存'
     }
-    return '为未单独配置的模型提供商提供默认出站代理'
+    return '未单独覆盖的外部请求（含行情与模型）默认走此代理'
   })()
 
   const persist = useCallback(async (next: SystemProxySettings) => {
@@ -195,7 +195,7 @@ export function SystemProxySettingsSection({
       const stored = resp.config.system_proxy ?? { enabled: false }
       onSaved(stored)
       setDraftUrl(stored.url ?? '')
-      toast.showSuccess(stored.enabled ? '系统代理已保存' : '系统代理已停用')
+      toast.showSuccess(stored.enabled ? '网络代理已保存' : '网络代理已停用')
     } catch (e) {
       toast.showError(e instanceof Error ? e.message : '保存失败')
     } finally {
@@ -224,14 +224,14 @@ export function SystemProxySettingsSection({
   return (
     <SettingsGroup>
       <SettingsRow
-        title="大模型网络代理"
+        title="网络代理"
         desc={rowDesc}
         last={!expanded}
         control={(
           <Switch
             checked={expanded}
             onChange={handleSwitchChange}
-            aria-label="展开或收起大模型网络代理设置"
+            aria-label="展开或收起网络代理设置"
           />
         )}
       />
@@ -285,7 +285,7 @@ export function SystemProxySettingsSection({
             ) : (
               <div className={s.panelFooter}>
                 <Text className={s.fieldHint} block>
-                  保存后对所有「跟随系统」的模型提供商生效；可在「大模型」中单独覆盖。
+                  保存后全局生效；可在「大模型」中为单个提供商覆盖或强制直连。
                 </Text>
                 {enabled ? (
                   <OpptrixButton

--- a/client-ui/src/pages/settings/settingsSearchIndex.ts
+++ b/client-ui/src/pages/settings/settingsSearchIndex.ts
@@ -60,7 +60,7 @@ export const SETTINGS_SEARCH_INDEX: SettingsSearchEntry[] = [
   { section: 'general', group: '外观', title: '提示音', desc: '对话完成或需要你确认时播放轻提示', keywords: ['提示音', '音效', '声音', 'sound', '通知音'] },
   { section: 'general', group: '偏好', title: '评分卡', desc: '因子评估默认使用的评分模板', keywords: ['scorecard', 'G=B+M', '因子'] },
   { section: 'general', group: '连接', title: '后端连接', desc: '检查 API 服务与 LLM 提供商配置', keywords: ['测试', 'health', '连接'] },
-  { section: 'general', group: '网络', title: '大模型系统代理', desc: '打开开关配置代理地址，在输入框旁保存', keywords: ['代理', 'proxy', 'socks', '网络'] },
+  { section: 'general', group: '网络', title: '网络代理', desc: '未单独覆盖的外部请求默认走此代理', keywords: ['代理', 'proxy', 'socks', '网络', '全局代理', '网络代理'] },
 
   // 大模型
   { section: 'models', title: '提供商', desc: '配置服务地址与密钥', keywords: ['大模型', 'LLM', 'OpenAI', '密钥', '提供商', '代理'] },

--- a/packages/agent/src/llm/provider.ts
+++ b/packages/agent/src/llm/provider.ts
@@ -58,8 +58,8 @@ export interface LlmConfig {
   temperature?: number
   maxTokens?: number
   timeout?: number
-  /** http(s):// or socks5:// — per-provider or system-resolved */
-  proxyUrl?: string
+  /** http(s):// or socks5:// — per-provider override; `false` forces direct */
+  proxyUrl?: string | false
 }
 
 export interface ToolCall {
@@ -628,7 +628,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
       },
       body: JSON.stringify(buildBody(stream)),
       signal: requestSignal,
-      ...(this.cfg.proxyUrl ? { proxyUrl: this.cfg.proxyUrl } : {}),
+      ...(this.cfg.proxyUrl !== undefined ? { proxyUrl: this.cfg.proxyUrl } : {}),
     })
 
     /** 上游拒收 tool_choice 时：先改 auto，再省略该字段后重试 */
@@ -776,7 +776,7 @@ export class OpenAiCompatibleProvider implements LlmProvider {
 
   async listModels() {
     return fetchOpenAiModelList(this.cfg.baseUrl, this.cfg.apiKey, {
-      proxyUrl: this.cfg.proxyUrl,
+      ...(this.cfg.proxyUrl !== undefined ? { proxyUrl: this.cfg.proxyUrl } : {}),
     }).catch(() => [])
   }
 }
@@ -803,13 +803,13 @@ export function joinOpenAiCompatibleUrl(baseUrl: string, relativePath: string): 
 export async function fetchOpenAiModelList(
   baseUrl: string,
   apiKey: string,
-  opts?: { proxyUrl?: string },
+  opts?: { proxyUrl?: string | false },
 ): Promise<string[]> {
   const url = joinOpenAiCompatibleUrl(baseUrl, 'models')
   const resp = await outboundFetch(url, {
     headers: { Authorization: `Bearer ${apiKey}` },
     signal: AbortSignal.timeout(30_000),
-    ...(opts?.proxyUrl ? { proxyUrl: opts.proxyUrl } : {}),
+    ...(opts?.proxyUrl !== undefined ? { proxyUrl: opts.proxyUrl } : {}),
   })
   if (!resp.ok) {
     const text = (await resp.text()).slice(0, 200)

--- a/packages/agent/src/llm/providers.ts
+++ b/packages/agent/src/llm/providers.ts
@@ -15,8 +15,8 @@ export interface ProviderProfile {
   baseUrl: string
   apiKey: string
   models: string[]
-  /** Resolved effective outbound proxy (provider overrides system). */
-  proxyUrl?: string
+  /** Resolved outbound proxy; `false` forces direct (ignore process default). */
+  proxyUrl?: string | false
 }
 
 export interface AvailableModel {
@@ -131,7 +131,7 @@ export class ProviderRegistry {
       apiKey: p.apiKey,
       model,
       baseUrl: normalizeBaseUrl(p.baseUrl),
-      ...(p.proxyUrl ? { proxyUrl: p.proxyUrl } : {}),
+      ...(p.proxyUrl !== undefined ? { proxyUrl: p.proxyUrl } : {}),
     }
   }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -59,10 +59,16 @@ export {
   formatOutboundFetchError,
   isOutboundTimeoutError,
   resetOutboundProxyAgentCacheForTests,
+  setDefaultOutboundProxyUrl,
+  getDefaultOutboundProxyUrl,
+  applySystemProxyAsDefault,
+  resetDefaultOutboundProxyUrlForTests,
+  resolveEffectiveOutboundProxyUrl,
   type OutboundFetchInit,
 } from './outbound-fetch.js'
 export {
   resolveEffectiveProxyUrl,
+  resolveOutboundProxyInit,
   validateProxyUrlInput,
   normalizeProxyUrlInput,
   normalizeProviderProxyMode,

--- a/packages/shared/src/outbound-fetch.ts
+++ b/packages/shared/src/outbound-fetch.ts
@@ -15,11 +15,75 @@ import {
 import { isValidProxyUrl, normalizeProxyUrlInput } from './proxy-config.js'
 
 export type OutboundFetchInit = RequestInit & {
-  /** http(s):// or socks5:// / socks4:// — routes this request through a proxy */
-  proxyUrl?: string
+  /**
+   * Outbound proxy for this request:
+   * - `string` — use that proxy
+   * - `false` — force direct (ignore process default)
+   * - `undefined` — use process default when set
+   */
+  proxyUrl?: string | false
 }
 
 const proxyAgentCache = new Map<string, Agent>()
+
+let defaultOutboundProxyUrl: string | undefined
+
+function isLoopbackHostname(hostname: string): boolean {
+  const host = hostname.replace(/^\[|\]$/g, '').toLowerCase()
+  return host === 'localhost'
+    || host === '127.0.0.1'
+    || host === '::1'
+    || host.endsWith('.localhost')
+}
+
+/** Set process-wide default outbound proxy. Invalid/empty clears. */
+export function setDefaultOutboundProxyUrl(url: string | undefined | null): void {
+  const raw = normalizeProxyUrlInput(url)
+  defaultOutboundProxyUrl = raw && isValidProxyUrl(raw) ? raw : undefined
+}
+
+export function getDefaultOutboundProxyUrl(): string | undefined {
+  return defaultOutboundProxyUrl
+}
+
+/** Apply Settings → 网络代理 (`system_proxy`) as the process default. */
+export function applySystemProxyAsDefault(
+  system: { enabled: boolean; url?: string } | null | undefined,
+): void {
+  if (system?.enabled) {
+    setDefaultOutboundProxyUrl(system.url)
+    return
+  }
+  setDefaultOutboundProxyUrl(undefined)
+}
+
+/** @internal tests only */
+export function resetDefaultOutboundProxyUrlForTests(): void {
+  defaultOutboundProxyUrl = undefined
+}
+
+/**
+ * Resolve the proxy URL actually used for a request.
+ * Loopback hosts skip the process default; an explicit `string` still applies.
+ */
+export function resolveEffectiveOutboundProxyUrl(
+  init: Pick<OutboundFetchInit, 'proxyUrl'> = {},
+  hostname = '',
+): string | undefined {
+  if (init.proxyUrl === false) return undefined
+
+  const explicit = typeof init.proxyUrl === 'string'
+    ? normalizeProxyUrlInput(init.proxyUrl)
+    : null
+  if (explicit) {
+    return isValidProxyUrl(explicit) ? explicit : undefined
+  }
+
+  const fallback = defaultOutboundProxyUrl
+  if (!fallback) return undefined
+  if (hostname && isLoopbackHostname(hostname)) return undefined
+  return fallback
+}
 
 function proxyAgentFor(url: string): Agent {
   let agent = proxyAgentCache.get(url)
@@ -155,23 +219,16 @@ function outboundFetchOnce(
   })
 }
 
-function resolveProxyFromInit(init: OutboundFetchInit): string | undefined {
-  const raw = normalizeProxyUrlInput(init.proxyUrl)
-  if (!raw) return undefined
-  if (!isValidProxyUrl(raw)) return undefined
-  return raw
-}
-
 /**
  * Outbound HTTP(S) fetch: IPv4 first per host; retry IPv6 only after v4 connect/DNS failure.
  * 一旦响应头到达并开始流式 body，不再换栈重放。
- * With `proxyUrl`, traffic routes through HTTP/HTTPS/SOCKS proxy (no dual-stack retry).
+ * With a resolved proxy URL, traffic routes through HTTP/HTTPS/SOCKS (no dual-stack retry).
  */
 export async function outboundFetch(url: string, init: OutboundFetchInit = {}): Promise<Response> {
   await ensureOutboundNetworkReady()
   const { proxyUrl: proxyOpt, ...fetchInit } = init
-  const proxyUrl = resolveProxyFromInit({ ...fetchInit, proxyUrl: proxyOpt })
   const hostname = new URL(url).hostname
+  const proxyUrl = resolveEffectiveOutboundProxyUrl({ proxyUrl: proxyOpt }, hostname)
   const families: OutboundConnectFamily[] = proxyUrl ? [4] : getConnectFamiliesForHost(hostname)
 
   let lastError: unknown

--- a/packages/shared/src/proxy-config.ts
+++ b/packages/shared/src/proxy-config.ts
@@ -1,4 +1,4 @@
-/** Per-provider proxy mode; `inherit` falls back to system proxy when enabled. */
+/** Per-provider proxy mode; `inherit` falls back to the global outbound proxy when enabled. */
 export type ProviderProxyMode = 'inherit' | 'none' | 'custom'
 
 export interface SystemProxySettings {
@@ -49,7 +49,8 @@ export function normalizeProviderProxyMode(mode: unknown): ProviderProxyMode {
 }
 
 /**
- * Resolve outbound proxy for an LLM provider.
+ * Resolve outbound proxy URL for an LLM provider (string or unset).
+ * `none` returns undefined — use {@link resolveOutboundProxyInit} when force-direct (`false`) is required.
  * Priority: provider custom > provider none (direct) > system > direct.
  */
 export function resolveEffectiveProxyUrl(
@@ -67,6 +68,25 @@ export function resolveEffectiveProxyUrl(
     if (url && isValidProxyUrl(url)) return url
   }
   return undefined
+}
+
+/**
+ * Map provider + system proxy settings to an outboundFetch `proxyUrl` init value.
+ * - `none` → `false` (force direct, ignore process default)
+ * - `custom` → validated URL, or `false` if missing/invalid
+ * - `inherit` → system URL when enabled, otherwise `undefined` (process default)
+ */
+export function resolveOutboundProxyInit(
+  provider: ProviderProxySettings | undefined | null,
+  system: SystemProxySettings | undefined | null,
+): string | false | undefined {
+  const mode = normalizeProviderProxyMode(provider?.mode)
+  if (mode === 'none') return false
+  if (mode === 'custom') {
+    const url = normalizeProxyUrlInput(provider?.url)
+    return url && isValidProxyUrl(url) ? url : false
+  }
+  return resolveEffectiveProxyUrl(provider, system)
 }
 
 /** Mask credentials in proxy URL for logs / previews. */

--- a/tests/outbound-default-proxy.test.mjs
+++ b/tests/outbound-default-proxy.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * Process-default outbound proxy: inherit / force-direct / loopback bypass.
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  applySystemProxyAsDefault,
+  getDefaultOutboundProxyUrl,
+  resetDefaultOutboundProxyUrlForTests,
+  resolveEffectiveOutboundProxyUrl,
+  setDefaultOutboundProxyUrl,
+} from '@opptrix/shared'
+
+const PROXY = 'http://127.0.0.1:7890'
+const OTHER = 'socks5://127.0.0.1:1080'
+
+describe('outbound default proxy', () => {
+  beforeEach(() => {
+    resetDefaultOutboundProxyUrlForTests()
+  })
+
+  afterEach(() => {
+    resetDefaultOutboundProxyUrlForTests()
+  })
+
+  it('setDefaultOutboundProxyUrl stores a valid url and clears invalid/empty', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(getDefaultOutboundProxyUrl(), PROXY)
+    setDefaultOutboundProxyUrl('not-a-proxy')
+    assert.equal(getDefaultOutboundProxyUrl(), undefined)
+    setDefaultOutboundProxyUrl(PROXY)
+    setDefaultOutboundProxyUrl('')
+    assert.equal(getDefaultOutboundProxyUrl(), undefined)
+    setDefaultOutboundProxyUrl(PROXY)
+    setDefaultOutboundProxyUrl(null)
+    assert.equal(getDefaultOutboundProxyUrl(), undefined)
+  })
+
+  it('applySystemProxyAsDefault sets when enabled+valid and clears otherwise', () => {
+    applySystemProxyAsDefault({ enabled: true, url: PROXY })
+    assert.equal(getDefaultOutboundProxyUrl(), PROXY)
+    applySystemProxyAsDefault({ enabled: true, url: 'ftp://nope' })
+    assert.equal(getDefaultOutboundProxyUrl(), undefined)
+    applySystemProxyAsDefault({ enabled: true, url: PROXY })
+    applySystemProxyAsDefault({ enabled: false, url: PROXY })
+    assert.equal(getDefaultOutboundProxyUrl(), undefined)
+    applySystemProxyAsDefault(null)
+    assert.equal(getDefaultOutboundProxyUrl(), undefined)
+  })
+
+  it('undefined init uses process default for remote hosts', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({}, 'api.example.com'),
+      PROXY,
+    )
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({ proxyUrl: undefined }, 'api.example.com'),
+      PROXY,
+    )
+  })
+
+  it('proxyUrl false ignores process default', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({ proxyUrl: false }, 'api.example.com'),
+      undefined,
+    )
+  })
+
+  it('explicit string overrides process default', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({ proxyUrl: OTHER }, 'api.example.com'),
+      OTHER,
+    )
+  })
+
+  it('loopback hosts ignore process default', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(resolveEffectiveOutboundProxyUrl({}, 'localhost'), undefined)
+    assert.equal(resolveEffectiveOutboundProxyUrl({}, '127.0.0.1'), undefined)
+    assert.equal(resolveEffectiveOutboundProxyUrl({}, '::1'), undefined)
+    assert.equal(resolveEffectiveOutboundProxyUrl({}, 'foo.localhost'), undefined)
+  })
+
+  it('explicit string on loopback still returns that string', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({ proxyUrl: OTHER }, '127.0.0.1'),
+      OTHER,
+    )
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({ proxyUrl: OTHER }, 'localhost'),
+      OTHER,
+    )
+  })
+
+  it('invalid explicit string does not fall back to default', () => {
+    setDefaultOutboundProxyUrl(PROXY)
+    assert.equal(
+      resolveEffectiveOutboundProxyUrl({ proxyUrl: 'ftp://bad' }, 'api.example.com'),
+      undefined,
+    )
+  })
+})

--- a/tests/proxy-config.test.mjs
+++ b/tests/proxy-config.test.mjs
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
 import {
   resolveEffectiveProxyUrl,
+  resolveOutboundProxyInit,
   isValidProxyUrl,
   validateProxyUrlInput,
   normalizeProviderProxyMode,
@@ -53,5 +54,30 @@ describe('proxy-config', () => {
 
   it('validateProxyUrlInput rejects invalid schemes', () => {
     assert.throws(() => validateProxyUrlInput('ftp://x'), /代理地址/)
+  })
+
+  it('resolveOutboundProxyInit maps none to false (force direct)', () => {
+    const system = { enabled: true, url: 'http://127.0.0.1:7890' }
+    assert.equal(resolveOutboundProxyInit({ mode: 'none' }, system), false)
+  })
+
+  it('resolveOutboundProxyInit maps invalid custom to false', () => {
+    assert.equal(resolveOutboundProxyInit({ mode: 'custom', url: 'not-a-url' }, null), false)
+    assert.equal(resolveOutboundProxyInit({ mode: 'custom' }, null), false)
+  })
+
+  it('resolveOutboundProxyInit inherit returns system url when enabled', () => {
+    const system = { enabled: true, url: 'http://127.0.0.1:7890' }
+    assert.equal(
+      resolveOutboundProxyInit({ mode: 'inherit' }, system),
+      'http://127.0.0.1:7890',
+    )
+  })
+
+  it('resolveOutboundProxyInit inherit is undefined when system disabled', () => {
+    assert.equal(
+      resolveOutboundProxyInit({ mode: 'inherit' }, { enabled: false }),
+      undefined,
+    )
   })
 })


### PR DESCRIPTION
## Summary
- Promote Settings → General network proxy (`system_proxy`) to Opptrix-wide default for `outboundFetch` / Provider SDK traffic
- LLM inherits by default; per-provider custom overrides or force-direct (`proxyUrl: false`); loopback skips the process default
- Retitle UI to「网络代理」/「跟随全局代理」

## Test plan
- [x] `npm run build:packages`
- [x] `node --test tests/proxy-config.test.mjs tests/outbound-*.test.mjs`
- [x] `npm run check:ui`
- [ ] Enable proxy in 常规 → 网络代理; confirm market data and LLM inherit
- [ ] Set one LLM provider to 直连; confirm it bypasses global proxy
- [ ] Set one LLM provider to 自定义; confirm override URL wins


Made with [Cursor](https://cursor.com)