### PR TITLE
feat(selfhost): add opptrix env command for compose.env management

### DIFF
--- a/packages/selfhost/README.md
+++ b/packages/selfhost/README.md
@@ -146,9 +146,11 @@ opptrix up --skip-models
 ```bash
 opptrix status        # 容器是否在跑
 opptrix logs -f       # 跟踪日志（出问题先看这里）
+opptrix env list      # 查看 compose.env（敏感项脱敏）
+opptrix env set OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS=12 LLM_API_KEY=sk-xxx
 opptrix stop          # 停止（数据还在）
 opptrix start         # 再启动（不强制重建镜像）
-opptrix restart       # 重启
+opptrix restart       # 重启（不改 env；改变量请用 env set，会自动 up -d）
 opptrix down          # 删容器但默认保留数据卷
 ```
 
@@ -251,6 +253,7 @@ opptrix up --skip-models    # 建议先跳过模型，确认能打开页面
 | `opptrix use <tag\|main>` | 写入版本偏好 | `.opptrix.json` 的 `appRef`；`--apply` 可立即启动 |
 | `opptrix up` | 优先 pull 预构建并后台启动 | 实例运行，默认可访问 8711 |
 | `opptrix start` / `stop` / `restart` | 启停重启 | 不强制重建镜像 |
+| `opptrix env set/get/list/unset` | 管理 `compose.env` | 默认写盘后 `compose up -d` 注入；`--no-restart` 仅保存 |
 | `opptrix down` | 移除容器 | 默认保留数据；加 `--volumes` 清空 |
 | `opptrix build` | 只本地构建镜像 | 不启动容器 |
 | `opptrix update` | 升级镜像 / 运行环境底座 | 重建容器；默认保留 data / models / system 卷与挂载；热更新另见产品内提示 |

