### PR TITLE
feat(chat): welcome market pulse with shared CN dynamics cache

### DIFF
--- a/client-ui/src/chat/ChatView.tsx
+++ b/client-ui/src/chat/ChatView.tsx
@@ -45,6 +45,7 @@ import {
   DESKTOP_TOOL_ICON_SIZE,
 } from '../desktop/constants'
 import { pickWelcomeVariant } from './chatWelcomeVariants'
+import ChatWelcomeMarketPulse from './ChatWelcomeMarketPulse'
 import MessageOutlineRail, { buildOutlineEntries } from './MessageOutlineRail'
 
 /** 消息区底 padding 初始/下限（ResizeObserver 测 composerInner 后覆盖） */
@@ -423,6 +424,9 @@ const useStyles = makeStyles({
     lineHeight: 1.6,
     maxWidth: '100%',
     animationDelay: '0.75s',
+  },
+  welcomePulse: {
+    animationDelay: '0.9s',
   },
   loadingRow: {
     alignSelf: 'stretch',
@@ -1174,6 +1178,14 @@ function ChatView({
                     <Text className={mergeClasses(s.welcomeSub, s.welcomeEnter)}>
                       {welcomeSubtitle}
                     </Text>
+                  ) : null}
+                  {!isExpertSession ? (
+                    <ChatWelcomeMarketPulse
+                      enabled={isEmpty}
+                      isMobile={isMobile}
+                      shuffleEpoch={welcomeEpoch}
+                      className={mergeClasses(s.welcomePulse, s.welcomeEnter)}
+                    />
                   ) : null}
                 </div>
               )}

