### PR TITLE
fix(client-ui): avoid shared barrel breaking UI startup

### DIFF
--- a/client-ui/src/data/cacheControl.ts
+++ b/client-ui/src/data/cacheControl.ts
@@ -10,7 +10,7 @@ export {
   parseIsoToMs,
   resolveFetchedAtMs,
   type RevalidateMode,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 
 export type VisibilityPoller = {
   acquire: () => void

--- a/client-ui/src/market/useFollowPortfolio.ts
+++ b/client-ui/src/market/useFollowPortfolio.ts
@@ -22,7 +22,7 @@ import {
   UI_POLL_INTERVAL_MS,
   decideRevalidate,
   resolveFetchedAtMs,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 import {
   readPortfolioSummarySessionCache,
   writePortfolioSummarySessionCache,

--- a/client-ui/src/market/watchlistQuotesRefresh.ts
+++ b/client-ui/src/market/watchlistQuotesRefresh.ts
@@ -2,7 +2,7 @@ import {
   UI_CACHE_TTL_MS,
   decideRevalidate,
   resolveFetchedAtMs,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 import { readWatchlistQuotesSessionCache } from './rightPanelSessionCache'
 
 /** 跨组件（右栏关注 / 市场动态看板）共享的上次成功拉取时间，避免重复打 Hub */

--- a/client-ui/src/pages/community/communityFeedCache.ts
+++ b/client-ui/src/pages/community/communityFeedCache.ts
@@ -4,7 +4,7 @@ import {
   UI_CACHE_TTL_MS,
   UI_POLL_INTERVAL_MS,
   decideRevalidate,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 import { createVisibilityPoller, type VisibilityPoller } from '../../data/cacheControl'
 
 /** 数据结构变更时递增，使旧内存缓存失效 */

--- a/client-ui/src/pages/market-dynamics/marketDynamicsCnStore.ts
+++ b/client-ui/src/pages/market-dynamics/marketDynamicsCnStore.ts
@@ -5,7 +5,7 @@ import {
   UI_POLL_INTERVAL_MS,
   decideRevalidate,
   resolveFetchedAtMs,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 import { createVisibilityPoller, type VisibilityPoller } from '../../data/cacheControl'
 import {
   readSessionCacheEnvelope,

--- a/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
+++ b/client-ui/src/pages/market-dynamics/useMarketDynamics.ts
@@ -4,7 +4,7 @@ import type { FeedArticle } from '../../types/schemas'
 import {
   decideRevalidate,
   resolveFetchedAtMs,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 import {
   ensureNewsFeedRefreshPolicyHydrated,
   getNewsFeedClientPollMs,

--- a/client-ui/src/pages/news/newsFeedRefreshPolicy.ts
+++ b/client-ui/src/pages/news/newsFeedRefreshPolicy.ts
@@ -3,7 +3,7 @@ import {
   clampNewsRefreshIntervalMin,
   newsFeedPollIntervalMs,
   newsFeedTtlMs,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 
 let refreshIntervalMin: number = NEWS_FEED_REFRESH_INTERVAL_MIN.default
 let clientTtlMs = newsFeedTtlMs(refreshIntervalMin)

--- a/client-ui/src/pages/news/newsFeedSession.ts
+++ b/client-ui/src/pages/news/newsFeedSession.ts
@@ -2,7 +2,7 @@ import { news } from '../../api/client'
 import {
   decideRevalidate,
   resolveFetchedAtMs,
-} from '@opptrix/shared'
+} from '@opptrix/shared/ui-cache-policy'
 import { createVisibilityPoller, type VisibilityPoller } from '../../data/cacheControl'
 import {
   applyNewsFeedRefreshIntervalMin,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -61,6 +61,10 @@
     "./auth-credentials": {
       "types": "./dist/auth-credentials.d.ts",
       "import": "./dist/auth-credentials.js"
+    },
+    "./ui-cache-policy": {
+      "types": "./dist/ui-cache-policy.d.ts",
+      "import": "./dist/ui-cache-policy.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- Client cache helpers imported `@opptrix/shared` barrel, pulling Node `outbound-fetch` / proxy agents into Vite and causing `Class extends value undefined is not a constructor or null`
- Import `@opptrix/shared/ui-cache-policy` subpath instead; add package export

## Test plan
- [x] `npm run build -w opptrix-client`
- [x] `npm run check:ui`
- [ ] Hard-refresh browser / restart `npm run dev:web` — UI loads without the Class extends error


Made with [Cursor](https://cursor.com)