### PR TITLE
feat(client-ui): compact mobile CN market dynamics feed

### DIFF
--- a/client-ui/src/pages/market-dynamics/CnDashboardFlexPanel.tsx
+++ b/client-ui/src/pages/market-dynamics/CnDashboardFlexPanel.tsx
@@ -29,6 +29,17 @@ const useStyles = makeStyles({
     borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
     minHeight: '44px',
   },
+  flexHeadStacked: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    gap: '8px',
+  },
+  headTop: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '8px',
+    minWidth: 0,
+  },
   headText: {
     flex: '1 1 auto',
     minWidth: 0,
@@ -45,6 +56,13 @@ const useStyles = makeStyles({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
+  titleWrap: {
+    whiteSpace: 'normal',
+    textOverflow: 'unset',
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+  },
   subtitle: {
     fontSize: 'var(--opptrix-font-xs)',
     color: opptrixCssVars.textTertiary,
@@ -60,6 +78,12 @@ const useStyles = makeStyles({
     display: 'flex',
     justifyContent: 'flex-end',
     overflow: 'hidden',
+  },
+  tabsSlotFull: {
+    maxWidth: '100%',
+    width: '100%',
+    justifyContent: 'flex-start',
+    overflowX: 'auto',
   },
   body: {
     flex: 1,
@@ -86,6 +110,10 @@ type Props<T extends string> = {
   className?: string
   fill?: boolean
   headExtra?: ReactNode
+  /** 标题允许两行完整展示（板块名等） */
+  titleWrap?: boolean
+  /** 标题+操作一行，Tab 另起一行（手机选中板块时） */
+  stackedHead?: boolean
 }
 
 export default function CnDashboardFlexPanel<T extends string>({
@@ -96,27 +124,49 @@ export default function CnDashboardFlexPanel<T extends string>({
   className,
   fill = false,
   headExtra,
+  titleWrap = false,
+  stackedHead = false,
 }: Props<T>) {
   const s = useStyles()
 
+  const titleBlock = (
+    <div className={s.headText}>
+      <Text className={mergeClasses(s.title, titleWrap && s.titleWrap)} block>
+        {title}
+      </Text>
+      {subtitle ? <Text className={s.subtitle} block>{subtitle}</Text> : null}
+    </div>
+  )
+
+  const tabs = tabConfig ? (
+    <div className={mergeClasses(s.tabsSlot, stackedHead && s.tabsSlotFull)}>
+      <PanelTitleTabs
+        tabs={tabConfig.tabs}
+        value={tabConfig.value}
+        onChange={tabConfig.onChange}
+        ariaLabel={tabConfig.ariaLabel}
+      />
+    </div>
+  ) : null
+
   return (
     <section className={mergeClasses(s.panel, fill && s.panelFill, className)}>
-      <header className={s.flexHead}>
-        <div className={s.headText}>
-          <Text className={s.title} block>{title}</Text>
-          {subtitle ? <Text className={s.subtitle} block>{subtitle}</Text> : null}
-        </div>
-        {tabConfig ? (
-          <div className={s.tabsSlot}>
-            <PanelTitleTabs
-              tabs={tabConfig.tabs}
-              value={tabConfig.value}
-              onChange={tabConfig.onChange}
-              ariaLabel={tabConfig.ariaLabel}
-            />
-          </div>
-        ) : null}
-        {headExtra}
+      <header className={mergeClasses(s.flexHead, stackedHead && s.flexHeadStacked)}>
+        {stackedHead ? (
+          <>
+            <div className={s.headTop}>
+              {titleBlock}
+              {headExtra}
+            </div>
+            {tabs}
+          </>
+        ) : (
+          <>
+            {titleBlock}
+            {tabs}
+            {headExtra}
+          </>
+        )}
       </header>
       <div className={s.body}>{children}</div>
     </section>

--- a/client-ui/src/pages/market-dynamics/CnHeroIndexStrip.tsx
+++ b/client-ui/src/pages/market-dynamics/CnHeroIndexStrip.tsx
@@ -1,20 +1,31 @@
-import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import { makeStyles, mergeClasses, Text } from '@fluentui/react-components'
 import type { MarketIndexQuote } from '../../types/schemas'
 import { chartCodeFromIndex, indexKey } from './marketBoardUtils'
 import { resolveIndexDisplayCode, resolveIndexDisplayName } from './cnIndexFormat'
 import CnQuoteUnitCard from './CnQuoteUnitCard'
-import { CN_DASH } from './cnDashboardTokens'
+import { CN_DASH, CN_DASH_MOBILE } from './cnDashboardTokens'
 import { useCnHeroCardStyles } from './cnSelectCardStyles'
 import { CnIndexStripSkeleton } from './cnDashboardSkeletons'
+import { opptrixCssVars } from '../../theme/tokens'
 
 const useStyles = makeStyles({
   strip: {
     display: 'flex',
     gap: CN_DASH.cardGap,
     minWidth: 0,
+    minHeight: '96px',
+    flexShrink: 0,
     overflowX: 'auto',
     scrollbarWidth: 'none',
     '&::-webkit-scrollbar': { display: 'none' },
+  },
+  stripEmpty: {
+    display: 'flex',
+    alignItems: 'center',
+    minHeight: '72px',
+    padding: '0 4px',
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
   },
   cardInner: {
     flex: '1 0 188px',
@@ -23,6 +34,12 @@ const useStyles = makeStyles({
     padding: '12px 14px',
     borderRadius: CN_DASH.cardRadius,
   },
+  cardInnerCompact: {
+    flex: `1 0 ${CN_DASH_MOBILE.heroCardMin}`,
+    minWidth: CN_DASH_MOBILE.heroCardMin,
+    maxWidth: '260px',
+    padding: '12px 14px',
+  },
 })
 
 type Props = {
@@ -30,6 +47,7 @@ type Props = {
   cnIndices: MarketIndexQuote[]
   selectedCode?: string | null
   loading?: boolean
+  compact?: boolean
   onSelect?: (item: MarketIndexQuote, chartCode: string) => void
 }
 
@@ -38,6 +56,7 @@ export default function CnHeroIndexStrip({
   cnIndices,
   selectedCode,
   loading = false,
+  compact = false,
   onSelect,
 }: Props) {
   const s = useStyles()
@@ -45,6 +64,14 @@ export default function CnHeroIndexStrip({
 
   if (loading && !indices.length) {
     return <CnIndexStripSkeleton />
+  }
+
+  if (!indices.length) {
+    return (
+      <Text className={s.stripEmpty} block>
+        暂无宽基指数，请点顶栏刷新
+      </Text>
+    )
   }
 
   return (
@@ -62,6 +89,7 @@ export default function CnHeroIndexStrip({
             className={mergeClasses(
               cardS.card,
               s.cardInner,
+              compact && s.cardInnerCompact,
               active && cardS.cardActive,
             )}
             title={displayName}
@@ -71,7 +99,7 @@ export default function CnHeroIndexStrip({
           >
             <CnQuoteUnitCard
               name={displayName}
-              midLabel={displayCode || null}
+              midLabel={compact ? null : (displayCode || null)}
               price={item.price}
               changePct={item.change_pct}
               changeAmt={item.change_amt}

--- a/client-ui/src/pages/market-dynamics/CnHotBoardPanel.tsx
+++ b/client-ui/src/pages/market-dynamics/CnHotBoardPanel.tsx
@@ -85,6 +85,7 @@ type Props = {
   hotStocks?: MarketHotItem[]
   loading?: boolean
   emotionSource?: 'tonghuashun' | null
+  isMobile?: boolean
 }
 
 function HotBoardList({
@@ -127,6 +128,7 @@ export default function CnHotBoardPanel({
   hotStocks = [],
   loading = false,
   emotionSource,
+  isMobile = false,
 }: Props) {
   const s = useStyles()
   const [tab, setTab] = useState<HotBoardTab>('skyrocket')
@@ -230,7 +232,11 @@ export default function CnHotBoardPanel({
             ) : null}
           </div>
         ) : null}
-        <CnInsightSplitView selected={selected} onSelect={setSelected}>
+        <CnInsightSplitView
+          selected={selected}
+          onSelect={setSelected}
+          presentation={isMobile ? 'drawer' : 'split'}
+        >
           {renderList()}
         </CnInsightSplitView>
       </div>

--- a/client-ui/src/pages/market-dynamics/CnInsightSplitView.tsx
+++ b/client-ui/src/pages/market-dynamics/CnInsightSplitView.tsx
@@ -1,7 +1,8 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { makeStyles, mergeClasses } from '@fluentui/react-components'
 import TradingViewChart from '../../market/TradingViewChart'
-import { opptrixCssVars } from '../../theme/tokens'
+import { opptrixCssVars, opptrixTokens } from '../../theme/tokens'
+import { motion } from '../../theme/mixins'
 import type { InstrumentRef } from '../../types/instrument'
 import { CnInsightStockSelectProvider } from './cnInsightStockContext'
 import type { CnInsightStockPick } from './cnInsightStockUtils'
@@ -9,6 +10,7 @@ import { cnInsightChartInputCode, cnInsightInstrumentFromCode } from './cnInsigh
 
 const useStyles = makeStyles({
   root: {
+    position: 'relative',
     flex: 1,
     minHeight: 0,
     display: 'grid',
@@ -18,6 +20,11 @@ const useStyles = makeStyles({
   },
   rootSplit: {
     gridTemplateColumns: 'minmax(0, 0.42fr) minmax(0, 0.58fr)',
+  },
+  rootDrawer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gridTemplateColumns: 'unset',
   },
   listPane: {
     minWidth: 0,
@@ -30,6 +37,10 @@ const useStyles = makeStyles({
   },
   listPaneSplit: {
     borderRightColor: opptrixCssVars.separatorHairline,
+  },
+  listPaneDrawer: {
+    flex: 1,
+    borderRight: 'none',
   },
   listInner: {
     flex: 1,
@@ -63,6 +74,59 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     overflow: 'hidden',
   },
+  scrim: {
+    position: 'absolute',
+    inset: 0,
+    zIndex: 20,
+    border: 'none',
+    padding: 0,
+    margin: 0,
+    backgroundColor: 'rgba(29, 29, 31, 0.18)',
+    opacity: 0,
+    pointerEvents: 'none',
+    transitionProperty: 'opacity',
+    transitionDuration: motion.normal,
+    transitionTimingFunction: motion.ease,
+  },
+  scrimOpen: {
+    opacity: 1,
+    pointerEvents: 'auto',
+  },
+  drawer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 21,
+    height: 'min(72%, 420px)',
+    minHeight: '280px',
+    display: 'flex',
+    flexDirection: 'column',
+    boxSizing: 'border-box',
+    borderRadius: `${opptrixTokens.radiusXl} ${opptrixTokens.radiusXl} 0 0`,
+    borderTop: `1px solid ${opptrixCssVars.separatorHairline}`,
+    backgroundColor: opptrixCssVars.surface,
+    boxShadow: '0 -8px 28px rgba(0, 0, 0, 0.12)',
+    transform: 'translateY(105%)',
+    transitionProperty: 'transform',
+    transitionDuration: motion.normal,
+    transitionTimingFunction: motion.easeOut,
+    overflow: 'hidden',
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '1ms',
+    },
+  },
+  drawerOpen: {
+    transform: 'translateY(0)',
+  },
+  drawerHandle: {
+    width: '32px',
+    height: '4px',
+    borderRadius: opptrixTokens.radiusFull,
+    backgroundColor: opptrixCssVars.borderStrong,
+    margin: '8px auto 4px',
+    flexShrink: 0,
+  },
 })
 
 type Props = {
@@ -71,6 +135,8 @@ type Props = {
   children: React.ReactNode
   instrumentFromCode?: (code: string) => InstrumentRef
   chartInputCode?: (ref: InstrumentRef) => string
+  /** split=桌面分栏；drawer=手机底部抽屉 */
+  presentation?: 'split' | 'drawer'
 }
 
 function ChartPane({
@@ -118,26 +184,79 @@ export default function CnInsightSplitView({
   children,
   instrumentFromCode = cnInsightInstrumentFromCode,
   chartInputCode: chartInputCodeFn = cnInsightChartInputCode,
+  presentation = 'split',
 }: Props) {
   const s = useStyles()
-  const split = selected != null
+  const drawerMode = presentation === 'drawer'
+  const open = selected != null
+  const [drawerPresented, setDrawerPresented] = useState(false)
+
+  useEffect(() => {
+    if (!drawerMode) {
+      setDrawerPresented(false)
+      return
+    }
+    if (open) {
+      const raf = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setDrawerPresented(true))
+      })
+      return () => cancelAnimationFrame(raf)
+    }
+    setDrawerPresented(false)
+    return undefined
+  }, [drawerMode, open])
+
+  const chart = selected ? (
+    <ChartPane
+      stock={selected}
+      onClose={() => onSelect(null)}
+      instrumentFromCode={instrumentFromCode}
+      chartInputCodeFn={chartInputCodeFn}
+    />
+  ) : null
 
   return (
     <CnInsightStockSelectProvider selected={selected} onSelect={onSelect}>
-      <div className={mergeClasses(s.root, split && s.rootSplit)}>
-        <div className={mergeClasses(s.listPane, split && s.listPaneSplit)}>
+      <div
+        className={mergeClasses(
+          s.root,
+          !drawerMode && open && s.rootSplit,
+          drawerMode && s.rootDrawer,
+        )}
+      >
+        <div
+          className={mergeClasses(
+            s.listPane,
+            !drawerMode && open && s.listPaneSplit,
+            drawerMode && s.listPaneDrawer,
+          )}
+        >
           <div className={s.listInner}>{children}</div>
         </div>
-        <div className={mergeClasses(s.chartPane, split && s.chartPaneOpen)}>
-          {selected ? (
-            <ChartPane
-              stock={selected}
-              onClose={() => onSelect(null)}
-              instrumentFromCode={instrumentFromCode}
-              chartInputCodeFn={chartInputCodeFn}
+
+        {!drawerMode ? (
+          <div className={mergeClasses(s.chartPane, open && s.chartPaneOpen)}>
+            {chart}
+          </div>
+        ) : open ? (
+          <>
+            <button
+              type="button"
+              className={mergeClasses(s.scrim, drawerPresented && s.scrimOpen)}
+              aria-label="关闭个股走势"
+              onClick={() => onSelect(null)}
             />
-          ) : null}
-        </div>
+            <div
+              className={mergeClasses(s.drawer, drawerPresented && s.drawerOpen)}
+              role="dialog"
+              aria-modal="true"
+              aria-label={selected ? `${selected.name} 走势` : '个股走势'}
+            >
+              <div className={s.drawerHandle} aria-hidden />
+              {chart}
+            </div>
+          </>
+        ) : null}
       </div>
     </CnInsightStockSelectProvider>
   )

--- a/client-ui/src/pages/market-dynamics/CnMarketChartPanel.tsx
+++ b/client-ui/src/pages/market-dynamics/CnMarketChartPanel.tsx
@@ -85,6 +85,37 @@ const useStyles = makeStyles({
   breadcrumbActive: {
     color: opptrixCssVars.textSecondary,
   },
+  breadcrumbCompact: {
+    flexWrap: 'nowrap',
+    overflow: 'hidden',
+    width: '100%',
+  },
+  breadcrumbTail: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: '6px',
+    minWidth: 0,
+    overflow: 'hidden',
+  },
+  breadcrumbName: {
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    color: opptrixCssVars.textPrimary,
+    fontWeight: 650,
+  },
+  breadcrumbCode: {
+    flexShrink: 0,
+    fontSize: '9px',
+    fontWeight: 650,
+    fontVariantNumeric: 'tabular-nums',
+    color: opptrixCssVars.textTertiary,
+    padding: '1px 5px',
+    borderRadius: '4px',
+    backgroundColor: opptrixCssVars.surfaceMuted,
+    lineHeight: 1.3,
+  },
   titleRow: {
     display: 'flex',
     alignItems: 'flex-start',
@@ -193,6 +224,44 @@ const useStyles = makeStyles({
     borderRadius: CN_DASH.cardRadius,
     backgroundColor: opptrixCssVars.canvasAlt,
   },
+  panelCompact: {
+    height: '100%',
+  },
+  compactHead: {
+    flexShrink: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    padding: '8px 12px 6px',
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+  },
+  compactChart: {
+    flex: 1,
+    minHeight: 0,
+    position: 'relative',
+    backgroundColor: opptrixCssVars.canvasAlt,
+  },
+  compactEmpty: {
+    position: 'absolute',
+    inset: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '16px',
+    boxSizing: 'border-box',
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    textAlign: 'center',
+    lineHeight: 1.55,
+  },
+  metricsGridCompact: {
+    gridTemplateColumns: '1fr 1fr 1fr',
+    gap: '8px',
+    marginTop: 0,
+  },
+  metricValueCompact: {
+    fontSize: '16px',
+  },
 })
 
 function chartDisplayCode(
@@ -226,6 +295,8 @@ type Props = {
   quoteTime?: string | null
   tradeState?: string | null
   loading?: boolean
+  /** 手机：元数据在上、图在下，避免左栏挤占 */
+  compact?: boolean
 }
 
 export default function CnMarketChartPanel({
@@ -239,6 +310,7 @@ export default function CnMarketChartPanel({
   quoteTime,
   tradeState,
   loading = false,
+  compact = false,
 }: Props) {
   const s = useStyles()
 
@@ -262,7 +334,7 @@ export default function CnMarketChartPanel({
     <>
       <div className={s.breadcrumb}>
         {breadcrumb.map((crumb, i) => (
-          <span key={crumb} style={{ display: 'inline-flex', alignItems: 'center', gap: '3px' }}>
+          <span key={`${crumb}-${i}`} style={{ display: 'inline-flex', alignItems: 'center', gap: '3px' }}>
             {i > 0 ? <ChevronRightRegular className={s.breadcrumbSep} fontSize={9} /> : null}
             <span className={i === breadcrumb.length - 1 ? s.breadcrumbActive : undefined}>
               {crumb}
@@ -277,8 +349,91 @@ export default function CnMarketChartPanel({
     </>
   )
 
+  /** 手机：名称+代码并入面包屑末级，省掉独立标题行 */
+  const compactMeta = (
+    <div className={mergeClasses(s.breadcrumb, s.breadcrumbCompact)}>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', flexShrink: 0 }}>
+        市场动态
+      </span>
+      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '3px', flexShrink: 0 }}>
+        <ChevronRightRegular className={s.breadcrumbSep} fontSize={9} />
+        指数
+      </span>
+      <span className={s.breadcrumbTail}>
+        <ChevronRightRegular className={s.breadcrumbSep} fontSize={9} />
+        <span className={s.breadcrumbName}>{title}</span>
+        {displayCode ? <span className={s.breadcrumbCode}>{displayCode}</span> : null}
+      </span>
+    </div>
+  )
+
+  const metrics = (
+    <div className={mergeClasses(s.metricsGrid, compact && s.metricsGridCompact)}>
+      <div className={mergeClasses(s.metricCell, !compact && s.metricCellWide)}>
+        <span className={s.metricLabel}>最新点位</span>
+        <span>
+          <span className={mergeClasses(s.metricValue, compact && s.metricValueCompact)}>
+            {formatIndexPoints(price, 2)}
+          </span>
+          <span className={s.metricUnit}>点</span>
+        </span>
+      </div>
+      <div className={s.metricCell}>
+        <span className={s.metricLabel}>今日涨跌</span>
+        <span className={mergeClasses(s.metricValueSm, deltaClass(s, changePct))}>
+          {changeAmtText}
+        </span>
+      </div>
+      <div className={s.metricCell}>
+        <span className={s.metricLabel}>涨跌幅</span>
+        <CnChangePill changePct={changePct} ghost compact />
+      </div>
+      {!compact ? (
+        <div className={mergeClasses(s.metricCell, s.metricCellWide)}>
+          <span className={s.metricLabel}>行情状态</span>
+          <span className={mergeClasses(s.metricValueSm, s.deltaFlat)}>
+            {quoteTime
+              ? `更新 ${quoteTime}${tradeState ? ` · ${tradeState}` : ''}`
+              : `${displayCode} · 日 K`}
+          </span>
+        </div>
+      ) : null}
+    </div>
+  )
+
   if (loading) {
     return <CnChartPanelSkeleton />
+  }
+
+  if (compact) {
+    return (
+      <section className={mergeClasses(s.panel, s.panelCompact, 'opptrix-cn-chart-panel')}>
+        <div className={s.compactHead}>
+          {compactMeta}
+          {chartCode ? metrics : (
+            <Text className={s.heroNote} block>
+              在顶部选择宽基指数，查看点位与走势
+            </Text>
+          )}
+        </div>
+        <div className={s.compactChart}>
+          {chartCode && instrument ? (
+            <TradingViewChart
+              code={chartInputCode}
+              instrument={instrument}
+              chartVariant="index"
+              expanded
+              embedMode
+              active
+            />
+          ) : (
+            <Text className={s.compactEmpty} block>
+              点击顶部宽基指数卡片，查看点位与走势
+            </Text>
+          )}
+        </div>
+      </section>
+    )
   }
 
   if (!chartCode) {
@@ -316,33 +471,7 @@ export default function CnMarketChartPanel({
         </div>
         <aside className={s.leftCol}>
           {leftMeta}
-          <div className={s.metricsGrid}>
-            <div className={mergeClasses(s.metricCell, s.metricCellWide)}>
-              <span className={s.metricLabel}>最新点位</span>
-              <span>
-                <span className={s.metricValue}>{formatIndexPoints(price, 2)}</span>
-                <span className={s.metricUnit}>点</span>
-              </span>
-            </div>
-            <div className={s.metricCell}>
-              <span className={s.metricLabel}>今日涨跌</span>
-              <span className={mergeClasses(s.metricValueSm, deltaClass(s, changePct))}>
-                {changeAmtText}
-              </span>
-            </div>
-            <div className={s.metricCell}>
-              <span className={s.metricLabel}>涨跌幅</span>
-              <CnChangePill changePct={changePct} ghost compact />
-            </div>
-            <div className={mergeClasses(s.metricCell, s.metricCellWide)}>
-              <span className={s.metricLabel}>行情状态</span>
-              <span className={mergeClasses(s.metricValueSm, s.deltaFlat)}>
-                {quoteTime
-                  ? `更新 ${quoteTime}${tradeState ? ` · ${tradeState}` : ''}`
-                  : `${displayCode} · 日 K`}
-              </span>
-            </div>
-          </div>
+          {metrics}
         </aside>
       </div>
     </section>

--- a/client-ui/src/pages/market-dynamics/CnMarketDynamicsView.tsx
+++ b/client-ui/src/pages/market-dynamics/CnMarketDynamicsView.tsx
@@ -14,7 +14,7 @@ import { resolveIndexDisplayName } from './cnIndexFormat'
 import { chartCodeFromIndex } from './marketBoardUtils'
 import { sectorIndexCode } from './MarketSectorStrip'
 import { useMarketDynamicsLayout } from './useMarketDynamicsLayout'
-import { CN_DASH } from './cnDashboardTokens'
+import { CN_DASH, CN_DASH_MOBILE } from './cnDashboardTokens'
 
 const useStyles = makeStyles({
   root: {
@@ -26,6 +26,10 @@ const useStyles = makeStyles({
     padding: CN_DASH.pagePad,
     overflow: 'hidden',
     backgroundColor: opptrixCssVars.canvasAlt,
+  },
+  rootMobile: {
+    gap: 0,
+    padding: 0,
   },
   body: {
     flex: 1,
@@ -88,6 +92,53 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     overflow: 'hidden',
   },
+  /** 手机信息流：单列纵滚 */
+  feedScroll: {
+    flex: 1,
+    minHeight: 0,
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    WebkitOverflowScrolling: 'touch',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: CN_DASH_MOBILE.pageGap,
+    padding: CN_DASH_MOBILE.pagePad,
+    paddingBottom: `max(16px, env(safe-area-inset-bottom))`,
+    boxSizing: 'border-box',
+  },
+  /** 顶部指数 / KPI：禁止被下方高块 flex 压扁 */
+  feedLead: {
+    flexShrink: 0,
+    minWidth: 0,
+  },
+  feedChart: {
+    flexShrink: 0,
+    height: CN_DASH_MOBILE.chartHeight,
+    minHeight: '240px',
+    maxHeight: '320px',
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  feedBlock: {
+    flexShrink: 0,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  feedBlockSectors: {
+    height: 'min(52vh, 360px)',
+    minHeight: '280px',
+  },
+  feedBlockInsight: {
+    height: 'min(62vh, 440px)',
+    minHeight: '320px',
+  },
+  feedBlockHot: {
+    height: 'min(52vh, 360px)',
+    minHeight: '280px',
+  },
 })
 
 type Props = {
@@ -95,6 +146,7 @@ type Props = {
   loading: boolean
   articles: FeedArticle[]
   insightsLoading: boolean
+  isMobile?: boolean
 }
 
 export default function CnMarketDynamicsView({
@@ -102,11 +154,15 @@ export default function CnMarketDynamicsView({
   loading,
   articles,
   insightsLoading,
+  isMobile = false,
 }: Props) {
   const s = useStyles()
   const containerRef = useRef<HTMLDivElement>(null)
+  const feedScrollRef = useRef<HTMLDivElement>(null)
+  const insightBlockRef = useRef<HTMLDivElement>(null)
   const layoutMode = useMarketDynamicsLayout(containerRef)
-  const stacked = layoutMode === 'stacked'
+  /** 手机走信息流；窄桌面仍用 stacked */
+  const stacked = !isMobile && layoutMode === 'stacked'
 
   const sections = useMemo(() => data?.sections ?? [], [data?.sections])
   const cnIndices = useMemo(
@@ -143,6 +199,13 @@ export default function CnMarketDynamicsView({
     writeCnIndexChartCode(defaultCode)
   }, [chartCode, cnIndices])
 
+  const scrollInsightIntoView = useCallback(() => {
+    if (!isMobile) return
+    requestAnimationFrame(() => {
+      insightBlockRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    })
+  }, [isMobile])
+
   const handleIndexSelect = (item: MarketIndexQuote, code: string) => {
     setActiveIndex(item)
     setChartCode(code)
@@ -156,6 +219,8 @@ export default function CnMarketDynamicsView({
       return
     }
     setSelectedSector(item)
+    setInsightTab('constituents')
+    scrollInsightIntoView()
   }
 
   const handleClearSector = () => setSelectedSector(null)
@@ -177,11 +242,118 @@ export default function CnMarketDynamicsView({
       if (topSector) {
         setSelectedSector(topSector)
         setInsightTab('constituents')
+        scrollInsightIntoView()
       }
       return
     }
     setInsightTab(action)
-  }, [topSector])
+    scrollInsightIntoView()
+  }, [topSector, scrollInsightIntoView])
+
+  const chartPanel = (
+    <CnMarketChartPanel
+      chartCode={chartCode}
+      activeIndex={activeIndex}
+      loading={loading}
+      compact={isMobile}
+      title={activeIndex ? resolveIndexDisplayName(activeIndex) : '指数走势'}
+      indexCode={activeIndex?.qt_code ?? activeIndex?.code}
+      price={activeIndex?.price}
+      changePct={activeIndex?.change_pct}
+      changeAmt={activeIndex?.change_amt}
+      quoteTime={activeIndex?.quote_time}
+      tradeState={activeIndex?.trade_state_label}
+    />
+  )
+
+  const insightPanel = (
+    <CnMarketInsightPanel
+      selectedSector={selectedSector}
+      selectedSectorCode={selectedSectorCode}
+      gainers={data?.cn_gainers ?? []}
+      losers={data?.cn_losers ?? []}
+      limitUp={data?.cn_limit_up}
+      limitBreak={data?.cn_limit_break}
+      skyrocket={data?.cn_skyrocket}
+      limitLadder={data?.cn_limit_ladder}
+      dragonTiger={data?.cn_dragon_tiger ?? []}
+      dragonTigerDate={data?.cn_dragon_tiger_date}
+      articles={articles}
+      insightsLoading={insightsLoading}
+      marketLoading={loading}
+      onClearSector={handleClearSector}
+      activeTab={insightTab}
+      onTabChange={setInsightTab}
+      isMobile={isMobile}
+    />
+  )
+
+  const sectorPanel = (
+    <CnSectorDiscoverGrid
+      sectors={sectorIndices}
+      selectedCode={selectedSectorCode}
+      loading={loading}
+      emptyHint={data?.cn_sector_hint}
+      columns={isMobile ? 2 : 3}
+      onSelect={handleSectorSelect}
+    />
+  )
+
+  const hotPanel = (
+    <CnHotBoardPanel
+      skyrocket={data?.cn_skyrocket}
+      hotStocks={data?.cn_hot_stocks}
+      loading={loading}
+      emotionSource={data?.cn_emotion_source ?? null}
+      isMobile={isMobile}
+    />
+  )
+
+  if (isMobile) {
+    return (
+      <div
+        ref={containerRef}
+        className={mergeClasses(s.root, s.rootMobile, 'opptrix-cn-market-dynamics')}
+      >
+        <div
+          ref={feedScrollRef}
+          className={mergeClasses(s.feedScroll, 'opptrix-scroll')}
+        >
+          <div className={s.feedLead}>
+            <CnHeroIndexStrip
+              indices={cnIndices}
+              cnIndices={cnIndices}
+              selectedCode={chartCode}
+              loading={loading}
+              compact
+              onSelect={handleIndexSelect}
+            />
+          </div>
+          <div className={s.feedLead}>
+            <CnCompactKpiRow
+              data={data}
+              sectors={sectorIndices}
+              loading={loading && !data}
+              onMetricClick={handleKpiClick}
+            />
+          </div>
+          <div className={s.feedChart}>{chartPanel}</div>
+          <div className={mergeClasses(s.feedBlock, s.feedBlockSectors)}>
+            {sectorPanel}
+          </div>
+          <div
+            ref={insightBlockRef}
+            className={mergeClasses(s.feedBlock, s.feedBlockInsight)}
+          >
+            {insightPanel}
+          </div>
+          <div className={mergeClasses(s.feedBlock, s.feedBlockHot)}>
+            {hotPanel}
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div
@@ -205,60 +377,13 @@ export default function CnMarketDynamicsView({
 
       <div className={mergeClasses(s.body, stacked && s.bodyStacked)}>
         <div className={s.mainCol}>
-          <div className={s.chartCol}>
-            <CnMarketChartPanel
-              chartCode={chartCode}
-              activeIndex={activeIndex}
-              loading={loading}
-              title={activeIndex ? resolveIndexDisplayName(activeIndex) : '指数走势'}
-              indexCode={activeIndex?.qt_code ?? activeIndex?.code}
-              price={activeIndex?.price}
-              changePct={activeIndex?.change_pct}
-              changeAmt={activeIndex?.change_amt}
-              quoteTime={activeIndex?.quote_time}
-              tradeState={activeIndex?.trade_state_label}
-            />
-          </div>
-          <div className={s.detailCol}>
-            <CnMarketInsightPanel
-              selectedSector={selectedSector}
-              selectedSectorCode={selectedSectorCode}
-              gainers={data?.cn_gainers ?? []}
-              losers={data?.cn_losers ?? []}
-              limitUp={data?.cn_limit_up}
-              limitBreak={data?.cn_limit_break}
-              skyrocket={data?.cn_skyrocket}
-              limitLadder={data?.cn_limit_ladder}
-              dragonTiger={data?.cn_dragon_tiger ?? []}
-              dragonTigerDate={data?.cn_dragon_tiger_date}
-              articles={articles}
-              insightsLoading={insightsLoading}
-              marketLoading={loading}
-              onClearSector={handleClearSector}
-              activeTab={insightTab}
-              onTabChange={setInsightTab}
-            />
-          </div>
+          <div className={s.chartCol}>{chartPanel}</div>
+          <div className={s.detailCol}>{insightPanel}</div>
         </div>
 
         <div className={s.sideCol}>
-          <div className={s.sectorCol}>
-            <CnSectorDiscoverGrid
-              sectors={sectorIndices}
-              selectedCode={selectedSectorCode}
-              loading={loading}
-              emptyHint={data?.cn_sector_hint}
-              onSelect={handleSectorSelect}
-            />
-          </div>
-          <div className={s.hotBoardCol}>
-            <CnHotBoardPanel
-              skyrocket={data?.cn_skyrocket}
-              hotStocks={data?.cn_hot_stocks}
-              loading={loading}
-              emotionSource={data?.cn_emotion_source ?? null}
-            />
-          </div>
+          <div className={s.sectorCol}>{sectorPanel}</div>
+          <div className={s.hotBoardCol}>{hotPanel}</div>
         </div>
       </div>
     </div>

--- a/client-ui/src/pages/market-dynamics/CnMarketInsightPanel.tsx
+++ b/client-ui/src/pages/market-dynamics/CnMarketInsightPanel.tsx
@@ -54,13 +54,20 @@ const useStyles = makeStyles({
     cursor: 'pointer',
     display: 'inline-flex',
     alignItems: 'center',
+    justifyContent: 'center',
     gap: '4px',
     fontSize: 'var(--opptrix-font-xs)',
     fontWeight: 600,
     padding: '4px 8px',
     borderRadius: '6px',
     whiteSpace: 'nowrap',
+    flexShrink: 0,
     ':hover': { backgroundColor: opptrixCssVars.surfaceHover },
+  },
+  clearBtnIcon: {
+    minWidth: '32px',
+    height: '32px',
+    padding: 0,
   },
   body: {
     flex: 1,
@@ -139,6 +146,7 @@ type Props = {
   onClearSector: () => void
   activeTab?: InsightTab
   onTabChange?: (tab: InsightTab) => void
+  isMobile?: boolean
 }
 
 export default function CnMarketInsightPanel({
@@ -158,6 +166,7 @@ export default function CnMarketInsightPanel({
   onClearSector,
   activeTab,
   onTabChange,
+  isMobile = false,
 }: Props) {
   const s = useStyles()
   const [internalTab, setInternalTab] = useState<InsightTab>('gainers')
@@ -185,11 +194,12 @@ export default function CnMarketInsightPanel({
       <CnInsightSplitView
         selected={selectedStock}
         onSelect={setSelectedStock}
+        presentation={isMobile ? 'drawer' : 'split'}
       >
         {content}
       </CnInsightSplitView>
     )
-  }, [selectedStock, tab])
+  }, [selectedStock, tab, isMobile])
 
   const tabs = useMemo(() => {
     const base = [
@@ -216,8 +226,9 @@ export default function CnMarketInsightPanel({
     selectedSector,
   ])
 
+  const panelTitle = selectedSector ? selectedSector.name : '数据明细'
   const panelSubtitle = selectedSector
-    ? `${selectedSector.name} · ${formatIndexPoints(selectedSector.price, 2)} 点`
+    ? `${formatIndexPoints(selectedSector.price, 2)} 点`
     : '涨幅、跌幅、涨停、连板、龙虎与资讯'
 
   const renderContent = () => {
@@ -413,9 +424,11 @@ export default function CnMarketInsightPanel({
 
   return (
     <CnDashboardFlexPanel
-      title="数据明细"
+      title={panelTitle}
       subtitle={panelSubtitle}
       fill
+      titleWrap={Boolean(selectedSector)}
+      stackedHead={isMobile && Boolean(selectedSector)}
       tabConfig={{
         tabs,
         value: tab,
@@ -424,14 +437,22 @@ export default function CnMarketInsightPanel({
       }}
       headExtra={selectedSector ? (
         <div className={s.sectorHeadExtra}>
-          <CnChangePill
-            changePct={selectedSector.change_pct}
-            changeAmt={selectedSector.change_amt}
-            ghost
-          />
-          <button type="button" className={s.clearBtn} onClick={onClearSector}>
-            <DismissRegular fontSize={12} />
-            取消板块
+          {!isMobile ? (
+            <CnChangePill
+              changePct={selectedSector.change_pct}
+              changeAmt={selectedSector.change_amt}
+              ghost
+            />
+          ) : null}
+          <button
+            type="button"
+            className={mergeClasses(s.clearBtn, isMobile && s.clearBtnIcon)}
+            onClick={onClearSector}
+            aria-label="取消板块"
+            title="取消板块"
+          >
+            <DismissRegular fontSize={isMobile ? 16 : 12} />
+            {!isMobile ? '取消板块' : null}
           </button>
         </div>
       ) : null}

--- a/client-ui/src/pages/market-dynamics/CnSectorDiscoverGrid.tsx
+++ b/client-ui/src/pages/market-dynamics/CnSectorDiscoverGrid.tsx
@@ -43,6 +43,9 @@ const useStyles = makeStyles({
     alignContent: 'start',
     gap: '8px',
   },
+  gridCols2: {
+    gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+  },
   cardInner: {
     padding: '10px 12px',
     borderRadius: '10px',
@@ -64,6 +67,8 @@ type Props = {
   selectedCode?: string | null
   loading?: boolean
   emptyHint?: string
+  /** 每行列数；手机信息流默认 2 */
+  columns?: 2 | 3
   onSelect?: (item: MarketIndexQuote) => void
 }
 
@@ -72,6 +77,7 @@ export default function CnSectorDiscoverGrid({
   selectedCode,
   loading = false,
   emptyHint,
+  columns = 3,
   onSelect,
 }: Props) {
   const s = useStyles()
@@ -117,7 +123,13 @@ export default function CnSectorDiscoverGrid({
         {loading && !sectors.length ? (
           <CnSectorGridSkeleton />
         ) : (
-          <div className={mergeClasses(s.grid, 'opptrix-scroll-hidden')}>
+          <div
+            className={mergeClasses(
+              s.grid,
+              columns === 2 && s.gridCols2,
+              'opptrix-scroll-hidden',
+            )}
+          >
             {!items.length ? (
               <Text className={s.empty} block>{emptyHint ?? '暂无板块数据'}</Text>
             ) : (

--- a/client-ui/src/pages/market-dynamics/MarketDynamicsPage.tsx
+++ b/client-ui/src/pages/market-dynamics/MarketDynamicsPage.tsx
@@ -94,6 +94,7 @@ function MarketDynamicsContent({
           loading={panelLoading && !hasData}
           articles={insights.articles}
           insightsLoading={insights.loading}
+          isMobile={isMobile}
         />
       </div>
     </div>

--- a/client-ui/src/pages/market-dynamics/cnDashboardTokens.ts
+++ b/client-ui/src/pages/market-dynamics/cnDashboardTokens.ts
@@ -14,3 +14,14 @@ export const CN_DASH = {
   tableRowPad: '10px 4px',
   tableHeadTracking: '0.06em',
 } as const
+
+/** 移动 Web 市场动态：更紧的页边距与卡片 */
+export const CN_DASH_MOBILE = {
+  pagePad: '10px',
+  pageGap: '10px',
+  cardGap: '8px',
+  headPad: '10px 12px 8px',
+  /** 加宽指数卡，便于完整展示名称 */
+  heroCardMin: '200px',
+  chartHeight: 'min(58vw, 300px)',
+} as const

--- a/docs/UI-LAYOUT.md
+++ b/docs/UI-LAYOUT.md
@@ -74,7 +74,7 @@
 | 概览 | Dashboard | Stat 行 + Module 网格 |
 | 个股研究 | StockResearch | PageHeader + Tab + 内容卡片 |
 | 机会与组合 | PortfolioHub | Tab + 表格/表单卡片 |
-| 市场动态 | MarketDynamicsPage | A股 **Stocky 式 Dashboard**：英雄指数卡（大价 + 涨跌 Pill + Sparkline）→ 紧凑 KPI 条 → 主区左（面包屑 + 大价 K 线 + 数据明细 Tab 表）/ 右（板块发现 2×N 网格）；美股不变 |
+| 市场动态 | MarketDynamicsPage | A股 **Stocky 式 Dashboard**：英雄指数卡 → 紧凑 KPI → 主区左（大价 K 线 + 数据明细）/ 右（板块发现 + 热榜）。**移动 Web**：单列信息流——更宽指数卡（隐代码）→ KPI → 更高紧凑图 → 板块（2 列）→ 明细 → 热榜；点个股走势以底部抽屉拉出；选中板块时标题展示完整板块名、清除为图标。美股不变 |
 | 投研写作 | StockWriter | 双栏 Editor 卡片 |
 | 设置 | Settings | 表单卡片堆叠 |
 | 新闻中心 | NewsCenter | 侧栏入口；feed / reader 双模式 |


### PR DESCRIPTION
## Summary
- Mobile CN market dynamics uses a single-column feed with denser hero/chart chrome and insight drawer.
- Chart compact head merges index name + code into the breadcrumb row to reclaim height.
- Sector grid and panel polish for small screens; docs updated.

## Test plan
- [ ] Mobile: open 市场动态 — hero/KPI/chart/sectors/insight scroll as one feed
- [ ] Compact chart head shows breadcrumb with name + code on one line
- [ ] Desktop layout unchanged
- [ ] `npm run check:ui` passes


Made with [Cursor](https://cursor.com)