--- a/packages/selfhost/bin/opptrix.js
+++ b/packages/selfhost/bin/opptrix.js
@@ -20,6 +20,16 @@ import {
 } from '../src/app-refs.mjs'
 import { detectDocker, gitPull, npmLinkCli, npmUnlinkCli, probeHealth, runCompose } from '../src/compose.mjs'
 import {
+  knownEnvKeysForRoot,
+  maskEnvValue,
+  parseEnvSetTokens,
+  readComposeEnvMap,
+  resolveComposeEnvFile,
+  warnPathEnvKey,
+  warnUnknownEnvKey,
+  writeComposeEnvPatch,
+} from '../src/compose-env.mjs'
+import {
   buildReleaseEnv,
   ensureBuildContext,
   ensureThinDeploy,
@@ -75,6 +85,7 @@ macOS / Windows: 自备 Docker + Node ≥24 后 npm i -g @opptrix/selfhost
   start             启动已有容器（不重建）
   stop              停止容器
   restart           重启容器
+  env               管理 compose.env 运行时变量（set / get / list / unset）
   down              停止并移除容器（默认保留数据卷；加 --volumes 才会删卷）
   build             仅本地构建镜像
   update            升级运行环境/镜像/Node 底座：拉新预构建并重建容器；
@@ -100,6 +111,8 @@ macOS / Windows: 自备 Docker + Node ≥24 后 npm i -g @opptrix/selfhost
   --volumes             down 时删除数据/模型/系统槽位卷（危险，不可恢复）
   -f, --follow          logs 跟踪输出
   --tail <n>            logs 尾部行数（默认 200）
+  --no-restart          env set/unset 后只写 compose.env，不重建容器
+  --force-recreate      env set/unset 后 docker compose up -d --force-recreate
 
 环境变量:
   OPPTRIX_DEPLOY_DIR    Compose / 部署目录（默认：当前 monorepo 或 ~/.opptrix/instances/default）
@@ -120,8 +133,167 @@ macOS / Windows: 自备 Docker + Node ≥24 后 npm i -g @opptrix/selfhost
   opptrix up --build
   opptrix up --ref ${meta.preferredAppTag}
   opptrix up --skip-models
+  opptrix env set OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS=6
+  opptrix env list
   opptrix logs -f
 `)
+}
+
+function printEnvHelp() {
+  console.log(`Opptrix compose.env 管理
+
+用法:
+  opptrix env set KEY=VALUE [KEY2=VALUE2 …]
+  opptrix env get KEY
+  opptrix env list
+  opptrix env unset KEY [KEY2 …]
+
+说明:
+  写入部署目录下的 compose.env（与 opptrix init 相同位置）。
+  默认在修改后执行 docker compose up -d，使新环境变量注入容器
+  （restart 不会重载 env_file，请勿用手动 restart 代替）。
+
+选项:
+  --no-restart        只更新 compose.env，不启动/重建容器
+  --force-recreate    修改后强制重建容器（路径类变量变更时推荐）
+
+示例:
+  opptrix env set OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS=12
+  opptrix env set LLM_API_KEY=sk-xxx LLM_PROVIDER=DeepSeek
+  opptrix env unset LLM_API_KEY
+  opptrix env list
+`)
+}
+
+/**
+ * @param {import('../src/parse.mjs').ParsedArgv} parsed
+ * @param {{ set?: Record<string, string>, unset?: string[] }} patch
+ */
+async function applyComposeEnvChange(parsed, patch) {
+  const root = resolveDeployRoot()
+  fs.mkdirSync(root, { recursive: true })
+  ensureThinDeploy(root)
+  const envFile = resolveComposeEnvFile(root)
+  const known = knownEnvKeysForRoot(root)
+
+  for (const key of [...Object.keys(patch.set ?? {}), ...(patch.unset ?? [])]) {
+    const unk = warnUnknownEnvKey(key, known)
+    if (unk) console.warn(unk)
+    const pathWarn = warnPathEnvKey(key)
+    if (pathWarn) console.warn(pathWarn)
+  }
+
+  const result = writeComposeEnvPatch(envFile, patch)
+  console.log(`[opptrix] compose.env 已更新 → ${result.path}`)
+
+  if (patch.set) {
+    for (const [key, value] of Object.entries(patch.set)) {
+      console.log(`[opptrix]   set ${key}=${maskEnvValue(key, value)}`)
+    }
+  }
+  if (patch.unset?.length) {
+    for (const key of patch.unset) {
+      console.log(`[opptrix]   unset ${key}`)
+    }
+  }
+
+  if (flagTrue(parsed.flags, 'no-restart')) {
+    console.log('[opptrix] 已跳过容器重建；请稍后执行 opptrix up 或 docker compose up -d 使配置生效')
+    return 0
+  }
+
+  const docker = detectDocker()
+  if (!docker.ok) {
+    console.warn(`[opptrix] WARN: ${docker.message}`)
+    console.warn('[opptrix] compose.env 已保存；Docker 就绪后请执行 opptrix up')
+    return 0
+  }
+
+  const { root: deployRoot, mirror, releaseEnv } = prepareRoot(parsed, { needFullSource: false })
+  const args = ['up', '-d']
+  if (flagTrue(parsed.flags, 'force-recreate')) args.push('--force-recreate')
+  console.log('[opptrix] 正在重建容器以注入新环境变量…')
+  return runCompose(args, { root: deployRoot, mirror, releaseEnv })
+}
+
+async function cmdEnv(parsed) {
+  const sub = (parsed.args[0] || '').trim()
+  const rest = parsed.args.slice(1)
+
+  if (!sub || sub === 'help' || sub === '-h' || sub === '--help') {
+    printEnvHelp()
+    return 0
+  }
+
+  const root = resolveDeployRoot()
+  ensureThinDeploy(root)
+  const envFile = resolveComposeEnvFile(root)
+
+  if (sub === 'list') {
+    const text = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf8') : ''
+    const map = readComposeEnvMap(text)
+    if (!map.size) {
+      console.log(`[opptrix] compose.env 暂无有效变量 → ${envFile}`)
+      return 0
+    }
+    console.log(`[opptrix] compose.env → ${envFile}`)
+    for (const [key, value] of [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+      console.log(`${key}=${maskEnvValue(key, value)}`)
+    }
+    return 0
+  }
+
+  if (sub === 'get') {
+    const key = (rest[0] || '').trim()
+    if (!key) {
+      console.error('[opptrix] 用法: opptrix env get KEY')
+      return 2
+    }
+    const text = fs.existsSync(envFile) ? fs.readFileSync(envFile, 'utf8') : ''
+    const map = readComposeEnvMap(text)
+    if (!map.has(key)) {
+      console.error(`[opptrix] compose.env 中未找到 ${key}`)
+      return 1
+    }
+    console.log(maskEnvValue(key, map.get(key) ?? ''))
+    return 0
+  }
+
+  if (sub === 'set') {
+    if (!rest.length) {
+      console.error('[opptrix] 用法: opptrix env set KEY=VALUE [KEY2=VALUE2 …]')
+      return 2
+    }
+    const { entries, errors } = parseEnvSetTokens(rest)
+    if (errors.length) {
+      for (const err of errors) console.error(`[opptrix] ${err}`)
+      return 2
+    }
+    if (!Object.keys(entries).length) {
+      console.error('[opptrix] 未解析到任何 KEY=VALUE')
+      return 2
+    }
+    return applyComposeEnvChange(parsed, { set: entries })
+  }
+
+  if (sub === 'unset') {
+    if (!rest.length) {
+      console.error('[opptrix] 用法: opptrix env unset KEY [KEY2 …]')
+      return 2
+    }
+    const keys = rest.map(k => k.trim()).filter(Boolean)
+    for (const key of keys) {
+      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+        console.error(`[opptrix] 无效键名 "${key}"`)
+        return 2
+      }
+    }
+    return applyComposeEnvChange(parsed, { unset: keys })
+  }
+
+  console.error(`[opptrix] 未知 env 子命令: ${sub}`)
+  printEnvHelp()
+  return 2
 }
 
 /**
@@ -668,6 +840,8 @@ async function main() {
         const { root, mirror, releaseEnv } = prepareRoot(parsed, { needFullSource: false })
         return runCompose(['restart'], { root, mirror, releaseEnv })
       }
+      case 'env':
+        return await cmdEnv(parsed)
       case 'down': {
         const { root, mirror, releaseEnv } = prepareRoot(parsed, { needFullSource: false })
         const args = ['down']

--- a/packages/selfhost/src/compose-env.mjs
+++ b/packages/selfhost/src/compose-env.mjs
@@ -1,0 +1,234 @@
+/**
+ * Read/write compose.env while preserving comments and blank lines.
+ */
+import fs from 'node:fs'
+import path from 'node:path'
+import { composeEnvExamplePath, composeEnvPath, ensureComposeEnv } from './paths.mjs'
+
+const ENV_LINE_RE = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
+
+/** Keys that affect container paths — changing them without recreate can break mounts. */
+const PATH_ENV_KEYS = new Set([
+  'OPPTRIX_HOME',
+  'OPPTRIX_DATA_DIR',
+  'OPPTRIX_AGENT_WORKSPACE_DIR',
+  'OPPTRIX_MOUNTS_DIR',
+  'OPPTRIX_MODELS_DIR',
+  'OPPTRIX_SYSTEM_DIR',
+  'OPPTRIX_SEED_ROOT',
+  'OPPTRIX_LLM_DIR',
+  'UI_DIST_PATH',
+])
+
+/**
+ * @param {string} line
+ * @returns {{ key: string, rawValue: string } | null}
+ */
+export function parseEnvLine(line) {
+  const trimmed = line.trim()
+  if (!trimmed || trimmed.startsWith('#')) return null
+  const m = ENV_LINE_RE.exec(trimmed)
+  if (!m) return null
+  return { key: m[1], rawValue: m[2] }
+}
+
+/**
+ * @param {string} raw
+ * @returns {string}
+ */
+export function unquoteEnvValue(raw) {
+  const t = raw.trim()
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    return t.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+  }
+  if (t.length >= 2 && t.startsWith("'") && t.endsWith("'")) {
+    return t.slice(1, -1)
+  }
+  return t
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+export function quoteEnvValue(value) {
+  if (value === '') return '""'
+  if (/[\s#"'\\]/.test(value)) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+  return value
+}
+
+/**
+ * @param {string} content
+ * @returns {Map<string, string>}
+ */
+export function readComposeEnvMap(content) {
+  /** @type {Map<string, string>} */
+  const map = new Map()
+  for (const line of content.split('\n')) {
+    const parsed = parseEnvLine(line)
+    if (!parsed) continue
+    map.set(parsed.key, unquoteEnvValue(parsed.rawValue))
+  }
+  return map
+}
+
+/**
+ * @param {string[]} lines
+ * @param {{ set?: Record<string, string>, unset?: string[] }} patch
+ * @returns {string[]}
+ */
+export function patchComposeEnvLines(lines, patch) {
+  const set = patch.set ?? {}
+  const unsetSet = new Set(patch.unset ?? [])
+  /** @type {Record<string, string>} */
+  const pending = { ...set }
+  /** @type {string[]} */
+  const result = []
+
+  for (const line of lines) {
+    const parsed = parseEnvLine(line)
+    if (!parsed) {
+      result.push(line)
+      continue
+    }
+    if (unsetSet.has(parsed.key)) continue
+    if (Object.prototype.hasOwnProperty.call(pending, parsed.key)) {
+      result.push(`${parsed.key}=${quoteEnvValue(pending[parsed.key])}`)
+      delete pending[parsed.key]
+      continue
+    }
+    result.push(line)
+  }
+
+  for (const [key, value] of Object.entries(pending)) {
+    if (unsetSet.has(key)) continue
+    result.push(`${key}=${quoteEnvValue(value)}`)
+  }
+
+  return result
+}
+
+/**
+ * @param {string} filePath
+ * @param {{ set?: Record<string, string>, unset?: string[] }} patch
+ * @returns {{ path: string, changed: string[], removed: string[] }}
+ */
+export function writeComposeEnvPatch(filePath, patch) {
+  const set = patch.set ?? {}
+  const unset = patch.unset ?? []
+  const prev = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : ''
+  const lines = prev.length ? prev.split('\n') : []
+  const nextLines = patchComposeEnvLines(lines, { set, unset })
+  const normalized = nextLines.join('\n')
+  const body = normalized.endsWith('\n') || normalized === '' ? normalized : `${normalized}\n`
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, body, 'utf8')
+  return {
+    path: filePath,
+    changed: Object.keys(set),
+    removed: [...unset],
+  }
+}
+
+/**
+ * @param {string} key
+ * @returns {boolean}
+ */
+export function isSensitiveEnvKey(key) {
+  return /(?:^|_)(KEY|TOKEN|SECRET|PASSWORD)(?:_|$)/i.test(key)
+    || key === 'LLM_API_KEY'
+    || key === 'HF_TOKEN'
+}
+
+/**
+ * @param {string} key
+ * @param {string} value
+ * @returns {string}
+ */
+export function maskEnvValue(key, value) {
+  if (!isSensitiveEnvKey(key)) return value
+  if (!value) return '(empty)'
+  if (value.length <= 4) return '****'
+  return `${value.slice(0, 2)}…${value.slice(-2)} (${value.length} chars)`
+}
+
+/**
+ * @param {string} examplePath
+ * @returns {Set<string>}
+ */
+export function loadKnownEnvKeys(examplePath) {
+  /** @type {Set<string>} */
+  const keys = new Set()
+  if (!fs.existsSync(examplePath)) return keys
+  const text = fs.readFileSync(examplePath, 'utf8')
+  for (const line of text.split('\n')) {
+    const m = /^\s*#?\s*([A-Za-z_][A-Za-z0-9_]*)\s*=/.exec(line)
+    if (m) keys.add(m[1])
+  }
+  return keys
+}
+
+/**
+ * @param {string} key
+ * @param {Set<string>} known
+ * @returns {string | null}
+ */
+export function warnUnknownEnvKey(key, known) {
+  if (known.size === 0) return null
+  if (known.has(key)) return null
+  return `[opptrix] WARN: ${key} 不在 compose.env.example 中；请确认键名正确`
+}
+
+/**
+ * @param {string} key
+ * @returns {string | null}
+ */
+export function warnPathEnvKey(key) {
+  if (!PATH_ENV_KEYS.has(key)) return null
+  return `[opptrix] WARN: ${key} 影响容器内路径；修改后需重建容器，且勿与已有数据卷布局冲突`
+}
+
+/**
+ * Parse KEY=VALUE tokens from CLI args.
+ * @param {string[]} tokens
+ * @returns {{ entries: Record<string, string>, errors: string[] }}
+ */
+export function parseEnvSetTokens(tokens) {
+  /** @type {Record<string, string>} */
+  const entries = {}
+  /** @type {string[]} */
+  const errors = []
+  for (const token of tokens) {
+    const eq = token.indexOf('=')
+    if (eq <= 0) {
+      errors.push(`无效项 "${token}"；请使用 KEY=VALUE 形式`)
+      continue
+    }
+    const key = token.slice(0, eq).trim()
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+      errors.push(`无效键名 "${key}"`)
+      continue
+    }
+    entries[key] = token.slice(eq + 1)
+  }
+  return { entries, errors }
+}
+
+/**
+ * Ensure compose.env exists and return its path.
+ * @param {string} root
+ */
+export function resolveComposeEnvFile(root) {
+  ensureComposeEnv(root)
+  return composeEnvPath(root)
+}
+
+/**
+ * @param {string} root
+ * @returns {Set<string>}
+ */
+export function knownEnvKeysForRoot(root) {
+  return loadKnownEnvKeys(composeEnvExamplePath(root))
+}

--- a/tests/opptrix-cli.test.mjs
+++ b/tests/opptrix-cli.test.mjs
@@ -3,6 +3,8 @@
  */
 import test from 'node:test'
 import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
 import { spawnSync } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -114,8 +116,28 @@ test('opptrix help exits 0 and lists commands', () => {
   assert.match(r.stdout, /--mirror/)
   assert.match(r.stdout, /\btags\b/)
   assert.match(r.stdout, /\buse\b/)
+  assert.match(r.stdout, /\benv\b/)
   assert.match(r.stdout, /opptrix-selfhost-v/)
   assert.match(r.stdout, /--ref/)
+})
+
+test('opptrix env set --no-restart writes compose.env in deploy dir', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-cli-env-'))
+  const r = spawnSync(process.execPath, [
+    CLI,
+    'env',
+    'set',
+    'OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS=6',
+    '--no-restart',
+  ], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, OPPTRIX_DEPLOY_DIR: dir },
+  })
+  assert.equal(r.status, 0, r.stderr || r.stdout)
+  assert.match(r.stdout, /compose\.env 已更新/)
+  const envText = fs.readFileSync(path.join(dir, 'compose.env'), 'utf8')
+  assert.match(envText, /OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS=6/)
 })
 
 test('opptrix doctor reports platform without requiring healthy docker', () => {

--- a/tests/selfhost-compose-env.test.mjs
+++ b/tests/selfhost-compose-env.test.mjs
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  isSensitiveEnvKey,
+  maskEnvValue,
+  parseEnvLine,
+  parseEnvSetTokens,
+  patchComposeEnvLines,
+  quoteEnvValue,
+  readComposeEnvMap,
+  unquoteEnvValue,
+  writeComposeEnvPatch,
+} from '../packages/selfhost/src/compose-env.mjs'
+
+test('parseEnvLine and quoting', () => {
+  assert.deepEqual(parseEnvLine('FOO=bar'), { key: 'FOO', rawValue: 'bar' })
+  assert.deepEqual(parseEnvLine('export BAZ=1'), { key: 'BAZ', rawValue: '1' })
+  assert.equal(parseEnvLine('# comment'), null)
+
+  assert.equal(unquoteEnvValue('"a b"'), 'a b')
+  assert.equal(unquoteEnvValue("'x'"), 'x')
+  assert.equal(quoteEnvValue('plain'), 'plain')
+  assert.equal(quoteEnvValue('has space'), '"has space"')
+})
+
+test('patchComposeEnvLines preserves comments and upserts keys', () => {
+  const input = [
+    '# header',
+    'KEEP=1',
+    'CHANGE=old',
+    '',
+    '# tail',
+  ]
+  const out = patchComposeEnvLines(input, {
+    set: { CHANGE: 'new', ADD: 'yes' },
+    unset: ['MISSING'],
+  })
+  assert.deepEqual(out, [
+    '# header',
+    'KEEP=1',
+    'CHANGE=new',
+    '',
+    '# tail',
+    'ADD=yes',
+  ])
+  const map = readComposeEnvMap(out.join('\n'))
+  assert.equal(map.get('CHANGE'), 'new')
+  assert.equal(map.get('ADD'), 'yes')
+})
+
+test('writeComposeEnvPatch round-trips on disk', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opptrix-env-'))
+  const file = path.join(dir, 'compose.env')
+  fs.writeFileSync(file, 'A=1\n# note\nB=two\n', 'utf8')
+  writeComposeEnvPatch(file, { set: { B: 'updated', C: 'three' }, unset: [] })
+  const text = fs.readFileSync(file, 'utf8')
+  assert.match(text, /^A=1/m)
+  assert.match(text, /# note/)
+  assert.match(text, /^B=updated/m)
+  assert.match(text, /^C=three/m)
+})
+
+test('parseEnvSetTokens validates KEY=VALUE', () => {
+  const ok = parseEnvSetTokens(['FOO=bar', 'NUM=42'])
+  assert.deepEqual(ok.entries, { FOO: 'bar', NUM: '42' })
+  assert.deepEqual(ok.errors, [])
+
+  const bad = parseEnvSetTokens(['nope', '1bad=x'])
+  assert.deepEqual(bad.entries, {})
+  assert.equal(bad.errors.length, 2)
+})
+
+test('maskEnvValue hides secrets', () => {
+  assert.equal(isSensitiveEnvKey('LLM_API_KEY'), true)
+  assert.equal(isSensitiveEnvKey('OPPTRIX_UPDATE_CHECK_INTERVAL_HOURS'), false)
+  assert.match(maskEnvValue('LLM_API_KEY', 'sk-abcdefghij'), /^sk…/)
+})


### PR DESCRIPTION
## Summary
- Add `opptrix env set/get/list/unset` to manage `compose.env` while preserving comments.
- Default after set/unset: `docker compose up -d` so env_file changes take effect (not restart).
- Mask sensitive values in output; warn on unknown keys and path-related variables.
- Add unit + CLI integration tests; document in selfhost README.

## Test plan
- [x] `node --test tests/selfhost-compose-env.test.mjs tests/opptrix-cli.test.mjs`


Made with [Cursor](https://cursor.com)