--- a/client-ui/src/chat/ChatWelcomeMarketPulse.tsx
+++ b/client-ui/src/chat/ChatWelcomeMarketPulse.tsx
@@ -1,0 +1,351 @@
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import { opptrixCssVars } from '../theme/tokens'
+import { MARKET_DOWN, MARKET_UP } from '../market/chartTheme'
+import { formatPct, pctTone } from '../market/format'
+import { formatIndexPoints } from '../pages/market-dynamics/cnIndexFormat'
+import {
+  WELCOME_PULSE_INTERVAL_MS,
+  WELCOME_PULSE_ROW_HEIGHT_PX,
+  WELCOME_PULSE_TRANSITION_MS,
+  resolveWelcomePulsePageSize,
+  type WelcomePulseItem,
+} from './welcomeMarketPulseModel'
+import { useChatWelcomeMarketPulse } from './useChatWelcomeMarketPulse'
+
+const useStyles = makeStyles({
+  root: {
+    width: '100%',
+    maxWidth: 'min(96vw, 540px)',
+    marginTop: '6px',
+    userSelect: 'none',
+    pointerEvents: 'none',
+  },
+  rootMobile: {
+    maxWidth: '100%',
+    paddingInline: '4px',
+    boxSizing: 'border-box',
+  },
+  viewport: {
+    position: 'relative',
+    overflow: 'hidden',
+    height: `${WELCOME_PULSE_ROW_HEIGHT_PX}px`,
+  },
+  track: {
+    display: 'flex',
+    flexDirection: 'column',
+    willChange: 'transform',
+  },
+  page: {
+    flex: `0 0 ${WELCOME_PULSE_ROW_HEIGHT_PX}px`,
+    height: `${WELCOME_PULSE_ROW_HEIGHT_PX}px`,
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) 1px minmax(0, 1fr) 1px minmax(0, 1fr)',
+    columnGap: '20px',
+    alignItems: 'center',
+    minWidth: 0,
+  },
+  pageMobile: {
+    gridTemplateColumns: 'minmax(0, 1fr) 1px minmax(0, 1fr)',
+    columnGap: '24px',
+  },
+  divider: {
+    width: '1px',
+    height: '30px',
+    justifySelf: 'center',
+    backgroundColor: opptrixCssVars.separatorHairline,
+    opacity: 0.9,
+  },
+  cell: {
+    minWidth: 0,
+    maxHeight: `${WELCOME_PULSE_ROW_HEIGHT_PX}px`,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1px',
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    textAlign: 'center',
+    paddingInline: '4px',
+    overflow: 'hidden',
+  },
+  cellMobile: {
+    paddingInline: '6px',
+  },
+  name: {
+    width: '100%',
+    fontSize: '10px',
+    fontWeight: 600,
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.2,
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    wordBreak: 'keep-all',
+    overflowWrap: 'anywhere',
+  },
+  nameMobile: {
+    fontSize: '11px',
+    WebkitLineClamp: 1,
+  },
+  valueRow: {
+    display: 'flex',
+    alignItems: 'baseline',
+    justifyContent: 'center',
+    flexWrap: 'nowrap',
+    gap: '4px',
+    minWidth: 0,
+    width: '100%',
+    whiteSpace: 'nowrap',
+  },
+  price: {
+    fontSize: '12px',
+    fontWeight: 650,
+    fontVariantNumeric: 'tabular-nums',
+    color: opptrixCssVars.textPrimary,
+    letterSpacing: '-0.02em',
+    lineHeight: 1.1,
+    flexShrink: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  priceMobile: {
+    fontSize: '13px',
+    flexShrink: 0,
+    overflow: 'visible',
+    textOverflow: 'clip',
+  },
+  pct: {
+    fontSize: '11px',
+    fontWeight: 600,
+    fontVariantNumeric: 'tabular-nums',
+    lineHeight: 1.1,
+    flexShrink: 0,
+  },
+  pctMobile: {
+    fontSize: '12px',
+  },
+  pctUp: { color: MARKET_UP },
+  pctDown: { color: MARKET_DOWN },
+  pctFlat: { color: opptrixCssVars.textTertiary },
+  skeletonPage: {
+    flex: `0 0 ${WELCOME_PULSE_ROW_HEIGHT_PX}px`,
+    height: `${WELCOME_PULSE_ROW_HEIGHT_PX}px`,
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) 1px minmax(0, 1fr) 1px minmax(0, 1fr)',
+    columnGap: '20px',
+    alignItems: 'center',
+  },
+  skeletonCell: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    alignItems: 'center',
+    paddingInline: '4px',
+  },
+  skeletonLine: {
+    height: '8px',
+    borderRadius: '999px',
+    backgroundColor: opptrixCssVars.surfaceMuted,
+    opacity: 0.55,
+  },
+  skeletonLineWide: {
+    width: '78%',
+  },
+  skeletonLineNarrow: {
+    width: '58%',
+  },
+  srOnly: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: 0,
+  },
+})
+
+type Props = {
+  enabled: boolean
+  isMobile?: boolean
+  shuffleEpoch?: number
+  className?: string
+}
+
+function PulseCell({ item, isMobile }: { item: WelcomePulseItem; isMobile: boolean }) {
+  const s = useStyles()
+  const tone = pctTone(item.changePct)
+  const pctClass = tone === 'up' ? s.pctUp : tone === 'down' ? s.pctDown : s.pctFlat
+
+  return (
+    <div className={mergeClasses(s.cell, isMobile && s.cellMobile)}>
+      <span className={mergeClasses(s.name, isMobile && s.nameMobile)} title={item.name}>
+        {item.name}
+      </span>
+      <div className={s.valueRow}>
+        <span className={mergeClasses(s.price, isMobile && s.priceMobile)}>
+          {formatIndexPoints(item.price, 2)}
+        </span>
+        <span className={mergeClasses(s.pct, isMobile && s.pctMobile, pctClass)}>
+          {formatPct(item.changePct, 2)}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function LoadingSkeleton({ columnCount, isMobile }: { columnCount: number; isMobile: boolean }) {
+  const s = useStyles()
+  return (
+    <div
+      className={mergeClasses(s.skeletonPage, isMobile && s.pageMobile)}
+      aria-hidden
+    >
+      {Array.from({ length: columnCount }, (_, i) => (
+        <Fragment key={i}>
+          {i > 0 ? <div className={s.divider} /> : null}
+          <div className={s.skeletonCell}>
+            <div className={mergeClasses(s.skeletonLine, s.skeletonLineWide)} />
+            <div className={mergeClasses(s.skeletonLine, s.skeletonLineNarrow)} />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
+function PulsePage({
+  page,
+  columnCount,
+  isMobile,
+}: {
+  page: WelcomePulseItem[]
+  columnCount: number
+  isMobile: boolean
+}) {
+  const s = useStyles()
+  const slots: WelcomePulseItem[] = [...page]
+  while (slots.length < columnCount) {
+    slots.push({
+      id: `pad:${slots.length}`,
+      name: '',
+      price: null,
+      changePct: null,
+      kind: 'index',
+    })
+  }
+
+  return (
+    <div className={mergeClasses(s.page, isMobile && s.pageMobile)}>
+      {slots.map((item, cellIdx) => (
+        <Fragment key={item.id}>
+          {cellIdx > 0 ? <div className={s.divider} aria-hidden /> : null}
+          {item.name ? (
+            <PulseCell item={item} isMobile={isMobile} />
+          ) : (
+            <div className={mergeClasses(s.cell, isMobile && s.cellMobile)} aria-hidden />
+          )}
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
+export default function ChatWelcomeMarketPulse({
+  enabled,
+  isMobile = false,
+  shuffleEpoch = 0,
+  className,
+}: Props) {
+  const s = useStyles()
+  const columnCount = resolveWelcomePulsePageSize(isMobile)
+  const { pages, loading } = useChatWelcomeMarketPulse(enabled, shuffleEpoch, isMobile)
+  const [pageIndex, setPageIndex] = useState(0)
+  const [transitioning, setTransitioning] = useState(false)
+  const reducedMotionRef = useRef(false)
+
+  useEffect(() => {
+    reducedMotionRef.current = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  }, [])
+
+  const pageCount = pages.length
+  const safeIndex = pageCount > 0 ? pageIndex % pageCount : 0
+
+  useEffect(() => {
+    setPageIndex(0)
+  }, [pageCount, shuffleEpoch, isMobile])
+
+  useEffect(() => {
+    if (!enabled || pageCount <= 1 || reducedMotionRef.current) return undefined
+
+    let timer = window.setTimeout(function tick() {
+      if (document.hidden) {
+        timer = window.setTimeout(tick, WELCOME_PULSE_INTERVAL_MS)
+        return
+      }
+      setTransitioning(true)
+      setPageIndex(prev => (prev + 1) % pageCount)
+      timer = window.setTimeout(tick, WELCOME_PULSE_INTERVAL_MS)
+    }, WELCOME_PULSE_INTERVAL_MS)
+
+    return () => window.clearTimeout(timer)
+  }, [enabled, pageCount])
+
+  useEffect(() => {
+    if (!transitioning) return undefined
+    const t = window.setTimeout(() => setTransitioning(false), WELCOME_PULSE_TRANSITION_MS)
+    return () => window.clearTimeout(t)
+  }, [transitioning, safeIndex])
+
+  const ariaSummary = useMemo(() => {
+    const page = pages[safeIndex]
+    if (!page?.length) return ''
+    return page
+      .filter(item => item.name)
+      .map(item => `${item.name} ${formatIndexPoints(item.price, 2)} ${formatPct(item.changePct, 2)}`)
+      .join('，')
+  }, [pages, safeIndex])
+
+  if (!enabled) return null
+  if (!loading && pageCount === 0) return null
+
+  const trackStyle = {
+    transform: `translateY(-${safeIndex * WELCOME_PULSE_ROW_HEIGHT_PX}px)`,
+    transition: transitioning && !reducedMotionRef.current
+      ? `transform ${WELCOME_PULSE_TRANSITION_MS}ms cubic-bezier(0.22, 1, 0.36, 1)`
+      : 'none',
+  }
+
+  return (
+    <div
+      className={mergeClasses(s.root, isMobile && s.rootMobile, className)}
+      role="region"
+      aria-label="A股主要指数"
+      aria-live="polite"
+    >
+      <div className={s.viewport}>
+        {loading ? (
+          <LoadingSkeleton columnCount={columnCount} isMobile={isMobile} />
+        ) : (
+          <div className={s.track} style={trackStyle}>
+            {pages.map(page => (
+              <PulsePage
+                key={page.map(item => item.id).join('|')}
+                page={page}
+                columnCount={columnCount}
+                isMobile={isMobile}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+      {ariaSummary ? (
+        <span className={s.srOnly}>{ariaSummary}</span>
+      ) : null}
+    </div>
+  )
+}

--- a/client-ui/src/chat/useChatWelcomeMarketPulse.ts
+++ b/client-ui/src/chat/useChatWelcomeMarketPulse.ts
@@ -1,0 +1,49 @@
+import { useEffect, useMemo, useSyncExternalStore } from 'react'
+import {
+  acquireMarketDynamicsCnPolling,
+  getMarketDynamicsCnSnapshot,
+  releaseMarketDynamicsCnPolling,
+  subscribeMarketDynamicsCn,
+} from '../pages/market-dynamics/marketDynamicsCnStore'
+import {
+  chunkWelcomePulsePages,
+  extractWelcomePulseItems,
+  resolveWelcomePulsePageSize,
+  type WelcomePulseItem,
+} from './welcomeMarketPulseModel'
+
+type State = {
+  pages: WelcomePulseItem[][]
+  loading: boolean
+}
+
+export function useChatWelcomeMarketPulse(
+  enabled: boolean,
+  shuffleEpoch = 0,
+  isMobile = false,
+): State {
+  useEffect(() => {
+    if (!enabled) return undefined
+    acquireMarketDynamicsCnPolling()
+    return releaseMarketDynamicsCnPolling
+  }, [enabled])
+
+  const snap = useSyncExternalStore(
+    subscribeMarketDynamicsCn,
+    getMarketDynamicsCnSnapshot,
+    getMarketDynamicsCnSnapshot,
+  )
+
+  const pageSize = resolveWelcomePulsePageSize(isMobile)
+
+  const pages = useMemo(() => {
+    if (!enabled) return []
+    const items = extractWelcomePulseItems(snap.data, { shuffleEpoch })
+    return chunkWelcomePulsePages(items, pageSize)
+  }, [enabled, isMobile, pageSize, shuffleEpoch, snap.data])
+
+  return {
+    pages,
+    loading: enabled && snap.loading && pages.length === 0,
+  }
+}

--- a/client-ui/src/chat/welcomeMarketPulseModel.ts
+++ b/client-ui/src/chat/welcomeMarketPulseModel.ts
@@ -1,0 +1,113 @@
+import type { MarketDynamicsData, MarketIndexQuote } from '../types/schemas'
+import { resolveIndexDisplayName } from '../pages/market-dynamics/cnIndexFormat'
+
+export type WelcomePulseItem = {
+  id: string
+  name: string
+  price: number | null
+  changePct: number | null
+  kind: 'index' | 'sector'
+}
+
+/** 宽基指数展示顺序（与 A 股用户心智一致） */
+const INDEX_CODE_ORDER = [
+  '000001',
+  '399001',
+  '399006',
+  '000688',
+  '000300',
+  '000905',
+  '000016',
+  '899050',
+] as const
+
+/** 欢迎区轮播每页 3 列；板块池随机抽取上限 */
+const WELCOME_PULSE_SECTOR_LIMIT = 15
+
+export const WELCOME_PULSE_PAGE_SIZE = 3
+export const WELCOME_PULSE_PAGE_SIZE_MOBILE = 2
+export const WELCOME_PULSE_INTERVAL_MS = 4_500
+export const WELCOME_PULSE_TRANSITION_MS = 480
+export const WELCOME_PULSE_ROW_HEIGHT_PX = 44
+
+function indexSortKey(item: MarketIndexQuote): number {
+  const code = (item.qt_code || item.code || '').trim()
+  const idx = INDEX_CODE_ORDER.indexOf(code as (typeof INDEX_CODE_ORDER)[number])
+  return idx >= 0 ? idx : INDEX_CODE_ORDER.length + 1
+}
+
+function hashSeed(input: string): number {
+  let h = 2_166_136_261
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 1_677_761_9)
+  }
+  return h >>> 0
+}
+
+function shuffleWithSeed<T>(items: T[], seed: number): T[] {
+  if (items.length <= 1) return [...items]
+  const out = [...items]
+  let state = seed || 1
+  for (let i = out.length - 1; i > 0; i -= 1) {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0
+    const j = state % (i + 1)
+    const tmp = out[i]!
+    out[i] = out[j]!
+    out[j] = tmp
+  }
+  return out
+}
+
+function toPulseItem(item: MarketIndexQuote, kind: 'index' | 'sector'): WelcomePulseItem {
+  const code = (item.qt_code || item.code || '').trim()
+  return {
+    id: `${kind}:${code || item.name}`,
+    name: resolveIndexDisplayName(item),
+    price: item.price ?? null,
+    changePct: item.change_pct ?? null,
+    kind,
+  }
+}
+
+function sectionItems(data: MarketDynamicsData | null | undefined, id: string): MarketIndexQuote[] {
+  return data?.sections?.find(sec => sec.id === id)?.items ?? []
+}
+
+export function extractWelcomePulseItems(
+  data: MarketDynamicsData | null | undefined,
+  opts?: { shuffleEpoch?: number },
+): WelcomePulseItem[] {
+  if (!data) return []
+
+  const indices = sectionItems(data, 'cn_major')
+  const sectors = sectionItems(data, 'cn_sectors')
+
+  const sortedIndices = [...indices].sort((a, b) => indexSortKey(a) - indexSortKey(b))
+  const shuffleSeed = hashSeed(data.refreshed_at ?? '') ^ (opts?.shuffleEpoch ?? 0)
+  const shuffledSectors = shuffleWithSeed(
+    sectors.filter(item => item.name?.trim()),
+    shuffleSeed,
+  ).slice(0, WELCOME_PULSE_SECTOR_LIMIT)
+
+  return [
+    ...sortedIndices.map(item => toPulseItem(item, 'index')),
+    ...shuffledSectors.map(item => toPulseItem(item, 'sector')),
+  ]
+}
+
+export function resolveWelcomePulsePageSize(isMobile: boolean): number {
+  return isMobile ? WELCOME_PULSE_PAGE_SIZE_MOBILE : WELCOME_PULSE_PAGE_SIZE
+}
+
+export function chunkWelcomePulsePages(
+  items: WelcomePulseItem[],
+  pageSize = WELCOME_PULSE_PAGE_SIZE,
+): WelcomePulseItem[][] {
+  if (!items.length) return []
+  const pages: WelcomePulseItem[][] = []
+  for (let i = 0; i < items.length; i += pageSize) {
+    pages.push(items.slice(i, i + pageSize))
+  }
+  return pages
+}

--- a/client-ui/src/pages/market-dynamics/marketDynamicsCnStore.ts
+++ b/client-ui/src/pages/market-dynamics/marketDynamicsCnStore.ts
@@ -1,0 +1,125 @@
+import { research } from '../../api/client'
+import type { MarketDynamicsData } from '../../types/schemas'
+
+/** 与 Hub `MARKET_DYNAMICS_CN_TTL_MS`(22s) 对齐，略长以避免边界重复打满 */
+export const MARKET_DYNAMICS_CN_REFRESH_MS = 30_000
+
+export type MarketDynamicsCnSnapshot = {
+  data: MarketDynamicsData | null
+  loading: boolean
+  refreshing: boolean
+  error: string
+}
+
+let snapshot: MarketDynamicsCnSnapshot = {
+  data: null,
+  loading: false,
+  refreshing: false,
+  error: '',
+}
+
+let pollRefCount = 0
+let refreshTimer: number | null = null
+let inflightLoad: Promise<void> | null = null
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  listeners.forEach(listener => listener())
+}
+
+async function loadMarketDynamicsCn(opts?: { silent?: boolean; force?: boolean }): Promise<void> {
+  if (inflightLoad) return inflightLoad
+
+  const silent = opts?.silent ?? false
+  const force = opts?.force ?? false
+
+  if (!silent && !snapshot.data) {
+    snapshot = { ...snapshot, loading: true }
+    emit()
+  } else if (silent && snapshot.data) {
+    snapshot = { ...snapshot, refreshing: true }
+    emit()
+  }
+
+  inflightLoad = (async () => {
+    try {
+      snapshot = { ...snapshot, error: '' }
+      const resp = await research.marketDynamics({
+        market: 'cn',
+        ...(force ? { refresh: true } : {}),
+      })
+      if (resp.success && resp.data) {
+        snapshot = {
+          data: {
+            ...resp.data,
+            market: resp.data.market ?? 'cn',
+          },
+          loading: false,
+          refreshing: false,
+          error: '',
+        }
+      } else {
+        snapshot = {
+          ...snapshot,
+          loading: false,
+          refreshing: false,
+          error: resp.message || '暂时无法获取市场数据',
+        }
+      }
+    } catch (e) {
+      snapshot = {
+        ...snapshot,
+        loading: false,
+        refreshing: false,
+        error: e instanceof Error ? e.message : '加载失败，请检查网络后重试',
+      }
+    } finally {
+      inflightLoad = null
+      emit()
+    }
+  })()
+
+  return inflightLoad
+}
+
+function startPolling(): void {
+  if (refreshTimer != null) return
+  void loadMarketDynamicsCn()
+  refreshTimer = window.setInterval(() => {
+    if (document.hidden) return
+    void loadMarketDynamicsCn({ silent: true })
+  }, MARKET_DYNAMICS_CN_REFRESH_MS)
+}
+
+function stopPolling(): void {
+  if (refreshTimer == null) return
+  window.clearInterval(refreshTimer)
+  refreshTimer = null
+}
+
+/** 有消费者时开启轮询；多路（市场动态页 + 聊天欢迎区）共享同一份内存态与 inflight */
+export function acquireMarketDynamicsCnPolling(): void {
+  pollRefCount += 1
+  if (pollRefCount === 1) startPolling()
+}
+
+export function releaseMarketDynamicsCnPolling(): void {
+  pollRefCount = Math.max(0, pollRefCount - 1)
+  if (pollRefCount === 0) stopPolling()
+}
+
+export function subscribeMarketDynamicsCn(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange)
+  return () => {
+    listeners.delete(onStoreChange)
+  }
+}
+
+export function getMarketDynamicsCnSnapshot(): MarketDynamicsCnSnapshot {
+  return snapshot
+}
+
+export function refreshMarketDynamicsCn(force = true): Promise<void> {
+  const silent = snapshot.data != null
+  return loadMarketDynamicsCn({ silent, force })
+}

--- a/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
+++ b/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
@@ -1,9 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
-import { news, research } from '../../api/client'
-import type { FeedArticle, MarketDynamicsData } from '../../types/schemas'
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { news } from '../../api/client'
+import type { FeedArticle } from '../../types/schemas'
+import {
+  acquireMarketDynamicsCnPolling,
+  getMarketDynamicsCnSnapshot,
+  refreshMarketDynamicsCn,
+  releaseMarketDynamicsCnPolling,
+  subscribeMarketDynamicsCn,
+} from './marketDynamicsCnStore'
 
 const NEWS_REFRESH_MS = 60_000
-const MARKET_REFRESH_MS = 30_000
 
 function filterCnArticles(articles: FeedArticle[]): FeedArticle[] {
   return articles.filter(article => {
@@ -50,58 +56,23 @@ export function useMarketInsights() {
 }
 
 export function useMarketDynamics() {
-  const [data, setData] = useState<MarketDynamicsData | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [refreshing, setRefreshing] = useState(false)
-  const [error, setError] = useState('')
-  const mountedRef = useRef(true)
-
-  const load = useCallback(async (opts?: { silent?: boolean; force?: boolean }) => {
-    const silent = opts?.silent ?? false
-    if (!silent) setLoading(true)
-    else setRefreshing(true)
-    setError('')
-    try {
-      const resp = await research.marketDynamics({
-        market: 'cn',
-        ...(opts?.force ? { refresh: true } : {}),
-      })
-      if (!mountedRef.current) return
-      if (resp.success && resp.data) {
-        setData({
-          ...resp.data,
-          market: resp.data.market ?? 'cn',
-        })
-      } else {
-        setError(resp.message || '暂时无法获取市场数据')
-      }
-    } catch (e) {
-      if (!mountedRef.current) return
-      setError(e instanceof Error ? e.message : '加载失败，请检查网络后重试')
-    } finally {
-      if (mountedRef.current) {
-        setLoading(false)
-        setRefreshing(false)
-      }
-    }
+  useEffect(() => {
+    acquireMarketDynamicsCnPolling()
+    return releaseMarketDynamicsCnPolling
   }, [])
 
-  useEffect(() => {
-    mountedRef.current = true
-    void load()
-    const timer = setInterval(() => { void load({ silent: true }) }, MARKET_REFRESH_MS)
-    return () => {
-      mountedRef.current = false
-      clearInterval(timer)
-    }
-  }, [load])
+  const snap = useSyncExternalStore(
+    subscribeMarketDynamicsCn,
+    getMarketDynamicsCnSnapshot,
+    getMarketDynamicsCnSnapshot,
+  )
 
   return {
-    data,
-    loading,
-    refreshing,
-    error,
-    refreshedAt: data?.refreshed_at ?? null,
-    refresh: () => load({ silent: true, force: true }),
+    data: snap.data,
+    loading: snap.loading,
+    refreshing: snap.refreshing,
+    error: snap.error,
+    refreshedAt: snap.data?.refreshed_at ?? null,
+    refresh: () => refreshMarketDynamicsCn(true),
   }
 }


### PR DESCRIPTION
## Summary
- Add a compact index/sector carousel under the empty-chat welcome copy (3 columns desktop, 2 on mobile)
- Share A-share market dynamics data via `marketDynamicsCnStore` so welcome and market pages reuse one poll/cache
- Mix shuffled top sectors with major indices; non-interactive display with reduced-motion support

## Test plan
- [x] `npm run check:ui`
- [ ] Open new chat on mobile: welcome shows 2 indices per slide, text not clipped
- [ ] Open new chat on desktop: 3 columns rotate; visit market dynamics first then return — data appears without extra loading
- [ ] Send first message — pulse hides; expert session — pulse hidden

Made with [Cursor](https://cursor.com)