### PR TITLE
feat(server): daily background update checks with versioned User-Agent

### DIFF
--- a/apps/server/src/system-update-channel.ts
+++ b/apps/server/src/system-update-channel.ts
@@ -2,6 +2,8 @@
  * CDN hot-update channel for selfhost runtime packages.
  * Default base: https://update.opptrix.org
  */
+import { buildSystemUpdateUserAgent } from './system-update-user-agent.js'
+
 export const DEFAULT_UPDATE_CDN_BASE = 'https://update.opptrix.org'
 
 export const SELFHOST_TAG_PREFIX = 'opptrix-selfhost-v'
@@ -153,6 +155,7 @@ async function fetchCheckUpdateJson(
   url: string,
   timeoutMs: number,
   signal?: AbortSignal,
+  userAgent?: string,
 ): Promise<unknown> {
   const ac = new AbortController()
   const onAbort = () => ac.abort()
@@ -166,7 +169,7 @@ async function fetchCheckUpdateJson(
       method: 'GET',
       headers: {
         Accept: 'application/json',
-        'User-Agent': 'Opptrix-system-update',
+        'User-Agent': userAgent ?? buildSystemUpdateUserAgent(),
       },
       signal: ac.signal,
     })
@@ -183,10 +186,10 @@ async function fetchCheckUpdateJson(
 /** Fetch latest hot-update descriptor from CDN check-update endpoint. */
 export async function fetchHotLatest(
   env: ChannelEnv = readChannelEnv(),
-  opts?: { timeoutMs?: number; signal?: AbortSignal },
+  opts?: { timeoutMs?: number; signal?: AbortSignal; userAgent?: string },
 ): Promise<HotLatestRelease | null> {
   const timeoutMs = opts?.timeoutMs ?? 25_000
   const url = hotCheckUpdateUrl(env.cdnBase)
-  const raw = await fetchCheckUpdateJson(url, timeoutMs, opts?.signal)
+  const raw = await fetchCheckUpdateJson(url, timeoutMs, opts?.signal, opts?.userAgent)
   return parseHotLatestPayload(raw, env.cdnBase)
 }

--- a/apps/server/src/system-update-check-schedule.ts
+++ b/apps/server/src/system-update-check-schedule.ts
@@ -1,0 +1,26 @@
+/** Background check cadence for long-running self-hosted servers. */
+
+/** Default: once per 24 hours (servers stay up; startup-only checks are insufficient). */
+export const DEFAULT_UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+const MIN_INTERVAL_MS = 60_000
+
+export function resolveUpdateCheckIntervalMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const explicitMs = env.OPPTRIX_UPDATE_CHECK_INTERVAL_MS?.trim()
+  if (explicitMs) {
+    const ms = Number.parseInt(explicitMs, 10)
+    if (Number.isFinite(ms) && ms >= MIN_INTERVAL_MS) return ms
+  }
+
+  const hoursRaw = env.OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS?.trim()
+  if (hoursRaw) {
+    const hours = Number.parseFloat(hoursRaw)
+    if (Number.isFinite(hours) && hours > 0) {
+      return Math.max(MIN_INTERVAL_MS, Math.round(hours * 60 * 60 * 1000))
+    }
+  }
+
+  return DEFAULT_UPDATE_CHECK_INTERVAL_MS
+}

--- a/apps/server/src/system-update-checker.ts
+++ b/apps/server/src/system-update-checker.ts
@@ -38,6 +38,7 @@ import {
   type ChannelEnv,
   type HotLatestRelease,
 } from './system-update-channel.js'
