### PR TITLE
feat(client-ui): login polish, PWA install, settings back row

### DIFF
--- a/client-ui/public/manifest.webmanifest
+++ b/client-ui/public/manifest.webmanifest
@@ -14,6 +14,13 @@
   "orientation": "any",
   "categories": ["finance", "productivity"],
   "prefer_related_applications": false,
+  "related_applications": [
+    {
+      "platform": "webapp",
+      "url": "/manifest.webmanifest",
+      "id": "/"
+    }
+  ],
   "icons": [
     {
       "src": "/icons/icon-192.png",

--- a/client-ui/src/App.tsx
+++ b/client-ui/src/App.tsx
@@ -2,6 +2,7 @@ import { AuthGate } from './auth/AuthGate'
 import ChatApp from './chat/ChatApp'
 import WindowFrameTitleBar from './desktop/WindowFrameTitleBar'
 import { OnboardingGate } from './onboarding/OnboardingWizard'
+import PwaInstallBanner from './pwa/PwaInstallBanner'
 import SystemUpdateHost from './system-update/SystemUpdateHost'
 
 export default function App() {
@@ -9,6 +10,7 @@ export default function App() {
     <>
       <WindowFrameTitleBar />
       <SystemUpdateHost />
+      <PwaInstallBanner />
       <AuthGate>
         <OnboardingGate>
           <ChatApp />

--- a/client-ui/src/auth/LoginView.tsx
+++ b/client-ui/src/auth/LoginView.tsx
@@ -1,13 +1,16 @@
-import { useCallback, useState, type FormEvent, type ReactNode } from 'react'
-import { Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
+import { useCallback, useEffect, useRef, useState, type CSSProperties, type FormEvent, type ReactNode } from 'react'
+import { Checkbox, Spinner, Text, makeStyles, mergeClasses } from '@fluentui/react-components'
 import { loginWithPassword, loginWithTotp } from '../api/auth'
 import OpptrixButton from '../components/opptrix/OpptrixButton'
 import MacTrafficLights from '../desktop/MacTrafficLights'
 import { desktopFrameTitlebarHeight } from '../desktop/layout'
 import { useElectronFullscreen } from '../hooks/useElectronFullscreen'
+import { OnboardingAtmosphere } from '../onboarding/OnboardingAtmosphere'
+import { OnboardingInlineLink, useOnboardingShellStyles } from '../onboarding/OnboardingShell'
+import { OPPTRIX_USER_AGREEMENT } from '../pages/settings/aboutLinks'
+import { openExternalUrl } from '../platform/openUrl'
 import { electronPlatform, isElectron } from '../platform/detect'
 import { opptrixCssVars } from '../theme/tokens'
-import { useOnboardingShellStyles } from '../onboarding/OnboardingShell'
 import {
   AuthCodeField,
   AuthFieldStack,
@@ -19,6 +22,7 @@ import { formatAuthError } from './authErrors'
 /** Electron shell chrome shared by login / loading / error (mac drag + traffic lights). */
 function AuthWindowShell({ children }: { children: ReactNode }) {
   const shell = useOnboardingShellStyles()
+  const shellRef = useRef<HTMLDivElement>(null)
   const macFullscreen = useElectronFullscreen()
   const electronChrome = isElectron()
   const electronWin = electronChrome && electronPlatform() !== 'darwin'
@@ -28,12 +32,15 @@ function AuthWindowShell({ children }: { children: ReactNode }) {
 
   return (
     <div
+      ref={shellRef}
       className={mergeClasses(
         shell.root,
         electronWin && shell.rootFrameTitlebar,
         'opptrix-onboarding-shell',
       )}
+      style={{ '--onb-dx': '0', '--onb-dy': '0' } as CSSProperties}
     >
+      <OnboardingAtmosphere hostRef={shellRef} />
       {showTitleBar ? (
         <header
           className={mergeClasses(
@@ -84,6 +91,34 @@ const useStyles = makeStyles({
     color: opptrixCssVars.textSecondary,
     lineHeight: 1.5,
   },
+  agreeRow: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: '8px',
+    marginTop: '14px',
+    padding: '10px 12px',
+    textAlign: 'left',
+    lineHeight: 1.4,
+    borderRadius: '10px',
+    border: `1px solid ${opptrixCssVars.borderStrong}`,
+    backgroundColor: opptrixCssVars.surface,
+    boxSizing: 'border-box',
+    cursor: 'pointer',
+    '& .fui-Checkbox': {
+      margin: 0,
+      flexShrink: 0,
+    },
+    '& .fui-Checkbox__indicator': {
+      margin: 0,
+    },
+  },
+  agreeText: {
+    display: 'inline',
+    fontSize: 'var(--opptrix-font-base)',
+    color: opptrixCssVars.textPrimary,
+    lineHeight: 1.45,
+  },
   actions: {
     marginTop: '16px',
     display: 'flex',
@@ -112,10 +147,15 @@ export function LoginView({ onSuccess }: { onSuccess: () => void }) {
   const [ticket, setTicket] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState('')
+  const [agreed, setAgreed] = useState(false)
 
   const totpStep = ticket != null
 
   const submitPassword = useCallback(async () => {
+    if (!agreed) {
+      setError('请先阅读并同意用户协议')
+      return
+    }
     if (!username.trim() || !password) {
       setError('请填写用户名和密码')
       return
@@ -139,7 +179,7 @@ export function LoginView({ onSuccess }: { onSuccess: () => void }) {
     } finally {
       setBusy(false)
     }
-  }, [username, password, onSuccess])
+  }, [agreed, username, password, onSuccess])
 
   const submitTotp = useCallback(async () => {
     if (!ticket) return
@@ -213,6 +253,25 @@ export function LoginView({ onSuccess }: { onSuccess: () => void }) {
                     />
                   )}
                 </AuthFieldStack>
+                {!totpStep && (
+                  <label className={s.agreeRow}>
+                    <Checkbox
+                      checked={agreed}
+                      onChange={(_, data) => setAgreed(Boolean(data.checked))}
+                      disabled={busy}
+                      aria-label="同意用户协议"
+                    />
+                    <Text className={s.agreeText}>
+                      我已阅读并同意
+                      {' '}
+                      <OnboardingInlineLink
+                        onClick={() => openExternalUrl(OPPTRIX_USER_AGREEMENT)}
+                      >
+                        《用户协议》
+                      </OnboardingInlineLink>
+                    </Text>
+                  </label>
+                )}
                 {error ? (
                   <Text className={shell.error} block role="alert">{error}</Text>
                 ) : null}
@@ -239,7 +298,7 @@ export function LoginView({ onSuccess }: { onSuccess: () => void }) {
                   <OpptrixButton
                     variant="primary"
                     type="submit"
-                    disabled={busy}
+                    disabled={busy || (!totpStep && !agreed)}
                   >
                     {busy ? '正在验证…' : totpStep ? '继续' : '登录'}
                   </OpptrixButton>

--- a/client-ui/src/hooks/usePwaInstall.ts
+++ b/client-ui/src/hooks/usePwaInstall.ts
@@ -1,59 +1,230 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { isElectron } from '../platform/detect'
+import {
+  classifyPwaClient,
+  resolvePwaInstallMode,
+  type PwaInstallMode,
+} from '../pwa/pwaInstallDetect'
+import {
+  bootstrapPwaInstallCapture,
+  clearCapturedInstallPrompt,
+  getCapturedInstallPrompt,
+  subscribeInstallPrompt,
+  waitForInstallPrompt,
+  type BeforeInstallPromptEvent,
+} from '../pwa/pwaInstallCapture'
 
-/** Chromium `beforeinstallprompt` event (not in lib.dom yet for all targets). */
-export type BeforeInstallPromptEvent = Event & {
-  prompt: () => Promise<void>
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+export type { BeforeInstallPromptEvent, PwaInstallMode }
+export type PwaInstallOutcome = 'accepted' | 'dismissed' | 'failed' | 'manual_seen'
+
+/** Bump when prompt UX changes so prior dismissals don't hide a fixed banner forever. */
+const STORAGE_KEY = 'opptrix-pwa-install-interaction-v3'
+
+type StoredInteraction = {
+  outcome: PwaInstallOutcome
+  at: number
+}
+
+type RelatedApp = {
+  platform: string
+  id?: string
+  url?: string
 }
 
 function isStandaloneDisplay(): boolean {
   if (typeof window === 'undefined') return false
   if (window.matchMedia('(display-mode: standalone)').matches) return true
+  if (window.matchMedia('(display-mode: minimal-ui)').matches) return true
   const nav = window.navigator as Navigator & { standalone?: boolean }
   return nav.standalone === true
 }
 
+function readInteraction(): StoredInteraction | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredInteraction
+    if (!parsed || typeof parsed.at !== 'number' || !parsed.outcome) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeInteraction(outcome: PwaInstallOutcome): void {
+  try {
+    const payload: StoredInteraction = { outcome, at: Date.now() }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+  } catch {
+    /* private mode / quota */
+  }
+}
+
+async function queryRelatedWebAppInstalled(): Promise<boolean> {
+  const nav = navigator as Navigator & {
+    getInstalledRelatedApps?: () => Promise<RelatedApp[]>
+  }
+  if (typeof nav.getInstalledRelatedApps !== 'function') return false
+  try {
+    const apps = await nav.getInstalledRelatedApps()
+    return apps.some((app) => app.platform === 'webapp')
+  } catch {
+    return false
+  }
+}
+
+function readClientFlags() {
+  if (typeof navigator === 'undefined') {
+    return classifyPwaClient('')
+  }
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } }
+  return classifyPwaClient(navigator.userAgent, {
+    platform: navigator.platform,
+    maxTouchPoints: navigator.maxTouchPoints,
+    uaPlatform: nav.userAgentData?.platform,
+  })
+}
+
 /**
- * Chrome / Edge：捕获安装提示，供设置页「安装到桌面」。
- * Safari / iOS：无 beforeinstallprompt，由 UI 引导「添加到主屏幕」。
+ * Chrome / Edge：优先用系统安装窗（beforeinstallprompt）。
+ * 已安装或探测后仍无安装事件 → 静默。
+ * Safari / Firefox / 等：分浏览器步骤引导。
  */
 export function usePwaInstall() {
-  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null)
+  const flags = useMemo(() => readClientFlags(), [])
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(() => (
+    isElectron() ? null : getCapturedInstallPrompt()
+  ))
   const [installed, setInstalled] = useState(() => isStandaloneDisplay())
+  const [interacted, setInteracted] = useState(() => readInteraction() != null)
+  const [probeReady, setProbeReady] = useState(() => Boolean(getCapturedInstallPrompt()))
 
   useEffect(() => {
-    if (isElectron()) return
+    if (isElectron()) {
+      setProbeReady(true)
+      return
+    }
 
-    const onBip = (e: Event) => {
-      e.preventDefault()
-      setDeferred(e as BeforeInstallPromptEvent)
-    }
-    const onInstalled = () => {
-      setDeferred(null)
+    bootstrapPwaInstallCapture()
+
+    const unsub = subscribeInstallPrompt((event) => {
+      setDeferred(event)
+      if (event) setProbeReady(true)
+    })
+
+    const timer = window.setTimeout(() => setProbeReady(true), 2000)
+
+    void queryRelatedWebAppInstalled().then((relatedInstalled) => {
+      if (!relatedInstalled) return
       setInstalled(true)
-    }
-    window.addEventListener('beforeinstallprompt', onBip)
-    window.addEventListener('appinstalled', onInstalled)
+      writeInteraction('accepted')
+      setInteracted(true)
+    })
+
     return () => {
-      window.removeEventListener('beforeinstallprompt', onBip)
-      window.removeEventListener('appinstalled', onInstalled)
+      unsub()
+      window.clearTimeout(timer)
     }
   }, [])
 
-  const promptInstall = useCallback(async (): Promise<boolean> => {
-    if (!deferred) return false
-    await deferred.prompt()
-    const { outcome } = await deferred.userChoice
-    setDeferred(null)
-    if (outcome === 'accepted') setInstalled(true)
-    return outcome === 'accepted'
-  }, [deferred])
+  useEffect(() => {
+    if (isElectron()) return
+    const onInstalled = () => {
+      clearCapturedInstallPrompt()
+      setDeferred(null)
+      setInstalled(true)
+      writeInteraction('accepted')
+      setInteracted(true)
+    }
+    window.addEventListener('appinstalled', onInstalled)
+    return () => window.removeEventListener('appinstalled', onInstalled)
+  }, [])
+
+  const markInteracted = useCallback((outcome: PwaInstallOutcome) => {
+    writeInteraction(outcome)
+    setInteracted(true)
+  }, [])
+
+  const promptInstall = useCallback(async (): Promise<'accepted' | 'dismissed' | 'unavailable'> => {
+    let event = deferred ?? getCapturedInstallPrompt()
+    if (!event && flags.isChromium) {
+      event = await waitForInstallPrompt(2800)
+      if (event) setDeferred(event)
+    }
+    if (!event) return 'unavailable'
+
+    try {
+      await event.prompt()
+      const { outcome } = await event.userChoice
+      clearCapturedInstallPrompt()
+      setDeferred(null)
+      if (outcome === 'accepted') {
+        setInstalled(true)
+        markInteracted('accepted')
+        return 'accepted'
+      }
+      markInteracted('dismissed')
+      return 'dismissed'
+    } catch {
+      clearCapturedInstallPrompt()
+      setDeferred(null)
+      markInteracted('failed')
+      return 'unavailable'
+    }
+  }, [deferred, flags.isChromium, markInteracted])
+
+  const dismissPrompt = useCallback(() => {
+    markInteracted('dismissed')
+  }, [markInteracted])
+
+  const acknowledgeManual = useCallback(() => {
+    markInteracted('manual_seen')
+  }, [markInteracted])
+
+  const likelyInstalled = flags.isChromium && probeReady && deferred == null && !installed
+
+  const mode: PwaInstallMode = useMemo(() => resolvePwaInstallMode({
+    isElectron: isElectron(),
+    installed,
+    interacted,
+    likelyInstalled,
+    probeReady,
+    hasDeferred: deferred != null,
+    isSafari: flags.isSafari,
+    isIos: flags.isIos,
+    isAndroid: flags.isAndroid,
+    isFirefox: flags.isFirefox,
+  }), [
+    deferred,
+    flags.isAndroid,
+    flags.isFirefox,
+    flags.isIos,
+    flags.isSafari,
+    installed,
+    interacted,
+    likelyInstalled,
+    probeReady,
+  ])
+
+  const canPrompt = deferred != null && !installed && !interacted && !likelyInstalled
+  const showBanner = mode === 'native' || mode === 'manual'
+  const isInstalledEffective = installed || (likelyInstalled && !interacted)
 
   return {
-    /** Chromium 已抛出可安装事件且尚未装成独立应用 */
-    canPrompt: deferred != null && !installed,
-    isInstalled: installed,
+    canPrompt,
+    isInstalled: isInstalledEffective,
+    hasInteracted: interacted,
+    mode,
+    showBanner,
+    isIos: flags.isIos,
+    isAndroid: flags.isAndroid,
+    isFirefox: flags.isFirefox,
+    isChromium: flags.isChromium,
+    isEdge: flags.isEdge,
+    isSafari: flags.isSafari,
+    isWindows: flags.isWindows,
     promptInstall,
+    dismissPrompt,
+    acknowledgeManual,
   }
 }

--- a/client-ui/src/main.tsx
+++ b/client-ui/src/main.tsx
@@ -13,19 +13,16 @@ import { ThemeProvider, useTheme } from './theme/ThemeContext'
 import { isDesktopApp, isElectron } from './platform/detect'
 import { applyFontFamily, readFontFamilyPreference } from './theme/fontFamily'
 import { applyFontScale, readFontScalePreference } from './theme/fontScale'
+import { bootstrapPwaInstallCapture } from './pwa/pwaInstallCapture'
 import './styles/fonts.css'
 import './styles/global.css'
 
 applyFontFamily(readFontFamilyPreference())
 applyFontScale(readFontScalePreference())
 
-/** Web PWA：生产环境注册最小 Service Worker（无 Push）；Electron 不注册 */
-if (!isElectron() && import.meta.env.PROD && 'serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    void navigator.serviceWorker.register('/sw.js').catch(() => {
-      /* installability best-effort */
-    })
-  })
+/** Capture BIP + register SW before React mounts (Chrome fires early). */
+if (!isElectron()) {
+  bootstrapPwaInstallCapture()
 }
 
 if (isDesktopApp()) {

--- a/client-ui/src/onboarding/OnboardingShell.tsx
+++ b/client-ui/src/onboarding/OnboardingShell.tsx
@@ -590,7 +590,11 @@ export function OnboardingInlineLink({
     <button
       type="button"
       className={mergeClasses(s.inlineLink, className)}
-      onClick={onClick}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onClick()
+      }}
     >
       {children}
     </button>

--- a/client-ui/src/pages/settings/PwaInstallSettingsSection.tsx
+++ b/client-ui/src/pages/settings/PwaInstallSettingsSection.tsx
@@ -2,27 +2,52 @@ import { useState } from 'react'
 import OpptrixButton from '../../components/opptrix/OpptrixButton'
 import { usePwaInstall } from '../../hooks/usePwaInstall'
 import { isElectron } from '../../platform/detect'
+import { resolvePwaInstallGuide } from '../../pwa/pwaInstallGuides'
 import { SettingsGroup, SettingsRow, SettingsSectionLabel } from './SettingsPrimitives'
 import { useSettingsToast } from './SettingsToast'
 
 /**
- * Web 端：Chrome 一键安装到桌面；Safari / iOS 引导「添加到主屏幕」。
+ * Web 端：Chrome / Edge 一键安装；其余浏览器按分端步骤引导。
  * Electron 壳不展示。
  */
 export default function PwaInstallSettingsSection() {
   const toast = useSettingsToast()
-  const { canPrompt, isInstalled, promptInstall } = usePwaInstall()
+  const {
+    canPrompt,
+    isInstalled,
+    promptInstall,
+    mode,
+    isIos,
+    isSafari,
+    isAndroid,
+    isFirefox,
+    isEdge,
+    isChromium,
+    isWindows,
+  } = usePwaInstall()
   const [busy, setBusy] = useState(false)
 
   if (isElectron()) return null
 
+  const guide = resolvePwaInstallGuide({
+    isIos,
+    isSafari,
+    isAndroid,
+    isFirefox,
+    isEdge,
+    isChromium,
+    isWindows,
+  })
+
   const handleInstall = async () => {
     setBusy(true)
     try {
-      const ok = await promptInstall()
-      if (ok) toast.showSuccess('已添加到桌面')
+      const result = await promptInstall()
+      if (result === 'accepted') toast.showSuccess('已添加到桌面')
+      else if (result === 'dismissed') toast.showError('未完成安装，可稍后在浏览器菜单中重试')
+      else toast.showError('暂时无法完成安装，请按浏览器内的安装步骤操作')
     } catch {
-      toast.showError('暂时无法完成安装，请稍后重试，或使用浏览器菜单添加')
+      toast.showError('暂时无法完成安装，请稍后重试，或按浏览器内的安装步骤操作')
     } finally {
       setBusy(false)
     }
@@ -35,7 +60,7 @@ export default function PwaInstallSettingsSection() {
         <SettingsGroup>
           <SettingsRow
             title="桌面应用"
-            desc="已从浏览器安装到本机，可从桌面或程序坞直接打开"
+            desc="本机已安装，请从桌面或程序坞打开，获得独立窗口体验"
             last
           />
         </SettingsGroup>
@@ -43,14 +68,16 @@ export default function PwaInstallSettingsSection() {
     )
   }
 
-  if (canPrompt) {
+  if (canPrompt || mode === 'native') {
     return (
       <div>
         <SettingsSectionLabel spaced>本机应用</SettingsSectionLabel>
         <SettingsGroup>
           <SettingsRow
             title="安装到桌面"
-            desc="安装后可从桌面或程序坞打开，独立窗口使用"
+            desc={isEdge
+              ? '使用 Edge 安装后，可从桌面或任务栏以独立窗口打开'
+              : '安装后可从桌面或程序坞打开，独立窗口使用'}
             control={(
               <OpptrixButton
                 variant="secondary"
@@ -73,8 +100,8 @@ export default function PwaInstallSettingsSection() {
       <SettingsSectionLabel spaced>本机应用</SettingsSectionLabel>
       <SettingsGroup>
         <SettingsRow
-          title="添加到主屏幕"
-          desc="在浏览器菜单中选择「添加到主屏幕」或「安装应用」，即可像本地应用一样打开"
+          title={guide.title}
+          desc={guide.meta}
           last
         />
       </SettingsGroup>

--- a/client-ui/src/pages/settings/SettingsBackRow.tsx
+++ b/client-ui/src/pages/settings/SettingsBackRow.tsx
@@ -1,32 +1,114 @@
 import { ArrowLeftRegular } from '@fluentui/react-icons'
 import { makeStyles, mergeClasses } from '@fluentui/react-components'
-import { SIDEBAR_TOP_MENU_ICON_SIZE, sidebarTopMenuIcon, sidebarTopMenuRow, ghostInteractive } from '../../theme/mixins'
+import { SIDEBAR_TOP_MENU_ICON_SIZE, sidebarTopMenuIcon, motion } from '../../theme/mixins'
 import {
   MOBILE_HEADER_ICON_SIZE,
   mobileHeaderBar,
 } from '../../theme/mobileChrome'
+import { DESKTOP_PAGE_HEADER_HEIGHT } from '../../theme/desktopPageChrome'
 import { opptrixCssVars } from '../../theme/tokens'
 
 const useStyles = makeStyles({
-  row: sidebarTopMenuRow,
-  icon: sidebarTopMenuIcon,
+  /**
+   * Full-bleed header hit target — same height as SessionSidebar brand row.
+   * Default blends with sidebar; hover/focus paints the whole strip (not an inner chip).
+   */
+  row: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '10px',
+    flexShrink: 0,
+    width: '100%',
+    height: `${DESKTOP_PAGE_HEADER_HEIGHT}px`,
+    minHeight: `${DESKTOP_PAGE_HEADER_HEIGHT}px`,
+    boxSizing: 'border-box',
+    margin: 0,
+    padding: '0 20px',
+    border: 'none',
+    borderRadius: 0,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+    backgroundColor: 'transparent',
+    color: opptrixCssVars.textPrimary,
+    fontSize: '13px',
+    fontWeight: 500,
+    textAlign: 'left',
+    cursor: 'pointer',
+    transitionProperty: 'background-color, font-weight, color',
+    transitionDuration: motion.fast,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      fontWeight: 650,
+    },
+    ':active': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      fontWeight: 700,
+    },
+    ':focus': {
+      outline: 'none',
+    },
+    ':focus-visible': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      fontWeight: 650,
+      outline: 'none',
+      boxShadow: `inset 0 0 0 1px ${opptrixCssVars.accent}`,
+    },
+  },
+  label: {
+    transitionProperty: 'font-weight',
+    transitionDuration: motion.fast,
+  },
+  icon: {
+    ...sidebarTopMenuIcon,
+    transitionProperty: 'color',
+    transitionDuration: motion.fast,
+  },
+  rowHoverIcon: {
+    ':hover .opptrix-settings-back-icon': {
+      color: opptrixCssVars.textPrimary,
+    },
+    ':focus-visible .opptrix-settings-back-icon': {
+      color: opptrixCssVars.textPrimary,
+    },
+  },
   rowMobile: {
     ...mobileHeaderBar,
-    ...ghostInteractive,
-    width: '100%',
-    margin: 0,
+    display: 'flex',
+    alignItems: 'center',
     justifyContent: 'flex-start',
     gap: '10px',
+    width: '100%',
+    margin: 0,
+    border: 'none',
+    borderRadius: 0,
+    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
+    backgroundColor: 'transparent',
     color: opptrixCssVars.textPrimary,
     fontSize: 'var(--opptrix-font-2xl)',
     fontWeight: 600,
     textAlign: 'left',
-    borderBottom: `1px solid ${opptrixCssVars.separatorHairline}`,
-    borderRadius: 0,
-    backgroundColor: opptrixCssVars.canvas,
+    cursor: 'pointer',
+    transitionProperty: 'background-color, font-weight, color',
+    transitionDuration: motion.fast,
+    ':hover': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      fontWeight: 700,
+    },
+    ':active': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      fontWeight: 700,
+    },
+    ':focus': {
+      outline: 'none',
+    },
+    ':focus-visible': {
+      backgroundColor: opptrixCssVars.surfaceHover,
+      fontWeight: 700,
+      outline: 'none',
+      boxShadow: `inset 0 0 0 1px ${opptrixCssVars.accent}`,
+    },
   },
   iconMobile: {
-    color: opptrixCssVars.textPrimary,
+    color: opptrixCssVars.textSecondary,
     flexShrink: 0,
   },
 })
@@ -40,17 +122,33 @@ interface Props {
 
 export default function SettingsBackRow({ onClick, className, mobile = false }: Props) {
   const s = useStyles()
+  if (mobile) {
+    return (
+      <button
+        type="button"
+        className={mergeClasses(s.rowMobile, s.rowHoverIcon, 'opptrix-focusable', className)}
+        onClick={onClick}
+      >
+        <ArrowLeftRegular
+          className={mergeClasses(s.iconMobile, 'opptrix-settings-back-icon')}
+          fontSize={MOBILE_HEADER_ICON_SIZE}
+        />
+        <span className={s.label}>返回应用</span>
+      </button>
+    )
+  }
+
   return (
     <button
       type="button"
-      className={mergeClasses(mobile ? s.rowMobile : s.row, 'opptrix-focusable', className)}
+      className={mergeClasses(s.row, s.rowHoverIcon, 'opptrix-focusable', className)}
       onClick={onClick}
     >
       <ArrowLeftRegular
-        className={mobile ? s.iconMobile : s.icon}
-        fontSize={mobile ? MOBILE_HEADER_ICON_SIZE : SIDEBAR_TOP_MENU_ICON_SIZE}
+        className={mergeClasses(s.icon, 'opptrix-settings-back-icon')}
+        fontSize={SIDEBAR_TOP_MENU_ICON_SIZE}
       />
-      <span>返回应用</span>
+      <span className={s.label}>返回应用</span>
     </button>
   )
 }

--- a/client-ui/src/pages/settings/aboutLinks.ts
+++ b/client-ui/src/pages/settings/aboutLinks.ts
@@ -3,10 +3,10 @@ export const OPPTRIX_WEBSITE = 'https://www.opptrix.org'
 /** Opptrix 量化投研交流社区（Discourse） */
 export const OPPTRIX_COMMUNITY = 'https://opptrix.net/'
 export const OPPTRIX_COMMUNITY_INVITE_CODE = 'A8SA8'
-/** 外链打开（关于页等） */
-export const OPPTRIX_USER_AGREEMENT = 'https://www.opptrix.org/user-agreement.html'
+/** 外链打开（关于页、登录同意等）— 与官网 legal 路由一致 */
+export const OPPTRIX_USER_AGREEMENT = 'https://opptrix.org/legal/user-agreement'
 /** 引导内嵌 iframe — 与站点路由一致 */
-export const OPPTRIX_USER_AGREEMENT_EMBED = 'https://www.opptrix.org/user-agreement'
+export const OPPTRIX_USER_AGREEMENT_EMBED = 'https://opptrix.org/legal/user-agreement'
 export const OPPTRIX_PRIVACY_POLICY = 'https://www.opptrix.org/privacy-policy.html'
 export const OPPTRIX_DISCLAIMER = 'https://opptrix.org/legal/disclaimer'
 

--- a/client-ui/src/pwa/PwaInstallBanner.tsx
+++ b/client-ui/src/pwa/PwaInstallBanner.tsx
@@ -1,0 +1,444 @@
+import { useCallback, useState } from 'react'
+import {
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  Text,
+  makeStyles,
+  mergeClasses,
+} from '@fluentui/react-components'
+import { DismissRegular } from '@fluentui/react-icons'
+import OpptrixButton from '../components/opptrix/OpptrixButton'
+import { usePwaInstall } from '../hooks/usePwaInstall'
+import { isElectron } from '../platform/detect'
+import { resolvePwaInstallGuide, type PwaInstallGuide } from './pwaInstallGuides'
+import { glassPanel } from '../theme/mixins'
+import { opptrixCssVars, opptrixTokens } from '../theme/tokens'
+
+const ICON_SRC = '/icons/icon-192.png'
+
+const useStyles = makeStyles({
+  wrap: {
+    position: 'fixed',
+    top: '12px',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: 4100,
+    width: 'min(440px, calc(100vw - 24px))',
+    pointerEvents: 'none',
+  },
+  card: {
+    ...glassPanel,
+    pointerEvents: 'auto',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '10px',
+    padding: '12px 14px',
+    borderRadius: opptrixTokens.radiusLg,
+    border: `1px solid ${opptrixCssVars.separator}`,
+    boxShadow: '0 8px 28px rgba(0, 0, 0, 0.08)',
+  },
+  row: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '10px',
+  },
+  logo: {
+    width: '36px',
+    height: '36px',
+    borderRadius: opptrixTokens.radiusMd,
+    flexShrink: 0,
+    objectFit: 'cover',
+    backgroundColor: opptrixCssVars.canvas,
+  },
+  body: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '4px',
+  },
+  title: {
+    fontSize: 'var(--opptrix-font-base)',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    color: opptrixCssVars.textPrimary,
+    lineHeight: 1.35,
+  },
+  meta: {
+    fontSize: 'var(--opptrix-font-md)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.45,
+  },
+  dismiss: {
+    flexShrink: 0,
+    minWidth: '28px',
+    width: '28px',
+    height: '28px',
+    padding: 0,
+    marginTop: '-2px',
+    marginRight: '-4px',
+    color: opptrixCssVars.textTertiary,
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: '10px',
+  },
+  later: {
+    minHeight: '28px',
+    height: '28px',
+    padding: '0 6px',
+    fontSize: 'var(--opptrix-font-md)',
+    fontWeight: 500,
+    color: opptrixCssVars.textTertiary,
+  },
+  primary: {
+    minHeight: '28px',
+    height: '28px',
+    padding: '0 12px',
+    fontSize: 'var(--opptrix-font-md)',
+    fontWeight: 600,
+  },
+  feedback: {
+    fontSize: 'var(--opptrix-font-md)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.45,
+  },
+  surface: {
+    width: 'min(420px, calc(100vw - 32px))',
+    maxWidth: '420px',
+  },
+  lead: {
+    fontSize: 'var(--opptrix-font-base)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.55,
+    marginBottom: '10px',
+  },
+  tip: {
+    fontSize: 'var(--opptrix-font-md)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.5,
+    padding: '8px 10px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.accentSoft,
+    border: `1px solid ${opptrixCssVars.separator}`,
+    marginBottom: '12px',
+  },
+  stepList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    margin: 0,
+    padding: 0,
+    listStyle: 'none',
+  },
+  stepCard: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: '10px',
+    padding: '10px 12px',
+    borderRadius: opptrixTokens.radiusMd,
+    backgroundColor: opptrixCssVars.canvasAlt,
+    border: `1px solid ${opptrixCssVars.separator}`,
+  },
+  stepNum: {
+    flexShrink: 0,
+    width: '22px',
+    height: '22px',
+    borderRadius: '999px',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: '12px',
+    fontWeight: 650,
+    color: opptrixCssVars.accent,
+    backgroundColor: opptrixCssVars.surface,
+    border: `1px solid ${opptrixCssVars.separator}`,
+    lineHeight: 1,
+    marginTop: '1px',
+  },
+  stepText: {
+    flex: 1,
+    minWidth: 0,
+    fontSize: 'var(--opptrix-font-base)',
+    color: opptrixCssVars.textSecondary,
+    lineHeight: 1.5,
+  },
+  altLabel: {
+    marginTop: '14px',
+    marginBottom: '8px',
+    fontSize: 'var(--opptrix-font-md)',
+    fontWeight: 600,
+    color: opptrixCssVars.textTertiary,
+    letterSpacing: '0.01em',
+  },
+  altList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '6px',
+    margin: 0,
+    padding: '0 0 0 1.15em',
+    fontSize: 'var(--opptrix-font-md)',
+    color: opptrixCssVars.textTertiary,
+    lineHeight: 1.5,
+  },
+})
+
+function GuideSteps({ guide, styles }: { guide: PwaInstallGuide; styles: ReturnType<typeof useStyles> }) {
+  return (
+    <>
+      <Text className={styles.lead} block>
+        {guide.meta}
+      </Text>
+      {guide.tip ? (
+        <Text className={styles.tip} block role="note">
+          {guide.tip}
+        </Text>
+      ) : null}
+      <ol className={styles.stepList}>
+        {guide.steps.map((step, index) => (
+          <li key={step} className={styles.stepCard}>
+            <span className={styles.stepNum} aria-hidden>
+              {index + 1}
+            </span>
+            <Text className={styles.stepText}>{step}</Text>
+          </li>
+        ))}
+      </ol>
+      {guide.alternateSteps && guide.alternateSteps.length > 0 ? (
+        <>
+          <Text className={styles.altLabel} block>
+            {guide.alternateLabel ?? '也可以这样'}
+          </Text>
+          <ol className={styles.altList}>
+            {guide.alternateSteps.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ol>
+        </>
+      ) : null}
+    </>
+  )
+}
+
+/**
+ * Web / PWA：可安装时顶部轻提示；交互一次后本地记录，不再反复打扰。
+ */
+export default function PwaInstallBanner() {
+  const s = useStyles()
+  const {
+    showBanner,
+    mode,
+    isIos,
+    isAndroid,
+    isFirefox,
+    isChromium,
+    isEdge,
+    isSafari,
+    isWindows,
+    promptInstall,
+    dismissPrompt,
+    acknowledgeManual,
+  } = usePwaInstall()
+  const [busy, setBusy] = useState(false)
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [guideOpen, setGuideOpen] = useState(false)
+
+  const guide = resolvePwaInstallGuide({
+    isIos,
+    isSafari,
+    isAndroid,
+    isFirefox,
+    isEdge,
+    isChromium,
+    isWindows,
+  })
+
+  /** Chrome / Edge 可弹系统窗；Safari / iOS 等用「安装到桌面」打开步骤。 */
+  const installCta = mode === 'native' || isChromium || isSafari || isIos
+    || isFirefox || isAndroid
+
+  const handleDismiss = useCallback(() => {
+    dismissPrompt()
+    setFeedback(null)
+  }, [dismissPrompt])
+
+  const handleManualOpen = useCallback(() => {
+    setGuideOpen(true)
+  }, [])
+
+  const handlePrimary = useCallback(async () => {
+    if (isSafari || isIos || isFirefox || (isAndroid && !isChromium)) {
+      handleManualOpen()
+      return
+    }
+    if (mode === 'native' || isChromium) {
+      setBusy(true)
+      setFeedback(null)
+      try {
+        const result = await promptInstall()
+        if (result === 'accepted') {
+          setFeedback('已安装到本机，可从桌面打开。')
+          return
+        }
+        if (result === 'dismissed') {
+          setFeedback('未完成安装。你可以稍后再次尝试，或使用地址栏的安装图标。')
+          return
+        }
+        // Chromium 无系统窗：多为已装；若仍要手动装，给出本浏览器步骤
+        if (isChromium) {
+          setGuideOpen(true)
+          return
+        }
+        setFeedback('暂时无法唤起安装。请按步骤在浏览器中完成。')
+      } catch {
+        setFeedback('安装未能完成，请稍后重试。')
+      } finally {
+        setBusy(false)
+      }
+      return
+    }
+    handleManualOpen()
+  }, [
+    handleManualOpen,
+    isAndroid,
+    isChromium,
+    isFirefox,
+    isIos,
+    isSafari,
+    mode,
+    promptInstall,
+  ])
+
+  const handleGuideDone = useCallback(() => {
+    setGuideOpen(false)
+    acknowledgeManual()
+  }, [acknowledgeManual])
+
+  const primaryLabel = busy
+    ? '正在打开…'
+    : installCta
+      ? '安装到桌面'
+      : '查看步骤'
+
+  const bannerTitle = installCta
+    ? (isIos ? '安装到主屏幕' : isSafari ? '安装到程序坞' : '安装 Opptrix 到桌面')
+    : guide.title
+
+  const bannerMeta = installCta
+    ? (isSafari || isIos
+      ? guide.meta
+      : isEdge
+        ? '安装后可像本地应用一样独立打开；Edge 与 Chrome 均支持一键安装。'
+        : '安装后可像本地应用一样独立打开，更快捷、更专注。')
+    : guide.meta
+
+  if (isElectron() || !showBanner) {
+    if (feedback) {
+      return (
+        <div className={s.wrap} role="status" aria-live="polite">
+          <div className={s.card}>
+            <div className={s.row}>
+              <div className={s.body}>
+                <Text className={s.feedback} block>{feedback}</Text>
+              </div>
+              <OpptrixButton
+                className={s.dismiss}
+                variant="ghost"
+                size="small"
+                aria-label="关闭"
+                icon={<DismissRegular fontSize={14} />}
+                onClick={() => setFeedback(null)}
+              />
+            </div>
+          </div>
+        </div>
+      )
+    }
+    return null
+  }
+
+  return (
+    <>
+      <div className={s.wrap} role="status" aria-live="polite">
+        <div className={s.card}>
+          <div className={s.row}>
+            <img className={s.logo} src={ICON_SRC} alt="" width={36} height={36} />
+            <div className={s.body}>
+              <Text className={s.title} block>
+                {bannerTitle}
+              </Text>
+              <Text className={s.meta} block>
+                {bannerMeta}
+              </Text>
+              {feedback ? (
+                <Text className={s.feedback} block>{feedback}</Text>
+              ) : null}
+            </div>
+            <OpptrixButton
+              className={s.dismiss}
+              variant="ghost"
+              size="small"
+              aria-label="关闭提醒"
+              title="关闭提醒"
+              icon={<DismissRegular fontSize={14} />}
+              onClick={handleDismiss}
+            />
+          </div>
+          <div className={s.footer}>
+            <OpptrixButton
+              className={mergeClasses(s.later, 'opptrix-focusable')}
+              variant="ghost"
+              size="small"
+              onClick={handleDismiss}
+            >
+              稍后
+            </OpptrixButton>
+            <OpptrixButton
+              className={mergeClasses(s.primary, 'opptrix-focusable')}
+              variant="primary"
+              size="small"
+              disabled={busy}
+              onClick={() => { void handlePrimary() }}
+            >
+              {primaryLabel}
+            </OpptrixButton>
+          </div>
+        </div>
+      </div>
+
+      <Dialog
+        open={guideOpen}
+        modalType="modal"
+        onOpenChange={(_, data) => {
+          if (!data.open) handleGuideDone()
+        }}
+      >
+        <DialogSurface
+          className={mergeClasses(
+            'opptrix-glass-dialog-surface',
+            'opptrix-dialog-alert-surface',
+            s.surface,
+          )}
+        >
+          <DialogBody className="opptrix-dialog-alert-body">
+            <DialogTitle className="opptrix-dialog-alert-title">{guide.title}</DialogTitle>
+            <DialogContent className="opptrix-dialog-alert-content">
+              <GuideSteps guide={guide} styles={s} />
+            </DialogContent>
+            <DialogActions className="opptrix-dialog-alert-actions">
+              <OpptrixButton variant="primary" onClick={handleGuideDone}>
+                知道了
+              </OpptrixButton>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+    </>
+  )
+}

--- a/client-ui/src/pwa/pwaInstallCapture.ts
+++ b/client-ui/src/pwa/pwaInstallCapture.ts
@@ -1,0 +1,91 @@
+/**
+ * Capture `beforeinstallprompt` as early as possible.
+ * Chromium often fires once before React mounts; missing it leaves the UI stuck on「查看步骤」.
+ */
+export type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+}
+
+type Listener = (event: BeforeInstallPromptEvent | null) => void
+
+const BOOT_FLAG = '__opptrixPwaInstallCaptureBooted'
+
+let deferred: BeforeInstallPromptEvent | null = null
+const listeners = new Set<Listener>()
+
+function notify(): void {
+  for (const listener of listeners) listener(deferred)
+}
+
+export function getCapturedInstallPrompt(): BeforeInstallPromptEvent | null {
+  return deferred
+}
+
+export function clearCapturedInstallPrompt(): void {
+  deferred = null
+  notify()
+}
+
+export function subscribeInstallPrompt(listener: Listener): () => void {
+  listeners.add(listener)
+  listener(deferred)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/**
+ * Wait until Chromium hands us a deferred prompt, or timeout.
+ */
+export function waitForInstallPrompt(timeoutMs = 2500): Promise<BeforeInstallPromptEvent | null> {
+  const existing = getCapturedInstallPrompt()
+  if (existing) return Promise.resolve(existing)
+
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (event: BeforeInstallPromptEvent | null) => {
+      if (settled) return
+      if (event == null && getCapturedInstallPrompt() == null) return
+      settled = true
+      window.clearTimeout(timer)
+      unsub()
+      resolve(getCapturedInstallPrompt())
+    }
+    const unsub = subscribeInstallPrompt((event) => {
+      if (event) finish(event)
+    })
+    const timer = window.setTimeout(() => {
+      settled = true
+      unsub()
+      resolve(getCapturedInstallPrompt())
+    }, timeoutMs)
+  })
+}
+
+export function bootstrapPwaInstallCapture(): void {
+  if (typeof window === 'undefined') return
+  const w = window as Window & { [BOOT_FLAG]?: boolean }
+  if (w[BOOT_FLAG]) return
+  w[BOOT_FLAG] = true
+
+  window.addEventListener('beforeinstallprompt', (event) => {
+    event.preventDefault()
+    deferred = event as BeforeInstallPromptEvent
+    notify()
+  })
+
+  window.addEventListener('appinstalled', () => {
+    deferred = null
+    notify()
+  })
+
+  if ('serviceWorker' in navigator) {
+    void navigator.serviceWorker
+      .register('/sw.js')
+      .then(() => navigator.serviceWorker.ready)
+      .catch(() => {
+        /* installability best-effort */
+      })
+  }
+}

--- a/client-ui/src/pwa/pwaInstallDetect.ts
+++ b/client-ui/src/pwa/pwaInstallDetect.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure UA / platform classification for PWA install UX (testable without React).
+ */
+
+export type PwaClientFlags = {
+  isIos: boolean
+  isSafari: boolean
+  isAndroid: boolean
+  isFirefox: boolean
+  isEdge: boolean
+  isChromium: boolean
+  isWindows: boolean
+}
+
+export type PwaInstallMode = 'native' | 'manual' | 'none'
+
+export function classifyPwaClient(
+  ua: string,
+  opts: { platform?: string; maxTouchPoints?: number; uaPlatform?: string } = {},
+): PwaClientFlags {
+  const platform = opts.platform ?? ''
+  const maxTouchPoints = opts.maxTouchPoints ?? 0
+  const uaPlatform = opts.uaPlatform ?? ''
+
+  const isIos = /iPad|iPhone|iPod/.test(ua)
+    || (platform === 'MacIntel' && maxTouchPoints > 1)
+  const isAndroid = /Android/i.test(ua)
+  const isFirefox = /Firefox\//i.test(ua) && !/Seamonkey/i.test(ua)
+  const isEdge = /Edg\//i.test(ua)
+  const isChromium = /Chrome\//i.test(ua) || /CriOS\//i.test(ua) || isEdge
+  const isSafari = !(/Chrome|CriOS|Chromium|Edg|EdgiOS|OPR|Firefox|FxiOS|Android/i.test(ua))
+    && /Safari/i.test(ua)
+  const isWindows = /Windows NT|Win64|Win32/i.test(ua) || /Windows/i.test(uaPlatform)
+
+  return {
+    isIos,
+    isSafari: isSafari && !isIos,
+    isAndroid,
+    isFirefox,
+    isEdge,
+    isChromium,
+    isWindows,
+  }
+}
+
+/** Resolve banner/settings mode from probed install state + client flags. */
+export function resolvePwaInstallMode(input: {
+  isElectron: boolean
+  installed: boolean
+  interacted: boolean
+  likelyInstalled: boolean
+  probeReady: boolean
+  hasDeferred: boolean
+  isSafari: boolean
+  isIos: boolean
+  isAndroid: boolean
+  isFirefox: boolean
+}): PwaInstallMode {
+  const {
+    isElectron,
+    installed,
+    interacted,
+    likelyInstalled,
+    probeReady,
+    hasDeferred,
+    isSafari,
+    isIos,
+    isAndroid,
+    isFirefox,
+  } = input
+
+  if (isElectron || installed || interacted || likelyInstalled) return 'none'
+  if (!probeReady && !hasDeferred) return 'none'
+  if (hasDeferred) return 'native'
+  if (isSafari || isIos || isAndroid || isFirefox) return 'manual'
+  return 'manual'
+}

--- a/client-ui/src/pwa/pwaInstallGuides.ts
+++ b/client-ui/src/pwa/pwaInstallGuides.ts
@@ -1,0 +1,179 @@
+/**
+ * Per-browser PWA install copy — primary path + alternate.
+ * Product language only; no engine/API jargon.
+ */
+
+export type PwaGuideBrowser =
+  | 'ios'
+  | 'safari-mac'
+  | 'android'
+  | 'firefox-windows'
+  | 'firefox-android'
+  | 'firefox-desktop-other'
+  | 'edge'
+  | 'chrome'
+  | 'generic'
+
+export type PwaInstallGuide = {
+  title: string
+  meta: string
+  /** Short tip above steps (capability caveat / Lab toggle). */
+  tip?: string
+  steps: string[]
+  alternateLabel?: string
+  alternateSteps?: string[]
+}
+
+export type PwaGuideContext = {
+  isIos: boolean
+  isSafari: boolean
+  isAndroid: boolean
+  isFirefox: boolean
+  isEdge: boolean
+  isChromium: boolean
+  isWindows: boolean
+}
+
+export function resolvePwaGuideBrowser(ctx: PwaGuideContext): PwaGuideBrowser {
+  if (ctx.isIos) return 'ios'
+  if (ctx.isSafari) return 'safari-mac'
+  if (ctx.isFirefox && ctx.isAndroid) return 'firefox-android'
+  if (ctx.isAndroid) return 'android'
+  if (ctx.isFirefox && ctx.isWindows) return 'firefox-windows'
+  if (ctx.isFirefox) return 'firefox-desktop-other'
+  if (ctx.isEdge) return 'edge'
+  if (ctx.isChromium) return 'chrome'
+  return 'generic'
+}
+
+const GUIDES: Record<PwaGuideBrowser, PwaInstallGuide> = {
+  ios: {
+    title: '安装到主屏幕',
+    meta: '添加到主屏幕后，可像常用 App 一样从主屏幕打开。',
+    tip: '请使用 Safari 打开本页（其他浏览器在 iPhone 上通常也走同一套步骤）。',
+    steps: [
+      '点底部分享按钮（方框加向上箭头）',
+      '向下滑动，点「添加到主屏幕」',
+      '如有「以网页 App 打开」，保持开启',
+      '确认名称后点「添加」',
+    ],
+    alternateLabel: '找不到「添加到主屏幕」时',
+    alternateSteps: [
+      '在分享列表最下方点「编辑操作」',
+      '打开「添加到主屏幕」后再返回分享菜单选择它',
+    ],
+  },
+  'safari-mac': {
+    title: '安装到程序坞',
+    meta: '添加到程序坞后，可从程序坞或聚焦搜索以独立窗口打开。',
+    tip: '需要 macOS Sonoma 14 或更高版本。',
+    steps: [
+      '点工具栏「分享」按钮',
+      '选择「添加到程序坞」',
+      '确认名称后点「添加」',
+    ],
+    alternateLabel: '也可以这样',
+    alternateSteps: [
+      '菜单栏选择「文件」→「添加到程序坞…」',
+      '确认名称后点「添加」',
+    ],
+  },
+  android: {
+    title: '安装到桌面',
+    meta: '安装后可从主屏幕打开，独立使用。',
+    steps: [
+      '点右上角「⋮」菜单',
+      '选择「安装应用」「安装」或「添加到主屏幕」',
+      '按提示确认',
+    ],
+    alternateLabel: '也可以这样',
+    alternateSteps: [
+      '查看地址栏是否出现「安装」提示并点按',
+      '按系统对话框完成安装',
+    ],
+  },
+  'firefox-windows': {
+    title: '固定到任务栏',
+    meta: '在 Windows 的 Firefox 中，可将本站以精简窗口固定到任务栏。',
+    tip: '若地址栏没有相关图标：打开「设置」→「Firefox 实验室」，开启「将网站添加到任务栏」。',
+    steps: [
+      '确认已开启「将网站添加到任务栏」',
+      '点地址栏右侧的「添加到任务栏」图标',
+      '在提示中确认添加',
+    ],
+    alternateLabel: '没有实验室选项时',
+    alternateSteps: [
+      '建议改用 Chrome 或 Edge 打开本站，一键安装到桌面',
+    ],
+  },
+  'firefox-android': {
+    title: '安装到主屏幕',
+    meta: '安装后可从主屏幕打开。',
+    steps: [
+      '点右上角「⋮」菜单',
+      '选择「安装」或「添加到主屏幕」',
+      '按提示确认',
+    ],
+  },
+  'firefox-desktop-other': {
+    title: '安装到桌面',
+    meta: '当前 Firefox 在此系统上对「安装为应用」支持有限。',
+    tip: '想获得完整的桌面应用体验，建议用 Chrome、Edge 或 Safari 打开本站再安装。',
+    steps: [
+      '用 Chrome 或 Edge 打开同一地址',
+      '按提示点「安装到桌面」或地址栏安装图标',
+      '确认后从桌面或程序坞打开',
+    ],
+    alternateLabel: '继续留在 Firefox 时',
+    alternateSteps: [
+      '可将本页加入书签，方便下次快速打开',
+    ],
+  },
+  edge: {
+    title: '安装 Opptrix 到桌面',
+    meta: '用 Edge 安装后，可像本地应用一样独立打开。',
+    tip: '优先点页面上的「安装到桌面」；若未弹出系统窗口，再按下列步骤。',
+    steps: [
+      '查看地址栏右侧是否有「应用」或安装图标并点击',
+      '在弹出窗口中确认安装',
+    ],
+    alternateLabel: '也可以这样',
+    alternateSteps: [
+      '点右上角「⋮」→「应用」',
+      '选择「将此站点安装为应用」或「安装 Opptrix」',
+      '确认名称后点「安装」',
+    ],
+  },
+  chrome: {
+    title: '安装 Opptrix 到桌面',
+    meta: '用 Chrome 安装后，可像本地应用一样独立打开。',
+    tip: '优先点页面上的「安装到桌面」；若未弹出系统窗口，再按下列步骤。',
+    steps: [
+      '查看地址栏右侧是否有「安装」图标（电脑样式）并点击',
+      '在弹出窗口中确认安装',
+    ],
+    alternateLabel: '也可以这样',
+    alternateSteps: [
+      '点右上角「⋮」→「保存并分享」（或「投放、保存和分享」）',
+      '选择「安装页面应用」或「安装 Opptrix…」',
+      '确认后完成安装',
+    ],
+  },
+  generic: {
+    title: '安装到桌面',
+    meta: '在浏览器菜单中选择安装或添加到主屏幕即可。',
+    steps: [
+      '打开浏览器菜单',
+      '选择「安装应用」「安装此站点」或「添加到主屏幕」',
+      '按提示完成',
+    ],
+  },
+}
+
+export function getPwaInstallGuide(browser: PwaGuideBrowser): PwaInstallGuide {
+  return GUIDES[browser]
+}
+
+export function resolvePwaInstallGuide(ctx: PwaGuideContext): PwaInstallGuide {
+  return getPwaInstallGuide(resolvePwaGuideBrowser(ctx))
+}

--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -4,7 +4,13 @@
 
 **安全上下文**：通知与 Service Worker 仅在 **HTTPS** 或 **localhost** 下可用。自托管时请用 HTTPS 反向代理，或本地 `http://127.0.0.1` 开发。
 
-**安装为应用（PWA）**：页面提供 `manifest.webmanifest`、favicon / 应用图标、安装截图与最小 Service Worker（仅满足可安装条件，不做离线缓存策略、不处理 push）。在 Chrome / Edge 中可通过地址栏「安装」，或在 **设置 → 常规 → 本机应用** 中一键安装到桌面。Electron 桌面壳不注册该 Service Worker，也不展示安装入口。
+**安装为应用（PWA）**：页面提供 `manifest.webmanifest`（含自描述 `related_applications` 以便检测是否已安装）、favicon / 应用图标、安装截图与最小 Service Worker（仅满足可安装条件，不做离线缓存策略、不处理 push）。
+
+- **Chrome / Edge**：优先唤起系统安装窗；已安装或浏览器不再提供安装事件时顶部提醒静默。兜底指引按浏览器区分最新菜单路径（Chrome：「保存并分享」；Edge：「应用 → 将此站点安装为应用」）。
+- **Safari（Mac）**：引导「分享 / 文件 → 添加到程序坞」。
+- **iPhone**：引导「分享 → 添加到主屏幕」（含「以网页 App 打开」）。
+- **Firefox**：Windows 引导任务栏固定（实验室开关）；Android 引导菜单安装；其他桌面说明能力有限并建议改用 Chrome / Edge / Safari。
+- **设置 → 常规 → 本机应用**：与上述分端文案一致。Electron 桌面壳不注册该 Service Worker，也不展示安装入口。
 
 ### iPhone / Safari「添加到主屏幕」
 

--- a/tests/pwa-install-guides.test.mjs
+++ b/tests/pwa-install-guides.test.mjs
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  classifyPwaClient,
+  resolvePwaInstallMode,
+} from '../client-ui/src/pwa/pwaInstallDetect.ts'
+import {
+  resolvePwaGuideBrowser,
+  resolvePwaInstallGuide,
+} from '../client-ui/src/pwa/pwaInstallGuides.ts'
+
+const CHROME_MAC =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36'
+const EDGE_WIN =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Safari/537.36 Edg/152.0.0.0'
+const SAFARI_MAC =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+const IOS_SAFARI =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1'
+const FIREFOX_WIN =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:143.0) Gecko/20100101 Firefox/143.0'
+const FIREFOX_MAC =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:143.0) Gecko/20100101 Firefox/143.0'
+const FIREFOX_ANDROID =
+  'Mozilla/5.0 (Android 14; Mobile; rv:143.0) Gecko/143.0 Firefox/143.0'
+const CHROME_ANDROID =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/152.0.0.0 Mobile Safari/537.36'
+
+test('classifyPwaClient — Chrome / Edge / Safari / Firefox', () => {
+  const chrome = classifyPwaClient(CHROME_MAC)
+  assert.equal(chrome.isChromium, true)
+  assert.equal(chrome.isEdge, false)
+  assert.equal(chrome.isSafari, false)
+
+  const edge = classifyPwaClient(EDGE_WIN)
+  assert.equal(edge.isEdge, true)
+  assert.equal(edge.isChromium, true)
+  assert.equal(edge.isWindows, true)
+
+  const safari = classifyPwaClient(SAFARI_MAC, { platform: 'MacIntel', maxTouchPoints: 0 })
+  assert.equal(safari.isSafari, true)
+  assert.equal(safari.isIos, false)
+  assert.equal(safari.isChromium, false)
+
+  const ios = classifyPwaClient(IOS_SAFARI)
+  assert.equal(ios.isIos, true)
+  assert.equal(ios.isSafari, false)
+
+  const ffWin = classifyPwaClient(FIREFOX_WIN)
+  assert.equal(ffWin.isFirefox, true)
+  assert.equal(ffWin.isWindows, true)
+  assert.equal(ffWin.isChromium, false)
+})
+
+test('resolvePwaGuideBrowser — 分浏览器路由', () => {
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(EDGE_WIN),
+    }),
+    'edge',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(CHROME_MAC),
+    }),
+    'chrome',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(SAFARI_MAC, { platform: 'MacIntel' }),
+    }),
+    'safari-mac',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(IOS_SAFARI),
+    }),
+    'ios',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(FIREFOX_WIN),
+    }),
+    'firefox-windows',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(FIREFOX_MAC),
+    }),
+    'firefox-desktop-other',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(FIREFOX_ANDROID),
+    }),
+    'firefox-android',
+  )
+  assert.equal(
+    resolvePwaGuideBrowser({
+      ...classifyPwaClient(CHROME_ANDROID),
+    }),
+    'android',
+  )
+})
+
+test('resolvePwaInstallGuide — Edge / Chrome 步骤含最新菜单文案', () => {
+  const edge = resolvePwaInstallGuide({ ...classifyPwaClient(EDGE_WIN) })
+  assert.match(edge.title, /桌面/)
+  assert.ok(edge.steps.length >= 2)
+  assert.ok(edge.alternateSteps?.some((s) => s.includes('应用')))
+  assert.ok(edge.alternateSteps?.some((s) => s.includes('安装为应用') || s.includes('安装 Opptrix')))
+
+  const chrome = resolvePwaInstallGuide({ ...classifyPwaClient(CHROME_MAC) })
+  assert.ok(chrome.alternateSteps?.some((s) => s.includes('保存并分享') || s.includes('投放')))
+  assert.ok(chrome.tip?.includes('安装到桌面'))
+
+  const safari = resolvePwaInstallGuide({
+    ...classifyPwaClient(SAFARI_MAC, { platform: 'MacIntel' }),
+  })
+  assert.ok(safari.steps.some((s) => s.includes('添加到程序坞')))
+  assert.ok(safari.alternateSteps?.some((s) => s.includes('文件')))
+
+  const ios = resolvePwaInstallGuide({ ...classifyPwaClient(IOS_SAFARI) })
+  assert.ok(ios.steps.some((s) => s.includes('添加到主屏幕')))
+  assert.ok(ios.steps.some((s) => s.includes('网页 App') || s.includes('添加')))
+
+  const ffOther = resolvePwaInstallGuide({ ...classifyPwaClient(FIREFOX_MAC) })
+  assert.ok(ffOther.tip?.includes('Chrome') || ffOther.tip?.includes('Edge'))
+})
+
+test('resolvePwaInstallMode — Chromium 有/无 deferred；已装静默', () => {
+  assert.equal(resolvePwaInstallMode({
+    isElectron: false,
+    installed: false,
+    interacted: false,
+    likelyInstalled: false,
+    probeReady: true,
+    hasDeferred: true,
+    isSafari: false,
+    isIos: false,
+    isAndroid: false,
+    isFirefox: false,
+  }), 'native')
+
+  assert.equal(resolvePwaInstallMode({
+    isElectron: false,
+    installed: false,
+    interacted: false,
+    likelyInstalled: true,
+    probeReady: true,
+    hasDeferred: false,
+    isSafari: false,
+    isIos: false,
+    isAndroid: false,
+    isFirefox: false,
+  }), 'none')
+
+  assert.equal(resolvePwaInstallMode({
+    isElectron: false,
+    installed: false,
+    interacted: false,
+    likelyInstalled: false,
+    probeReady: true,
+    hasDeferred: false,
+    isSafari: true,
+    isIos: false,
+    isAndroid: false,
+    isFirefox: false,
+  }), 'manual')
+
+  assert.equal(resolvePwaInstallMode({
+    isElectron: false,
+    installed: false,
+    interacted: false,
+    likelyInstalled: false,
+    probeReady: true,
+    hasDeferred: false,
+    isSafari: false,
+    isIos: false,
+    isAndroid: false,
+    isFirefox: true,
+  }), 'manual')
+})


### PR DESCRIPTION
## Summary
- Align login with onboarding atmosphere and gate on the user agreement
- Add web PWA install banner with Chromium system prompt, per-browser guides, and silent mode when already installed
- Make settings「返回应用」a full header-strip hit target without chip hover background

## Test plan
- [ ] Login: atmosphere visible; submit blocked until agreement checked; agreement link opens legal page
- [ ] Chrome/Edge (not installed): banner → system install dialog
- [ ] Chrome/Edge (already installed): no install nag; settings shows installed
- [ ] Safari Mac / iOS / Firefox: guide steps match current menus
- [ ] Settings back: hover paints full top strip; default blends with sidebar
- [ ] `npm run check:ui` and `node --test tests/pwa-install-guides.test.mjs`


Made with [Cursor](https://cursor.com)