### PR TITLE
feat(news): mobile drawer and faster group/source filters

### DIFF
--- a/client-ui/src/api/client.ts
+++ b/client-ui/src/api/client.ts
@@ -48,6 +48,8 @@ export class ApiHttpError extends Error {
 /** Vite dev/preview proxies /api → backend (default :8711). */
 const API_BASE = import.meta.env.VITE_API_BASE || '/api'
 const REQUEST_TIMEOUT = 10000 // 10s — quick reads / mutations
+/** Grouped news feed may scan many subscriptions locally on the server. */
+const NEWS_GROUPED_FEED_TIMEOUT = 60_000
 /** 本机重活（语义模型卸载、深度整理卸载、大附件上传等）；勿抬高全局 REQUEST_TIMEOUT。 */
 const LOCAL_HEAVY_TIMEOUT = 180_000
 /** Agent chat: multiple LLM + tool rounds (server LLM timeout up to 10m per round). */
@@ -2655,8 +2657,12 @@ export type SenseVoiceEnsureJobSnapshot = {
   error: string | null
 }
 
-async function newsJsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  return jsonFetch<T>(path, init)
+async function newsJsonFetch<T>(
+  path: string,
+  init?: RequestInit,
+  timeoutMs = REQUEST_TIMEOUT,
+): Promise<T> {
+  return jsonFetch<T>(path, init, timeoutMs)
 }
 
 export const news = {
@@ -2765,7 +2771,7 @@ export const news = {
   },
 
   getGroupedFeed: () =>
-    newsJsonFetch<NewsGroupedFeed>('/news/feed/grouped'),
+    newsJsonFetch<NewsGroupedFeed>('/news/feed/grouped', undefined, NEWS_GROUPED_FEED_TIMEOUT),
 
   getArticle: (id: string) =>
     newsJsonFetch<{ article: FeedArticle }>(`/news/articles/${encodeURIComponent(id)}`),

--- a/client-ui/src/pages/news/NewsArticleDetail.tsx
+++ b/client-ui/src/pages/news/NewsArticleDetail.tsx
@@ -13,6 +13,9 @@ import { enhanceFeedMedia, formatRelativeTime, sanitizeFeedHtml, stripHtml, buil
 import { useArticleTranslation } from './useArticleTranslation'
 import { useArticleEnrichment } from './useArticleEnrichment'
 
+/** 内容预览顶栏：暂时隐藏翻译与配图音视频入口 */
+const SHOW_ARTICLE_PREVIEW_TRANSLATION_ENRICHMENT = false
+
 const useStyles = makeStyles({
   root: {
     display: 'flex',
@@ -339,7 +342,7 @@ export default function NewsArticleDetail({ article, onDiscussArticle }: Props) 
               查看原文
             </span>
           )}
-          {translation.available && (
+          {SHOW_ARTICLE_PREVIEW_TRANSLATION_ENRICHMENT && translation.available && (
             <>
               <span className={s.metaSep} aria-hidden>·</span>
               <button
@@ -370,7 +373,7 @@ export default function NewsArticleDetail({ article, onDiscussArticle }: Props) 
               </button>
             </>
           )}
-          {translation.hasTranslation && (
+          {SHOW_ARTICLE_PREVIEW_TRANSLATION_ENRICHMENT && translation.hasTranslation && (
             <div className={s.viewToggle}>
               <button
                 type="button"
@@ -394,7 +397,7 @@ export default function NewsArticleDetail({ article, onDiscussArticle }: Props) 
               </button>
             </div>
           )}
-          {enrichment.available && (
+          {SHOW_ARTICLE_PREVIEW_TRANSLATION_ENRICHMENT && enrichment.available && (
             <>
               <span className={s.metaSep} aria-hidden>·</span>
               <button
@@ -438,9 +441,10 @@ export default function NewsArticleDetail({ article, onDiscussArticle }: Props) 
           )}
         </div>
       </div>
-      {(progressLabel || translation.error || enrichment.progressLabel || enrichment.error
-        || (!translation.available && translation.likelyForeign)
-        || (!translation.canTranslate && translation.available && !translation.hasTranslation)) && (
+      {SHOW_ARTICLE_PREVIEW_TRANSLATION_ENRICHMENT
+        && (progressLabel || translation.error || enrichment.progressLabel || enrichment.error
+          || (!translation.available && translation.likelyForeign)
+          || (!translation.canTranslate && translation.available && !translation.hasTranslation)) && (
         <Text
           block
           className={mergeClasses(

--- a/client-ui/src/pages/news/NewsArticleDrawer.tsx
+++ b/client-ui/src/pages/news/NewsArticleDrawer.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Spinner, makeStyles, mergeClasses } from '@fluentui/react-components'
+import type { FeedArticle } from '../../types/schemas'
+import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
+import { motion } from '../../theme/mixins'
+import {
+  MARKET_PANEL_DRAWER_CLOSE_MS,
+  MARKET_PANEL_DRAWER_MAX_HEIGHT,
+} from '../../market/marketPanelDrawer'
+import NewsArticleDetail from './NewsArticleDetail'
+
+const useStyles = makeStyles({
+  scrim: {
+    position: 'absolute',
+    inset: 0,
+    zIndex: 29,
+    border: 'none',
+    padding: 0,
+    margin: 0,
+    backgroundColor: 'rgba(29, 29, 31, 0.18)',
+    cursor: 'default',
+    opacity: 0,
+    pointerEvents: 'none',
+    transitionProperty: 'opacity',
+    transitionDuration: motion.normal,
+    transitionTimingFunction: motion.ease,
+  },
+  scrimOpen: {
+    opacity: 1,
+    pointerEvents: 'auto',
+  },
+  anchor: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 30,
+    display: 'flex',
+    justifyContent: 'center',
+    pointerEvents: 'none',
+    padding: 0,
+    boxSizing: 'border-box',
+  },
+  drawer: {
+    width: '100%',
+    minWidth: 0,
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    maxHeight: MARKET_PANEL_DRAWER_MAX_HEIGHT,
+    borderRadius: `${opptrixTokens.radiusXl} ${opptrixTokens.radiusXl} 0 0`,
+    borderTop: `1px solid ${opptrixCssVars.separatorStrong}`,
+    backgroundColor: opptrixCssVars.canvas,
+    boxShadow: '0 -8px 32px rgba(0, 0, 0, 0.12)',
+    transform: 'translateY(100%)',
+    transitionProperty: 'transform',
+    transitionDuration: motion.normal,
+    transitionTimingFunction: motion.easeOut,
+    pointerEvents: 'auto',
+    overflow: 'hidden',
+  },
+  drawerOpen: {
+    transform: 'translateY(0)',
+  },
+  handle: {
+    width: '36px',
+    height: '4px',
+    borderRadius: opptrixTokens.radiusFull,
+    backgroundColor: opptrixCssVars.borderStrong,
+    margin: '8px auto 0',
+    flexShrink: 0,
+  },
+  body: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
+  loading: {
+    flex: 1,
+    minHeight: '240px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+})
+
+type Props = {
+  open: boolean
+  article: FeedArticle | null
+  loading?: boolean
+  onClose: () => void
+  onDiscussArticle?: (article: FeedArticle) => void
+}
+
+export default function NewsArticleDrawer({
+  open,
+  article,
+  loading = false,
+  onClose,
+  onDiscussArticle,
+}: Props) {
+  const s = useStyles()
+  const closingRef = useRef(false)
+  const [presented, setPresented] = useState(false)
+
+  const finishClose = useCallback(() => {
+    if (!closingRef.current) return
+    closingRef.current = false
+    onClose()
+  }, [onClose])
+
+  const beginClose = useCallback(() => {
+    if (closingRef.current) return
+    if (!presented) {
+      onClose()
+      return
+    }
+    closingRef.current = true
+    setPresented(false)
+  }, [onClose, presented])
+
+  const handleDrawerTransitionEnd = useCallback((e: React.TransitionEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return
+    if (e.propertyName !== 'transform') return
+    finishClose()
+  }, [finishClose])
+
+  useEffect(() => {
+    if (!open) return undefined
+    closingRef.current = false
+    setPresented(false)
+    const id = requestAnimationFrame(() => setPresented(true))
+    return () => cancelAnimationFrame(id)
+  }, [open])
+
+  useEffect(() => {
+    if (presented || !closingRef.current) return undefined
+    const timer = window.setTimeout(finishClose, MARKET_PANEL_DRAWER_CLOSE_MS + 40)
+    return () => window.clearTimeout(timer)
+  }, [presented, finishClose])
+
+  useEffect(() => {
+    if (!open || !presented) return undefined
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') beginClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [beginClose, open, presented])
+
+  useEffect(() => {
+    if (open) return
+    if (!presented) return
+    closingRef.current = true
+    setPresented(false)
+  }, [open, presented])
+
+  if (!open && !presented && !closingRef.current) return null
+
+  return (
+    <>
+      <button
+        type="button"
+        className={mergeClasses(s.scrim, 'opptrix-news-drawer-scrim', presented && s.scrimOpen)}
+        aria-label="关闭文章"
+        onClick={beginClose}
+      />
+      <div className={s.anchor}>
+        <div
+          className={mergeClasses(s.drawer, 'opptrix-news-article-drawer', presented && s.drawerOpen)}
+          role="dialog"
+          aria-modal="true"
+          aria-label={article?.title ?? '资讯详情'}
+          onTransitionEnd={handleDrawerTransitionEnd}
+        >
+          <div className={s.handle} aria-hidden />
+          <div className={s.body}>
+            {loading && !article ? (
+              <div className={s.loading}>
+                <Spinner size="medium" label="正在加载资讯…" />
+              </div>
+            ) : article ? (
+              <NewsArticleDetail article={article} onDiscussArticle={onDiscussArticle} />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/client-ui/src/pages/news/NewsCenterPage.tsx
+++ b/client-ui/src/pages/news/NewsCenterPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../desktop/constants'
 import NewsFeedSidebar from './NewsFeedSidebar'
 import NewsArticleDetail from './NewsArticleDetail'
+import NewsArticleDrawer from './NewsArticleDrawer'
 import NewsReaderEmpty from './NewsReaderEmpty'
 import { useNewsFeed } from './useNewsFeed'
 import type { FeedArticle } from '../../types/schemas'
@@ -32,6 +33,7 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: opptrixCssVars.canvas,
     overflow: 'hidden',
+    position: 'relative',
   },
   /** Electron: let app-main tint show through (sidebar/detail keep own surfaces). */
   rootElectron: {
@@ -89,6 +91,14 @@ const useStyles = makeStyles({
     flexDirection: 'column',
     overflow: 'hidden',
   },
+  listFull: {
+    flex: 1,
+    minWidth: 0,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
   detail: {
     flex: 1,
     minWidth: 0,
@@ -130,6 +140,7 @@ function NewsCenterContent({
   const feed = useNewsFeed()
   const {
     articles,
+    filteredArticles,
     grouped,
     groups,
     subscriptions,
@@ -140,8 +151,10 @@ function NewsCenterContent({
     selectedId,
     selected,
     hasMore,
+    filteredHasMore,
     listCapReached,
     total,
+    filteredTotal,
     view,
     setSelectedId,
     setView,
@@ -263,11 +276,13 @@ function NewsCenterContent({
       {webHead}
 
       <div className={s.body}>
-        <div className={s.sidebar}>
+        <div className={isMobile ? s.listFull : s.sidebar}>
           <NewsFeedSidebar
+            fullWidth={isMobile}
             view={view}
             onViewChange={setView}
             articles={articles}
+            filteredArticles={filteredArticles}
             grouped={grouped}
             groups={groups}
             subscriptions={subscriptions}
@@ -284,29 +299,43 @@ function NewsCenterContent({
             loading={loading}
             loadingMore={loadingMore}
             hasMore={hasMore}
+            filteredHasMore={filteredHasMore}
             listCapReached={listCapReached}
             total={total}
+            filteredTotal={filteredTotal}
             hasAnyArticles={hasAnyArticles}
             hasSubscriptions={subscriptions.length > 0}
             onLoadMore={() => { void loadMore() }}
             error={error}
           />
         </div>
-        <div className={s.detail}>
-          {loading && !selected ? (
-            <div className={s.detailLoading}>
-              <Spinner size="medium" label="正在加载资讯…" />
-            </div>
-          ) : selected ? (
-            <NewsArticleDetail article={selected} onDiscussArticle={onDiscussArticle} />
-          ) : (
-            <NewsReaderEmpty
-              hasArticles={hasAnyArticles}
-              hasSubscriptions={subscriptions.length > 0}
-            />
-          )}
-        </div>
+        {!isMobile ? (
+          <div className={s.detail}>
+            {loading && !selected ? (
+              <div className={s.detailLoading}>
+                <Spinner size="medium" label="正在加载资讯…" />
+              </div>
+            ) : selected ? (
+              <NewsArticleDetail article={selected} onDiscussArticle={onDiscussArticle} />
+            ) : (
+              <NewsReaderEmpty
+                hasArticles={hasAnyArticles}
+                hasSubscriptions={subscriptions.length > 0}
+              />
+            )}
+          </div>
+        ) : null}
       </div>
+
+      {isMobile && selectedId ? (
+        <NewsArticleDrawer
+          open={Boolean(selectedId)}
+          article={selected}
+          loading={loading && !selected}
+          onClose={() => setSelectedId(null)}
+          onDiscussArticle={onDiscussArticle}
+        />
+      ) : null}
     </div>
   )
 }

--- a/client-ui/src/pages/news/NewsFeedFilterBar.tsx
+++ b/client-ui/src/pages/news/NewsFeedFilterBar.tsx
@@ -1,12 +1,21 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Text, makeStyles } from '@fluentui/react-components'
 import { DismissRegular } from '@fluentui/react-icons'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import OpptrixSelect, { OpptrixOption } from '../../components/opptrix/OpptrixSelect'
 import TradeDateField from '../../market/TradeDateField'
-import type { FeedGroup, FeedSubscription } from '../../types/schemas'
+import type { FeedGroup, FeedSubscription, NewsGroupedFeed } from '../../types/schemas'
 import type { NewsListView } from './useNewsFeed'
-import { opptrixTokens, opptrixCssVars } from '../../theme/tokens'
+import { opptrixCssVars } from '../../theme/tokens'
+import {
+  buildGroupFilterOptions,
+  buildSourceFilterOptions,
+} from './newsFeedFilters'
+
+const FILTER_LISTBOX_STYLE = {
+  minWidth: 'min(240px, 88vw)',
+  maxWidth: 'min(360px, 92vw)',
+} as const
 
 const useStyles = makeStyles({
   bar: {
@@ -28,7 +37,7 @@ const useStyles = makeStyles({
   },
   filterField: {
     flex: 1,
-    minWidth: 0,
+    minWidth: '120px',
   },
   meta: {
     flexShrink: 0,
@@ -44,12 +53,20 @@ const useStyles = makeStyles({
   clearBtn: {
     flexShrink: 0,
   },
+  filterHint: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 'var(--opptrix-font-sm)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.35,
+  },
 })
 
 type Props = {
   view: NewsListView
   groups: FeedGroup[]
   subscriptions: FeedSubscription[]
+  grouped: NewsGroupedFeed | null
   timelineDate: string | null
   groupFilterId: string | null
   sourceFilterId: string | null
@@ -75,6 +92,7 @@ export default function NewsFeedFilterBar({
   view,
   groups,
   subscriptions,
+  grouped,
   timelineDate,
   groupFilterId,
   sourceFilterId,
@@ -87,6 +105,15 @@ export default function NewsFeedFilterBar({
 }: Props) {
   const s = useStyles()
   const [dateDraft, setDateDraft] = useState(timelineDate ?? '')
+
+  const groupOptions = useMemo(
+    () => buildGroupFilterOptions(groups, grouped),
+    [groups, grouped],
+  )
+  const sourceOptions = useMemo(
+    () => buildSourceFilterOptions(subscriptions, grouped),
+    [subscriptions, grouped],
+  )
 
   useEffect(() => {
     setDateDraft(timelineDate ?? '')
@@ -139,38 +166,47 @@ export default function NewsFeedFilterBar({
               )}
             </>
           )}
-          {view === 'group' && groupFilterId && (
-            <OpptrixSelect
-              className={s.filterField}
-              size="small"
-              selectedOptions={[groupFilterId]}
-              positioning={{ autoSize: 'width' }}
-              onOptionSelect={(_, d) => {
-                const v = d.optionValue
-                if (v) onGroupFilterChange(v)
-              }}
-            >
-              {groups.map(g => (
-                <OpptrixOption key={g.id} value={g.id}>{g.title}</OpptrixOption>
-              ))}
-              <OpptrixOption value="__ungrouped__">未分组</OpptrixOption>
-            </OpptrixSelect>
+          {view === 'group' && (
+            groupOptions.length > 0 && groupFilterId ? (
+              <OpptrixSelect
+                className={s.filterField}
+                size="small"
+                selectedOptions={[groupFilterId]}
+                positioning={{ position: 'below', align: 'start' }}
+                listbox={{ style: FILTER_LISTBOX_STYLE }}
+                onOptionSelect={(_, d) => {
+                  const v = d.optionValue
+                  if (v) onGroupFilterChange(v)
+                }}
+              >
+                {groupOptions.map(option => (
+                  <OpptrixOption key={option.id} value={option.id}>{option.title}</OpptrixOption>
+                ))}
+              </OpptrixSelect>
+            ) : (
+              <Text className={s.filterHint} block>暂无可用分组</Text>
+            )
           )}
-          {view === 'source' && sourceFilterId && (
-            <OpptrixSelect
-              className={s.filterField}
-              size="small"
-              selectedOptions={[sourceFilterId]}
-              positioning={{ autoSize: 'width' }}
-              onOptionSelect={(_, d) => {
-                const v = d.optionValue
-                if (v) onSourceFilterChange(v)
-              }}
-            >
-              {subscriptions.map(sub => (
-                <OpptrixOption key={sub.id} value={sub.id}>{sub.title}</OpptrixOption>
-              ))}
-            </OpptrixSelect>
+          {view === 'source' && (
+            sourceOptions.length > 0 && sourceFilterId ? (
+              <OpptrixSelect
+                className={s.filterField}
+                size="small"
+                selectedOptions={[sourceFilterId]}
+                positioning={{ position: 'below', align: 'start' }}
+                listbox={{ style: FILTER_LISTBOX_STYLE }}
+                onOptionSelect={(_, d) => {
+                  const v = d.optionValue
+                  if (v) onSourceFilterChange(v)
+                }}
+              >
+                {sourceOptions.map(option => (
+                  <OpptrixOption key={option.id} value={option.id}>{option.title}</OpptrixOption>
+                ))}
+              </OpptrixSelect>
+            ) : (
+              <Text className={s.filterHint} block>暂无可用来源</Text>
+            )
           )}
         </div>
         <Text className={s.meta} block title={metaText}>{metaText}</Text>

--- a/client-ui/src/pages/news/NewsFeedSidebar.tsx
+++ b/client-ui/src/pages/news/NewsFeedSidebar.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { Spinner, Tab, TabList, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import type { NewsGroupedFeed } from '../../types/schemas'
 import type { NewsListView } from './useNewsFeed'
@@ -15,6 +14,9 @@ const useStyles = makeStyles({
     height: '100%',
     backgroundColor: opptrixCssVars.canvas,
     borderRight: `1px solid ${opptrixCssVars.separatorStrong}`,
+  },
+  rootFullWidth: {
+    borderRight: 'none',
   },
   chrome: {
     flexShrink: 0,
@@ -68,12 +70,11 @@ const useStyles = makeStyles({
   },
 })
 
-type Section = { key: string; label: string; articles: FeedArticle[] }
-
 type Props = {
   view: NewsListView
   onViewChange: (view: NewsListView) => void
   articles: FeedArticle[]
+  filteredArticles: FeedArticle[]
   grouped: NewsGroupedFeed | null
   groups: FeedGroup[]
   subscriptions: FeedSubscription[]
@@ -90,39 +91,22 @@ type Props = {
   loading: boolean
   loadingMore: boolean
   hasMore: boolean
+  filteredHasMore: boolean
   listCapReached?: boolean
   total: number
+  filteredTotal: number
   hasAnyArticles: boolean
   hasSubscriptions: boolean
   onLoadMore: () => void
   error?: string
-}
-
-function buildGroupSections(
-  grouped: NewsGroupedFeed,
-  groupFilterId: string,
-): Section[] {
-  if (groupFilterId === '__ungrouped__') {
-    return grouped.ungrouped.length
-      ? [{ key: '__ungrouped__', label: '未分组', articles: grouped.ungrouped }]
-      : []
-  }
-  const g = grouped.groups.find(x => x.id === groupFilterId)
-  return g ? [{ key: g.id, label: g.title, articles: g.articles }] : []
-}
-
-function buildSourceSections(
-  grouped: NewsGroupedFeed,
-  sourceFilterId: string,
-): Section[] {
-  const s = grouped.by_source.find(x => x.subscription_id === sourceFilterId)
-  return s ? [{ key: s.subscription_id, label: s.title, articles: s.articles }] : []
+  fullWidth?: boolean
 }
 
 export default function NewsFeedSidebar({
   view,
   onViewChange,
   articles,
+  filteredArticles,
   grouped,
   groups,
   subscriptions,
@@ -139,35 +123,25 @@ export default function NewsFeedSidebar({
   loading,
   loadingMore,
   hasMore,
+  filteredHasMore,
   listCapReached = false,
   total,
+  filteredTotal,
   hasAnyArticles,
   hasSubscriptions,
   onLoadMore,
   error = '',
+  fullWidth = false,
 }: Props) {
   const s = useStyles()
 
-  const sections = useMemo(() => {
-    if (!grouped || view === 'timeline') return undefined
-    if (view === 'group') {
-      if (!groupFilterId) return []
-      return buildGroupSections(grouped, groupFilterId)
-    }
-    if (!sourceFilterId) return []
-    return buildSourceSections(grouped, sourceFilterId)
-  }, [grouped, view, groupFilterId, sourceFilterId])
-
-  const visibleCount = useMemo(() => {
-    if (view === 'timeline') return articles.length
-    if (!sections) return 0
-    return sections.reduce((sum, sec) => sum + sec.articles.length, 0)
-  }, [view, articles.length, sections])
-
-  const displayTotal = view === 'timeline' ? total : visibleCount
+  const listArticles = view === 'timeline' ? articles : filteredArticles
+  const listHasMore = view === 'timeline' ? hasMore : filteredHasMore
+  const displayTotal = view === 'timeline' ? total : filteredTotal
+  const visibleCount = listArticles.length
 
   return (
-    <div className={mergeClasses(s.root, 'opptrix-news-sidebar')}>
+    <div className={mergeClasses(s.root, fullWidth && s.rootFullWidth, 'opptrix-news-sidebar')}>
       <div className={s.chrome}>
         <div className={s.tabs}>
           <TabList
@@ -186,6 +160,7 @@ export default function NewsFeedSidebar({
           view={view}
           groups={groups}
           subscriptions={subscriptions}
+          grouped={grouped}
           timelineDate={timelineDate}
           groupFilterId={groupFilterId}
           sourceFilterId={sourceFilterId}
@@ -209,16 +184,15 @@ export default function NewsFeedSidebar({
           </div>
         ) : (
           <NewsArticleList
-            sections={sections}
-            articles={view === 'timeline' ? articles : undefined}
+            articles={listArticles}
             selectedId={selectedId}
             onSelect={onSelect}
             compact
             listPulseEpoch={listPulseEpoch}
             loadingMore={loadingMore || listSyncing}
-            hasMore={view === 'timeline' ? hasMore : false}
+            hasMore={listHasMore}
             listCapReached={view === 'timeline' ? listCapReached : false}
-            onLoadMore={view === 'timeline' ? onLoadMore : undefined}
+            onLoadMore={onLoadMore}
             hasAnyArticles={hasAnyArticles}
             hasSubscriptions={hasSubscriptions}
           />

--- a/client-ui/src/pages/news/newsFeedFilters.ts
+++ b/client-ui/src/pages/news/newsFeedFilters.ts
@@ -1,0 +1,162 @@
+import type {
+  FeedArticle,
+  FeedGroup,
+  FeedSubscription,
+  NewsGroupedFeed,
+} from '../../types/schemas'
+
+export type NewsFilterOption = {
+  id: string
+  title: string
+}
+
+export function buildGroupFilterOptions(
+  groups: FeedGroup[],
+  grouped: NewsGroupedFeed | null,
+): NewsFilterOption[] {
+  if (grouped) {
+    const fromGrouped: NewsFilterOption[] = grouped.groups.map(g => ({
+      id: g.id,
+      title: g.title,
+    }))
+    if (grouped.ungrouped.length > 0) {
+      fromGrouped.push({ id: '__ungrouped__', title: '未分组' })
+    }
+    if (fromGrouped.length > 0) return fromGrouped
+  }
+
+  const fromMeta = groups.map(g => ({ id: g.id, title: g.title }))
+  if (fromMeta.length > 0) return fromMeta
+  return [{ id: '__ungrouped__', title: '未分组' }]
+}
+
+export function buildSourceFilterOptions(
+  subscriptions: FeedSubscription[],
+  grouped: NewsGroupedFeed | null,
+): NewsFilterOption[] {
+  if (grouped?.by_source.length) {
+    return grouped.by_source.map(s => ({
+      id: s.subscription_id,
+      title: s.title,
+    }))
+  }
+  const enabled = subscriptions.filter(s => s.enabled)
+  const list = enabled.length > 0 ? enabled : subscriptions
+  return list.map(s => ({ id: s.id, title: s.title }))
+}
+
+export function defaultGroupFilterId(
+  groups: FeedGroup[],
+  grouped: NewsGroupedFeed | null,
+): string | null {
+  const options = buildGroupFilterOptions(groups, grouped)
+  return options[0]?.id ?? null
+}
+
+export function defaultSourceFilterId(
+  subscriptions: FeedSubscription[],
+  grouped: NewsGroupedFeed | null,
+): string | null {
+  const options = buildSourceFilterOptions(subscriptions, grouped)
+  return options[0]?.id ?? null
+}
+
+export function resolveGroupFilterId(
+  groups: FeedGroup[],
+  grouped: NewsGroupedFeed | null,
+  current: string | null,
+): string | null {
+  const options = buildGroupFilterOptions(groups, grouped)
+  if (!options.length) return null
+  if (current && options.some(o => o.id === current)) return current
+  return options[0]?.id ?? null
+}
+
+export function resolveSourceFilterId(
+  subscriptions: FeedSubscription[],
+  grouped: NewsGroupedFeed | null,
+  current: string | null,
+): string | null {
+  const options = buildSourceFilterOptions(subscriptions, grouped)
+  if (!options.length) return null
+  if (current && options.some(o => o.id === current)) return current
+  return options[0]?.id ?? null
+}
+
+function dedupeArticles(items: FeedArticle[]): FeedArticle[] {
+  const seen = new Set<string>()
+  const out: FeedArticle[] = []
+  for (const item of items) {
+    if (seen.has(item.id)) continue
+    seen.add(item.id)
+    out.push(item)
+  }
+  return out
+}
+
+export function articlesForGroupFilter(
+  grouped: NewsGroupedFeed,
+  groupFilterId: string,
+  subscriptions: FeedSubscription[],
+): FeedArticle[] {
+  if (groupFilterId === '__ungrouped__') return grouped.ungrouped
+
+  const section = grouped.groups.find(g => g.id === groupFilterId)
+  if (section) return section.articles
+
+  const subIds = new Set(
+    subscriptions
+      .filter(s => s.group_id === groupFilterId)
+      .map(s => s.id),
+  )
+  if (!subIds.size) return []
+
+  return dedupeArticles([
+    ...grouped.by_source.flatMap(s => s.articles),
+    ...grouped.ungrouped,
+  ].filter(a => subIds.has(a.subscription_id)))
+}
+
+export function articlesForSourceFilter(
+  grouped: NewsGroupedFeed,
+  sourceFilterId: string,
+): FeedArticle[] {
+  return grouped.by_source.find(s => s.subscription_id === sourceFilterId)?.articles ?? []
+}
+
+/** Degraded grouped payload from timeline + meta when /feed/grouped is unavailable. */
+export function buildGroupedFeedFallback(
+  articles: FeedArticle[],
+  subscriptions: FeedSubscription[],
+  groups: FeedGroup[],
+): NewsGroupedFeed {
+  const bySub = new Map<string, FeedArticle[]>()
+  for (const sub of subscriptions) bySub.set(sub.id, [])
+  for (const article of articles) {
+    bySub.get(article.subscription_id)?.push(article)
+  }
+
+  const by_source = subscriptions
+    .map(sub => ({
+      subscription_id: sub.id,
+      title: sub.title,
+      articles: bySub.get(sub.id) ?? [],
+    }))
+    .filter(s => s.articles.length > 0)
+
+  const groupedSections = groups
+    .map(g => {
+      const subIds = new Set(subscriptions.filter(s => s.group_id === g.id).map(s => s.id))
+      return {
+        id: g.id,
+        title: g.title,
+        articles: articles.filter(a => subIds.has(a.subscription_id)),
+      }
+    })
+    .filter(g => g.articles.length > 0)
+
+  const ungroupedSubIds = new Set(subscriptions.filter(s => !s.group_id).map(s => s.id))
+  const ungrouped = articles.filter(a => ungroupedSubIds.has(a.subscription_id))
+
+  return { groups: groupedSections, ungrouped, by_source }
+}

--- a/client-ui/src/pages/news/newsFeedSession.ts
+++ b/client-ui/src/pages/news/newsFeedSession.ts
@@ -10,6 +10,11 @@ import {
   NEWS_ARTICLES_MEMORY_CAP,
 } from './articlesMemoryCap'
 import { dedupeArticlesByTitle } from './newsUtils'
+import {
+  buildGroupedFeedFallback,
+  resolveGroupFilterId as resolveGroupFilter,
+  resolveSourceFilterId as resolveSourceFilter,
+} from './newsFeedFilters'
 
 export type NewsListView = 'timeline' | 'group' | 'source'
 
@@ -20,6 +25,11 @@ export { NEWS_ARTICLES_MEMORY_CAP }
 export type NewsFeedSnapshot = {
   articles: FeedArticle[]
   grouped: NewsGroupedFeed | null
+  /** 分组 / 来源视图：经 /news/feed 分页筛选，不依赖 grouped 大包 */
+  filteredArticles: FeedArticle[]
+  filteredCursor: string | null
+  filteredHasMore: boolean
+  filteredTotal: number
   subscriptions: FeedSubscription[]
   groups: FeedGroup[]
   refreshedAt: string | null
@@ -50,6 +60,10 @@ function emptySnapshot(): NewsFeedSnapshot {
   return {
     articles: [],
     grouped: null,
+    filteredArticles: [],
+    filteredCursor: null,
+    filteredHasMore: false,
+    filteredTotal: 0,
     subscriptions: [],
     groups: [],
     refreshedAt: null,
@@ -96,14 +110,13 @@ export function subscribeNewsFeed(listener: () => void): () => void {
   return () => listeners.delete(listener)
 }
 
-function findSelected(
-  selectedId: string | null,
-  articles: FeedArticle[],
-  grouped: NewsGroupedFeed | null,
-): FeedArticle | null {
+function findSelected(selectedId: string | null): FeedArticle | null {
   if (!selectedId) return null
-  const fromTimeline = articles.find(a => a.id === selectedId)
+  const fromTimeline = snapshot.articles.find(a => a.id === selectedId)
   if (fromTimeline) return fromTimeline
+  const fromFiltered = snapshot.filteredArticles.find(a => a.id === selectedId)
+  if (fromFiltered) return fromFiltered
+  const grouped = snapshot.grouped
   if (!grouped) return null
   return grouped.groups.flatMap(g => g.articles).find(a => a.id === selectedId)
     ?? grouped.ungrouped.find(a => a.id === selectedId)
@@ -112,59 +125,16 @@ function findSelected(
 }
 
 export function getSelectedArticle(): FeedArticle | null {
-  return findSelected(snapshot.selectedId, snapshot.articles, snapshot.grouped)
-}
-
-function defaultGroupFilterId(
-  groups: FeedGroup[],
-  grouped: NewsGroupedFeed | null,
-): string | null {
-  if (groups.length > 0) return groups[0].id
-  if ((grouped?.ungrouped.length ?? 0) > 0) return '__ungrouped__'
-  return null
-}
-
-function defaultSourceFilterId(
-  subscriptions: FeedSubscription[],
-  grouped: NewsGroupedFeed | null,
-): string | null {
-  if (grouped?.by_source.length) return grouped.by_source[0].subscription_id
-  const sub = subscriptions.find(s => s.enabled) ?? subscriptions[0]
-  return sub?.id ?? null
-}
-
-function resolveGroupFilterId(
-  groups: FeedGroup[],
-  grouped: NewsGroupedFeed | null,
-  current: string | null,
-): string | null {
-  const fallback = defaultGroupFilterId(groups, grouped)
-  if (!current) return fallback
-  if (current === '__ungrouped__') {
-    return (grouped?.ungrouped.length ?? 0) > 0 ? current : fallback
-  }
-  return groups.some(g => g.id === current) ? current : fallback
-}
-
-function resolveSourceFilterId(
-  subscriptions: FeedSubscription[],
-  grouped: NewsGroupedFeed | null,
-  current: string | null,
-): string | null {
-  const fallback = defaultSourceFilterId(subscriptions, grouped)
-  if (!current) return fallback
-  if (grouped?.by_source.some(s => s.subscription_id === current)) return current
-  if (subscriptions.some(s => s.id === current)) return current
-  return fallback
+  return findSelected(snapshot.selectedId)
 }
 
 function normalizeListFilters() {
-  const groupFilterId = resolveGroupFilterId(
+  const groupFilterId = resolveGroupFilter(
     snapshot.groups,
     snapshot.grouped,
     snapshot.groupFilterId,
   )
-  const sourceFilterId = resolveSourceFilterId(
+  const sourceFilterId = resolveSourceFilter(
     snapshot.subscriptions,
     snapshot.grouped,
     snapshot.sourceFilterId,
@@ -175,7 +145,7 @@ function normalizeListFilters() {
 }
 
 function articleVisibleInCurrentView(articleId: string): boolean {
-  const { view, articles, grouped, timelineDate, groupFilterId, sourceFilterId } = snapshot
+  const { view, articles, filteredArticles, timelineDate } = snapshot
   if (view === 'timeline') {
     const hit = articles.some(a => a.id === articleId)
     if (!hit) return false
@@ -185,16 +155,7 @@ function articleVisibleInCurrentView(articleId: string): boolean {
     const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
     return ymd === timelineDate
   }
-  if (!grouped) return false
-  if (view === 'group') {
-    if (groupFilterId === '__ungrouped__') {
-      return grouped.ungrouped.some(a => a.id === articleId)
-    }
-    const sec = grouped.groups.find(g => g.id === groupFilterId)
-    return sec?.articles.some(a => a.id === articleId) ?? false
-  }
-  const sec = grouped.by_source.find(s => s.subscription_id === sourceFilterId)
-  return sec?.articles.some(a => a.id === articleId) ?? false
+  return filteredArticles.some(a => a.id === articleId)
 }
 
 function pruneSelection() {
@@ -211,9 +172,97 @@ async function loadMeta() {
   })
 }
 
+function groupedHasContent(grouped: NewsGroupedFeed | null): grouped is NewsGroupedFeed {
+  if (!grouped) return false
+  return grouped.by_source.length > 0
+    || grouped.groups.length > 0
+    || grouped.ungrouped.length > 0
+}
+
 async function loadGrouped() {
-  const grouped = await news.getGroupedFeed()
-  patch({ grouped })
+  try {
+    const grouped = await news.getGroupedFeed()
+    patch({ grouped })
+    normalizeListFilters()
+    return
+  } catch {
+    if (groupedHasContent(snapshot.grouped)) return
+    const fallback = buildGroupedFeedFallback(
+      snapshot.articles,
+      snapshot.subscriptions,
+      snapshot.groups,
+    )
+    if (groupedHasContent(fallback)) {
+      patch({ grouped: fallback })
+      normalizeListFilters()
+    }
+  }
+}
+
+async function loadFilteredPage(append: boolean) {
+  const { view, groupFilterId, sourceFilterId } = snapshot
+  const query: {
+    limit: number
+    cursor: string | null
+    group_id?: string | null
+    subscription_id?: string | null
+  } = {
+    limit: NEWS_PAGE_SIZE,
+    cursor: append ? snapshot.filteredCursor : null,
+  }
+  if (view === 'group') {
+    if (!groupFilterId) return
+    query.group_id = groupFilterId
+  } else if (view === 'source') {
+    if (!sourceFilterId) return
+    query.subscription_id = sourceFilterId
+  } else {
+    return
+  }
+
+  const resp = await news.getFeed(query)
+  const merged = append ? [...snapshot.filteredArticles, ...resp.articles] : resp.articles
+  patch({
+    filteredArticles: merged,
+    filteredCursor: resp.next_cursor,
+    filteredHasMore: resp.has_more,
+    filteredTotal: resp.total,
+    refreshedAt: resp.refreshed_at ?? snapshot.refreshedAt,
+  })
+  pruneSelection()
+}
+
+async function loadFilteredView() {
+  const { view, groupFilterId, sourceFilterId } = snapshot
+  if (view === 'group' && !groupFilterId) return
+  if (view === 'source' && !sourceFilterId) return
+  patch({
+    listSyncing: true,
+    error: '',
+    filteredCursor: null,
+    filteredArticles: [],
+    filteredHasMore: false,
+    filteredTotal: 0,
+  })
+  try {
+    await loadFilteredPage(false)
+  } catch (e) {
+    patch({ error: e instanceof Error ? e.message : '加载筛选列表失败' })
+  } finally {
+    patch({ listSyncing: false })
+  }
+}
+
+async function syncFeedLists() {
+  await loadTimelinePage(false)
+  void loadGrouped()
+}
+
+async function syncCurrentViewLists() {
+  await syncFeedLists()
+  if (snapshot.view === 'group' || snapshot.view === 'source') {
+    await loadFilteredView()
+  }
 }
 
 async function loadTimelinePage(append: boolean) {
@@ -245,10 +294,7 @@ async function softSync() {
   softSyncPromise = (async () => {
     try {
       await loadMeta()
-      await Promise.all([
-        loadTimelinePage(false),
-        loadGrouped(),
-      ])
+      await syncCurrentViewLists()
       normalizeListFilters()
       patch({ hydrated: true, error: '' })
     } catch (e) {
@@ -270,10 +316,7 @@ async function bootstrap() {
   bootstrapPromise = (async () => {
     try {
       await loadMeta()
-      await Promise.all([
-        loadTimelinePage(false),
-        loadGrouped(),
-      ])
+      await syncFeedLists()
       normalizeListFilters()
       patch({ hydrated: true, error: '' })
     } catch (e) {
@@ -305,6 +348,9 @@ export function setNewsFeedView(next: NewsListView) {
   patch({ view: next })
   normalizeListFilters()
   pruneSelection()
+  if (next === 'group' || next === 'source') {
+    void loadFilteredView()
+  }
 }
 
 export function setNewsFeedSelectedId(id: string | null) {
@@ -327,22 +373,41 @@ export async function setNewsFeedTimelineDate(date: string | null) {
 export function setNewsFeedGroupFilter(groupId: string) {
   patch({ groupFilterId: groupId })
   pruneSelection()
+  if (snapshot.view === 'group') void loadFilteredView()
 }
 
 export function setNewsFeedSourceFilter(subscriptionId: string) {
   patch({ sourceFilterId: subscriptionId })
   pruneSelection()
+  if (snapshot.view === 'source') void loadFilteredView()
 }
 
 export async function loadMoreNewsFeed() {
-  if (snapshot.view !== 'timeline' || snapshot.loadingMore || !snapshot.hasMore || snapshot.listSyncing) return
-  if (snapshot.listCapReached || snapshot.articles.length >= NEWS_ARTICLES_MEMORY_CAP) {
-    patch({ hasMore: false, listCapReached: true })
+  if (snapshot.loadingMore || snapshot.listSyncing) return
+
+  if (snapshot.view === 'timeline') {
+    if (!snapshot.hasMore) return
+    if (snapshot.listCapReached || snapshot.articles.length >= NEWS_ARTICLES_MEMORY_CAP) {
+      patch({ hasMore: false, listCapReached: true })
+      return
+    }
+    patch({ loadingMore: true, error: '' })
+    try {
+      await loadTimelinePage(true)
+    } catch (e) {
+      patch({ error: e instanceof Error ? e.message : '加载更多失败' })
+    } finally {
+      patch({ loadingMore: false })
+    }
     return
   }
+
+  if (snapshot.view !== 'group' && snapshot.view !== 'source') return
+  if (!snapshot.filteredHasMore) return
+
   patch({ loadingMore: true, error: '' })
   try {
-    await loadTimelinePage(true)
+    await loadFilteredPage(true)
   } catch (e) {
     patch({ error: e instanceof Error ? e.message : '加载更多失败' })
   } finally {
@@ -356,10 +421,7 @@ export async function refreshNewsFeed(): Promise<NewsFeedRefreshResult> {
   try {
     patch({ cursor: null })
     await loadMeta()
-    await Promise.all([
-      loadTimelinePage(false),
-      loadGrouped(),
-    ])
+    await syncCurrentViewLists()
     normalizeListFilters()
     patch({ hydrated: true, listPulseEpoch: snapshot.listPulseEpoch + 1 })
     pruneSelection()
@@ -375,6 +437,6 @@ export async function refreshNewsFeed(): Promise<NewsFeedRefreshResult> {
 
 /** 设置页变更订阅后，由外部触发重新同步 */
 export async function reloadNewsFeed() {
-  patch({ cursor: null })
+  patch({ cursor: null, filteredCursor: null })
   await softSync()
 }

--- a/client-ui/src/pages/news/useNewsFeed.ts
+++ b/client-ui/src/pages/news/useNewsFeed.ts
@@ -59,14 +59,11 @@ export function useNewsFeed() {
     if (subscriptionId) setNewsFeedSourceFilter(subscriptionId)
   }, [])
 
-  const listReady = snap.hydrated || (
-    snap.view === 'timeline'
-      ? snap.articles.length > 0
-      : snap.grouped != null
-  )
+  const listReady = snap.hydrated || snap.articles.length > 0
 
   return {
     articles: snap.articles,
+    filteredArticles: snap.filteredArticles,
     grouped: snap.grouped,
     subscriptions: snap.subscriptions,
     groups: snap.groups,
@@ -80,8 +77,10 @@ export function useNewsFeed() {
     selectedId: snap.selectedId,
     selected: getSelectedArticle(),
     hasMore: snap.hasMore,
+    filteredHasMore: snap.filteredHasMore,
     listCapReached: snap.listCapReached,
     total: snap.total,
+    filteredTotal: snap.filteredTotal,
     view: snap.view,
     timelineDate: snap.timelineDate,
     groupFilterId: snap.groupFilterId,

--- a/packages/news-feed/src/index.ts
+++ b/packages/news-feed/src/index.ts
@@ -211,10 +211,7 @@ export function getArticlesGrouped(): {
   const subs = store.listSubscriptions()
   const groups = store.listGroups()
 
-  const bySub = new Map<string, FeedArticle[]>()
-  for (const sub of subs) {
-    bySub.set(sub.id, store.listArticlesBySubscription(sub.id, MAX_ARTICLES_PER_FETCH))
-  }
+  const bySub = store.listArticlesBucketedBySubscription(MAX_ARTICLES_PER_FETCH)
 
   const by_source = subs.map(sub => ({
     subscription_id: sub.id,

--- a/packages/news-feed/src/store.ts
+++ b/packages/news-feed/src/store.ts
@@ -536,6 +536,39 @@ export class NewsFeedStore {
     return this.listArticlesPage({ subscription_id: subscriptionId, limit }).articles
   }
 
+  /**
+   * Single index pass: bucket article ids by subscription, dedupe per bucket, cap each.
+   * Avoids O(subscriptions × articles) rescans from repeated listArticlesPage calls.
+   */
+  listArticlesBucketedBySubscription(maxPerSub: number): Map<string, FeedArticle[]> {
+    this.ensureMigrated()
+    const subs = this.listSubscriptions()
+    const subIds = new Set(subs.map(s => s.id))
+    const idBuckets = new Map<string, string[]>()
+    for (const sub of subs) idBuckets.set(sub.id, [])
+
+    const index = this.getIndex()
+    for (const id of index.article_order) {
+      const doc = this.getArticleDoc(id)
+      if (!doc || !subIds.has(doc.subscription_id)) continue
+      idBuckets.get(doc.subscription_id)!.push(id)
+    }
+
+    const result = new Map<string, FeedArticle[]>()
+    for (const sub of subs) {
+      const dedupedIds = dedupeArticleIdsByContentKey(
+        idBuckets.get(sub.id) ?? [],
+        id => this.getArticleDoc(id),
+      )
+      const articles = dedupedIds
+        .slice(0, maxPerSub)
+        .map(articleId => this.getArticleDoc(articleId))
+        .filter((a): a is FeedArticle => !!a)
+      result.set(sub.id, articles)
+    }
+    return result
+  }
+
   listArticles(limit = 100): FeedArticle[] {
     return this.listArticlesPage({ limit }).articles
   }


### PR DESCRIPTION
## Summary
- Add mobile news article bottom drawer and full-width list layout
- Load group/source views via paginated `/news/feed` filters instead of blocking on grouped bundle
- Optimize grouped feed indexing on server; increase grouped timeout as safety net
- Temporarily hide translation and media enrichment actions in article preview header

## Test plan
- [ ] Mobile: open news center, switch group/source tabs, verify list loads without timeout
- [ ] Mobile: tap article opens bottom drawer; close via scrim
- [ ] Desktop: split view unchanged; filters still work
- [ ] `npm run check:ui` passes
- [ ] `npm run build:packages` passes


Made with [Cursor](https://cursor.com)