+import { buildSystemUpdateUserAgent } from './system-update-user-agent.js'
 import { downloadToFile } from './system-update-download.js'
 import {
   buildSystemUpdateStatus,
@@ -48,8 +49,8 @@ import {
   userFacingUpdateError,
   type SystemUpdateStatusDto,
 } from './system-update-service.js'
+import { resolveUpdateCheckIntervalMs } from './system-update-check-schedule.js'
 
-const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000
 const CHECK_TIMEOUT_MS = 30_000
 const DOWNLOAD_TIMEOUT_MS = 180_000
 
@@ -77,11 +78,13 @@ export async function runUpdateCheck(opts?: {
 
     const env = readChannelEnv()
     const current = state.currentVersion ?? resolveOpptrixAppVersion()
+    const userAgent = buildSystemUpdateUserAgent(current)
     let latest: HotLatestRelease | null
     try {
       latest = await fetchHotLatest(env, {
         timeoutMs: CHECK_TIMEOUT_MS,
         signal: opts?.signal,
+        userAgent,
       })
     } catch (err) {
       patchState({
@@ -132,7 +135,8 @@ async function startSilentDownload(
   })
 
   try {
-    const headers: Record<string, string> = { 'User-Agent': 'Opptrix-system-update' }
+    const userAgent = buildSystemUpdateUserAgent(version)
+    const headers: Record<string, string> = { 'User-Agent': userAgent }
 
     await downloadToFile(latest.binUrl, archivePath, {
       headers,
@@ -295,7 +299,7 @@ export function startSystemUpdateBackground(opts?: {
     }, 2_000).unref?.()
   }
 
-  const ms = opts?.intervalMs ?? CHECK_INTERVAL_MS
+  const ms = opts?.intervalMs ?? resolveUpdateCheckIntervalMs()
   intervalHandle = setInterval(() => {
     void runUpdateCheck().catch(() => {})
   }, ms)

--- a/apps/server/src/system-update-import.ts
+++ b/apps/server/src/system-update-import.ts
@@ -22,6 +22,7 @@ import {
   parseSemver,
   readChannelEnv,
 } from './system-update-channel.js'
+import { buildSystemUpdateUserAgent } from './system-update-user-agent.js'
 import {
   buildSystemUpdateStatus,
   type SystemUpdateStatusDto,
@@ -127,7 +128,7 @@ async function crossCheckCdnSha256WhenOnline(
       method: 'GET',
       headers: {
         Accept: 'text/plain,*/*',
-        'User-Agent': 'Opptrix-system-update',
+        'User-Agent': buildSystemUpdateUserAgent(version),
       },
       signal: ac.signal,
     })

--- a/apps/server/src/system-update-user-agent.ts
+++ b/apps/server/src/system-update-user-agent.ts
@@ -1,0 +1,12 @@
+import { resolveOpptrixAppVersion } from '@opptrix/shared'
+import { readState } from '@opptrix/system-update'
+
+const UA_PRODUCT = 'Opptrix-system-update'
+
+/** User-Agent for hot-update CDN requests; includes the running runtime version. */
+export function buildSystemUpdateUserAgent(version?: string | null): string {
+  const raw = (version ?? readState().currentVersion ?? resolveOpptrixAppVersion()).trim()
+  const normalized = raw.replace(/^v/i, '')
+  if (!normalized || normalized === 'unknown') return UA_PRODUCT
+  return `${UA_PRODUCT}/${normalized}`
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -167,11 +167,13 @@ Cookie：`opptrix_session`（HttpOnly; Path=/; SameSite=Lax）。亦可使用 `A
 | `OPPTRIX_UPDATE_CHANNEL` | 通道，默认 `selfhost` |
 | `OPPTRIX_UPDATE_CDN_BASE` | 热更新 CDN 根，默认 `https://update.opptrix.org` |
 | `OPPTRIX_UPDATE_ENABLED` | `1` 强制开 / `0` 强制关 |
+| `OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS` | 后台定期检查间隔（小时），默认 `24`；服务启动后仍会先做一次检查 |
+| `OPPTRIX_UPDATE_CHECK_INTERVAL_MS` | 同上，毫秒粒度（优先于 `…_HOURS`） |
 | `OPPTRIX_SYSTEM_DIR` | 系统槽位根目录（见 `@opptrix/system-update`） |
 | `OPPTRIX_BASE_VERSION` | Docker/自托管底座身份（如 `opptrix-selfhost-v1.4.0`）；热更新对照 `requires.minBaseImage` |
 | `OPPTRIX_RELEASE_TAG` | 发版标签；未设 `OPPTRIX_BASE_VERSION` 时可作为底座回退 |
 
-检查与下载：`GET {OPPTRIX_UPDATE_CDN_BASE}/hot/check-update`（固定返回 latest）；包 `{base}/hot/packages/opptrix-runtime-vX.Y.Z.bin` + 同名 `.sha256`。打包、信任模型与槽位流程见 **[`docs/SYSTEM-UPDATE.md`](./SYSTEM-UPDATE.md)**。
+检查与下载：`GET {OPPTRIX_UPDATE_CDN_BASE}/hot/check-update`（固定返回 latest）；包 `{base}/hot/packages/opptrix-runtime-vX.Y.Z.bin` + 同名 `.sha256`。请求头 `User-Agent` 为 `Opptrix-system-update/{currentVersion}`，便于更新服务识别实例版本。后台默认每 24 小时自动检查一次（另在进程启动约 2s 后检查）；打包、信任模型与槽位流程见 **[`docs/SYSTEM-UPDATE.md`](./SYSTEM-UPDATE.md)**。
 
 ### 端点
 

--- a/docs/SYSTEM-UPDATE.md
+++ b/docs/SYSTEM-UPDATE.md
@@ -249,7 +249,11 @@ Docker：`scripts/docker-entrypoint.sh` + tini。
 | `OPPTRIX_UPDATE_CHANNEL` | 默认 `selfhost` |
 | `OPPTRIX_UPDATE_CDN_BASE` | CDN 根，默认 `https://update.opptrix.org` |
 | `OPPTRIX_UPDATE_ENABLED` | `1`/`0` 强制开/关 |
+| `OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS` | 后台定期检查间隔（小时），默认 `24` |
+| `OPPTRIX_UPDATE_CHECK_INTERVAL_MS` | 同上，毫秒粒度（优先于 `…_HOURS`） |
 | `OPPTRIX_DESKTOP=1` | 桌面端默认关热更新 |
+
+长运行服务（Docker / 自托管）在进程启动约 2s 后会检查一次远程 `check-update`，之后按上述间隔定时复查；请求 CDN 时 `User-Agent` 为 `Opptrix-system-update/{currentVersion}`，便于统计各版本实例。
 
 API 细节见 `docs/API.md`。
 

--- a/tests/system-update-check-schedule.test.mjs
+++ b/tests/system-update-check-schedule.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+/** @type {typeof import('../apps/server/dist/system-update-check-schedule.js')} */
+let schedule
+/** @type {typeof import('../apps/server/dist/system-update-user-agent.js')} */
+let ua
+
+describe('system-update check schedule', () => {
+  it('loads built server modules', async () => {
+    schedule = await import('../apps/server/dist/system-update-check-schedule.js')
+    ua = await import('../apps/server/dist/system-update-user-agent.js')
+    assert.ok(schedule.resolveUpdateCheckIntervalMs)
+    assert.ok(ua.buildSystemUpdateUserAgent)
+  })
+
+  it('defaults to 24h interval', () => {
+    const ms = schedule.resolveUpdateCheckIntervalMs({})
+    assert.equal(ms, 24 * 60 * 60 * 1000)
+  })
+
+  it('respects OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS', () => {
+    const ms = schedule.resolveUpdateCheckIntervalMs({
+      OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS: '12',
+    })
+    assert.equal(ms, 12 * 60 * 60 * 1000)
+  })
+
+  it('respects OPPTRIX_UPDATE_CHECK_INTERVAL_MS', () => {
+    const ms = schedule.resolveUpdateCheckIntervalMs({
+      OPPTRIX_UPDATE_CHECK_INTERVAL_MS: '3600000',
+    })
+    assert.equal(ms, 3_600_000)
+  })
+})
+
+describe('system-update user agent', () => {
+  it('includes explicit version', () => {
+    assert.equal(
+      ua.buildSystemUpdateUserAgent('1.4.2'),
+      'Opptrix-system-update/1.4.2',
+    )
+    assert.equal(
+      ua.buildSystemUpdateUserAgent('v1.4.2'),
+      'Opptrix-system-update/1.4.2',
+    )
+  })
+
+  it('falls back to product token when version unknown', () => {
+    assert.equal(ua.buildSystemUpdateUserAgent('unknown'), 'Opptrix-system-update')
+    assert.equal(ua.buildSystemUpdateUserAgent(''), 'Opptrix-system-update')
+  })
+})


### PR DESCRIPTION
## Summary
- Add 24h default background update check interval for long-running self-hosted servers (startup check unchanged at ~2s).
- Send `User-Agent: Opptrix-system-update/{currentVersion}` on CDN check/download/import requests.
- Configurable via `OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS` or `OPPTRIX_UPDATE_CHECK_INTERVAL_MS`.
- Document env vars in `docs/API.md` and `docs/SYSTEM-UPDATE.md`; add schedule/UA unit tests.

## Test plan
- [x] `npm run build -w @opptrix/server`
- [x] `node --test tests/system-update-check-schedule.test.mjs`


Made with [Cursor](https://cursor.com)