### PR TITLE
Add light fintech atmosphere to onboarding

### DIFF
--- a/client-ui/src/onboarding/OnboardingAtmosphere.tsx
+++ b/client-ui/src/onboarding/OnboardingAtmosphere.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useRef, type RefObject } from 'react'
+import { makeStyles, mergeClasses } from '@fluentui/react-components'
+import { opptrixCssVars } from '../theme/tokens'
+
+const useStyles = makeStyles({
+  root: {
+    position: 'absolute',
+    inset: 0,
+    zIndex: 0,
+    overflow: 'hidden',
+    pointerEvents: 'none',
+    userSelect: 'none',
+  },
+  wash: {
+    position: 'absolute',
+    inset: 0,
+    backgroundImage: `
+      radial-gradient(ellipse 90% 70% at 50% -10%, color-mix(in srgb, ${opptrixCssVars.accent} 7%, transparent) 0%, transparent 55%),
+      radial-gradient(ellipse 70% 50% at 100% 100%, color-mix(in srgb, ${opptrixCssVars.accent} 4%, transparent) 0%, transparent 50%),
+      linear-gradient(180deg, ${opptrixCssVars.canvas} 0%, color-mix(in srgb, ${opptrixCssVars.canvasAlt} 55%, ${opptrixCssVars.canvas}) 100%)
+    `,
+  },
+  /** Idle drift kept separate from pointer warp via CSS vars on host. */
+  grid: {
+    position: 'absolute',
+    inset: '-6%',
+    opacity: 0.55,
+    backgroundImage: `
+      linear-gradient(to right, color-mix(in srgb, ${opptrixCssVars.separator} 72%, transparent) 1px, transparent 1px),
+      linear-gradient(to bottom, color-mix(in srgb, ${opptrixCssVars.separator} 72%, transparent) 1px, transparent 1px)
+    `,
+    backgroundSize: '44px 44px',
+    maskImage: 'radial-gradient(ellipse 85% 75% at 50% 45%, #000 20%, transparent 78%)',
+    transformOrigin: '50% 45%',
+    transform: `
+      translate3d(
+        calc(var(--onb-dx, 0) * -14px),
+        calc(var(--onb-dy, 0) * -10px),
+        0
+      )
+      skewX(calc(var(--onb-dx, 0) * -1.1deg))
+      skewY(calc(var(--onb-dy, 0) * 0.7deg))
+    `,
+    transitionProperty: 'transform',
+    transitionDuration: '420ms',
+    transitionTimingFunction: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    willChange: 'transform',
+    animationName: {
+      '0%': { backgroundPosition: '0 0' },
+      '50%': { backgroundPosition: '-10px -6px' },
+      '100%': { backgroundPosition: '0 0' },
+    },
+    animationDuration: '48s',
+    animationTimingFunction: 'ease-in-out',
+    animationIterationCount: 'infinite',
+    '@media (prefers-reduced-motion: reduce)': {
+      animationName: 'none',
+      animationDuration: '0.01ms',
+      transitionDuration: '0.01ms',
+      transform: 'none',
+    },
+  },
+  diagonal: {
+    position: 'absolute',
+    inset: '-10%',
+    opacity: 0.28,
+    backgroundImage: `repeating-linear-gradient(
+      -32deg,
+      transparent 0,
+      transparent 11px,
+      color-mix(in srgb, ${opptrixCssVars.borderStrong} 28%, transparent) 11px,
+      color-mix(in srgb, ${opptrixCssVars.borderStrong} 28%, transparent) 12px
+    )`,
+    maskImage: 'radial-gradient(ellipse 80% 70% at 50% 50%, #000 15%, transparent 72%)',
+    transformOrigin: '50% 50%',
+    transform: `
+      translate3d(
+        calc(var(--onb-dx, 0) * 18px),
+        calc(var(--onb-dy, 0) * 12px),
+        0
+      )
+      skewX(calc(var(--onb-dx, 0) * 1.4deg))
+      skewY(calc(var(--onb-dy, 0) * -0.9deg))
+    `,
+    transitionProperty: 'transform',
+    transitionDuration: '480ms',
+    transitionTimingFunction: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    willChange: 'transform',
+    animationName: {
+      '0%': { backgroundPosition: '0 0' },
+      '50%': { backgroundPosition: '8px 4px' },
+      '100%': { backgroundPosition: '0 0' },
+    },
+    animationDuration: '64s',
+    animationTimingFunction: 'ease-in-out',
+    animationIterationCount: 'infinite',
+    animationDirection: 'alternate',
+    '@media (prefers-reduced-motion: reduce)': {
+      animationName: 'none',
+      animationDuration: '0.01ms',
+      transitionDuration: '0.01ms',
+      transform: 'none',
+    },
+  },
+  vignette: {
+    position: 'absolute',
+    inset: 0,
+    boxShadow: `inset 0 0 120px color-mix(in srgb, ${opptrixCssVars.canvas} 70%, transparent)`,
+  },
+})
+
+/**
+ * Light fintech atmosphere — grid + diagonal with pointer-driven warp (no color spotlight).
+ */
+export function OnboardingAtmosphere({
+  hostRef,
+}: {
+  /** Shell root — `--onb-dx` / `--onb-dy` in [-1, 1] */
+  hostRef: RefObject<HTMLElement | null>
+}) {
+  const s = useStyles()
+  const rafRef = useRef(0)
+  const reduceRef = useRef(false)
+
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const sync = () => { reduceRef.current = mq.matches }
+    sync()
+    mq.addEventListener('change', sync)
+    return () => mq.removeEventListener('change', sync)
+  }, [])
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+
+    const onMove = (ev: PointerEvent) => {
+      if (reduceRef.current) return
+      const rect = host.getBoundingClientRect()
+      if (rect.width <= 0 || rect.height <= 0) return
+      // Normalize to [-1, 1] from center
+      const dx = ((ev.clientX - rect.left) / rect.width) * 2 - 1
+      const dy = ((ev.clientY - rect.top) / rect.height) * 2 - 1
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = requestAnimationFrame(() => {
+        host.style.setProperty('--onb-dx', dx.toFixed(4))
+        host.style.setProperty('--onb-dy', dy.toFixed(4))
+      })
+    }
+
+    const onLeave = () => {
+      if (reduceRef.current) return
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = requestAnimationFrame(() => {
+        host.style.setProperty('--onb-dx', '0')
+        host.style.setProperty('--onb-dy', '0')
+      })
+    }
+
+    host.addEventListener('pointermove', onMove, { passive: true })
+    host.addEventListener('pointerleave', onLeave)
+    return () => {
+      host.removeEventListener('pointermove', onMove)
+      host.removeEventListener('pointerleave', onLeave)
+      cancelAnimationFrame(rafRef.current)
+    }
+  }, [hostRef])
+
+  return (
+    <div
+      className={mergeClasses(s.root, 'opptrix-onboarding-atmosphere')}
+      aria-hidden
+    >
+      <div className={s.wash} />
+      <div className={s.grid} />
+      <div className={s.diagonal} />
+      <div className={s.vignette} />
+    </div>
+  )
+}

