### PR TITLE
fix(onboarding): content panel white bg and LLM list scroll

### DIFF
--- a/client-ui/src/onboarding/OnboardingShell.tsx
+++ b/client-ui/src/onboarding/OnboardingShell.tsx
@@ -6,12 +6,15 @@ import { desktopFrameTitlebarHeight } from '../desktop/layout'
 import MacTrafficLights from '../desktop/MacTrafficLights'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
 import { electronPlatform, isElectron } from '../platform/detect'
-import { opptrixCssVars } from '../theme/tokens'
+import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
 import { OnboardingAtmosphere } from './OnboardingAtmosphere'
 import { type OnboardingNavStep } from './onboardingTheme'
 
 /** Shared horizontal inset: tight on mobile, expands on wide screens. */
 const SHELL_PAD_X = 'clamp(16px, 4vw, 72px)'
+/** Matches `footerDock` height — scroll pad must clear this + safe-area. */
+const FOOTER_DOCK_HEIGHT_PX = 135
+const SCROLL_FOOTER_GAP_PX = 16
 
 export const useOnboardingShellStyles = makeStyles({
   root: {
@@ -92,8 +95,8 @@ export const useOnboardingShellStyles = makeStyles({
     flexDirection: 'column',
     alignItems: 'center',
     padding: `clamp(16px, 3vh, 28px) ${SHELL_PAD_X}`,
-    /** Clears fixed footer dock (~135px) on config/workflow steps */
-    paddingBottom: '150px',
+    /** Clears footer dock height + safe-area + gap so last list rows stay visible */
+    paddingBottom: `calc(${FOOTER_DOCK_HEIGHT_PX + SCROLL_FOOTER_GAP_PX}px + env(safe-area-inset-bottom, 0px))`,
   },
   scrollInnerFlush: {
     justifyContent: 'flex-start',
@@ -110,6 +113,14 @@ export const useOnboardingShellStyles = makeStyles({
     flexDirection: 'column',
     alignItems: 'center',
     textAlign: 'center',
+  },
+  /** Workflow steps: opaque white panel so Atmosphere grid does not show through */
+  contentPanel: {
+    padding: 'clamp(16px, 2.5vh, 22px) clamp(16px, 3vw, 22px)',
+    borderRadius: opptrixTokens.radiusLg,
+    border: `1px solid ${opptrixCssVars.border}`,
+    backgroundColor: '#FFFFFF',
+    boxSizing: 'border-box',
   },
   contentDisplay: {
     maxWidth: '640px',
@@ -310,8 +321,8 @@ export const useOnboardingShellStyles = makeStyles({
     display: 'flex',
     alignItems: 'center',
     backgroundColor: 'transparent',
-    minHeight: '135px',
-    height: '135px',
+    minHeight: `${FOOTER_DOCK_HEIGHT_PX}px`,
+    height: `${FOOTER_DOCK_HEIGHT_PX}px`,
     paddingTop: 0,
     paddingBottom: 'env(safe-area-inset-bottom, 0px)',
     paddingLeft: SHELL_PAD_X,
@@ -509,6 +520,7 @@ export function OnboardingShell({
             <div
               className={mergeClasses(
                 s.content,
+                !isDisplay && s.contentPanel,
                 isDisplay && s.contentDisplay,
                 contentWide && s.contentWide,
                 contentAlignStart && s.contentAlignStart,

--- a/client-ui/src/pages/ProviderWizard.tsx
+++ b/client-ui/src/pages/ProviderWizard.tsx
@@ -87,6 +87,13 @@ const useStyles = makeStyles({
     minHeight: 0,
     overflow: 'hidden',
   },
+  /** Onboarding: grow with content; outer OnboardingShell scroll handles overflow */
+  rootOnboarding: {
+    flex: 'none',
+    minHeight: 'auto',
+    overflow: 'visible',
+    width: '100%',
+  },
   steps: {
     display: 'flex',
     gap: '6px',
@@ -110,6 +117,13 @@ const useStyles = makeStyles({
     overflowY: 'auto',
     marginRight: '-4px',
     paddingRight: '4px',
+  },
+  scrollOnboarding: {
+    flex: 'none',
+    minHeight: 'auto',
+    overflow: 'visible',
+    marginRight: 0,
+    paddingRight: 0,
   },
   bodyInner: {
     display: 'flex',
@@ -181,7 +195,7 @@ const useStyles = makeStyles({
     border: `1px solid ${opptrixCssVars.border}`,
     borderRadius: opptrixTokens.radiusMd,
     padding: '4px',
-    overflow: 'hidden',
+    overflow: 'visible',
   },
   presetRow: {
     ...ghostInteractive,
@@ -710,7 +724,7 @@ export default function ProviderWizard({
   const onboardingInputClass = isOnboarding ? 'opptrix-onboarding-input' : undefined
 
   return (
-    <div className={s.root}>
+    <div className={mergeClasses(s.root, isOnboarding && s.rootOnboarding)}>
       {(isOnboarding || !compact) && (
       <div className={s.steps}>
         {[1, 2, 3].map(n => (
@@ -719,7 +733,7 @@ export default function ProviderWizard({
       </div>
       )}
 
-      <div className={`${s.scroll} opptrix-scroll`}>
+      <div className={mergeClasses(s.scroll, isOnboarding && s.scrollOnboarding, 'opptrix-scroll')}>
         <div className={s.bodyInner}>
 
           {step === 1 && showPresetList && (


### PR DESCRIPTION
## Summary
- Workflow onboarding steps use an opaque white content panel so Atmosphere does not show through.
- LLM provider list scrolls via the outer shell; footer dock clearance uses dock height + safe-area + gap.

## Test plan
- [ ] Open onboarding workflow steps: content sits on solid white panel over Atmosphere
- [ ] LLM step: scroll provider list to the last item without footer covering it
- [ ] Intro display step still shows Atmosphere (no white card)

Made with [Cursor](https://cursor.com)