### PR TITLE
feat(client-ui): polish mobile slide panels and compact chrome

### DIFF
--- a/client-ui/src/chat/ChatApp.tsx
+++ b/client-ui/src/chat/ChatApp.tsx
@@ -107,7 +107,6 @@ import { copyTextToClipboard } from '../platform/clipboard'
 import { desktopChromeToolbarReserve } from '../desktop/layout'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { useDesktopShell } from '../hooks/useDesktopShell'
-import { OVERLAY_SIDEBAR_MS, useOverlaySidebarAnimation } from '../hooks/useOverlaySidebarAnimation'
 import { electronPlatform, isElectron } from '../platform/detect'
 import {
   buildChatAskNotification,
@@ -201,53 +200,61 @@ const useStyles = makeStyles({
     transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
     transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
   },
-  /** Mobile：保持横向，左栏 / 主列 / 右 sheet 真推布局 */
+  /** Mobile：裁切视口；内层 track 整段 translate（主列不被挤压） */
   contentWorkspaceMobile: {
     flexDirection: 'row',
+    position: 'relative',
+    overflow: 'hidden',
   },
   contentWorkspaceElectron: {
     paddingTop: `${DESKTOP_TITLEBAR_HEIGHT}px`,
   },
-  /** Mobile：右栏推入（width 动画），非 fixed 遮罩覆盖 */
-  mobileRightSheet: {
-    position: 'relative',
-    flexShrink: 0,
-    width: 0,
-    height: '100%',
-    overflow: 'hidden',
+  /** [drawer | main | right?] 固定宽滑轨 */
+  mobileSlideTrack: {
     display: 'flex',
-    flexDirection: 'column',
-    backgroundColor: opptrixCssVars.canvas,
-    boxSizing: 'border-box',
-    transitionProperty: 'width',
-    transitionDuration: `${OVERLAY_SIDEBAR_MS}ms`,
+    flexDirection: 'row',
+    flexShrink: 0,
+    height: '100%',
+    willChange: 'transform',
+    transitionProperty: 'transform',
+    transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
     transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
-    pointerEvents: 'none',
-    willChange: 'width',
     '@media (prefers-reduced-motion: reduce)': {
       transitionDuration: '1ms',
     },
   },
-  mobileRightSheetOpen: {
-    width: '100%',
-    pointerEvents: 'auto',
-  },
-  /** 锚定右缘，随 shell 变宽从右侧推出并挤开主列 */
-  mobileRightSheetInner: {
-    position: 'absolute',
-    top: 0,
-    right: 0,
-    bottom: 0,
-    width: '100vw',
-    maxWidth: '100vw',
+  /** 主列：恒为视口宽，随轨平移 */
+  mobileSlideMain: {
+    flexShrink: 0,
+    height: '100%',
+    minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
+    overflow: 'hidden',
+    boxSizing: 'border-box',
+  },
+  /** 右栏：恒为视口宽，挂在轨上 */
+  mobileRightSheet: {
+    flexShrink: 0,
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    backgroundColor: opptrixCssVars.canvas,
     boxSizing: 'border-box',
     paddingTop: 'env(safe-area-inset-top)',
     paddingRight: 'env(safe-area-inset-right)',
     paddingBottom: 'env(safe-area-inset-bottom)',
     paddingLeft: 'env(safe-area-inset-left)',
-    backgroundColor: opptrixCssVars.canvas,
+  },
+  mobileRightSheetInner: {
+    flex: 1,
+    minHeight: 0,
+    minWidth: 0,
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
     '& > *': {
       flex: 1,
       minHeight: 0,
@@ -363,10 +370,9 @@ export default function ChatApp() {
   const [preview, setPreview] = useState<{ sessionId: string; attachment: ChatAttachmentMeta } | null>(null)
   /** 本会话停留期间用户主动关闭预览后，不再自动打开 */
   const previewAutoOpenDismissedRef = useRef(false)
-  /** 移动端右栏全屏 sheet：行情 / 文件预览（与桌面 split 独立） */
+  /** 移动端右栏：与左抽屉同轨 translate（常驻第三列，不二次挂载） */
   const [mobileRightSheet, setMobileRightSheet] = useState<null | 'market' | 'preview'>(null)
   const mobileSheetOpen = isMobile && view === 'chat' && mobileRightSheet != null
-  const { mounted: mobileSheetMounted, presented: mobileSheetPresented } = useOverlaySidebarAnimation(mobileSheetOpen)
 
   useEffect(() => {
     if (!isMobile || view !== 'chat') {
@@ -427,6 +433,29 @@ export default function ChatApp() {
     openDrawer,
     closeDrawer,
   } = useSidebarPreference(isMobile, sidebarWidth)
+  /** 与 SessionSidebar drawer / tokens.mobileDrawerWidth 对齐 */
+  const mobileDrawerPx = Math.min(Math.round(viewportWidth * 0.88), 272)
+  /** 关闭：主列居中（轨左移 drawer）；开左：轨归零；开右：再左移一个视口 */
+  const mobileTrackX = !isMobile
+    ? 0
+    : mobileSheetOpen
+      ? -(mobileDrawerPx + viewportWidth)
+      : drawerOpen
+        ? 0
+        : -mobileDrawerPx
+  const mobileSlideTrackStyle = {
+    ['--opptrix-mobile-drawer-width' as string]: `${mobileDrawerPx}px`,
+    transform: `translate3d(${mobileTrackX}px, 0, 0)`,
+  }
+  const mobileSlideMainStyle = {
+    flex: `0 0 ${viewportWidth}px`,
+    width: viewportWidth,
+  }
+  const mobileRightSheetStyle = {
+    flex: `0 0 ${viewportWidth}px`,
+    width: viewportWidth,
+    pointerEvents: mobileSheetOpen ? 'auto' as const : 'none' as const,
+  }
   const [settingsSidebarVisible, setSettingsSidebarVisible] = useState(() => {
     if (typeof window === 'undefined') return false
     return window.innerWidth >= sidebarExpandThreshold(SIDEBAR_DEFAULT_WIDTH)
@@ -478,8 +507,11 @@ export default function ChatApp() {
       setSettingsSidebarVisible(prev => !prev)
       return
     }
+    if (isMobile && mobileRightSheet != null) {
+      closeMobileRightSheet()
+    }
     toggleVisible()
-  }, [view, toggleVisible])
+  }, [view, toggleVisible, isMobile, mobileRightSheet, closeMobileRightSheet])
 
   const [sessions, setSessions] = useState<SessionMeta[]>([])
   const [archivedGroups, setArchivedGroups] = useState<ArchiveFolderGroup[]>([])
@@ -2846,32 +2878,46 @@ export default function ChatApp() {
             )}
             aria-hidden={!isNews}
           >
-            {isMobile && isNews && (
-              <SessionSidebar
-                mode="drawer"
-                width={sidebarWidth}
-                drawerOpen={drawerOpen}
-                onClose={closeDrawer}
-                {...sidebarProps}
-              />
+            {isMobile ? (
+              <div className={s.mobileSlideTrack} style={mobileSlideTrackStyle}>
+                {isNews ? (
+                  <SessionSidebar
+                    mode="drawer"
+                    width={sidebarWidth}
+                    drawerOpen={drawerOpen}
+                    onClose={closeDrawer}
+                    {...sidebarProps}
+                  />
+                ) : null}
+                <div
+                  className={mergeClasses(s.chatColumn, s.mobileSlideMain)}
+                  style={mobileSlideMainStyle}
+                  onClick={drawerOpen ? closeDrawer : undefined}
+                >
+                  <NewsCenterPage
+                    electronChrome={electronChrome}
+                    chromeToolbarReserve={chromeToolbarReserve}
+                    isMobile={isMobile}
+                    sidebarDrawerOpen={drawerOpen}
+                    onOpenSidebar={toggleVisible}
+                    onOpenSettings={openNewsSettings}
+                    onDiscussArticle={handleDiscussArticle}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className={mergeClasses(s.chatColumn, electronChrome && s.chatColumnElectron)}>
+                <NewsCenterPage
+                  electronChrome={electronChrome}
+                  chromeToolbarReserve={chromeToolbarReserve}
+                  isMobile={isMobile}
+                  sidebarDrawerOpen={drawerOpen}
+                  onOpenSidebar={toggleVisible}
+                  onOpenSettings={openNewsSettings}
+                  onDiscussArticle={handleDiscussArticle}
+                />
+              </div>
             )}
-            <div
-              className={mergeClasses(
-                s.chatColumn,
-                electronChrome && s.chatColumnElectron,
-              )}
-              onClick={isMobile && drawerOpen ? closeDrawer : undefined}
-            >
-              <NewsCenterPage
-                electronChrome={electronChrome}
-                chromeToolbarReserve={chromeToolbarReserve}
-                isMobile={isMobile}
-                sidebarDrawerOpen={drawerOpen}
-                onOpenSidebar={toggleVisible}
-                onOpenSettings={openNewsSettings}
-                onDiscussArticle={handleDiscussArticle}
-              />
-            </div>
           </div>
         )}
 
@@ -2886,30 +2932,42 @@ export default function ChatApp() {
             )}
             aria-hidden={!isMarket}
           >
-            {isMobile && isMarket && (
-              <SessionSidebar
-                mode="drawer"
-                width={sidebarWidth}
-                drawerOpen={drawerOpen}
-                onClose={closeDrawer}
-                {...sidebarProps}
-              />
+            {isMobile ? (
+              <div className={s.mobileSlideTrack} style={mobileSlideTrackStyle}>
+                {isMarket ? (
+                  <SessionSidebar
+                    mode="drawer"
+                    width={sidebarWidth}
+                    drawerOpen={drawerOpen}
+                    onClose={closeDrawer}
+                    {...sidebarProps}
+                  />
+                ) : null}
+                <div
+                  className={mergeClasses(s.chatColumn, s.mobileSlideMain)}
+                  style={mobileSlideMainStyle}
+                  onClick={drawerOpen ? closeDrawer : undefined}
+                >
+                  <MarketDynamicsPage
+                    electronChrome={electronChrome}
+                    chromeToolbarReserve={chromeToolbarReserve}
+                    isMobile={isMobile}
+                    sidebarDrawerOpen={drawerOpen}
+                    onOpenSidebar={toggleVisible}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className={mergeClasses(s.chatColumn, electronChrome && s.chatColumnElectron)}>
+                <MarketDynamicsPage
+                  electronChrome={electronChrome}
+                  chromeToolbarReserve={chromeToolbarReserve}
+                  isMobile={isMobile}
+                  sidebarDrawerOpen={drawerOpen}
+                  onOpenSidebar={toggleVisible}
+                />
+              </div>
             )}
-            <div
-              className={mergeClasses(
-                s.chatColumn,
-                electronChrome && s.chatColumnElectron,
-              )}
-              onClick={isMobile && drawerOpen ? closeDrawer : undefined}
-            >
-              <MarketDynamicsPage
-                electronChrome={electronChrome}
-                chromeToolbarReserve={chromeToolbarReserve}
-                isMobile={isMobile}
-                sidebarDrawerOpen={drawerOpen}
-                onOpenSidebar={toggleVisible}
-              />
-            </div>
           </div>
         )}
 
@@ -2924,30 +2982,42 @@ export default function ChatApp() {
             )}
             aria-hidden={!isCommunity}
           >
-            {isMobile && isCommunity && (
-              <SessionSidebar
-                mode="drawer"
-                width={sidebarWidth}
-                drawerOpen={drawerOpen}
-                onClose={closeDrawer}
-                {...sidebarProps}
-              />
+            {isMobile ? (
+              <div className={s.mobileSlideTrack} style={mobileSlideTrackStyle}>
+                {isCommunity ? (
+                  <SessionSidebar
+                    mode="drawer"
+                    width={sidebarWidth}
+                    drawerOpen={drawerOpen}
+                    onClose={closeDrawer}
+                    {...sidebarProps}
+                  />
+                ) : null}
+                <div
+                  className={mergeClasses(s.chatColumn, s.mobileSlideMain)}
+                  style={mobileSlideMainStyle}
+                  onClick={drawerOpen ? closeDrawer : undefined}
+                >
+                  <CommunityFeedPage
+                    electronChrome={electronChrome}
+                    chromeToolbarReserve={chromeToolbarReserve}
+                    isMobile={isMobile}
+                    sidebarDrawerOpen={drawerOpen}
+                    onOpenSidebar={toggleVisible}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className={mergeClasses(s.chatColumn, electronChrome && s.chatColumnElectron)}>
+                <CommunityFeedPage
+                  electronChrome={electronChrome}
+                  chromeToolbarReserve={chromeToolbarReserve}
+                  isMobile={isMobile}
+                  sidebarDrawerOpen={drawerOpen}
+                  onOpenSidebar={toggleVisible}
+                />
+              </div>
             )}
-            <div
-              className={mergeClasses(
-                s.chatColumn,
-                electronChrome && s.chatColumnElectron,
-              )}
-              onClick={isMobile && drawerOpen ? closeDrawer : undefined}
-            >
-              <CommunityFeedPage
-                electronChrome={electronChrome}
-                chromeToolbarReserve={chromeToolbarReserve}
-                isMobile={isMobile}
-                sidebarDrawerOpen={drawerOpen}
-                onOpenSidebar={toggleVisible}
-              />
-            </div>
           </div>
         )}
 
@@ -2962,32 +3032,46 @@ export default function ChatApp() {
             )}
             aria-hidden={!isExperts}
           >
-            {isMobile && isExperts && (
-              <SessionSidebar
-                mode="drawer"
-                width={sidebarWidth}
-                drawerOpen={drawerOpen}
-                onClose={closeDrawer}
-                {...sidebarProps}
-              />
+            {isMobile ? (
+              <div className={s.mobileSlideTrack} style={mobileSlideTrackStyle}>
+                {isExperts ? (
+                  <SessionSidebar
+                    mode="drawer"
+                    width={sidebarWidth}
+                    drawerOpen={drawerOpen}
+                    onClose={closeDrawer}
+                    {...sidebarProps}
+                  />
+                ) : null}
+                <div
+                  className={mergeClasses(s.chatColumn, s.mobileSlideMain)}
+                  style={mobileSlideMainStyle}
+                  onClick={drawerOpen ? closeDrawer : undefined}
+                >
+                  <ExpertMarketPage
+                    electronChrome={electronChrome}
+                    chromeToolbarReserve={chromeToolbarReserve}
+                    isMobile={isMobile}
+                    sidebarDrawerOpen={drawerOpen}
+                    onOpenSidebar={toggleVisible}
+                    onSelectExpert={handleSelectExpert}
+                    onExpertSaved={() => setExpertRefreshKey(k => k + 1)}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className={mergeClasses(s.chatColumn, electronChrome && s.chatColumnElectron)}>
+                <ExpertMarketPage
+                  electronChrome={electronChrome}
+                  chromeToolbarReserve={chromeToolbarReserve}
+                  isMobile={isMobile}
+                  sidebarDrawerOpen={drawerOpen}
+                  onOpenSidebar={toggleVisible}
+                  onSelectExpert={handleSelectExpert}
+                  onExpertSaved={() => setExpertRefreshKey(k => k + 1)}
+                />
+              </div>
             )}
-            <div
-              className={mergeClasses(
-                s.chatColumn,
-                electronChrome && s.chatColumnElectron,
-              )}
-              onClick={isMobile && drawerOpen ? closeDrawer : undefined}
-            >
-              <ExpertMarketPage
-                electronChrome={electronChrome}
-                chromeToolbarReserve={chromeToolbarReserve}
-                isMobile={isMobile}
-                sidebarDrawerOpen={drawerOpen}
-                onOpenSidebar={toggleVisible}
-                onSelectExpert={handleSelectExpert}
-                onExpertSaved={() => setExpertRefreshKey(k => k + 1)}
-              />
-            </div>
           </div>
         )}
 
@@ -3002,177 +3086,250 @@ export default function ChatApp() {
           )}
           aria-hidden={isSettings || isStandaloneView}
         >
-          {isMobile && !isStandaloneView && !isSettings && (
-            <SessionSidebar
-              mode="drawer"
-              width={sidebarWidth}
-              drawerOpen={drawerOpen}
-              onClose={closeDrawer}
-              {...sidebarProps}
-            />
-          )}
-
-          {(isMobile || chatVisible) && (
-            <div
-              className={mergeClasses(
-                s.chatColumn,
-                electronChrome && s.chatColumnElectron,
-                isDragging && s.chatColumnDragging,
-              )}
-              onClick={isMobile && drawerOpen ? closeDrawer : undefined}
-              style={!isMobile ? (
-                isDragging && showSplitter
-                  ? {
-                      flex: '0 0 auto',
-                      width: chatWidth,
-                      minWidth: chatWidth,
-                    }
-                  : {
-                      // Stay flexible while the right panel width animates so the panel
-                      // grows/shrinks from the window's right edge (not into a pre-reserved gap).
-                      flex: 1,
-                      width: undefined,
-                      minWidth: showSplitter ? WORKSPACE_CHAT_MIN_WIDTH : 0,
-                    }
-              ) : undefined}
-            >
-              {electronChrome && (
-                <div className={mergeClasses(s.chatTitleBar, 'opptrix-chat-title-bar')} aria-hidden />
-              )}
-              <div className={mergeClasses(s.chatPanel, electronChrome && 'opptrix-chat-panel')}>
-                <ChatView
-                  title={activeSession?.title ?? '新对话'}
-                  titleSlot={electronChrome ? undefined : chatTitleSlot}
-                  overlaySlot={rolePersonaDrawer}
-                  contextHint={contextHintBanner}
-                  sessionId={activeId}
-                  expertId={activeSession?.expertId ?? null}
-                  expertRefreshKey={expertRefreshKey}
-                  welcomeEpoch={welcomeEpoch}
-                  chatScrollEpoch={chatScrollEpoch}
-                  messages={collaborationViewTab === 'main' ? messages : collaborationChildMessages}
-                  contextRef={collaborationViewTab === 'main' ? contextRef : null}
-                  composerDraft={composerDraft}
-                  loading={collaborationViewTab === 'main' ? loading : false}
-                  wakeWaiting={collaborationViewTab === 'main' ? wakeWaiting : false}
-                  streamUiRef={streamUiRef}
-                  error={collaborationViewTab === 'main' ? error : ''}
-                  availableModels={availableModels}
-                  sessionModel={resolvedSessionModel}
-                  sessionLlmParams={sessionLlmParams}
-                  contextUsage={contextUsage}
-                  isMobile={isMobile}
-                  sidebarVisible={sidebarVisible}
-                  sidebarDrawerOpen={drawerOpen}
-                  llmLabel={llmLabel}
-                  backendOk={backendOk}
-                  onSubmit={handleSubmit}
-                  ensureSession={ensureSession}
-                  onStop={handleStop}
-                  promptQueue={promptQueue}
-                  onPromptQueueRemove={handlePromptQueueRemove}
-                  onPromptQueueRunNow={handlePromptQueueRunNow}
-                  backgroundJobs={sessionBackgroundJobs}
-                  onCancelBackgroundJob={handleCancelBackgroundJob}
-                  collaborationTasks={sessionCollaborationTasks}
-                  onCancelCollaborationTask={handleCancelCollaborationTask}
-                  onDismissCollaborationTask={handleDismissCollaborationTask}
-                  onSelectCollaborationRun={handleSelectCollaborationRun}
-                  collaborationViewTab={collaborationViewTab}
-                  onCollaborationViewTabChange={handleCollaborationViewTabChange}
-                  collaborationChildLoading={collaborationChildLoading}
-                  collaborationChildError={collaborationChildError}
-                  collaborationChildLiveTrace={collaborationChildLiveTrace}
-                  collaborationChildStreaming={collaborationChildStreaming}
-                  onReloadCollaborationChild={handleReloadCollaborationChild}
-                  onForkMessage={handleForkFromMessage}
-                  onEditResend={handleEditResend}
-                  onQuoteSelection={activeId && collaborationViewTab === 'main' ? handleQuoteSelection : undefined}
-                  onEphemeralAsk={activeId && collaborationViewTab === 'main' ? handleEphemeralAsk : undefined}
-                  onClearContextRef={contextRef && collaborationViewTab === 'main' ? handleClearContextRef : undefined}
-                  onModelChange={availableModels.length ? handleModelChange : undefined}
-                  onLlmParamsChange={availableModels.length ? handleLlmParamsChange : undefined}
-                  onOpenSidebar={toggleVisible}
-                  onNewChat={handleNew}
-                  onOpenSettings={openSystemSettings}
-                  onToggleSidebar={!isMobile ? handleToggleSidebar : undefined}
-                  rightPanelOpen={isMobile ? mobileRightSheet === 'market' : rightPanelVisible}
-                  chatColumnVisible={chatVisible}
-                  onToggleRightPanel={!isMobile ? handleToggleRightPanel : undefined}
-                  onToggleChatColumn={!isMobile && canToggleChatColumn ? handleToggleChatColumn : undefined}
-                  onOpenFilePreview={handleOpenFilePreview}
-                  onStreamError={handleStreamError}
-                  resolveStreamSnapshot={resolveStreamSnapshot}
-                  onClearPendingUserPrompt={clearPendingUserPrompt}
-                  sessionFilesPreviewOpen={isMobile ? mobileRightSheet === 'preview' : mode === 'preview'}
-                  onToggleSessionFilesPreview={handleToggleSessionFilesPreview}
-                  onOpenMobileMarketPanel={isMobile ? handleOpenMobileMarketPanel : undefined}
-                  onOpenMobileFilesPanel={isMobile ? handleOpenMobileFilesPanel : undefined}
+          {isMobile ? (
+            <div className={s.mobileSlideTrack} style={mobileSlideTrackStyle}>
+              {!isStandaloneView && !isSettings ? (
+                <SessionSidebar
+                  mode="drawer"
+                  width={sidebarWidth}
+                  drawerOpen={drawerOpen}
+                  onClose={closeDrawer}
+                  {...sidebarProps}
                 />
+              ) : null}
+
+              <div
+                className={mergeClasses(s.chatColumn, s.mobileSlideMain)}
+                style={mobileSlideMainStyle}
+                onClick={drawerOpen ? closeDrawer : undefined}
+              >
+                <div className={s.chatPanel}>
+                  <ChatView
+                    title={activeSession?.title ?? '新对话'}
+                    titleSlot={electronChrome ? undefined : chatTitleSlot}
+                    overlaySlot={rolePersonaDrawer}
+                    contextHint={contextHintBanner}
+                    sessionId={activeId}
+                    expertId={activeSession?.expertId ?? null}
+                    expertRefreshKey={expertRefreshKey}
+                    welcomeEpoch={welcomeEpoch}
+                    chatScrollEpoch={chatScrollEpoch}
+                    messages={collaborationViewTab === 'main' ? messages : collaborationChildMessages}
+                    contextRef={collaborationViewTab === 'main' ? contextRef : null}
+                    composerDraft={composerDraft}
+                    loading={collaborationViewTab === 'main' ? loading : false}
+                    wakeWaiting={collaborationViewTab === 'main' ? wakeWaiting : false}
+                    streamUiRef={streamUiRef}
+                    error={collaborationViewTab === 'main' ? error : ''}
+                    availableModels={availableModels}
+                    sessionModel={resolvedSessionModel}
+                    sessionLlmParams={sessionLlmParams}
+                    contextUsage={contextUsage}
+                    isMobile={isMobile}
+                    sidebarVisible={sidebarVisible}
+                    sidebarDrawerOpen={drawerOpen}
+                    llmLabel={llmLabel}
+                    backendOk={backendOk}
+                    onSubmit={handleSubmit}
+                    ensureSession={ensureSession}
+                    onStop={handleStop}
+                    promptQueue={promptQueue}
+                    onPromptQueueRemove={handlePromptQueueRemove}
+                    onPromptQueueRunNow={handlePromptQueueRunNow}
+                    backgroundJobs={sessionBackgroundJobs}
+                    onCancelBackgroundJob={handleCancelBackgroundJob}
+                    collaborationTasks={sessionCollaborationTasks}
+                    onCancelCollaborationTask={handleCancelCollaborationTask}
+                    onDismissCollaborationTask={handleDismissCollaborationTask}
+                    onSelectCollaborationRun={handleSelectCollaborationRun}
+                    collaborationViewTab={collaborationViewTab}
+                    onCollaborationViewTabChange={handleCollaborationViewTabChange}
+                    collaborationChildLoading={collaborationChildLoading}
+                    collaborationChildError={collaborationChildError}
+                    collaborationChildLiveTrace={collaborationChildLiveTrace}
+                    collaborationChildStreaming={collaborationChildStreaming}
+                    onReloadCollaborationChild={handleReloadCollaborationChild}
+                    onForkMessage={handleForkFromMessage}
+                    onEditResend={handleEditResend}
+                    onQuoteSelection={activeId && collaborationViewTab === 'main' ? handleQuoteSelection : undefined}
+                    onEphemeralAsk={activeId && collaborationViewTab === 'main' ? handleEphemeralAsk : undefined}
+                    onClearContextRef={contextRef && collaborationViewTab === 'main' ? handleClearContextRef : undefined}
+                    onModelChange={availableModels.length ? handleModelChange : undefined}
+                    onLlmParamsChange={availableModels.length ? handleLlmParamsChange : undefined}
+                    onOpenSidebar={handleToggleSidebar}
+                    onNewChat={handleNew}
+                    onOpenSettings={openSystemSettings}
+                    onToggleSidebar={undefined}
+                    rightPanelOpen={mobileRightSheet === 'market'}
+                    chatColumnVisible={chatVisible}
+                    onToggleRightPanel={undefined}
+                    onToggleChatColumn={undefined}
+                    onOpenFilePreview={handleOpenFilePreview}
+                    onStreamError={handleStreamError}
+                    resolveStreamSnapshot={resolveStreamSnapshot}
+                    onClearPendingUserPrompt={clearPendingUserPrompt}
+                    sessionFilesPreviewOpen={mobileRightSheet === 'preview'}
+                    onToggleSessionFilesPreview={handleToggleSessionFilesPreview}
+                    onOpenMobileMarketPanel={handleOpenMobileMarketPanel}
+                    onOpenMobileFilesPanel={handleOpenMobileFilesPanel}
+                  />
+                </div>
+              </div>
+
+              <div
+                className={s.mobileRightSheet}
+                style={mobileRightSheetStyle}
+                role="dialog"
+                aria-modal={mobileSheetOpen}
+                aria-label={mobileRightSheet === 'preview' ? '文件预览' : '关注与持仓'}
+                aria-hidden={!mobileSheetOpen}
+              >
+                <div className={s.mobileRightSheetInner}>
+                  <RightPanel
+                    visible
+                    fullWidth
+                    transitionEnabled={false}
+                    focusStockCode={focusStockCode}
+                    onFocusStockConsumed={handleFocusStockConsumed}
+                    onToggleRightPanel={mobileSheetOpen ? closeMobileRightSheet : undefined}
+                    onDiscussInChat={mobileSheetOpen ? handleStockDiscuss : undefined}
+                    previewMode={mobileRightSheet === 'preview'}
+                    preview={preview}
+                    previewSessionId={activeId}
+                    onSelectAttachment={handleSelectPreviewAttachment}
+                    onClosePreview={closeMobileRightSheet}
+                  />
+                </div>
               </div>
             </div>
-          )}
-
-          {!isMobile && showSplitter && (
-            <WorkspaceSplitDivider
-              electronChrome={electronChrome}
-              extendIntoSecondaryChrome={electronChrome}
-              isDragging={isDragging}
-              onBeginDrag={beginDrag}
-            />
-          )}
-
-          {!isMobile && (
-            <RightPanel
-              visible={rightPanelVisible}
-              width={rightPanelWidth}
-              fullWidth={!chatVisible}
-              transitionEnabled={!isDragging}
-              electronChrome={electronChrome}
-              chatColumnVisible={chatVisible}
-              chromeToolbarReserve={chromeToolbarReserve}
-              focusStockCode={focusStockCode}
-              onFocusStockConsumed={handleFocusStockConsumed}
-              onToggleRightPanel={handleToggleRightPanel}
-              onToggleChatColumn={canToggleChatColumn ? handleToggleChatColumn : undefined}
-              onDiscussInChat={handleStockDiscuss}
-              previewMode={mode === 'preview'}
-              preview={preview}
-              previewSessionId={activeId}
-              onSelectAttachment={handleSelectPreviewAttachment}
-              onClosePreview={handleClosePreview}
-              onSlideTransitionEnd={handlePeerSlideTransitionEnd}
-            />
-          )}
-
-          {mobileSheetMounted && mobileRightSheet != null && (
-            <div
-              className={mergeClasses(
-                s.mobileRightSheet,
-                mobileSheetPresented && s.mobileRightSheetOpen,
+          ) : (
+            <>
+              {chatVisible && (
+                <div
+                  className={mergeClasses(
+                    s.chatColumn,
+                    electronChrome && s.chatColumnElectron,
+                    isDragging && s.chatColumnDragging,
+                  )}
+                  style={
+                    isDragging && showSplitter
+                      ? {
+                          flex: '0 0 auto',
+                          width: chatWidth,
+                          minWidth: chatWidth,
+                        }
+                      : {
+                          flex: 1,
+                          width: undefined,
+                          minWidth: showSplitter ? WORKSPACE_CHAT_MIN_WIDTH : 0,
+                        }
+                  }
+                >
+                  {electronChrome && (
+                    <div className={mergeClasses(s.chatTitleBar, 'opptrix-chat-title-bar')} aria-hidden />
+                  )}
+                  <div className={mergeClasses(s.chatPanel, electronChrome && 'opptrix-chat-panel')}>
+                    <ChatView
+                      title={activeSession?.title ?? '新对话'}
+                      titleSlot={electronChrome ? undefined : chatTitleSlot}
+                      overlaySlot={rolePersonaDrawer}
+                      contextHint={contextHintBanner}
+                      sessionId={activeId}
+                      expertId={activeSession?.expertId ?? null}
+                      expertRefreshKey={expertRefreshKey}
+                      welcomeEpoch={welcomeEpoch}
+                      chatScrollEpoch={chatScrollEpoch}
+                      messages={collaborationViewTab === 'main' ? messages : collaborationChildMessages}
+                      contextRef={collaborationViewTab === 'main' ? contextRef : null}
+                      composerDraft={composerDraft}
+                      loading={collaborationViewTab === 'main' ? loading : false}
+                      wakeWaiting={collaborationViewTab === 'main' ? wakeWaiting : false}
+                      streamUiRef={streamUiRef}
+                      error={collaborationViewTab === 'main' ? error : ''}
+                      availableModels={availableModels}
+                      sessionModel={resolvedSessionModel}
+                      sessionLlmParams={sessionLlmParams}
+                      contextUsage={contextUsage}
+                      isMobile={isMobile}
+                      sidebarVisible={sidebarVisible}
+                      sidebarDrawerOpen={drawerOpen}
+                      llmLabel={llmLabel}
+                      backendOk={backendOk}
+                      onSubmit={handleSubmit}
+                      ensureSession={ensureSession}
+                      onStop={handleStop}
+                      promptQueue={promptQueue}
+                      onPromptQueueRemove={handlePromptQueueRemove}
+                      onPromptQueueRunNow={handlePromptQueueRunNow}
+                      backgroundJobs={sessionBackgroundJobs}
+                      onCancelBackgroundJob={handleCancelBackgroundJob}
+                      collaborationTasks={sessionCollaborationTasks}
+                      onCancelCollaborationTask={handleCancelCollaborationTask}
+                      onDismissCollaborationTask={handleDismissCollaborationTask}
+                      onSelectCollaborationRun={handleSelectCollaborationRun}
+                      collaborationViewTab={collaborationViewTab}
+                      onCollaborationViewTabChange={handleCollaborationViewTabChange}
+                      collaborationChildLoading={collaborationChildLoading}
+                      collaborationChildError={collaborationChildError}
+                      collaborationChildLiveTrace={collaborationChildLiveTrace}
+                      collaborationChildStreaming={collaborationChildStreaming}
+                      onReloadCollaborationChild={handleReloadCollaborationChild}
+                      onForkMessage={handleForkFromMessage}
+                      onEditResend={handleEditResend}
+                      onQuoteSelection={activeId && collaborationViewTab === 'main' ? handleQuoteSelection : undefined}
+                      onEphemeralAsk={activeId && collaborationViewTab === 'main' ? handleEphemeralAsk : undefined}
+                      onClearContextRef={contextRef && collaborationViewTab === 'main' ? handleClearContextRef : undefined}
+                      onModelChange={availableModels.length ? handleModelChange : undefined}
+                      onLlmParamsChange={availableModels.length ? handleLlmParamsChange : undefined}
+                      onOpenSidebar={toggleVisible}
+                      onNewChat={handleNew}
+                      onOpenSettings={openSystemSettings}
+                      onToggleSidebar={handleToggleSidebar}
+                      rightPanelOpen={rightPanelVisible}
+                      chatColumnVisible={chatVisible}
+                      onToggleRightPanel={handleToggleRightPanel}
+                      onToggleChatColumn={canToggleChatColumn ? handleToggleChatColumn : undefined}
+                      onOpenFilePreview={handleOpenFilePreview}
+                      onStreamError={handleStreamError}
+                      resolveStreamSnapshot={resolveStreamSnapshot}
+                      onClearPendingUserPrompt={clearPendingUserPrompt}
+                      sessionFilesPreviewOpen={mode === 'preview'}
+                      onToggleSessionFilesPreview={handleToggleSessionFilesPreview}
+                    />
+                  </div>
+                </div>
               )}
-              role="dialog"
-              aria-modal="true"
-              aria-label={mobileRightSheet === 'preview' ? '文件预览' : '关注与持仓'}
-              aria-hidden={!mobileSheetPresented}
-            >
-              <div className={s.mobileRightSheetInner}>
-                <RightPanel
-                  visible
-                  fullWidth
-                  transitionEnabled={false}
-                  focusStockCode={focusStockCode}
-                  onFocusStockConsumed={handleFocusStockConsumed}
-                  onToggleRightPanel={closeMobileRightSheet}
-                  onDiscussInChat={handleStockDiscuss}
-                  previewMode={mobileRightSheet === 'preview'}
-                  preview={preview}
-                  previewSessionId={activeId}
-                  onSelectAttachment={handleSelectPreviewAttachment}
-                  onClosePreview={closeMobileRightSheet}
+
+              {showSplitter && (
+                <WorkspaceSplitDivider
+                  electronChrome={electronChrome}
+                  extendIntoSecondaryChrome={electronChrome}
+                  isDragging={isDragging}
+                  onBeginDrag={beginDrag}
                 />
-              </div>
-            </div>
+              )}
+
+              <RightPanel
+                visible={rightPanelVisible}
+                width={rightPanelWidth}
+                fullWidth={!chatVisible}
+                transitionEnabled={!isDragging}
+                electronChrome={electronChrome}
+                chatColumnVisible={chatVisible}
+                chromeToolbarReserve={chromeToolbarReserve}
+                focusStockCode={focusStockCode}
+                onFocusStockConsumed={handleFocusStockConsumed}
+                onToggleRightPanel={handleToggleRightPanel}
+                onToggleChatColumn={canToggleChatColumn ? handleToggleChatColumn : undefined}
+                onDiscussInChat={handleStockDiscuss}
+                previewMode={mode === 'preview'}
+                preview={preview}
+                previewSessionId={activeId}
+                onSelectAttachment={handleSelectPreviewAttachment}
+                onClosePreview={handleClosePreview}
+                onSlideTransitionEnd={handlePeerSlideTransitionEnd}
+              />
+            </>
           )}
         </div>
 

--- a/client-ui/src/chat/ChatComposer.tsx
+++ b/client-ui/src/chat/ChatComposer.tsx
@@ -104,8 +104,8 @@ const useStyles = makeStyles({
     gap: '8px',
   },
   startersMobile: {
-    flexWrap: 'nowrap',
-    overflowX: 'auto',
+    flexWrap: 'wrap',
+    overflowX: 'hidden',
   },
   /** 专家快捷：贴在 composer 输入区顶部；与「接下来」分区（无标题，省纵向空间） */
   expertStarterBar: {
@@ -120,11 +120,11 @@ const useStyles = makeStyles({
   },
   expertStarterTrack: {
     display: 'flex',
-    flexWrap: 'nowrap',
+    flexWrap: 'wrap',
     alignItems: 'center',
     gap: '8px',
     width: '100%',
-    overflowX: 'auto',
+    overflowX: 'hidden',
     overflowY: 'hidden',
   },
   starterChip: {
@@ -463,7 +463,7 @@ const useStyles = makeStyles({
     paddingBottom: opptrixTokens.chatComposerBottomInset,
   },
   composerFooterMobile: {
-    paddingBottom: `max(${opptrixTokens.chatComposerBottomInset}, env(safe-area-inset-bottom))`,
+    paddingBottom: `max(${opptrixTokens.chatComposerBottomInsetMobile}, env(safe-area-inset-bottom))`,
   },
   /** 底栏 AI 提示：相对 composer 水平居中（用量改到工具栏模型左侧） */
   disclaimerRow: {
@@ -479,6 +479,11 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
     userSelect: 'none',
     minHeight: '22px',
+  },
+  disclaimerRowMobile: {
+    margin: '0',
+    padding: '2px 10px 0',
+    minHeight: '18px',
   },
   disclaimer: {
     flexShrink: 0,
@@ -1052,7 +1057,7 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
           )}
         >
           <Text className={s.startersLabel}>你可以这样问</Text>
-          <div className={mergeClasses(s.starters, isMobile && `${s.startersMobile} opptrix-scroll-x`)}>
+          <div className={mergeClasses(s.starters, isMobile && s.startersMobile)}>
             {starters.map((st, index) => (
               <OpptrixButton
                 key={listRowKey(index, st.label, st.text)}
@@ -1278,7 +1283,7 @@ const ChatComposer = forwardRef<ChatComposerHandle, ChatComposerProps>(function 
             isMobile && s.composerFooterMobile,
           )}
         >
-          <div className={s.disclaimerRow}>
+          <div className={mergeClasses(s.disclaimerRow, isMobile && s.disclaimerRowMobile)}>
             <span className={s.disclaimer}>
               内容由AI生成，不构成投资建议，请核实重要信息
             </span>

--- a/client-ui/src/chat/FilePreviewPanel.tsx
+++ b/client-ui/src/chat/FilePreviewPanel.tsx
@@ -32,6 +32,16 @@ import {
 } from '../desktop/constants'
 import { electronPlatform } from '../platform/detect'
 import { opptrixCssVars } from '../theme/tokens'
+import { ghostInteractive } from '../theme/mixins'
+import {
+  MOBILE_HEADER_BAR_HEIGHT,
+  MOBILE_HEADER_HIT,
+  MOBILE_HEADER_ICON_SIZE,
+  MOBILE_HEADER_PAD_X,
+  mobileHeaderBarInset,
+  mobileHeaderIconBtn,
+} from '../theme/mobileChrome'
+import OpptrixButton from '../components/opptrix/OpptrixButton'
 
 const MONO_FONT = 'var(--opptrix-font-mono)'
 
@@ -68,6 +78,16 @@ const useStyles = makeStyles({
     height: '40px',
     zIndex: 1,
   },
+  headerMobile: {
+    ...mobileHeaderBarInset,
+    height: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+    minHeight: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+    zIndex: 1,
+    paddingRight: `${MOBILE_HEADER_PAD_X}px`,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+    backgroundColor: opptrixCssVars.canvas,
+    position: 'relative',
+  },
   /**
    * Match DesktopWindowChrome / RightMarketPanel: top inset + center within
    * remaining chromeBand so tools / title share the left chrome midline.
@@ -96,12 +116,25 @@ const useStyles = makeStyles({
     paddingLeft: '8px',
     overflow: 'hidden',
   },
+  titleClusterMobile: {
+    height: `${MOBILE_HEADER_HIT}px`,
+    paddingLeft: '4px',
+  },
   headerTrail: {
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
     gap: `${DESKTOP_TOOL_GAP}px`,
     height: '28px',
+  },
+  headerTrailMobile: {
+    height: `${MOBILE_HEADER_HIT}px`,
+    gap: '2px',
+  },
+  mobileActionBtn: {
+    ...ghostInteractive,
+    ...mobileHeaderIconBtn,
+    color: opptrixCssVars.textSecondary,
   },
   /** 非 PDF 预览内部工具条（与 PdfPreviewViewer toolbar 对齐） */
   previewTools: {
@@ -599,12 +632,15 @@ export default function FilePreviewPanel({
     && !isWeb
     && !showCenterPicker
 
+  const mobileChrome = panelFullWidth && !electronChrome
+
   return (
     <div className={mergeClasses(s.root, electronChrome && s.rootElectron)}>
       <div
         className={mergeClasses(
           s.header,
-          !electronChrome && s.headerWeb,
+          !electronChrome && !mobileChrome && s.headerWeb,
+          mobileChrome && s.headerMobile,
           electronChrome && s.headerElectron,
           electronChrome && s.headerElectronFill,
           electronChrome && 'opptrix-right-panel-title-bar',
@@ -618,17 +654,35 @@ export default function FilePreviewPanel({
             aria-hidden
           />
         )}
-        <div className={mergeClasses(s.titleCluster, 'opptrix-panel-title-no-drag')}>
+        <div
+          className={mergeClasses(
+            s.titleCluster,
+            mobileChrome && s.titleClusterMobile,
+            'opptrix-panel-title-no-drag',
+          )}
+        >
           {attachment ? (
-            <ChromeToolButton
-              label={fileListToggleLabel}
-              iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
-              active={showSidebarList}
-              onClick={toggleFileList}
-              disabled={!sessionId || !hasAttachment}
-            >
-              <TextBulletListSquareRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-            </ChromeToolButton>
+            mobileChrome ? (
+              <OpptrixButton
+                className={s.mobileActionBtn}
+                variant="ghost"
+                icon={<TextBulletListSquareRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+                onClick={toggleFileList}
+                disabled={!sessionId || !hasAttachment}
+                aria-label={fileListToggleLabel}
+                aria-pressed={showSidebarList}
+              />
+            ) : (
+              <ChromeToolButton
+                label={fileListToggleLabel}
+                iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
+                active={showSidebarList}
+                onClick={toggleFileList}
+                disabled={!sessionId || !hasAttachment}
+              >
+                <TextBulletListSquareRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+              </ChromeToolButton>
+            )
           ) : (
             <span className={s.name}>文件预览</span>
           )}
@@ -640,14 +694,30 @@ export default function FilePreviewPanel({
           )}
           aria-hidden
         />
-        <div className={mergeClasses(s.headerTrail, 'opptrix-panel-title-no-drag')}>
-          <ChromeToolButton
-            label="关闭预览"
-            iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
-            onClick={onClose}
-          >
-            <DismissRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-          </ChromeToolButton>
+        <div
+          className={mergeClasses(
+            s.headerTrail,
+            mobileChrome && s.headerTrailMobile,
+            'opptrix-panel-title-no-drag',
+          )}
+        >
+          {mobileChrome ? (
+            <OpptrixButton
+              className={s.mobileActionBtn}
+              variant="ghost"
+              icon={<DismissRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+              onClick={onClose}
+              aria-label="关闭预览"
+            />
+          ) : (
+            <ChromeToolButton
+              label="关闭预览"
+              iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
+              onClick={onClose}
+            >
+              <DismissRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+            </ChromeToolButton>
+          )}
         </div>
       </div>
       <div className={s.main}>

--- a/client-ui/src/chat/MobileTopBar.tsx
+++ b/client-ui/src/chat/MobileTopBar.tsx
@@ -8,28 +8,26 @@ import {
   PanelRightExpandRegular,
 } from './chatIcons'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
+import {
+  MOBILE_HEADER_ICON_SIZE,
+  mobileHeaderBar,
+  mobileHeaderIconBtn,
+  mobileHeaderTitle,
+} from '../theme/mobileChrome'
 import { ghostInteractive, hairlineBottom } from '../theme/mixins'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 
 const useStyles = makeStyles({
   bar: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: '4px',
-    padding: '6px 8px',
-    paddingTop: 'max(6px, env(safe-area-inset-top))',
+    ...mobileHeaderBar,
     backgroundColor: opptrixCssVars.surface,
     ...hairlineBottom,
-    flexShrink: 0,
     zIndex: 10,
-    minHeight: '44px',
   },
   menuBtn: {
     ...ghostInteractive,
-    minWidth: '44px',
-    height: '44px',
+    ...mobileHeaderIconBtn,
     color: opptrixCssVars.textPrimary,
-    flexShrink: 0,
   },
   center: {
     flex: 1,
@@ -39,16 +37,7 @@ const useStyles = makeStyles({
     gap: '8px',
     padding: '0 4px',
   },
-  title: {
-    flex: 1,
-    minWidth: 0,
-    fontSize: 'var(--opptrix-font-2xl)',
-    fontWeight: 600,
-    color: opptrixCssVars.textPrimary,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  },
+  title: mobileHeaderTitle,
   statusDot: {
     width: '6px',
     height: '6px',
@@ -65,8 +54,7 @@ const useStyles = makeStyles({
   },
   actionBtn: {
     ...ghostInteractive,
-    minWidth: '44px',
-    height: '44px',
+    ...mobileHeaderIconBtn,
     color: opptrixCssVars.textSecondary,
   },
   actionBtnActive: {
@@ -111,8 +99,8 @@ export default function MobileTopBar({
         className={s.menuBtn}
         variant="ghost"
         icon={drawerOpen
-          ? <PanelLeftContractRegular fontSize={22} />
-          : <PanelLeftExpandRegular fontSize={22} />}
+          ? <PanelLeftContractRegular fontSize={MOBILE_HEADER_ICON_SIZE} />
+          : <PanelLeftExpandRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
         onClick={onOpenDrawer}
         aria-label={drawerOpen ? '收起侧栏' : '打开侧栏'}
         aria-pressed={drawerOpen}
@@ -128,31 +116,31 @@ export default function MobileTopBar({
         <OpptrixButton
           className={s.actionBtn}
           variant="ghost"
-          icon={<ChatAddRegular fontSize={22} />}
+          icon={<ChatAddRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
           onClick={onNewChat}
           aria-label="新对话"
         />
+        {onOpenFilesPanel ? (
+          <OpptrixButton
+            className={mergeClasses(s.actionBtn, filesPanelOpen && s.actionBtnActive)}
+            variant="ghost"
+            icon={<FolderListRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+            onClick={onOpenFilesPanel}
+            disabled={filesPanelDisabled}
+            aria-label={filesPanelOpen ? '收起文件预览' : '打开文件预览'}
+            aria-pressed={filesPanelOpen}
+          />
+        ) : null}
         {onOpenMarketPanel ? (
           <OpptrixButton
             className={mergeClasses(s.actionBtn, marketPanelOpen && s.actionBtnActive)}
             variant="ghost"
             icon={marketPanelOpen
-              ? <PanelRightContractRegular fontSize={22} />
-              : <PanelRightExpandRegular fontSize={22} />}
+              ? <PanelRightContractRegular fontSize={MOBILE_HEADER_ICON_SIZE} />
+              : <PanelRightExpandRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
             onClick={onOpenMarketPanel}
             aria-label={marketPanelOpen ? '收起关注与持仓' : '打开关注与持仓'}
             aria-pressed={marketPanelOpen}
-          />
-        ) : null}
-        {onOpenFilesPanel ? (
-          <OpptrixButton
-            className={mergeClasses(s.actionBtn, filesPanelOpen && s.actionBtnActive)}
-            variant="ghost"
-            icon={<FolderListRegular fontSize={22} />}
-            onClick={onOpenFilesPanel}
-            disabled={filesPanelDisabled}
-            aria-label={filesPanelOpen ? '收起文件预览' : '打开文件预览'}
-            aria-pressed={filesPanelOpen}
           />
         ) : null}
       </div>

--- a/client-ui/src/chat/SessionSidebar.tsx
+++ b/client-ui/src/chat/SessionSidebar.tsx
@@ -2,11 +2,12 @@ import { useState, useRef, useCallback, memo, useEffect } from 'react'
 import {
   makeStyles, mergeClasses,
 } from '@fluentui/react-components'
-import { SettingsRegular, DeleteRegular, DismissRegular, NewsRegular, ArchiveRegular, GlobeRegular, CommentMultipleRegular, PeopleTeamRegular } from '@fluentui/react-icons'
+import { SettingsRegular, DeleteRegular, NewsRegular, ArchiveRegular, GlobeRegular, CommentMultipleRegular, PeopleTeamRegular } from '@fluentui/react-icons'
 import { ChatAddRegular } from './chatIcons'
 import type { SessionMeta } from '../types/chat'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { ghostInteractive, motion, nativeIconInteractive, sidebarItemSelected, sidebarTopMenuIcon, sidebarTopMenuRow, SIDEBAR_TOP_MENU_ICON_SIZE } from '../theme/mixins'
+import { MOBILE_HEADER_BAR_HEIGHT, mobileHeaderBarInset } from '../theme/mobileChrome'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import OpptrixSegmentedControl from '../components/opptrix/OpptrixSegmentedControl'
 import ThinkingDots from '../components/ThinkingDots'
@@ -72,53 +73,30 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
     height: '100%',
   },
-  /** Mobile push shell：宽 0↔drawer，挤开主列（非 fixed 遮罩） */
+  /** Mobile 滑轨内左栏：固定宽，由外层 track translate 露出（不挤主列） */
   drawerShell: {
     flexShrink: 0,
-    width: 0,
+    width: 'var(--opptrix-mobile-drawer-width, min(88vw, 272px))',
+    maxWidth: '300px',
     height: '100%',
     overflow: 'hidden',
-    pointerEvents: 'none',
-    transitionProperty: 'width',
-    transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
-    transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
     backgroundColor: opptrixCssVars.canvasAlt,
-    '@media (prefers-reduced-motion: reduce)': {
-      transitionDuration: '1ms',
-    },
+    boxSizing: 'border-box',
   },
-  drawerShellOpen: {
-    width: opptrixTokens.mobileDrawerWidth,
-    maxWidth: '300px',
+  drawerShellInteractive: {
     pointerEvents: 'auto',
   },
+  drawerShellInert: {
+    pointerEvents: 'none',
+  },
   sidebarDrawer: {
-    width: opptrixTokens.mobileDrawerWidth,
-    maxWidth: '300px',
+    width: '100%',
     height: '100%',
     boxSizing: 'border-box',
     paddingTop: 'env(safe-area-inset-top)',
     paddingBottom: 'env(safe-area-inset-bottom)',
     backgroundColor: opptrixCssVars.canvasAlt,
     borderRight: `1px solid ${opptrixCssVars.separator}`,
-    opacity: 0,
-    transform: 'translate3d(-12px, 0, 0)',
-    transitionProperty: 'opacity, transform',
-    transitionDuration: `${DESKTOP_SIDEBAR_LAYOUT_MS}ms`,
-    transitionTimingFunction: DESKTOP_SIDEBAR_LAYOUT_EASE,
-    '@media (prefers-reduced-motion: reduce)': {
-      transitionDuration: '1ms',
-    },
-  },
-  sidebarDrawerOpen: {
-    opacity: 1,
-    transform: 'translate3d(0, 0, 0)',
-  },
-  drawerHead: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    padding: '8px 8px 0',
   },
   brandRow: {
     display: 'flex',
@@ -130,6 +108,16 @@ const useStyles = makeStyles({
     padding: '4px 20px 0',
     overflow: 'hidden',
     lineHeight: 1,
+  },
+  /** 移动抽屉：与右栏 sheet header 同高，品牌文字垂直居中 */
+  brandRowDrawer: {
+    ...mobileHeaderBarInset,
+    /* 覆盖 inset 左右垫，保持与菜单图标左缘对齐 */
+    paddingLeft: '20px',
+    paddingRight: '20px',
+    height: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+    minHeight: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+    alignItems: 'center',
   },
   brandName: {
     flexShrink: 0,
@@ -229,12 +217,17 @@ const useStyles = makeStyles({
   itemTrailing: {
     position: 'relative',
     flexShrink: 0,
+    zIndex: 1,
     height: '18px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     transitionProperty: 'min-width',
     transitionDuration: motion.fast,
+    /* 触控：归档+删除常显，预留宽度避免压住标题（穿透） */
+    '@media (hover: none)': {
+      minWidth: '44px',
+    },
   },
   itemSpinner: {
     display: 'inline-flex',
@@ -312,12 +305,6 @@ const useStyles = makeStyles({
     paddingTop: '5px',
     paddingBottom: '5px',
     borderRadius: opptrixTokens.radiusMd,
-  },
-  iconBtn: {
-    minWidth: '36px',
-    height: '36px',
-    borderRadius: opptrixTokens.radiusMd,
-    color: opptrixCssVars.textTertiary,
   },
 })
 
@@ -429,14 +416,11 @@ function SessionSidebar({
 
   const sidebarBody = (
     <>
-      {isDrawer && (
-        <div className={s.drawerHead}>
-          <OpptrixButton className={s.iconBtn} variant="ghost" icon={<DismissRegular />} onClick={onClose} aria-label="关闭" />
-        </div>
-      )}
-
       {showSidebarBrand ? (
-        <div className={s.brandRow} aria-label={brandAriaLabel}>
+        <div
+          className={mergeClasses(s.brandRow, isDrawer && s.brandRowDrawer)}
+          aria-label={brandAriaLabel}
+        >
           <span className={s.brandName} aria-hidden="true">Opptrix 工作台</span>
           {versionLabel ? (
             <span className={s.brandVersion} aria-hidden="true">{versionLabel}</span>
@@ -678,7 +662,6 @@ function SessionSidebar({
         isDrawer && s.sidebarDrawer,
         !isDrawer && s.sidebarPanel,
         !isDrawer && visible && s.sidebarPanelVisible,
-        isDrawer && drawerOpen && s.sidebarDrawerOpen,
         !electronChrome && !isDrawer && s.sidebarWeb,
         electronChrome && s.sidebarElectron,
         sidebarSolidDark && s.sidebarElectronSolid,
@@ -695,7 +678,10 @@ function SessionSidebar({
   if (isDrawer) {
     return (
       <div
-        className={mergeClasses(s.drawerShell, drawerOpen && s.drawerShellOpen)}
+        className={mergeClasses(
+          s.drawerShell,
+          drawerOpen ? s.drawerShellInteractive : s.drawerShellInert,
+        )}
         aria-hidden={!drawerOpen}
       >
         {sidebarEl}

--- a/client-ui/src/chat/SessionSidebarArchivePanel.tsx
+++ b/client-ui/src/chat/SessionSidebarArchivePanel.tsx
@@ -309,12 +309,16 @@ const useStyles = makeStyles({
   sessionTrailing: {
     position: 'relative',
     flexShrink: 0,
+    zIndex: 1,
     height: '18px',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     transitionProperty: 'min-width',
     transitionDuration: motion.fast,
+    '@media (hover: none)': {
+      minWidth: '22px',
+    },
   },
   sessionSpinner: {
     display: 'inline-flex',

--- a/client-ui/src/components/MobileNavMenuButton.tsx
+++ b/client-ui/src/components/MobileNavMenuButton.tsx
@@ -2,15 +2,14 @@ import { makeStyles, mergeClasses } from '@fluentui/react-components'
 import OpptrixButton from './opptrix/OpptrixButton'
 import { PanelLeftContractRegular, PanelLeftExpandRegular } from '../chat/chatIcons'
 import { opptrixCssVars } from '../theme/tokens'
+import { MOBILE_HEADER_ICON_SIZE, mobileHeaderIconBtn } from '../theme/mobileChrome'
 import { ghostInteractive } from '../theme/mixins'
 
 const useStyles = makeStyles({
   btn: {
     ...ghostInteractive,
-    minWidth: '44px',
-    height: '44px',
+    ...mobileHeaderIconBtn,
     color: opptrixCssVars.textPrimary,
-    flexShrink: 0,
   },
 })
 
@@ -37,8 +36,8 @@ export default function MobileNavMenuButton({
       className={mergeClasses(s.btn, className)}
       variant="ghost"
       icon={open
-        ? <PanelLeftContractRegular fontSize={22} />
-        : <PanelLeftExpandRegular fontSize={22} />}
+        ? <PanelLeftContractRegular fontSize={MOBILE_HEADER_ICON_SIZE} />
+        : <PanelLeftExpandRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
       onClick={onClick}
       aria-label={label}
       aria-pressed={open}

--- a/client-ui/src/hooks/useTouchAxisLockedScroll.ts
+++ b/client-ui/src/hooks/useTouchAxisLockedScroll.ts
@@ -1,0 +1,70 @@
+import { useEffect, type RefObject } from 'react'
+
+const AXIS_LOCK_SLOP_PX = 8
+
+/**
+ * 双轴 overflow 容器上，按手势主轴锁定滚动（只上下或只左右，禁止斜向同滚）。
+ * 须在 touchmove 上 preventDefault，故 listener 为非 passive。
+ */
+export function useTouchAxisLockedScroll(ref: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    let axis: 'x' | 'y' | null = null
+    let startX = 0
+    let startY = 0
+    let startLeft = 0
+    let startTop = 0
+
+    const onStart = (e: TouchEvent) => {
+      if (e.touches.length !== 1) {
+        axis = null
+        return
+      }
+      const t = e.touches[0]
+      axis = null
+      startX = t.clientX
+      startY = t.clientY
+      startLeft = el.scrollLeft
+      startTop = el.scrollTop
+    }
+
+    const onMove = (e: TouchEvent) => {
+      if (e.touches.length !== 1) return
+      const t = e.touches[0]
+      const dx = t.clientX - startX
+      const dy = t.clientY - startY
+
+      if (!axis) {
+        if (Math.abs(dx) < AXIS_LOCK_SLOP_PX && Math.abs(dy) < AXIS_LOCK_SLOP_PX) return
+        axis = Math.abs(dx) > Math.abs(dy) ? 'x' : 'y'
+      }
+
+      e.preventDefault()
+      if (axis === 'x') {
+        el.scrollLeft = startLeft - dx
+        el.scrollTop = startTop
+      } else {
+        el.scrollTop = startTop - dy
+        el.scrollLeft = startLeft
+      }
+    }
+
+    const onEnd = () => {
+      axis = null
+    }
+
+    el.addEventListener('touchstart', onStart, { passive: true })
+    el.addEventListener('touchmove', onMove, { passive: false })
+    el.addEventListener('touchend', onEnd, { passive: true })
+    el.addEventListener('touchcancel', onEnd, { passive: true })
+
+    return () => {
+      el.removeEventListener('touchstart', onStart)
+      el.removeEventListener('touchmove', onMove)
+      el.removeEventListener('touchend', onEnd)
+      el.removeEventListener('touchcancel', onEnd)
+    }
+  }, [ref])
+}

--- a/client-ui/src/market/FollowStockDialog.tsx
+++ b/client-ui/src/market/FollowStockDialog.tsx
@@ -35,7 +35,7 @@ import { MARKET_DOWN, MARKET_UP } from './chartTheme'
 import TradeDateField, { todayTradeDate } from './TradeDateField'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { ghostInteractive, motion, nativeIconInteractive } from '../theme/mixins'
-import { MARKET_PANEL_DRAWER_CLOSE_MS, MARKET_PANEL_DRAWER_MAX_WIDTH } from './marketPanelDrawer'
+import { MARKET_PANEL_DRAWER_CLOSE_MS, MARKET_PANEL_DRAWER_MAX_HEIGHT, MARKET_PANEL_DRAWER_MAX_WIDTH } from './marketPanelDrawer'
 
 type DialogTab = 'records' | 'trade'
 
@@ -82,7 +82,7 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
-    maxHeight: 'min(78%, 520px)',
+    maxHeight: MARKET_PANEL_DRAWER_MAX_HEIGHT,
     borderRadius: `${opptrixTokens.radiusXl} ${opptrixTokens.radiusXl} 0 0`,
     borderTop: '1px solid rgba(255, 255, 255, 0.55)',
     backgroundColor: 'rgba(255, 255, 255, 0.88)',

--- a/client-ui/src/market/RightMarketPanel.tsx
+++ b/client-ui/src/market/RightMarketPanel.tsx
@@ -17,6 +17,15 @@ import { useFollowPortfolio } from './useFollowPortfolio'
 import type { WatchlistItem } from '../types/market'
 import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
 import { ghostInteractive } from '../theme/mixins'
+import {
+  MOBILE_HEADER_BAR_HEIGHT,
+  MOBILE_HEADER_HIT,
+  MOBILE_HEADER_ICON_SIZE,
+  MOBILE_HEADER_PAD_X,
+  mobileHeaderBarInset,
+  mobileHeaderIconBtn,
+} from '../theme/mobileChrome'
+import OpptrixButton from '../components/opptrix/OpptrixButton'
 import ChromeToolButton from '../desktop/ChromeToolButton'
 import {
   DESKTOP_CHROME_TOP_OFFSET,
@@ -90,6 +99,17 @@ const useStyles = makeStyles({
     height: '40px',
     zIndex: 1,
   },
+  /** 移动全屏 sheet：与 MobileTopBar 同高/同触控（父级已垫 safe-area） */
+  titleBarMobile: {
+    ...mobileHeaderBarInset,
+    height: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+    minHeight: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+    zIndex: 1,
+    paddingRight: `${MOBILE_HEADER_PAD_X}px`,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+    backgroundColor: opptrixCssVars.canvas,
+    position: 'relative',
+  },
   /**
    * Match DesktopWindowChrome tool band: top inset + center within remaining
    * chromeBand so tabs / actions share the file-box vertical midline.
@@ -118,6 +138,10 @@ const useStyles = makeStyles({
     WebkitAppRegion: 'no-drag',
     pointerEvents: 'auto',
     '&::-webkit-scrollbar': { display: 'none' },
+  },
+  tabsWrapMobile: {
+    height: `${MOBILE_HEADER_HIT}px`,
+    paddingLeft: '4px',
   },
   /** Text pill — same hit height as ChromeToolButton md (28×28), ghost / accentSoft. */
   tab: {
@@ -174,6 +198,15 @@ const useStyles = makeStyles({
     height: '28px',
     WebkitAppRegion: 'no-drag',
     pointerEvents: 'auto',
+  },
+  titleBarActionsMobile: {
+    height: `${MOBILE_HEADER_HIT}px`,
+    gap: '2px',
+  },
+  mobileActionBtn: {
+    ...ghostInteractive,
+    ...mobileHeaderIconBtn,
+    color: opptrixCssVars.textSecondary,
   },
   content: {
     flex: 1,
@@ -426,13 +459,15 @@ function RightMarketPanel({
   )
 
   const showWorkspaceActions = Boolean(onToggleRightPanel || onToggleChatColumn)
+  const mobileChrome = panelFullWidth && !electronChrome
 
   return (
     <div className={mergeClasses(s.root, electronChrome && s.rootElectron)}>
       <div
         className={mergeClasses(
           s.titleBar,
-          !electronChrome && s.titleBarWeb,
+          !electronChrome && !mobileChrome && s.titleBarWeb,
+          mobileChrome && s.titleBarMobile,
           electronChrome && s.titleBarElectron,
           electronChrome && s.titleBarElectronFill,
           electronChrome && 'opptrix-right-panel-title-bar',
@@ -447,7 +482,11 @@ function RightMarketPanel({
           />
         )}
         <div
-          className={mergeClasses(s.tabsWrap, 'opptrix-panel-title-no-drag')}
+          className={mergeClasses(
+            s.tabsWrap,
+            mobileChrome && s.tabsWrapMobile,
+            'opptrix-panel-title-no-drag',
+          )}
           role="tablist"
           aria-label="行情面板"
         >
@@ -483,27 +522,55 @@ function RightMarketPanel({
         />
 
         {showWorkspaceActions && (
-          <div className={mergeClasses(s.titleBarActions, 'opptrix-panel-title-no-drag')}>
+          <div
+            className={mergeClasses(
+              s.titleBarActions,
+              mobileChrome && s.titleBarActionsMobile,
+              'opptrix-panel-title-no-drag',
+            )}
+          >
             {onToggleChatColumn && (
-              <ChromeToolButton
-                label={chatColumnVisible ? '最大化右侧面板' : '恢复聊天区域'}
-                iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
-                onClick={onToggleChatColumn}
-              >
-                {chatColumnVisible
-                  ? <ArrowMaximizeRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-                  : <ArrowMinimizeRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />}
-              </ChromeToolButton>
+              mobileChrome ? (
+                <OpptrixButton
+                  className={s.mobileActionBtn}
+                  variant="ghost"
+                  icon={chatColumnVisible
+                    ? <ArrowMaximizeRegular fontSize={MOBILE_HEADER_ICON_SIZE} />
+                    : <ArrowMinimizeRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+                  onClick={onToggleChatColumn}
+                  aria-label={chatColumnVisible ? '最大化右侧面板' : '恢复聊天区域'}
+                />
+              ) : (
+                <ChromeToolButton
+                  label={chatColumnVisible ? '最大化右侧面板' : '恢复聊天区域'}
+                  iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
+                  onClick={onToggleChatColumn}
+                >
+                  {chatColumnVisible
+                    ? <ArrowMaximizeRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+                    : <ArrowMinimizeRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />}
+                </ChromeToolButton>
+              )
             )}
             {onToggleRightPanel && (
-              <ChromeToolButton
-                label="收起右侧面板"
-                iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
-                active
-                onClick={onToggleRightPanel}
-              >
-                <PanelRightContractRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-              </ChromeToolButton>
+              mobileChrome ? (
+                <OpptrixButton
+                  className={s.mobileActionBtn}
+                  variant="ghost"
+                  icon={<PanelRightContractRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+                  onClick={onToggleRightPanel}
+                  aria-label="收起右侧面板"
+                />
+              ) : (
+                <ChromeToolButton
+                  label="收起右侧面板"
+                  iconPadding={DESKTOP_SIDEBAR_TOOL_ICON_PADDING}
+                  active
+                  onClick={onToggleRightPanel}
+                >
+                  <PanelRightContractRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+                </ChromeToolButton>
+              )
             )}
           </div>
         )}

--- a/client-ui/src/market/WatchlistGroupsDrawer.tsx
+++ b/client-ui/src/market/WatchlistGroupsDrawer.tsx
@@ -5,7 +5,7 @@ import type { WatchlistGroupsDocument, WatchlistItem } from '../types/market'
 import WatchlistGroupsPanel from './WatchlistGroupsPanel'
 import { opptrixTokens, opptrixCssVars } from '../theme/tokens'
 import { motion, nativeIconInteractive } from '../theme/mixins'
-import { MARKET_PANEL_DRAWER_CLOSE_MS, MARKET_PANEL_DRAWER_MAX_WIDTH } from './marketPanelDrawer'
+import { MARKET_PANEL_DRAWER_CLOSE_MS, MARKET_PANEL_DRAWER_MAX_HEIGHT, MARKET_PANEL_DRAWER_MAX_WIDTH } from './marketPanelDrawer'
 
 const DRAWER_CLOSE_MS = MARKET_PANEL_DRAWER_CLOSE_MS
 
@@ -48,7 +48,7 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
     display: 'flex',
     flexDirection: 'column',
-    maxHeight: 'min(88%, 560px)',
+    maxHeight: MARKET_PANEL_DRAWER_MAX_HEIGHT,
     borderRadius: `${opptrixTokens.radiusXl} ${opptrixTokens.radiusXl} 0 0`,
     borderTop: '1px solid rgba(255, 255, 255, 0.55)',
     backgroundColor: 'rgba(255, 255, 255, 0.88)',

--- a/client-ui/src/market/WatchlistGroupsPanel.tsx
+++ b/client-ui/src/market/WatchlistGroupsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEvent, type PointerEvent } from 'react'
 import {
   Checkbox,
   Input,
@@ -65,7 +65,7 @@ const useStyles = makeStyles({
   },
   columnLeftDrawer: {
     flex: '0 0 auto',
-    maxHeight: '148px',
+    maxHeight: 'none',
   },
   columnRightDrawer: {
     flex: 1,
@@ -116,6 +116,13 @@ const useStyles = makeStyles({
     flex: 1,
     minHeight: 0,
     overflowY: 'auto',
+  },
+  /** 抽屉：分组列表最多约 3 行，超出纵滚 */
+  groupListDrawer: {
+    flex: '0 1 auto',
+    maxHeight: 'calc(32px * 3 + 4px * 2)',
+    overflowY: 'auto',
+    WebkitOverflowScrolling: 'touch',
   },
   groupRow: {
     display: 'flex',
@@ -539,6 +546,32 @@ export default function WatchlistGroupsPanel({
     await onSave(toPersistableDoc(nextDoc))
   }, [newTitle, onSave, selectGroup, toPersistableDoc])
 
+  /** 触屏：在 pointerDown 确认，避免 Input 失焦吞掉对勾点击 */
+  const confirmNewGroupPointer = useCallback((e: PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    void addGroup()
+  }, [addGroup])
+
+  const confirmEditPointer = useCallback((e: PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    void commitEdit()
+  }, [commitEdit])
+
+  const cancelCreatePointer = useCallback((e: PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setCreating(false)
+    setNewTitle('')
+  }, [])
+
+  const cancelEditPointer = useCallback((e: PointerEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    cancelEdit()
+  }, [cancelEdit])
+
   const moveGroup = useCallback(async (id: string, direction: 'up' | 'down') => {
     const prev = draftRef.current
     const sorted = sortGroups(prev.groups)
@@ -654,19 +687,28 @@ export default function WatchlistGroupsPanel({
                         value={newTitle}
                         onChange={(_, data) => setNewTitle(data.value)}
                         onKeyDown={e => {
+                          if (e.nativeEvent.isComposing || e.keyCode === 229) return
                           if (e.key === 'Enter') void addGroup()
                           if (e.key === 'Escape') { setCreating(false); setNewTitle('') }
                         }}
                         autoFocus
                       />
                       <div className={s.rowActions}>
-                        <button type="button" className={s.iconBtn} aria-label="创建分组" onClick={() => { void addGroup() }}>
+                        <button
+                          type="button"
+                          className={s.iconBtn}
+                          aria-label="创建分组"
+                          disabled={!newTitle.trim()}
+                          onPointerDown={confirmNewGroupPointer}
+                          onClick={() => { void addGroup() }}
+                        >
                           <CheckmarkRegular fontSize={14} />
                         </button>
                         <button
                           type="button"
                           className={s.iconBtn}
                           aria-label="取消"
+                          onPointerDown={cancelCreatePointer}
                           onClick={() => { setCreating(false); setNewTitle('') }}
                         >
                           <DismissRegular fontSize={14} />
@@ -679,7 +721,7 @@ export default function WatchlistGroupsPanel({
                       新建分组
                     </button>
                   )}
-                  <div className={mergeClasses(s.groupList, 'opptrix-scroll')}>
+                  <div className={mergeClasses(s.groupList, isDrawer && s.groupListDrawer, 'opptrix-scroll')}>
                     {sortedGroups.length === 0 && !creating && (
                       <Text className={s.emptyHint} block>
                         还没有自定义分组{'\n'}新建分组后，可把已有关注加入其中
@@ -719,16 +761,30 @@ export default function WatchlistGroupsPanel({
                               onClick={stopRowClick}
                               onKeyDown={e => {
                                 e.stopPropagation()
+                                if (e.nativeEvent.isComposing || e.keyCode === 229) return
                                 if (e.key === 'Enter') void commitEdit()
                                 if (e.key === 'Escape') cancelEdit()
                               }}
                               autoFocus
                             />
                             <div className={s.rowActions} onClick={stopRowClick}>
-                              <button type="button" className={s.iconBtn} aria-label="保存名称" onClick={() => { void commitEdit() }}>
+                              <button
+                                type="button"
+                                className={s.iconBtn}
+                                aria-label="保存名称"
+                                disabled={!editTitle.trim()}
+                                onPointerDown={confirmEditPointer}
+                                onClick={() => { void commitEdit() }}
+                              >
                                 <CheckmarkRegular fontSize={14} />
                               </button>
-                              <button type="button" className={s.iconBtn} aria-label="取消编辑" onClick={cancelEdit}>
+                              <button
+                                type="button"
+                                className={s.iconBtn}
+                                aria-label="取消编辑"
+                                onPointerDown={cancelEditPointer}
+                                onClick={cancelEdit}
+                              >
                                 <DismissRegular fontSize={14} />
                               </button>
                             </div>

--- a/client-ui/src/market/WatchlistTab.tsx
+++ b/client-ui/src/market/WatchlistTab.tsx
@@ -18,6 +18,7 @@ import SidebarListEmpty from './SidebarListEmpty'
 import WatchlistGroupFilterBar from './WatchlistGroupFilterBar'
 import WatchlistGroupSummaryStrip from './WatchlistGroupSummaryStrip'
 import WatchlistGroupsDrawer from './WatchlistGroupsDrawer'
+import { useTouchAxisLockedScroll } from '../hooks/useTouchAxisLockedScroll'
 import { computeWatchlistGroupSummary } from './watchlistGroupCalc'
 import { filterWatchlistByGroup, useWatchlistGroups } from './WatchlistGroupsContext'
 import { research } from '../api/client'
@@ -277,6 +278,9 @@ const useStyles = makeStyles({
     minHeight: 0,
     overflow: 'auto',
     padding: `10px ${CONTENT_PAD}`,
+    /* 双轴可滚；斜向由 useTouchAxisLockedScroll 主轴锁定 */
+    touchAction: 'none',
+    WebkitOverflowScrolling: 'touch',
   },
   listCentered: {
     display: 'flex',
@@ -324,14 +328,7 @@ const useStyles = makeStyles({
     whiteSpace: 'nowrap',
     fontVariantNumeric: 'tabular-nums',
   },
-  headerEndPad: {
-    flexShrink: 0,
-    width: ROW_SCROLL_END_PAD,
-    minWidth: ROW_SCROLL_END_PAD,
-    height: '1px',
-  },
   row: {...ghostInteractive,
-
     display: 'grid',
     gridTemplateColumns: `${IDENTITY_WIDTH} minmax(${METRICS_MIN_WIDTH}, 1fr) ${ROW_SCROLL_END_PAD}`,
     gridTemplateRows: '48px',
@@ -348,6 +345,25 @@ const useStyles = makeStyles({
     boxSizing: 'border-box',
     color: opptrixCssVars.textPrimary,
     cursor: 'pointer',
+    /* 触屏：无 sticky focus/hover 底；保留操作列 */
+    '@media (hover: none)': {
+      ':hover': {
+        backgroundColor: 'transparent',
+      },
+      ':active': {
+        backgroundColor: 'transparent',
+        opacity: 1,
+      },
+      ':focus': {
+        outline: 'none',
+        boxShadow: 'none',
+        backgroundColor: 'transparent',
+      },
+      ':focus-visible': {
+        outline: 'none',
+        boxShadow: 'none',
+      },
+    },
   },
   rowActive: {...sidebarItemSelected},
   rowIdentity: {
@@ -436,14 +452,18 @@ const useStyles = makeStyles({
     alignItems: 'center',
     justifyContent: 'flex-end',
     boxSizing: 'border-box',
+    backgroundColor: opptrixCssVars.canvas,
+    boxShadow: `-10px 0 12px -6px ${opptrixCssVars.canvas}`,
   },
-  rowMetricsWrap: {
-    gridColumn: '2',
-    gridRow: '1',
-    zIndex: 1,
-    minWidth: METRICS_MIN_WIDTH,
-    display: 'flex',
-    alignItems: 'center',
+  headerEndPad: {
+    flexShrink: 0,
+    width: ROW_SCROLL_END_PAD,
+    minWidth: ROW_SCROLL_END_PAD,
+    height: '1px',
+    position: 'sticky',
+    right: 0,
+    zIndex: 2,
+    backgroundColor: opptrixCssVars.canvas,
   },
   rowQuote: {
     display: 'flex',
@@ -453,9 +473,6 @@ const useStyles = makeStyles({
     width: '100%',
     transitionProperty: 'opacity',
     transitionDuration: motion.fast,
-    '@media (hover: none)': {
-      display: 'none',
-    },
   },
   rowActions: {
     display: 'inline-flex',
@@ -465,6 +482,7 @@ const useStyles = makeStyles({
     pointerEvents: 'none',
     transitionProperty: 'opacity',
     transitionDuration: motion.fast,
+    /* 触屏：常显编辑/删除，不依赖 hover/focus */
     '@media (hover: none)': {
       opacity: 1,
       pointerEvents: 'auto',
@@ -484,10 +502,40 @@ const useStyles = makeStyles({
     cursor: 'pointer',
     lineHeight: 0,
     flexShrink: 0,
-    ':hover': {
-      backgroundColor: 'rgba(29, 29, 31, 0.08)',
-      color: opptrixCssVars.textPrimary,
+    WebkitTapHighlightColor: 'transparent',
+    '@media (hover: hover)': {
+      ':hover': {
+        backgroundColor: 'rgba(29, 29, 31, 0.08)',
+        color: opptrixCssVars.textPrimary,
+      },
     },
+    '@media (hover: none)': {
+      ':hover': {
+        backgroundColor: 'transparent',
+        color: opptrixCssVars.textSecondary,
+      },
+      ':focus': {
+        outline: 'none',
+        boxShadow: 'none',
+        backgroundColor: 'transparent',
+      },
+      ':focus-visible': {
+        outline: 'none',
+        boxShadow: 'none',
+      },
+      ':active': {
+        opacity: 0.55,
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+  rowMetricsWrap: {
+    gridColumn: '2',
+    gridRow: '1',
+    zIndex: 1,
+    minWidth: METRICS_MIN_WIDTH,
+    display: 'flex',
+    alignItems: 'center',
   },
   empty: {
     padding: `12px ${CONTENT_PAD}`,
@@ -586,6 +634,8 @@ export default function WatchlistTab({
   onPatchItem,
 }: Props) {
   const s = useStyles()
+  const listRef = useRef<HTMLDivElement>(null)
+  useTouchAxisLockedScroll(listRef)
   const {
     groups,
     membership,
@@ -1121,6 +1171,7 @@ export default function WatchlistTab({
       )}
 
       <div
+        ref={listRef}
         className={mergeClasses(s.list, 'opptrix-scroll', 'opptrix-scroll-hover', !filteredItems.length && s.listCentered)}
       >
         {!filteredItems.length && !items.length && (
@@ -1231,11 +1282,15 @@ export default function WatchlistTab({
                   role="button"
                   tabIndex={0}
                   title={rowTooltip}
-                  onClick={() => onSelect(item)}
+                  onClick={e => {
+                    onSelect(item)
+                    if (e.currentTarget instanceof HTMLElement) e.currentTarget.blur()
+                  }}
                   onKeyDown={e => {
                     if (e.key === 'Enter' || e.key === ' ') {
                       e.preventDefault()
                       onSelect(item)
+                      if (e.currentTarget instanceof HTMLElement) e.currentTarget.blur()
                     }
                   }}
                 >
@@ -1378,7 +1433,7 @@ export default function WatchlistTab({
                     </div>
                   </div>
                   <div
-                    className={s.rowTrailing}
+                    className={mergeClasses(s.rowTrailing, 'opptrix-follow-trailing')}
                     onPointerDown={stopRowActionPointer}
                     onMouseDown={stopRowActionPointer}
                     onClick={stopRowActionPointer}
@@ -1388,8 +1443,12 @@ export default function WatchlistTab({
                         <button
                           type="button"
                           className={mergeClasses(s.rowActionBtn, 'opptrix-focusable')}
-                          aria-label={`修改 ${displayName}`}
-                          onClick={() => onManage(item)}
+                          aria-label={`编辑持仓 ${displayName}`}
+                          onClick={e => {
+                            e.stopPropagation()
+                            onManage(item)
+                            e.currentTarget.blur()
+                          }}
                         >
                           <EditRegular fontSize={14} />
                         </button>
@@ -1398,7 +1457,11 @@ export default function WatchlistTab({
                         type="button"
                         className={mergeClasses(s.rowActionBtn, 'opptrix-focusable')}
                         aria-label={`删除 ${displayName}`}
-                        onClick={() => onRemove(item)}
+                        onClick={e => {
+                          e.stopPropagation()
+                          onRemove(item)
+                          e.currentTarget.blur()
+                        }}
                       >
                         <DeleteRegular fontSize={14} />
                       </button>

--- a/client-ui/src/market/marketPanelDrawer.ts
+++ b/client-ui/src/market/marketPanelDrawer.ts
@@ -1,4 +1,10 @@
 /** 右栏底部抽屉（持仓录入 / 管理分组等）统一最大宽度 */
 export const MARKET_PANEL_DRAWER_MAX_WIDTH = 440
 
+/**
+ * 移动端勿用 %（父级高度不定时失效会撑满屏，无法点遮罩关闭）。
+ * 用 dvh 限制高度，顶部留出可点的 scrim。
+ */
+export const MARKET_PANEL_DRAWER_MAX_HEIGHT = 'min(80dvh, 640px)'
+
 export const MARKET_PANEL_DRAWER_CLOSE_MS = 220

--- a/client-ui/src/pages/SettingsPage.tsx
+++ b/client-ui/src/pages/SettingsPage.tsx
@@ -136,6 +136,9 @@ const useStyles = makeStyles({
     paddingLeft: '12px',
     paddingRight: '12px',
   },
+  contentHeaderMobile: {
+    paddingTop: '12px',
+  },
   contentHeaderFlush: {
     /** 无次级 title band 时略增顶距，避免贴窗沿 */
     paddingTop: '28px',
@@ -152,6 +155,10 @@ const useStyles = makeStyles({
   contentBack: {
     marginBottom: '12px',
     marginLeft: '-2px',
+  },
+  contentBackMobile: {
+    marginBottom: 0,
+    marginLeft: 0,
   },
   pageTitle: {
     fontSize: '17px',
@@ -857,9 +864,17 @@ function SettingsPageView({
             contentFlush && s.contentColumnFlush,
             isMobile && s.contentColumnMobile,
           )}>
-            <header className={mergeClasses(s.contentHeader, contentFlush && s.contentHeaderFlush)}>
+            <header className={mergeClasses(
+              s.contentHeader,
+              contentFlush && s.contentHeaderFlush,
+              isMobile && s.contentHeaderMobile,
+            )}>
               {sidebarOverlayMode && !sidebarVisible && (
-                <SettingsBackRow className={s.contentBack} onClick={onBack} />
+                <SettingsBackRow
+                  className={mergeClasses(s.contentBack, isMobile && s.contentBackMobile)}
+                  onClick={onBack}
+                  mobile={isMobile}
+                />
               )}
               <Text className={s.pageTitle} block>{sectionTitle}</Text>
               <Text

--- a/client-ui/src/pages/community/CommunityFeedPage.tsx
+++ b/client-ui/src/pages/community/CommunityFeedPage.tsx
@@ -18,6 +18,12 @@ import {
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
 } from '../../desktop/constants'
 import { ghostInteractive } from '../../theme/mixins'
+import {
+  MOBILE_HEADER_ICON_SIZE,
+  mobileHeaderBar,
+  mobileHeaderIconBtn,
+  mobileHeaderTitle,
+} from '../../theme/mobileChrome'
 import { openExternalUrl } from '../../platform/openUrl'
 import { OPPTRIX_COMMUNITY, OPPTRIX_COMMUNITY_INVITE_CODE } from '../settings/aboutLinks'
 import type { CommunityFeedKind, CommunityTopic } from '../../types/schemas'
@@ -51,16 +57,21 @@ const useStyles = makeStyles({
     borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
   },
   webHeadMobile: {
-    gap: '4px',
-    padding: '6px 8px',
-    paddingTop: 'max(6px, env(safe-area-inset-top))',
-    minHeight: '44px',
+    ...mobileHeaderBar,
+    backgroundColor: opptrixCssVars.canvas,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
   },
   webTitle: {
     fontSize: 'var(--opptrix-font-xl)',
     fontWeight: 650,
     color: opptrixCssVars.textPrimary,
     flex: 1,
+  },
+  webTitleMobile: mobileHeaderTitle,
+  mobileActionBtn: {
+    ...ghostInteractive,
+    ...mobileHeaderIconBtn,
+    color: opptrixCssVars.textSecondary,
   },
   toolbarMeta: {
     fontSize: 'var(--opptrix-font-sm)',
@@ -363,21 +374,43 @@ function CommunityFeedContent({
 
   const toolbar = (
     <>
-      {statusLabel ? <span className={s.toolbarMeta}>{statusLabel}</span> : null}
+      {!isMobile && statusLabel ? <span className={s.toolbarMeta}>{statusLabel}</span> : null}
       <div className={s.toolbarActions}>
-        <ChromeToolButton
-          label="刷新"
-          disabled={refreshing}
-          onClick={refresh}
-        >
-          <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-        </ChromeToolButton>
-        <ChromeToolButton
-          label="访问社区"
-          onClick={handleOpenCommunity}
-        >
-          <OpenRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
-        </ChromeToolButton>
+        {isMobile ? (
+          <>
+            <OpptrixButton
+              className={s.mobileActionBtn}
+              variant="ghost"
+              icon={<ArrowSyncRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+              disabled={refreshing}
+              onClick={refresh}
+              aria-label={refreshing ? '正在刷新' : '刷新'}
+            />
+            <OpptrixButton
+              className={s.mobileActionBtn}
+              variant="ghost"
+              icon={<OpenRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+              onClick={handleOpenCommunity}
+              aria-label="访问社区"
+            />
+          </>
+        ) : (
+          <>
+            <ChromeToolButton
+              label="刷新"
+              disabled={refreshing}
+              onClick={refresh}
+            >
+              <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+            </ChromeToolButton>
+            <ChromeToolButton
+              label="访问社区"
+              onClick={handleOpenCommunity}
+            >
+              <OpenRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
+            </ChromeToolButton>
+          </>
+        )}
       </div>
     </>
   )
@@ -410,11 +443,11 @@ function CommunityFeedContent({
           )}
         />
       ) : (
-        <div className={mergeClasses(s.webHead, isMobile && s.webHeadMobile)}>
+        <div className={isMobile ? s.webHeadMobile : s.webHead}>
           {isMobile && onOpenSidebar ? (
             <MobileNavMenuButton open={sidebarDrawerOpen} onClick={onOpenSidebar} />
           ) : null}
-          <Text className={s.webTitle}>社区讨论</Text>
+          <Text className={mergeClasses(s.webTitle, isMobile && s.webTitleMobile)}>社区讨论</Text>
           {toolbar}
         </div>
       )}

--- a/client-ui/src/pages/experts/ExpertMarketPage.tsx
+++ b/client-ui/src/pages/experts/ExpertMarketPage.tsx
@@ -12,7 +12,13 @@ import {
   SearchRegular,
 } from '@fluentui/react-icons'
 import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
-import { inputShellInteractive, nativeIconInteractive } from '../../theme/mixins'
+import { inputShellInteractive, nativeIconInteractive, ghostInteractive } from '../../theme/mixins'
+import {
+  MOBILE_HEADER_ICON_SIZE,
+  mobileHeaderBar,
+  mobileHeaderIconBtn,
+  mobileHeaderTitle,
+} from '../../theme/mobileChrome'
 import {
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
@@ -53,10 +59,9 @@ const useStyles = makeStyles({
     borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
   },
   webHeadMobile: {
-    gap: '4px',
-    padding: '6px 8px',
-    paddingTop: 'max(6px, env(safe-area-inset-top))',
-    minHeight: '44px',
+    ...mobileHeaderBar,
+    backgroundColor: opptrixCssVars.canvas,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
   },
   webTitle: {
     fontSize: 'var(--opptrix-font-xl)',
@@ -64,11 +69,17 @@ const useStyles = makeStyles({
     color: opptrixCssVars.textPrimary,
     flex: 1,
   },
+  webTitleMobile: mobileHeaderTitle,
   webActions: {
     display: 'flex',
     alignItems: 'center',
     gap: '8px',
     flexShrink: 0,
+  },
+  mobileActionBtn: {
+    ...ghostInteractive,
+    ...mobileHeaderIconBtn,
+    color: opptrixCssVars.textSecondary,
   },
   scrollBody: {
     flex: 1,
@@ -362,6 +373,15 @@ export default function ExpertMarketPage({
     >
       <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
     </ChromeToolButton>
+  ) : isMobile ? (
+    <OpptrixButton
+      className={s.mobileActionBtn}
+      variant="ghost"
+      icon={<ArrowSyncRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+      disabled={loading}
+      onClick={() => { void loadExperts(debouncedQuery) }}
+      aria-label={loading ? '正在刷新' : '刷新'}
+    />
   ) : (
     <OpptrixButton
       variant="secondary"
@@ -396,11 +416,11 @@ export default function ExpertMarketPage({
           actions={refreshAction}
         />
       ) : (
-        <div className={mergeClasses(s.webHead, isMobile && s.webHeadMobile)}>
+        <div className={isMobile ? s.webHeadMobile : s.webHead}>
           {isMobile && onOpenSidebar ? (
             <MobileNavMenuButton open={sidebarDrawerOpen} onClick={onOpenSidebar} />
           ) : null}
-          <Text className={s.webTitle}>专家中心</Text>
+          <Text className={mergeClasses(s.webTitle, isMobile && s.webTitleMobile)}>专家中心</Text>
           <div className={s.webActions}>{refreshAction}</div>
         </div>
       )}

--- a/client-ui/src/pages/market-dynamics/MarketDynamicsHeader.tsx
+++ b/client-ui/src/pages/market-dynamics/MarketDynamicsHeader.tsx
@@ -6,6 +6,13 @@ import MobileNavMenuButton from '../../components/MobileNavMenuButton'
 import ChromeToolButton from '../../desktop/ChromeToolButton'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import { opptrixCssVars } from '../../theme/tokens'
+import { ghostInteractive } from '../../theme/mixins'
+import {
+  MOBILE_HEADER_ICON_SIZE,
+  mobileHeaderBar,
+  mobileHeaderIconBtn,
+  mobileHeaderTitle,
+} from '../../theme/mobileChrome'
 import {
   DESKTOP_CHROME_TOP_OFFSET,
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
@@ -38,10 +45,12 @@ const useStyles = makeStyles({
     padding: '0 12px',
   },
   rootWebMobile: {
+    ...mobileHeaderBar,
     height: 'auto',
-    minHeight: '44px',
-    padding: '6px 8px',
-    paddingTop: 'max(6px, env(safe-area-inset-top))',
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+    backgroundColor: opptrixCssVars.canvas,
+    position: 'relative',
+    zIndex: DESKTOP_Z_PANEL_TITLE,
   },
   titleTabs: {
     flexShrink: 0,
@@ -58,6 +67,12 @@ const useStyles = makeStyles({
     color: opptrixCssVars.textPrimary,
     lineHeight: 1.2,
     whiteSpace: 'nowrap',
+  },
+  titleMobile: mobileHeaderTitle,
+  mobileActionBtn: {
+    ...ghostInteractive,
+    ...mobileHeaderIconBtn,
+    color: opptrixCssVars.textSecondary,
   },
   spacer: {
     flex: 1,
@@ -130,6 +145,15 @@ export default function MarketDynamicsHeader({
     >
       <ArrowSyncRegular fontSize={DESKTOP_SIDEBAR_TOOL_ICON_SIZE} />
     </ChromeToolButton>
+  ) : isMobile ? (
+    <OpptrixButton
+      className={s.mobileActionBtn}
+      variant="ghost"
+      icon={<ArrowSyncRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+      disabled={refreshing}
+      onClick={onRefresh}
+      aria-label={refreshing ? '正在刷新' : '刷新'}
+    />
   ) : (
     <OpptrixButton
       variant="secondary"
@@ -147,7 +171,7 @@ export default function MarketDynamicsHeader({
       className={mergeClasses(
         s.root,
         electronChrome && s.rootElectron,
-        !electronChrome && s.rootWeb,
+        !electronChrome && !isMobile && s.rootWeb,
         !electronChrome && isMobile && s.rootWebMobile,
         'opptrix-market-dynamics-title-bar',
       )}
@@ -160,13 +184,15 @@ export default function MarketDynamicsHeader({
         {!electronChrome && isMobile && onOpenSidebar ? (
           <MobileNavMenuButton open={sidebarDrawerOpen} onClick={onOpenSidebar} />
         ) : null}
-        <Text className={s.title}>市场动态</Text>
+        <Text className={mergeClasses(s.title, isMobile && s.titleMobile)}>市场动态</Text>
       </div>
       <div
         className={mergeClasses(s.spacer, electronChrome && dragRegionClassName)}
         aria-hidden
       />
-      <Text className={mergeClasses(s.meta, 'opptrix-panel-title-no-drag')}>{statusLabel}</Text>
+      {!isMobile ? (
+        <Text className={mergeClasses(s.meta, 'opptrix-panel-title-no-drag')}>{statusLabel}</Text>
+      ) : null}
       <div className={mergeClasses(s.actions, 'opptrix-panel-title-no-drag')}>
         {refreshBtn}
       </div>

--- a/client-ui/src/pages/news/NewsCenterPage.tsx
+++ b/client-ui/src/pages/news/NewsCenterPage.tsx
@@ -5,6 +5,13 @@ import MobileNavMenuButton from '../../components/MobileNavMenuButton'
 import ChromeToolButton from '../../desktop/ChromeToolButton'
 import StandaloneElectronTitleBar from '../../desktop/StandaloneElectronTitleBar'
 import { opptrixCssVars } from '../../theme/tokens'
+import { ghostInteractive } from '../../theme/mixins'
+import {
+  MOBILE_HEADER_ICON_SIZE,
+  mobileHeaderBar,
+  mobileHeaderIconBtn,
+  mobileHeaderTitle,
+} from '../../theme/mobileChrome'
 import {
   DESKTOP_SIDEBAR_TOOL_ICON_PADDING,
   DESKTOP_SIDEBAR_TOOL_ICON_SIZE,
@@ -50,16 +57,21 @@ const useStyles = makeStyles({
     borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
   },
   webHeadMobile: {
-    gap: '4px',
-    padding: '6px 8px',
-    paddingTop: 'max(6px, env(safe-area-inset-top))',
-    minHeight: '44px',
+    ...mobileHeaderBar,
+    backgroundColor: opptrixCssVars.canvas,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
   },
   webTitle: {
     fontSize: 'var(--opptrix-font-xl)',
     fontWeight: 650,
     color: opptrixCssVars.textPrimary,
     flex: 1,
+  },
+  webTitleMobile: mobileHeaderTitle,
+  mobileActionBtn: {
+    ...ghostInteractive,
+    ...mobileHeaderIconBtn,
+    color: opptrixCssVars.textSecondary,
   },
   body: {
     flex: 1,
@@ -197,26 +209,50 @@ function NewsCenterContent({
   ) : null
 
   const webHead = !electronChrome ? (
-    <div className={mergeClasses(s.webHead, isMobile && s.webHeadMobile)}>
+    <div className={isMobile ? s.webHeadMobile : s.webHead}>
       {isMobile && onOpenSidebar ? (
             <MobileNavMenuButton open={sidebarDrawerOpen} onClick={onOpenSidebar} />
           ) : null}
-      <Text className={s.webTitle} block>新闻中心</Text>
-      {updatedLabel && <Text className={s.toolbarMeta}>更新 {updatedLabel}</Text>}
+      <Text className={mergeClasses(s.webTitle, isMobile && s.webTitleMobile)} block>新闻中心</Text>
+      {!isMobile && updatedLabel ? <Text className={s.toolbarMeta}>更新 {updatedLabel}</Text> : null}
       <div className={s.toolbarActions}>
-        {onOpenSettings && (
-          <OpptrixButton variant="ghost" icon={<SettingsRegular />} onClick={onOpenSettings}>
-            订阅设置
-          </OpptrixButton>
+        {isMobile ? (
+          <>
+            {onOpenSettings ? (
+              <OpptrixButton
+                className={s.mobileActionBtn}
+                variant="ghost"
+                icon={<SettingsRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+                onClick={onOpenSettings}
+                aria-label="订阅设置"
+              />
+            ) : null}
+            <OpptrixButton
+              className={s.mobileActionBtn}
+              variant="ghost"
+              icon={<ArrowSyncRegular fontSize={MOBILE_HEADER_ICON_SIZE} />}
+              disabled={refreshing}
+              onClick={() => { void refresh() }}
+              aria-label={refreshing ? '正在刷新' : '刷新列表'}
+            />
+          </>
+        ) : (
+          <>
+            {onOpenSettings && (
+              <OpptrixButton variant="ghost" icon={<SettingsRegular />} onClick={onOpenSettings}>
+                订阅设置
+              </OpptrixButton>
+            )}
+            <OpptrixButton
+              variant="secondary"
+              icon={<ArrowSyncRegular />}
+              disabled={refreshing}
+              onClick={() => { void refresh() }}
+            >
+              {refreshing ? '刷新中…' : '刷新列表'}
+            </OpptrixButton>
+          </>
         )}
-        <OpptrixButton
-          variant="secondary"
-          icon={<ArrowSyncRegular />}
-          disabled={refreshing}
-          onClick={() => { void refresh() }}
-        >
-          {refreshing ? '刷新中…' : '刷新列表'}
-        </OpptrixButton>
       </div>
     </div>
   ) : null

--- a/client-ui/src/pages/settings/SettingsBackRow.tsx
+++ b/client-ui/src/pages/settings/SettingsBackRow.tsx
@@ -1,26 +1,55 @@
 import { ArrowLeftRegular } from '@fluentui/react-icons'
 import { makeStyles, mergeClasses } from '@fluentui/react-components'
-import { SIDEBAR_TOP_MENU_ICON_SIZE, sidebarTopMenuIcon, sidebarTopMenuRow } from '../../theme/mixins'
+import { SIDEBAR_TOP_MENU_ICON_SIZE, sidebarTopMenuIcon, sidebarTopMenuRow, ghostInteractive } from '../../theme/mixins'
+import {
+  MOBILE_HEADER_ICON_SIZE,
+  mobileHeaderBar,
+} from '../../theme/mobileChrome'
+import { opptrixCssVars } from '../../theme/tokens'
 
 const useStyles = makeStyles({
   row: sidebarTopMenuRow,
   icon: sidebarTopMenuIcon,
+  rowMobile: {
+    ...mobileHeaderBar,
+    ...ghostInteractive,
+    width: '100%',
+    margin: 0,
+    justifyContent: 'flex-start',
+    gap: '10px',
+    color: opptrixCssVars.textPrimary,
+    fontSize: 'var(--opptrix-font-2xl)',
+    fontWeight: 600,
+    textAlign: 'left',
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+    borderRadius: 0,
+    backgroundColor: opptrixCssVars.canvas,
+  },
+  iconMobile: {
+    color: opptrixCssVars.textPrimary,
+    flexShrink: 0,
+  },
 })
 
 interface Props {
   onClick: () => void
   className?: string
+  /** Web 移动端：与聊天 MobileTopBar 同高 / 同 icon */
+  mobile?: boolean
 }
 
-export default function SettingsBackRow({ onClick, className }: Props) {
+export default function SettingsBackRow({ onClick, className, mobile = false }: Props) {
   const s = useStyles()
   return (
     <button
       type="button"
-      className={mergeClasses(s.row, 'opptrix-focusable', className)}
+      className={mergeClasses(mobile ? s.rowMobile : s.row, 'opptrix-focusable', className)}
       onClick={onClick}
     >
-      <ArrowLeftRegular className={s.icon} fontSize={SIDEBAR_TOP_MENU_ICON_SIZE} />
+      <ArrowLeftRegular
+        className={mobile ? s.iconMobile : s.icon}
+        fontSize={mobile ? MOBILE_HEADER_ICON_SIZE : SIDEBAR_TOP_MENU_ICON_SIZE}
+      />
       <span>返回应用</span>
     </button>
   )

--- a/client-ui/src/pages/settings/SettingsSidebar.tsx
+++ b/client-ui/src/pages/settings/SettingsSidebar.tsx
@@ -302,7 +302,7 @@ export default function SettingsSidebar({
 
   const body = (
     <>
-      {onBack && <SettingsBackRow onClick={onBack} />}
+      {onBack && <SettingsBackRow onClick={onBack} mobile={isMobile} />}
 
       {!isMobile && (
         <div className={mergeClasses(s.searchWrap, isOverlay && s.searchWrapOverlay)}>

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -2684,6 +2684,16 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
     opacity: 1;
     pointer-events: auto;
   }
+
+  .opptrix-follow-item:hover .opptrix-follow-trailing {
+    background-color: var(--opptrix-surface-hover);
+    box-shadow: -10px 0 12px -6px var(--opptrix-surface-hover);
+  }
+}
+
+.opptrix-follow-item-active .opptrix-follow-trailing {
+  background-color: var(--opptrix-accent-soft);
+  box-shadow: -10px 0 12px -6px var(--opptrix-accent-soft);
 }
 
 @keyframes opptrix-hover-marquee-scroll {
@@ -2698,6 +2708,69 @@ html.opptrix-electron .opptrix-session-title-btn:disabled {
 }
 
 @media (hover: none) {
+  /* 关注列表：常显编辑/删除；禁止 sticky focus / hover 底影响操作 */
+  .opptrix-follow-item,
+  .opptrix-follow-item:hover,
+  .opptrix-follow-item:focus,
+  .opptrix-follow-item:focus-visible,
+  .opptrix-follow-item:focus-within,
+  .opptrix-follow-item:active {
+    background-color: transparent !important;
+    outline: none !important;
+    box-shadow: none !important;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  .opptrix-follow-item.opptrix-follow-item-active,
+  .opptrix-follow-item.opptrix-follow-item-active:hover,
+  .opptrix-follow-item.opptrix-follow-item-active:focus-within {
+    background-color: var(--opptrix-accent-soft) !important;
+  }
+
+  .opptrix-follow-item:hover .opptrix-follow-quote,
+  .opptrix-follow-item:focus-within .opptrix-follow-quote {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+
+  .opptrix-follow-item .opptrix-follow-actions,
+  .opptrix-follow-item:hover .opptrix-follow-actions,
+  .opptrix-follow-item:focus-within .opptrix-follow-actions {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+    display: inline-flex !important;
+  }
+
+  .opptrix-follow-item .opptrix-follow-trailing,
+  .opptrix-follow-item:hover .opptrix-follow-trailing,
+  .opptrix-follow-item:focus-within .opptrix-follow-trailing {
+    background-color: var(--opptrix-canvas) !important;
+    box-shadow: -10px 0 12px -6px var(--opptrix-canvas) !important;
+  }
+
+  .opptrix-follow-item.opptrix-follow-item-active .opptrix-follow-trailing,
+  .opptrix-follow-item.opptrix-follow-item-active:hover .opptrix-follow-trailing,
+  .opptrix-follow-item.opptrix-follow-item-active:focus-within .opptrix-follow-trailing {
+    background-color: var(--opptrix-accent-soft) !important;
+    box-shadow: -10px 0 12px -6px var(--opptrix-accent-soft) !important;
+  }
+
+  .opptrix-follow-item .opptrix-focusable:focus,
+  .opptrix-follow-item .opptrix-focusable:focus-visible,
+  .opptrix-follow-item.opptrix-focusable:focus,
+  .opptrix-follow-item.opptrix-focusable:focus-visible {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+
+  .opptrix-session-item .opptrix-session-trailing {
+    min-width: 44px;
+  }
+
+  .opptrix-archive-session-item .opptrix-archive-session-trailing {
+    min-width: 22px;
+  }
+
   .opptrix-archive-folder-head .opptrix-archive-folder-count {
     display: none;
   }

--- a/client-ui/src/theme/mobileChrome.ts
+++ b/client-ui/src/theme/mobileChrome.ts
@@ -1,0 +1,62 @@
+/**
+ * Web 移动端顶栏规格 — 以聊天 `MobileTopBar` 为基准，各页 / 侧栏 / sheet 共用。
+ * 勿在业务组件内再手写触控高度 / 内边距数字。
+ */
+
+import { opptrixCssVars } from './tokens'
+
+export const MOBILE_HEADER_ICON_SIZE = 20
+/** 触控目标；略低于 44 以压缩顶栏占比，仍可点 */
+export const MOBILE_HEADER_HIT = 40
+export const MOBILE_HEADER_PAD_Y = 4
+export const MOBILE_HEADER_PAD_X = 8
+export const MOBILE_HEADER_GAP = 4
+/** 内容区最小高度（与触控目标同高） */
+export const MOBILE_HEADER_MIN_HEIGHT = MOBILE_HEADER_HIT
+/** 父级已垫 safe-area 时的顶栏总高（与右栏 sheet header / 左栏品牌行一致） */
+export const MOBILE_HEADER_BAR_HEIGHT = MOBILE_HEADER_PAD_Y * 2 + MOBILE_HEADER_HIT
+
+/** 顶栏自身吃掉 safe-area（聊天 / 新闻 / 市场等主列顶栏） */
+export const mobileHeaderBar = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: `${MOBILE_HEADER_GAP}px`,
+  boxSizing: 'border-box' as const,
+  padding: `${MOBILE_HEADER_PAD_Y}px ${MOBILE_HEADER_PAD_X}px`,
+  paddingTop: `max(${MOBILE_HEADER_PAD_Y}px, env(safe-area-inset-top))`,
+  minHeight: `${MOBILE_HEADER_MIN_HEIGHT}px`,
+  flexShrink: 0,
+} as const
+
+/**
+ * 父级已垫 `env(safe-area-inset-top)` 时用（如左抽屉整栏、右 sheet 外壳）。
+ * 视觉内容高度与 `mobileHeaderBar` 的「安全区以下」段对齐。
+ */
+export const mobileHeaderBarInset = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: `${MOBILE_HEADER_GAP}px`,
+  boxSizing: 'border-box' as const,
+  padding: `${MOBILE_HEADER_PAD_Y}px ${MOBILE_HEADER_PAD_X}px`,
+  height: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+  minHeight: `${MOBILE_HEADER_BAR_HEIGHT}px`,
+  flexShrink: 0,
+} as const
+
+export const mobileHeaderIconBtn = {
+  minWidth: `${MOBILE_HEADER_HIT}px`,
+  height: `${MOBILE_HEADER_HIT}px`,
+  flexShrink: 0,
+} as const
+
+/** 与 MobileTopBar 标题一致 */
+export const mobileHeaderTitle = {
+  flex: 1,
+  minWidth: 0,
+  fontSize: 'var(--opptrix-font-2xl)',
+  fontWeight: 600,
+  color: opptrixCssVars.textPrimary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap' as const,
+} as const

--- a/client-ui/src/theme/tokens.ts
+++ b/client-ui/src/theme/tokens.ts
@@ -42,6 +42,9 @@ const layoutTokens = {
   chatComposerRadius: '20px',
   chatComposerBottomInset: '25px',
   chatComposerBottomInsetPx: 25,
+  /** 移动 Web：底栏再贴底一点（仍不低于 safe-area） */
+  chatComposerBottomInsetMobile: '12px',
+  chatComposerBottomInsetMobilePx: 12,
   chatThreadScrollPadBottom: '212px',
   chatThreadScrollPadBottomMobile: '196px',
   chatThreadAlignInset: '3px',

--- a/docs/UI-LAYOUT.md
+++ b/docs/UI-LAYOUT.md
@@ -42,8 +42,9 @@
 - **内联模式**：侧栏右缘可拖拽调宽（复用 `WorkspaceSplitDivider` 交互）
 - **浮层模式**：窗口宽度 &lt; 当前侧栏宽度 × 2.5 时侧栏浮于内容之上；≥ × 3 时窗口放大可自动展开内联侧栏
 - **Web 打开入口**：移动 Web（≤767）在聊天 `MobileTopBar` 与新闻 / 市场 / 社区 / 专家页顶栏使用同一套 `PanelLeftExpand/Contract` 侧栏开合按钮（随 `drawerOpen` 切换，点击 toggle）；桌面 Web 聊天顶栏左侧常显侧栏开合按钮，不依赖 Electron 标题栏工具
-- **移动推开布局**：左会话栏与右关注/文件栏均为 flex **width 推挤**主列（非遮罩覆盖）；开左侧栏主内容右移，开右侧栏主内容左移；时长与 `DESKTOP_SIDEBAR_LAYOUT_MS` 对齐；无半透明 backdrop
-- **移动端右栏**：聊天 `MobileTopBar` 可打开关注/持仓与文件预览为**全屏 sheet**（复用 `RightPanel` `fullWidth`，非并排分栏）；关闭后回到对话
+- **移动端顶栏规格**：共享 `client-ui/src/theme/mobileChrome.ts`（触控目标 40、图标 20、内边距 `4px 8px`、safe-area；内容带约 48px）。聊天 / 各 Web 页顶栏、设置「返回应用」、右栏全屏 sheet 顶栏均对齐该规格；右 sheet 外壳已垫 safe-area 时内栏用 inset 变体避免双垫。左会话抽屉不设独立关闭钮（由主列顶栏侧栏 icon 收起），品牌行上移与顶栏内容带对齐。移动端 composer 底栏 inset 为 `max(12px, safe-area-inset-bottom)`（桌面仍为 25px）。
+- **移动推开布局**：左会话栏与右关注/文件栏均为三列固定宽滑轨（drawer + 视口宽主列 + 视口宽右栏），以 `translate3d` **整轨平移**；主列宽度恒为视口，不被挤压。关闭时轨偏移 `-drawerW` 露出主列；开左归零；开右再偏 `-(drawerW+视口宽)`。左栏与右栏均**常驻于轨上**（不二次挂载），开合只改轨偏移；时长与 `DESKTOP_SIDEBAR_LAYOUT_MS` 对齐。开右时关左；开左时若右开则先关右。
+- **移动端右栏**：聊天 `MobileTopBar` 可打开关注/持仓与文件预览为轨上全屏列（复用 `RightPanel` `fullWidth`，非并排分栏）；关闭后轨回到主列。
 - **右侧顶栏**：关注 / 组合 / 详情为文字 Tab；进入详情时显示「详情」Tab
 - 左列名称（名录同步全称，过长 hover 横向滚动）+ 代码在下；右列表头四指标——最新价、关注收益、成本价、持仓收益（持仓成本与收益来自组合账本，含费率）；列表区 `overflow: auto` 支持横向滚动，收窄时不重叠；hover 行显示编辑/删除，操作钮 sticky 吸附在面板可视区右缘（行不横滚时保持行尾原位）
 - **窗口标题栏**：macOS 为 `hiddenInset`，系统红绿灯隐藏后由二级 chrome 内紧凑自定义红绿灯（约 14px）承接；侧栏展开时顶栏工具与 Windows 一致——收起在左（红绿灯右侧）、前进/后退靠右贴侧栏分割线。Windows / Linux 在窗口最顶部额外一条与左侧栏同色毛玻璃的 frame titlebar：左侧 App 图标 + 纯文字「Opptrix工作台」（无 wordmark SVG、无版本号）+ 模拟原生菜单（文件 / 编辑 / 视图 / 窗口 / 帮助），右侧为 Win11 风格 caption 按钮（高满条、宽 46px；关闭 hover 红底白标，其余灰底深色标）。左侧栏分割线不向上贯穿该 frame titlebar。


### PR DESCRIPTION
## Summary
- Align mobile left/right panels on a persistent three-column translate track (open/close timing matched; no overlay remount for the right sheet)
- Shared compact mobile chrome tokens; tighten composer bottom inset on mobile
- Watchlist touch UX: axis-locked scroll, drawer height cap, group create checkmark fix, always-visible row actions on touch

## Test plan
- [ ] Mobile Web: open/close left drawer and right market/files panel — slide feels symmetric
- [ ] Mobile headers across chat / news / market / community / experts / settings look shorter and aligned
- [ ] Composer sits closer to the bottom (safe-area still respected)
- [ ] Watchlist: vertical scroll, group create via checkmark, group list ~3-row scroll
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)