--- a/client-ui/src/onboarding/OnboardingShell.tsx
+++ b/client-ui/src/onboarding/OnboardingShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react'
+import { useRef, type CSSProperties, type ReactNode } from 'react'
 import { makeStyles, mergeClasses } from '@fluentui/react-components'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import { DESKTOP_FRAME_TITLEBAR_HEIGHT, DESKTOP_TITLEBAR_HEIGHT } from '../desktop/constants'
@@ -7,6 +7,7 @@ import MacTrafficLights from '../desktop/MacTrafficLights'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { electronPlatform, isElectron } from '../platform/detect'
 import { opptrixCssVars } from '../theme/tokens'
+import { OnboardingAtmosphere } from './OnboardingAtmosphere'
 import { type OnboardingNavStep } from './onboardingTheme'
 
 /** Shared horizontal inset: tight on mobile, expands on wide screens. */
@@ -22,12 +23,22 @@ export const useOnboardingShellStyles = makeStyles({
     backgroundColor: opptrixCssVars.canvas,
     overflow: 'hidden',
   },
+  stage: {
+    position: 'relative',
+    zIndex: 1,
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+  },
   rootFrameTitlebar: {
     paddingTop: `${DESKTOP_FRAME_TITLEBAR_HEIGHT}px`,
     boxSizing: 'border-box',
   },
   electronTitleBar: {
     position: 'relative',
+    zIndex: 2,
     flexShrink: 0,
     height: `${DESKTOP_TITLEBAR_HEIGHT}px`,
     boxSizing: 'border-box',
@@ -36,7 +47,7 @@ export const useOnboardingShellStyles = makeStyles({
     justifyContent: 'flex-end',
     paddingLeft: '12px',
     borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
-    backgroundColor: opptrixCssVars.canvas,
+    backgroundColor: 'transparent',
   },
   electronTitleBarMac: {
     justifyContent: 'flex-end',
@@ -64,13 +75,6 @@ export const useOnboardingShellStyles = makeStyles({
     color: opptrixCssVars.accent,
     whiteSpace: 'nowrap',
     pointerEvents: 'none',
-  },
-  stage: {
-    flex: 1,
-    minHeight: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
   },
   scrollViewport: {
     flex: 1,
@@ -134,7 +138,7 @@ export const useOnboardingShellStyles = makeStyles({
     flexShrink: 0,
     width: '100%',
     boxSizing: 'border-box',
-    backgroundColor: opptrixCssVars.canvas,
+    backgroundColor: 'transparent',
     padding: `clamp(14px, 2.5vh, 20px) ${SHELL_PAD_X}`,
   },
   progressDots: {
@@ -305,7 +309,7 @@ export const useOnboardingShellStyles = makeStyles({
     boxSizing: 'border-box',
     display: 'flex',
     alignItems: 'center',
-    backgroundColor: opptrixCssVars.canvas,
+    backgroundColor: 'transparent',
     minHeight: '135px',
     height: '135px',
     paddingTop: 0,
@@ -425,6 +429,7 @@ export function OnboardingShell({
   children,
 }: OnboardingShellProps) {
   const s = useOnboardingShellStyles()
+  const shellRef = useRef<HTMLDivElement>(null)
   const macFullscreen = useElectronFullscreen()
   const electronChrome = isElectron()
   const electronWin = electronChrome && electronPlatform() !== 'darwin'
@@ -454,15 +459,18 @@ export function OnboardingShell({
 
   return (
     <div
+      ref={shellRef}
       className={mergeClasses(
         s.root,
         electronWin && s.rootFrameTitlebar,
         'opptrix-onboarding-shell',
       )}
+      style={{ '--onb-dx': '0', '--onb-dy': '0' } as CSSProperties}
       role="dialog"
       aria-modal="true"
       aria-label="Opptrix 启动引导"
     >
+      <OnboardingAtmosphere hostRef={shellRef} />
       {electronTitleBar}
 
       <div className={s.stage}>

--- a/client-ui/src/styles/global.css
+++ b/client-ui/src/styles/global.css
@@ -274,11 +274,11 @@ html.opptrix-electron .opptrix-onboarding-title-drag {
 }
 
 html.opptrix-electron .opptrix-onboarding-footer-dock {
-  background: var(--opptrix-canvas) !important;
+  background: transparent !important;
 }
 
 html.opptrix-electron .opptrix-onboarding-progress-dock {
-  background: var(--opptrix-canvas) !important;
+  background: transparent !important;
 }
 
 /* 引导协议勾选 — 彻底去除 Checkbox 所有状态下的 outline / ring / box-shadow */


### PR DESCRIPTION
## Summary
- Subtle grid + diagonal texture behind the full onboarding shell
- Pointer motion warps the pattern via parallax/skew (no color spotlight)
- Progress/footer docks stay transparent so the atmosphere reads continuously

## Test plan
- [ ] Hard-refresh onboarding; atmosphere visible on all steps without hurting copy contrast
- [ ] Move pointer — grid/diagonal warp; leave shell — pattern eases back
- [ ] `prefers-reduced-motion` freezes warp/drift
- [ ] `npm run check:ui`


Made with [Cursor](https://cursor.com)